### PR TITLE
Update DataProtection for StackExchange.Redis 2.0+

### DIFF
--- a/src/Security/Security.sln
+++ b/src/Security/Security.sln
@@ -55,6 +55,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Steeltoe.CloudFoundry.Conne
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Steeltoe.Common.Http", "..\Common\src\Common.Http\Steeltoe.Common.Http.csproj", "{495C7871-EE98-4B53-ABAE-26294046DDDC}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Steeltoe.Common", "..\Common\src\Common\Steeltoe.Common.csproj", "{E0BE23BB-47B5-4838-B845-254A6CE8F791}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Steeltoe.Extensions.Configuration.CloudFoundryBase", "..\Configuration\src\CloudFoundryBase\Steeltoe.Extensions.Configuration.CloudFoundryBase.csproj", "{321350A1-20CE-4672-B901-9C58F12B43A8}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -125,6 +129,14 @@ Global
 		{495C7871-EE98-4B53-ABAE-26294046DDDC}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{495C7871-EE98-4B53-ABAE-26294046DDDC}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{495C7871-EE98-4B53-ABAE-26294046DDDC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E0BE23BB-47B5-4838-B845-254A6CE8F791}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E0BE23BB-47B5-4838-B845-254A6CE8F791}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E0BE23BB-47B5-4838-B845-254A6CE8F791}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E0BE23BB-47B5-4838-B845-254A6CE8F791}.Release|Any CPU.Build.0 = Release|Any CPU
+		{321350A1-20CE-4672-B901-9C58F12B43A8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{321350A1-20CE-4672-B901-9C58F12B43A8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{321350A1-20CE-4672-B901-9C58F12B43A8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{321350A1-20CE-4672-B901-9C58F12B43A8}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -146,6 +158,8 @@ Global
 		{950B0827-634F-43F9-86C4-4E615ED36A22} = {BA3B33D3-64A5-4219-B4C2-787C4BD505F7}
 		{9E65D8C3-5BCE-43D2-952A-C0A6C4477401} = {2FE6A5FE-4512-41A9-9994-90C12DF1C409}
 		{495C7871-EE98-4B53-ABAE-26294046DDDC} = {2FE6A5FE-4512-41A9-9994-90C12DF1C409}
+		{E0BE23BB-47B5-4838-B845-254A6CE8F791} = {2FE6A5FE-4512-41A9-9994-90C12DF1C409}
+		{321350A1-20CE-4672-B901-9C58F12B43A8} = {2FE6A5FE-4512-41A9-9994-90C12DF1C409}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {BED45957-EDAD-4686-B959-BD5DA962F7B0}

--- a/src/Security/src/DataProtection.RedisCore/CloudFoundryRedisXmlRepository.cs
+++ b/src/Security/src/DataProtection.RedisCore/CloudFoundryRedisXmlRepository.cs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using Microsoft.AspNetCore.DataProtection;
+using Microsoft.AspNetCore.DataProtection.StackExchangeRedis;
 using StackExchange.Redis;
 
 namespace Steeltoe.Security.DataProtection.Redis

--- a/src/Security/src/DataProtection.RedisCore/Steeltoe.Security.DataProtection.RedisCore.csproj
+++ b/src/Security/src/DataProtection.RedisCore/Steeltoe.Security.DataProtection.RedisCore.csproj
@@ -12,7 +12,7 @@
   <Import Project="..\..\..\..\sharedproject.props" />
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="$(AspNetCoreVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.DataProtection.Redis" Version="$(AspNetCoreDataProtectionRedisVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="$(AspNetCoreDataProtectionRedisVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection.StackExchangeRedis" Version="$(AspNetCoreDataProtectionRedisVersion)" />
   </ItemGroup>
 </Project>

--- a/versions.props
+++ b/versions.props
@@ -5,7 +5,7 @@
 
     <AspNetVersion>5.2.4</AspNetVersion>
     <AspNetCoreVersion>2.0.0</AspNetCoreVersion>
-    <AspNetCoreDataProtectionRedisVersion>0.3.0</AspNetCoreDataProtectionRedisVersion>
+    <AspNetCoreDataProtectionRedisVersion>2.2.0</AspNetCoreDataProtectionRedisVersion>
     <AspNetCoreDepTestVersion>2.1.0</AspNetCoreDepTestVersion>
     <AspNetCoreTestVersion>2.1.0</AspNetCoreTestVersion>
     <AspNetCoreMvcTestVersion>2.1.0</AspNetCoreMvcTestVersion>


### PR DESCRIPTION
This is a small change here, but has a ripple of requiring other dependency changes:

- Microsoft.AspNetCore.DataProtection >= 2.0.0 goes to >= 2.2.0
- Microsoft.AspNetCore.Cryptography.Internal >= 2.0.0 goes to >= 2.2.0
- Microsoft.AspNetCore.DataProtection.Abstractions >= 2.0.0 goes to >= 2.2.0
- Microsoft.AspNetCore.Hosting.Abstractions >= 2.0.0 goes to >= 2.2.0
- Microsoft.Extensions.DependencyInjection.Abstractions >= 2.0.0 goes to >=| 2.2.0
- Microsoft.Extensions.Logging.Abstractions >= 2.0.0 goes to >= 2.2.0
- Microsoft.Extensions.Options >= 2.0.0 goes to >= 2.2.0
- Microsoft.Win32.Registry >= 4.4.0 goes to >= 4.5.0
- System.Security.Cryptography.Xml >= 4.4.0 goes to >= 4.5.0
- adds System.Security.Principal.Windows (>= 4.5.0)

This change should be fine for Steeltoe 3.0. The upgrade does not appear to cause issues in the Steeltoe sample when leaving everything else unchanged, so it _may_ be fine to include with the next Steeltoe 2.x as well

#40 