### PR TITLE
Microsoft HealthChecks: Remove 3rd Party Deps, add tests

### DIFF
--- a/src/Connectors/src/ConnectorBase/Cache/RedisConnectionInfo.cs
+++ b/src/Connectors/src/ConnectorBase/Cache/RedisConnectionInfo.cs
@@ -19,16 +19,19 @@ namespace Steeltoe.CloudFoundry.Connector.Redis
 {
     public class RedisConnectionInfo : IConnectorInfo
     {
-        public Connection Get(IConfiguration configuration)
+        public Connection Get(IConfiguration configuration, string serviceName = null)
         {
-            var info = configuration.GetSingletonServiceInfo<RedisServiceInfo>();
+            var info = serviceName == null
+                ? configuration.GetSingletonServiceInfo<RedisServiceInfo>()
+                : configuration.GetRequiredServiceInfo<RedisServiceInfo>(serviceName);
+
             var redisConfig = new RedisCacheConnectorOptions(configuration);
             var configurer = new RedisCacheConfigurer();
             var connString = configurer.Configure(info, redisConfig).ToString();
             return new Connection
             {
                 ConnectionString = connString,
-                Name = "Redis"
+                Name = "Redis" + serviceName?.Insert(0, "-")
             };
         }
     }

--- a/src/Connectors/src/ConnectorBase/Cache/RedisConnectionInfo.cs
+++ b/src/Connectors/src/ConnectorBase/Cache/RedisConnectionInfo.cs
@@ -1,0 +1,35 @@
+// Copyright 2017 the original author or authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Microsoft.Extensions.Configuration;
+using Steeltoe.CloudFoundry.Connector.Services;
+
+namespace Steeltoe.CloudFoundry.Connector.Redis
+{
+    public class RedisConnectionInfo : IConnectorInfo
+    {
+        public Connection Get(IConfiguration configuration)
+        {
+            var info = configuration.GetSingletonServiceInfo<RedisServiceInfo>();
+            var redisConfig = new RedisCacheConnectorOptions(configuration);
+            var configurer = new RedisCacheConfigurer();
+            var connString = configurer.Configure(info, redisConfig).ToString();
+            return new Connection
+            {
+                ConnectionString = connString,
+                Name = "Redis"
+            };
+        }
+    }
+}

--- a/src/Connectors/src/ConnectorBase/Cache/RedisConnectionInfo.cs
+++ b/src/Connectors/src/ConnectorBase/Cache/RedisConnectionInfo.cs
@@ -17,7 +17,7 @@ using Steeltoe.CloudFoundry.Connector.Services;
 
 namespace Steeltoe.CloudFoundry.Connector.Redis
 {
-    public class RedisConnectionInfo : IConnectorInfo
+    public class RedisConnectionInfo : IConnectionInfo
     {
         public Connection Get(IConfiguration configuration, string serviceName = null)
         {

--- a/src/Connectors/src/ConnectorBase/ConnectionStringManager.cs
+++ b/src/Connectors/src/ConnectorBase/ConnectionStringManager.cs
@@ -28,7 +28,7 @@ namespace Steeltoe.CloudFoundry.Connector
         }
 
         public Connection Get<T>(string serviceName = null)
-            where T : IConnectorInfo, new()
+            where T : IConnectionInfo, new()
         {
             return new T().Get(_configuration, serviceName);
         }

--- a/src/Connectors/src/ConnectorBase/ConnectionStringManager.cs
+++ b/src/Connectors/src/ConnectorBase/ConnectionStringManager.cs
@@ -27,10 +27,10 @@ namespace Steeltoe.CloudFoundry.Connector
             _configuration = configuration;
         }
 
-        public Connection Get<T>()
+        public Connection Get<T>(string serviceName = null)
             where T : IConnectorInfo, new()
         {
-            return new T().Get(_configuration);
+            return new T().Get(_configuration, serviceName);
         }
     }
 }

--- a/src/Connectors/src/ConnectorBase/ConnectionStringManager.cs
+++ b/src/Connectors/src/ConnectorBase/ConnectionStringManager.cs
@@ -1,0 +1,36 @@
+// Copyright 2017 the original author or authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Microsoft.Extensions.Configuration;
+using System;
+using System.Reflection;
+
+namespace Steeltoe.CloudFoundry.Connector
+{
+    public class ConnectionStringManager
+    {
+        private readonly IConfiguration _configuration;
+
+        public ConnectionStringManager(IConfiguration configuration)
+        {
+            _configuration = configuration;
+        }
+
+        public Connection Get<T>()
+            where T : IConnectorInfo, new()
+        {
+            return new T().Get(_configuration);
+        }
+    }
+}

--- a/src/Connectors/src/ConnectorBase/DocumentDB/MongoDb/MongoDbConnectionInfo.cs
+++ b/src/Connectors/src/ConnectorBase/DocumentDB/MongoDb/MongoDbConnectionInfo.cs
@@ -21,15 +21,18 @@ namespace Steeltoe.CloudFoundry.Connector
 {
     public class MongoDbConnectionInfo : IConnectorInfo
     {
-        public Connection Get(IConfiguration configuration)
+        public Connection Get(IConfiguration configuration, string serviceName)
         {
-            var info = configuration.GetSingletonServiceInfo<MongoDbServiceInfo>();
+            var info = serviceName == null
+               ? configuration.GetSingletonServiceInfo<MongoDbServiceInfo>()
+               : configuration.GetRequiredServiceInfo<MongoDbServiceInfo>(serviceName);
+
             var mongoConfig = new MongoDbConnectorOptions(configuration);
             var configurer = new MongoDbProviderConfigurer();
             return new Connection
             {
                 ConnectionString = configurer.Configure(info, mongoConfig),
-                Name = "MongoDb"
+                Name = "MongoDb" + serviceName?.Insert(0, "-")
             };
         }
     }

--- a/src/Connectors/src/ConnectorBase/DocumentDB/MongoDb/MongoDbConnectionInfo.cs
+++ b/src/Connectors/src/ConnectorBase/DocumentDB/MongoDb/MongoDbConnectionInfo.cs
@@ -1,0 +1,36 @@
+// Copyright 2017 the original author or authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Microsoft.Extensions.Configuration;
+using Steeltoe.CloudFoundry.Connector.MongoDb;
+using Steeltoe.CloudFoundry.Connector.MySql;
+using Steeltoe.CloudFoundry.Connector.Services;
+
+namespace Steeltoe.CloudFoundry.Connector
+{
+    public class MongoDbConnectionInfo : IConnectorInfo
+    {
+        public Connection Get(IConfiguration configuration)
+        {
+            var info = configuration.GetSingletonServiceInfo<MongoDbServiceInfo>();
+            var mongoConfig = new MongoDbConnectorOptions(configuration);
+            var configurer = new MongoDbProviderConfigurer();
+            return new Connection
+            {
+                ConnectionString = configurer.Configure(info, mongoConfig),
+                Name = "MongoDb"
+            };
+        }
+    }
+}

--- a/src/Connectors/src/ConnectorBase/DocumentDB/MongoDb/MongoDbConnectionInfo.cs
+++ b/src/Connectors/src/ConnectorBase/DocumentDB/MongoDb/MongoDbConnectionInfo.cs
@@ -19,7 +19,7 @@ using Steeltoe.CloudFoundry.Connector.Services;
 
 namespace Steeltoe.CloudFoundry.Connector
 {
-    public class MongoDbConnectionInfo : IConnectorInfo
+    public class MongoDbConnectionInfo : IConnectionInfo
     {
         public Connection Get(IConfiguration configuration, string serviceName)
         {

--- a/src/Connectors/src/ConnectorBase/IConnectionInfo.cs
+++ b/src/Connectors/src/ConnectorBase/IConnectionInfo.cs
@@ -18,7 +18,7 @@ using System.Reflection;
 
 namespace Steeltoe.CloudFoundry.Connector
 {
-    public interface IConnectorInfo
+    public interface IConnectionInfo
     {
         Connection Get(IConfiguration configuration, string serviceName);
     }

--- a/src/Connectors/src/ConnectorBase/IConnectorInfo.cs
+++ b/src/Connectors/src/ConnectorBase/IConnectorInfo.cs
@@ -1,0 +1,32 @@
+// Copyright 2017 the original author or authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Microsoft.Extensions.Configuration;
+using System;
+using System.Reflection;
+
+namespace Steeltoe.CloudFoundry.Connector
+{
+    public interface IConnectorInfo
+    {
+        Connection Get(IConfiguration configuration);
+    }
+
+    public class Connection
+    {
+        public string ConnectionString { get; set; }
+
+        public string Name { get; set; }
+    }
+}

--- a/src/Connectors/src/ConnectorBase/IConnectorInfo.cs
+++ b/src/Connectors/src/ConnectorBase/IConnectorInfo.cs
@@ -20,7 +20,7 @@ namespace Steeltoe.CloudFoundry.Connector
 {
     public interface IConnectorInfo
     {
-        Connection Get(IConfiguration configuration);
+        Connection Get(IConfiguration configuration, string serviceName);
     }
 
     public class Connection

--- a/src/Connectors/src/ConnectorBase/Queue/RabbitMQConnectionInfo.cs
+++ b/src/Connectors/src/ConnectorBase/Queue/RabbitMQConnectionInfo.cs
@@ -1,0 +1,35 @@
+// Copyright 2017 the original author or authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Microsoft.Extensions.Configuration;
+using Steeltoe.CloudFoundry.Connector.MySql;
+using Steeltoe.CloudFoundry.Connector.Services;
+
+namespace Steeltoe.CloudFoundry.Connector.RabbitMQ
+{
+    public class RabbitMQConnectionInfo : IConnectorInfo
+    {
+        public Connection Get(IConfiguration configuration)
+        {
+            var info = configuration.GetSingletonServiceInfo<RabbitMQServiceInfo>();
+            var rabbitConfig = new RabbitMQProviderConnectorOptions(configuration);
+            var configurer = new RabbitMQProviderConfigurer();
+            return new Connection
+            {
+                ConnectionString = configurer.Configure(info, rabbitConfig),
+                Name = "RabbitMQ"
+            };
+        }
+    }
+}

--- a/src/Connectors/src/ConnectorBase/Queue/RabbitMQConnectionInfo.cs
+++ b/src/Connectors/src/ConnectorBase/Queue/RabbitMQConnectionInfo.cs
@@ -18,7 +18,7 @@ using Steeltoe.CloudFoundry.Connector.Services;
 
 namespace Steeltoe.CloudFoundry.Connector.RabbitMQ
 {
-    public class RabbitMQConnectionInfo : IConnectorInfo
+    public class RabbitMQConnectionInfo : IConnectionInfo
     {
         public Connection Get(IConfiguration configuration, string serviceName)
         {

--- a/src/Connectors/src/ConnectorBase/Queue/RabbitMQConnectionInfo.cs
+++ b/src/Connectors/src/ConnectorBase/Queue/RabbitMQConnectionInfo.cs
@@ -20,15 +20,18 @@ namespace Steeltoe.CloudFoundry.Connector.RabbitMQ
 {
     public class RabbitMQConnectionInfo : IConnectorInfo
     {
-        public Connection Get(IConfiguration configuration)
+        public Connection Get(IConfiguration configuration, string serviceName)
         {
-            var info = configuration.GetSingletonServiceInfo<RabbitMQServiceInfo>();
+            var info = serviceName == null
+              ? configuration.GetSingletonServiceInfo<RabbitMQServiceInfo>()
+              : configuration.GetRequiredServiceInfo<RabbitMQServiceInfo>(serviceName);
+
             var rabbitConfig = new RabbitMQProviderConnectorOptions(configuration);
             var configurer = new RabbitMQProviderConfigurer();
             return new Connection
             {
                 ConnectionString = configurer.Configure(info, rabbitConfig),
-                Name = "RabbitMQ"
+                Name = "RabbitMQ" + serviceName?.Insert(0, "-")
             };
         }
     }

--- a/src/Connectors/src/ConnectorBase/Relational/MySql/MySqlConnectionInfo.cs
+++ b/src/Connectors/src/ConnectorBase/Relational/MySql/MySqlConnectionInfo.cs
@@ -20,16 +20,19 @@ namespace Steeltoe.CloudFoundry.Connector
 {
     public class MySqlConnectionInfo : IConnectorInfo
     {
-        public Connection Get(IConfiguration configuration)
+        public Connection Get(IConfiguration configuration, string serviceName)
         {
-            MySqlServiceInfo info = configuration.GetSingletonServiceInfo<MySqlServiceInfo>();
+            var info = serviceName == null
+              ? configuration.GetSingletonServiceInfo<MySqlServiceInfo>()
+              : configuration.GetRequiredServiceInfo<MySqlServiceInfo>(serviceName);
+
             var mySqlConfig = new MySqlProviderConnectorOptions(configuration);
             var configurer = new MySqlProviderConfigurer();
             var connString = configurer.Configure(info, mySqlConfig);
             return new Connection
             {
                 ConnectionString = connString,
-                Name = "MySql"
+                Name = "MySql" + serviceName?.Insert(0, "-")
             };
         }
     }

--- a/src/Connectors/src/ConnectorBase/Relational/MySql/MySqlConnectionInfo.cs
+++ b/src/Connectors/src/ConnectorBase/Relational/MySql/MySqlConnectionInfo.cs
@@ -1,0 +1,36 @@
+// Copyright 2017 the original author or authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Microsoft.Extensions.Configuration;
+using Steeltoe.CloudFoundry.Connector.MySql;
+using Steeltoe.CloudFoundry.Connector.Services;
+
+namespace Steeltoe.CloudFoundry.Connector
+{
+    public class MySqlConnectionInfo : IConnectorInfo
+    {
+        public Connection Get(IConfiguration configuration)
+        {
+            MySqlServiceInfo info = configuration.GetSingletonServiceInfo<MySqlServiceInfo>();
+            var mySqlConfig = new MySqlProviderConnectorOptions(configuration);
+            var configurer = new MySqlProviderConfigurer();
+            var connString = configurer.Configure(info, mySqlConfig);
+            return new Connection
+            {
+                ConnectionString = connString,
+                Name = "MySql"
+            };
+        }
+    }
+}

--- a/src/Connectors/src/ConnectorBase/Relational/MySql/MySqlConnectionInfo.cs
+++ b/src/Connectors/src/ConnectorBase/Relational/MySql/MySqlConnectionInfo.cs
@@ -18,7 +18,7 @@ using Steeltoe.CloudFoundry.Connector.Services;
 
 namespace Steeltoe.CloudFoundry.Connector
 {
-    public class MySqlConnectionInfo : IConnectorInfo
+    public class MySqlConnectionInfo : IConnectionInfo
     {
         public Connection Get(IConfiguration configuration, string serviceName)
         {

--- a/src/Connectors/src/ConnectorBase/Relational/PostgreSQL/PostgresConnectionInfo.cs
+++ b/src/Connectors/src/ConnectorBase/Relational/PostgreSQL/PostgresConnectionInfo.cs
@@ -17,7 +17,7 @@ using Steeltoe.CloudFoundry.Connector.Services;
 
 namespace Steeltoe.CloudFoundry.Connector.PostgreSql
 {
-    public class PostgresConnectionInfo : IConnectorInfo
+    public class PostgresConnectionInfo : IConnectionInfo
     {
         public Connection Get(IConfiguration configuration, string serviceName)
         {

--- a/src/Connectors/src/ConnectorBase/Relational/PostgreSQL/PostgresConnectionInfo.cs
+++ b/src/Connectors/src/ConnectorBase/Relational/PostgreSQL/PostgresConnectionInfo.cs
@@ -1,0 +1,34 @@
+// Copyright 2017 the original author or authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Microsoft.Extensions.Configuration;
+using Steeltoe.CloudFoundry.Connector.Services;
+
+namespace Steeltoe.CloudFoundry.Connector.PostgreSql
+{
+    public class PostgresConnectionInfo : IConnectorInfo
+    {
+        public Connection Get(IConfiguration configuration)
+        {
+            var info = configuration.GetSingletonServiceInfo<PostgresServiceInfo>();
+            var postgresConfig = new PostgresProviderConnectorOptions(configuration);
+            var configurer = new PostgresProviderConfigurer();
+            return new Connection
+            {
+                ConnectionString = configurer.Configure(info, postgresConfig),
+                Name = "Postgres"
+            };
+        }
+    }
+}

--- a/src/Connectors/src/ConnectorBase/Relational/PostgreSQL/PostgresConnectionInfo.cs
+++ b/src/Connectors/src/ConnectorBase/Relational/PostgreSQL/PostgresConnectionInfo.cs
@@ -19,15 +19,18 @@ namespace Steeltoe.CloudFoundry.Connector.PostgreSql
 {
     public class PostgresConnectionInfo : IConnectorInfo
     {
-        public Connection Get(IConfiguration configuration)
+        public Connection Get(IConfiguration configuration, string serviceName)
         {
-            var info = configuration.GetSingletonServiceInfo<PostgresServiceInfo>();
+            var info = serviceName == null
+             ? configuration.GetSingletonServiceInfo<PostgresServiceInfo>()
+             : configuration.GetRequiredServiceInfo<PostgresServiceInfo>(serviceName);
+
             var postgresConfig = new PostgresProviderConnectorOptions(configuration);
             var configurer = new PostgresProviderConfigurer();
             return new Connection
             {
                 ConnectionString = configurer.Configure(info, postgresConfig),
-                Name = "Postgres"
+                Name = "Postgres" + serviceName?.Insert(0, "-")
             };
         }
     }

--- a/src/Connectors/src/ConnectorBase/Relational/SqlServer/SqlServerConnectionInfo.cs
+++ b/src/Connectors/src/ConnectorBase/Relational/SqlServer/SqlServerConnectionInfo.cs
@@ -17,7 +17,7 @@ using Steeltoe.CloudFoundry.Connector.Services;
 
 namespace Steeltoe.CloudFoundry.Connector.SqlServer
 {
-    public class SqlServerConnectionInfo : IConnectorInfo
+    public class SqlServerConnectionInfo : IConnectionInfo
     {
         public Connection Get(IConfiguration configuration, string serviceName)
         {

--- a/src/Connectors/src/ConnectorBase/Relational/SqlServer/SqlServerConnectionInfo.cs
+++ b/src/Connectors/src/ConnectorBase/Relational/SqlServer/SqlServerConnectionInfo.cs
@@ -1,0 +1,34 @@
+// Copyright 2017 the original author or authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Microsoft.Extensions.Configuration;
+using Steeltoe.CloudFoundry.Connector.Services;
+
+namespace Steeltoe.CloudFoundry.Connector.SqlServer
+{
+    public class SqlServerConnectionInfo : IConnectorInfo
+    {
+        public Connection Get(IConfiguration configuration)
+        {
+            var info = configuration.GetSingletonServiceInfo<SqlServerServiceInfo>();
+            var sqlConfig = new SqlServerProviderConnectorOptions(configuration);
+            var configurer = new SqlServerProviderConfigurer();
+            return new Connection
+            {
+                ConnectionString = configurer.Configure(info, sqlConfig),
+                Name = "SqlServer"
+            };
+        }
+    }
+}

--- a/src/Connectors/src/ConnectorBase/Relational/SqlServer/SqlServerConnectionInfo.cs
+++ b/src/Connectors/src/ConnectorBase/Relational/SqlServer/SqlServerConnectionInfo.cs
@@ -19,15 +19,18 @@ namespace Steeltoe.CloudFoundry.Connector.SqlServer
 {
     public class SqlServerConnectionInfo : IConnectorInfo
     {
-        public Connection Get(IConfiguration configuration)
+        public Connection Get(IConfiguration configuration, string serviceName)
         {
-            var info = configuration.GetSingletonServiceInfo<SqlServerServiceInfo>();
+            var info = serviceName == null
+            ? configuration.GetSingletonServiceInfo<SqlServerServiceInfo>()
+            : configuration.GetRequiredServiceInfo<SqlServerServiceInfo>(serviceName);
+
             var sqlConfig = new SqlServerProviderConnectorOptions(configuration);
             var configurer = new SqlServerProviderConfigurer();
             return new Connection
             {
                 ConnectionString = configurer.Configure(info, sqlConfig),
-                Name = "SqlServer"
+                Name = "SqlServer" + serviceName?.Insert(0, "-")
             };
         }
     }

--- a/src/Connectors/src/ConnectorCore/PostgresProviderServiceCollectionExtensions.cs
+++ b/src/Connectors/src/ConnectorCore/PostgresProviderServiceCollectionExtensions.cs
@@ -101,9 +101,6 @@ namespace Steeltoe.CloudFoundry.Connector.PostgreSql
             {
                 services.Add(new ServiceDescriptor(typeof(IHealthContributor), ctx => new RelationalHealthContributor((IDbConnection)factory.Create(ctx), ctx.GetService<ILogger<RelationalHealthContributor>>()), ServiceLifetime.Singleton));
             }
-
-            var foo = new PostgresProviderConfigurer();
-            factory.CreateConnectionString();
         }
     }
 }

--- a/src/Connectors/src/ConnectorCore/PostgresProviderServiceCollectionExtensions.cs
+++ b/src/Connectors/src/ConnectorCore/PostgresProviderServiceCollectionExtensions.cs
@@ -14,6 +14,7 @@
 
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Logging;
 using Steeltoe.CloudFoundry.Connector.Relational;
 using Steeltoe.CloudFoundry.Connector.Relational.PostgreSql;
@@ -21,6 +22,7 @@ using Steeltoe.CloudFoundry.Connector.Services;
 using Steeltoe.Common.HealthChecks;
 using System;
 using System.Data;
+using System.Linq;
 
 namespace Steeltoe.CloudFoundry.Connector.PostgreSql
 {
@@ -33,10 +35,10 @@ namespace Steeltoe.CloudFoundry.Connector.PostgreSql
         /// <param name="config">App configuration</param>
         /// <param name="contextLifetime">Lifetime of the service to inject</param>
         /// <param name="logFactory">logger factory</param>
-        /// <param name="healthChecksBuilder">Microsoft HealthChecksBuilder</param>
+        /// <param name="addSteeltoeHealthChecks">Add Steeltoe healthChecks</param>
         /// <returns>IServiceCollection for chaining</returns>
         /// <remarks>NpgsqlConnection is retrievable as both NpgsqlConnection and IDbConnection</remarks>
-        public static IServiceCollection AddPostgresConnection(this IServiceCollection services, IConfiguration config, ServiceLifetime contextLifetime = ServiceLifetime.Scoped, ILoggerFactory logFactory = null, IHealthChecksBuilder healthChecksBuilder = null)
+        public static IServiceCollection AddPostgresConnection(this IServiceCollection services, IConfiguration config, ServiceLifetime contextLifetime = ServiceLifetime.Scoped, ILoggerFactory logFactory = null, bool addSteeltoeHealthChecks = false)
         {
             if (services == null)
             {
@@ -50,7 +52,7 @@ namespace Steeltoe.CloudFoundry.Connector.PostgreSql
 
             PostgresServiceInfo info = config.GetSingletonServiceInfo<PostgresServiceInfo>();
 
-            DoAdd(services, info, config, contextLifetime, healthChecksBuilder);
+            DoAdd(services, info, config, contextLifetime, addSteeltoeHealthChecks);
             return services;
         }
 
@@ -62,10 +64,10 @@ namespace Steeltoe.CloudFoundry.Connector.PostgreSql
         /// <param name="serviceName">cloud foundry service name binding</param>
         /// <param name="contextLifetime">Lifetime of the service to inject</param>
         /// <param name="logFactory">logger factory</param>
-        /// <param name="healthChecksBuilder">Microsoft HealthChecksBuilder</param>
+        /// <param name="addSteeltoeHealthChecks">Add Steeltoe healthChecks</param>
         /// <returns>IServiceCollection for chaining</returns>
         /// <remarks>NpgsqlConnection is retrievable as both NpgsqlConnection and IDbConnection</remarks>
-        public static IServiceCollection AddPostgresConnection(this IServiceCollection services, IConfiguration config, string serviceName, ServiceLifetime contextLifetime = ServiceLifetime.Scoped, ILoggerFactory logFactory = null, IHealthChecksBuilder healthChecksBuilder = null)
+        public static IServiceCollection AddPostgresConnection(this IServiceCollection services, IConfiguration config, string serviceName, ServiceLifetime contextLifetime = ServiceLifetime.Scoped, ILoggerFactory logFactory = null, bool addSteeltoeHealthChecks = false)
         {
             if (services == null)
             {
@@ -84,25 +86,24 @@ namespace Steeltoe.CloudFoundry.Connector.PostgreSql
 
             PostgresServiceInfo info = config.GetRequiredServiceInfo<PostgresServiceInfo>(serviceName);
 
-            DoAdd(services, info, config, contextLifetime, healthChecksBuilder);
+            DoAdd(services, info, config, contextLifetime, addSteeltoeHealthChecks);
             return services;
         }
 
-        private static void DoAdd(IServiceCollection services, PostgresServiceInfo info, IConfiguration config, ServiceLifetime contextLifetime, IHealthChecksBuilder healthChecksBuilder)
+        private static void DoAdd(IServiceCollection services, PostgresServiceInfo info, IConfiguration config, ServiceLifetime contextLifetime, bool addSteeltoeHealthChecks)
         {
             Type postgresConnection = ConnectorHelpers.FindType(PostgreSqlTypeLocator.Assemblies, PostgreSqlTypeLocator.ConnectionTypeNames);
             var postgresConfig = new PostgresProviderConnectorOptions(config);
             var factory = new PostgresProviderConnectorFactory(info, postgresConfig, postgresConnection);
             services.Add(new ServiceDescriptor(typeof(IDbConnection), factory.Create, contextLifetime));
             services.Add(new ServiceDescriptor(postgresConnection, factory.Create, contextLifetime));
-            if (healthChecksBuilder == null)
+            if (!services.Any(s => s.ServiceType == typeof(HealthCheckService)) || addSteeltoeHealthChecks)
             {
                 services.Add(new ServiceDescriptor(typeof(IHealthContributor), ctx => new RelationalHealthContributor((IDbConnection)factory.Create(ctx), ctx.GetService<ILogger<RelationalHealthContributor>>()), ServiceLifetime.Singleton));
             }
-            else
-            {
-                healthChecksBuilder.AddNpgSql(factory.CreateConnectionString());
-            }
+
+            var foo = new PostgresProviderConfigurer();
+            factory.CreateConnectionString();
         }
     }
 }

--- a/src/Connectors/src/ConnectorCore/RedisCacheServiceCollectionExtensions.cs
+++ b/src/Connectors/src/ConnectorCore/RedisCacheServiceCollectionExtensions.cs
@@ -14,10 +14,12 @@
 
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Logging;
 using Steeltoe.CloudFoundry.Connector.Services;
 using Steeltoe.Common.HealthChecks;
 using System;
+using System.Linq;
 using System.Reflection;
 
 namespace Steeltoe.CloudFoundry.Connector.Redis
@@ -32,10 +34,10 @@ namespace Steeltoe.CloudFoundry.Connector.Redis
         /// <param name="services">Service collection to add to</param>
         /// <param name="config">App configuration</param>
         /// <param name="logFactory">logger factory</param>
-        /// <param name="healthChecksBuilder">Microsoft HealthChecksBuilder</param>
+        /// <param name="addSteeltoeHealthChecks">Add steeltoe health check when community healthchecks exist</param>
         /// <returns>IServiceCollection for chaining</returns>
         /// <remarks>RedisCache is retrievable as both RedisCache and IDistributedCache</remarks>
-        public static IServiceCollection AddDistributedRedisCache(this IServiceCollection services, IConfiguration config, ILoggerFactory logFactory = null, IHealthChecksBuilder healthChecksBuilder = null)
+        public static IServiceCollection AddDistributedRedisCache(this IServiceCollection services, IConfiguration config, ILoggerFactory logFactory = null, bool addSteeltoeHealthChecks = false)
         {
             if (services == null)
             {
@@ -47,7 +49,7 @@ namespace Steeltoe.CloudFoundry.Connector.Redis
                 throw new ArgumentNullException(nameof(config));
             }
 
-            return services.AddDistributedRedisCache(config, config, null, healthChecksBuilder: healthChecksBuilder);
+            return services.AddDistributedRedisCache(config, config, null, addSteeltoeHealthChecks: addSteeltoeHealthChecks);
         }
 
         /// <summary>
@@ -57,10 +59,10 @@ namespace Steeltoe.CloudFoundry.Connector.Redis
         /// <param name="config">App configuration</param>
         /// <param name="serviceName">Name of service to add</param>
         /// <param name="logFactory">logger factory</param>
-        /// <param name="healthChecksBuilder">Microsoft HealthChecksBuilder</param>
+        /// <param name="addSteeltoeHealthChecks">Add steeltoe health check when community healthchecks exist</param>
         /// <returns>IServiceCollection for chaining</returns>
         /// <remarks>RedisCache is retrievable as both RedisCache and IDistributedCache</remarks>
-        public static IServiceCollection AddDistributedRedisCache(this IServiceCollection services, IConfiguration config, string serviceName, ILoggerFactory logFactory = null, IHealthChecksBuilder healthChecksBuilder = null)
+        public static IServiceCollection AddDistributedRedisCache(this IServiceCollection services, IConfiguration config, string serviceName, ILoggerFactory logFactory = null, bool addSteeltoeHealthChecks = false)
         {
             if (services == null)
             {
@@ -77,7 +79,7 @@ namespace Steeltoe.CloudFoundry.Connector.Redis
                 throw new ArgumentNullException(nameof(config));
             }
 
-            return services.AddDistributedRedisCache(config, config, serviceName, healthChecksBuilder: healthChecksBuilder);
+            return services.AddDistributedRedisCache(config, config, serviceName, addSteeltoeHealthChecks: addSteeltoeHealthChecks);
         }
 
         /// <summary>
@@ -88,10 +90,10 @@ namespace Steeltoe.CloudFoundry.Connector.Redis
         /// <param name="connectorConfiguration">Connector configuration</param>
         /// <param name="serviceName">Name of service to add</param>
         /// <param name="contextLifetime"><see cref="ServiceLifetime"/> of the service to inject</param>
-        /// <param name="healthChecksBuilder">Microsoft HealthChecksBuilder</param>
+        /// <param name="addSteeltoeHealthChecks">Add Steeltoe health check when community healthchecks exist</param>
         /// <returns>IServiceCollection for chaining</returns>
         /// <remarks>RedisCache is retrievable as both RedisCache and IDistributedCache</remarks>
-        public static IServiceCollection AddDistributedRedisCache(this IServiceCollection services, IConfiguration applicationConfiguration, IConfiguration connectorConfiguration, string serviceName, ServiceLifetime contextLifetime = ServiceLifetime.Singleton, IHealthChecksBuilder healthChecksBuilder = null)
+        public static IServiceCollection AddDistributedRedisCache(this IServiceCollection services, IConfiguration applicationConfiguration, IConfiguration connectorConfiguration, string serviceName, ServiceLifetime contextLifetime = ServiceLifetime.Singleton, bool addSteeltoeHealthChecks = false)
         {
             if (services == null)
             {
@@ -109,7 +111,7 @@ namespace Steeltoe.CloudFoundry.Connector.Redis
                 ? configToConfigure.GetRequiredServiceInfo<RedisServiceInfo>(serviceName)
                 : configToConfigure.GetSingletonServiceInfo<RedisServiceInfo>();
 
-            DoAddIDistributedCache(services, info, configToConfigure, contextLifetime, healthChecksBuilder);
+            DoAddIDistributedCache(services, info, configToConfigure, contextLifetime, addSteeltoeHealthChecks);
             return services;
         }
 
@@ -122,10 +124,10 @@ namespace Steeltoe.CloudFoundry.Connector.Redis
         /// </summary>
         /// <param name="services">Service collection to add to</param>
         /// <param name="config">App configuration</param>
-        /// <param name="healthChecksBuilder">Microsoft HealthChecksBuilder</param>
+        /// <param name="addSteeltoeHealthChecks">Add Steeltoe health check when community healthchecks exist</param>
         /// <returns>IServiceCollection for chaining</returns>
         /// <remarks>ConnectionMultiplexer is retrievable as both ConnectionMultiplexer and IConnectionMultiplexer</remarks>
-        public static IServiceCollection AddRedisConnectionMultiplexer(this IServiceCollection services, IConfiguration config, IHealthChecksBuilder healthChecksBuilder = null)
+        public static IServiceCollection AddRedisConnectionMultiplexer(this IServiceCollection services, IConfiguration config, bool addSteeltoeHealthChecks = false)
         {
             if (services == null)
             {
@@ -137,7 +139,7 @@ namespace Steeltoe.CloudFoundry.Connector.Redis
                 throw new ArgumentNullException(nameof(config));
             }
 
-            return services.AddRedisConnectionMultiplexer(config, config, null, healthChecksBuilder: healthChecksBuilder);
+            return services.AddRedisConnectionMultiplexer(config, config, null, addSteeltoeHealthChecks: addSteeltoeHealthChecks);
         }
 
         /// <summary>
@@ -146,10 +148,10 @@ namespace Steeltoe.CloudFoundry.Connector.Redis
         /// <param name="services">Service collection to add to</param>
         /// <param name="config">App configuration</param>
         /// <param name="serviceName">Name of service to add</param>
-        /// <param name="healthChecksBuilder">Microsoft HealthChecksBuilder</param>
+        /// <param name="addSteeltoeHealthChecks">Add Steeltoe health check when community healthchecks exist</param>
         /// <returns>IServiceCollection for chaining</returns>
         /// <remarks>ConnectionMultiplexer is retrievable as both ConnectionMultiplexer and IConnectionMultiplexer</remarks>
-        public static IServiceCollection AddRedisConnectionMultiplexer(this IServiceCollection services, IConfiguration config, string serviceName, IHealthChecksBuilder healthChecksBuilder = null)
+        public static IServiceCollection AddRedisConnectionMultiplexer(this IServiceCollection services, IConfiguration config, string serviceName, bool addSteeltoeHealthChecks = false)
         {
             if (services == null)
             {
@@ -166,7 +168,7 @@ namespace Steeltoe.CloudFoundry.Connector.Redis
                 throw new ArgumentNullException(nameof(config));
             }
 
-            return services.AddRedisConnectionMultiplexer(config, config, serviceName, healthChecksBuilder: healthChecksBuilder);
+            return services.AddRedisConnectionMultiplexer(config, config, serviceName, addSteeltoeHealthChecks: addSteeltoeHealthChecks);
         }
 
         /// <summary>
@@ -177,10 +179,10 @@ namespace Steeltoe.CloudFoundry.Connector.Redis
         /// <param name="connectorConfiguration">Connector configuration</param>
         /// <param name="serviceName">Name of service to add</param>
         /// <param name="contextLifetime"><see cref="ServiceLifetime"/> of the service to inject</param>
-        /// <param name="healthChecksBuilder">Microsoft HealthChecksBuilder</param>
+        /// <param name="addSteeltoeHealthChecks">Add Steeltoe health check when community healthchecks exist</param>
         /// <returns>IServiceCollection for chaining</returns>
         /// <remarks>ConnectionMultiplexer is retrievable as both ConnectionMultiplexer and IConnectionMultiplexer</remarks>
-        public static IServiceCollection AddRedisConnectionMultiplexer(this IServiceCollection services, IConfiguration applicationConfiguration, IConfiguration connectorConfiguration, string serviceName, ServiceLifetime contextLifetime = ServiceLifetime.Singleton, IHealthChecksBuilder healthChecksBuilder = null)
+        public static IServiceCollection AddRedisConnectionMultiplexer(this IServiceCollection services, IConfiguration applicationConfiguration, IConfiguration connectorConfiguration, string serviceName, ServiceLifetime contextLifetime = ServiceLifetime.Singleton, bool addSteeltoeHealthChecks = false)
         {
             if (services == null)
             {
@@ -194,13 +196,13 @@ namespace Steeltoe.CloudFoundry.Connector.Redis
 
             var configToConfigure = connectorConfiguration ?? applicationConfiguration;
             RedisServiceInfo info = serviceName == null ? configToConfigure.GetSingletonServiceInfo<RedisServiceInfo>() : configToConfigure.GetRequiredServiceInfo<RedisServiceInfo>(serviceName);
-            DoAddConnectionMultiplexer(services, info, configToConfigure, contextLifetime, healthChecksBuilder);
+            DoAddConnectionMultiplexer(services, info, configToConfigure, contextLifetime, addSteeltoeHealthChecks);
             return services;
         }
 
         #endregion
 
-        private static void DoAddIDistributedCache(IServiceCollection services, RedisServiceInfo info, IConfiguration config, ServiceLifetime contextLifetime, IHealthChecksBuilder healthChecksBuilder = null)
+        private static void DoAddIDistributedCache(IServiceCollection services, RedisServiceInfo info, IConfiguration config, ServiceLifetime contextLifetime, bool addSteeltoeHealthChecks = false)
         {
             Type interfaceType = RedisTypeLocator.MicrosoftInterface;
             Type connectionType = RedisTypeLocator.MicrosoftImplementation;
@@ -210,17 +212,13 @@ namespace Steeltoe.CloudFoundry.Connector.Redis
             RedisServiceConnectorFactory factory = new RedisServiceConnectorFactory(info, redisConfig, connectionType, optionsType, null);
             services.Add(new ServiceDescriptor(interfaceType, factory.Create, contextLifetime));
             services.Add(new ServiceDescriptor(connectionType, factory.Create, contextLifetime));
-            if (healthChecksBuilder == null)
+            if (!services.Any(s => s.ServiceType == typeof(HealthCheckService)) || addSteeltoeHealthChecks)
             {
                 services.Add(new ServiceDescriptor(typeof(IHealthContributor), ctx => new RedisHealthContributor(factory, connectionType, ctx.GetService<ILogger<RedisHealthContributor>>()), ServiceLifetime.Singleton));
             }
-            else
-            {
-                healthChecksBuilder.AddRedis(redisConfig.ToString());
-            }
         }
 
-        private static void DoAddConnectionMultiplexer(IServiceCollection services, RedisServiceInfo info, IConfiguration config, ServiceLifetime contextLifetime, IHealthChecksBuilder healthChecksBuilder)
+        private static void DoAddConnectionMultiplexer(IServiceCollection services, RedisServiceInfo info, IConfiguration config, ServiceLifetime contextLifetime, bool addSteeltoeHealthChecks)
         {
             Type redisInterface = RedisTypeLocator.StackExchangeInterface;
             Type redisImplementation = RedisTypeLocator.StackExchangeImplementation;
@@ -231,14 +229,9 @@ namespace Steeltoe.CloudFoundry.Connector.Redis
             RedisServiceConnectorFactory factory = new RedisServiceConnectorFactory(info, redisConfig, redisImplementation, redisOptions, initializer ?? null);
             services.Add(new ServiceDescriptor(redisInterface, factory.Create, contextLifetime));
             services.Add(new ServiceDescriptor(redisImplementation, factory.Create, contextLifetime));
-            if (healthChecksBuilder == null)
+            if (!services.Any(s => s.ServiceType == typeof(HealthCheckService)) || addSteeltoeHealthChecks)
             {
                 services.Add(new ServiceDescriptor(typeof(IHealthContributor), ctx => new RedisHealthContributor(factory, redisImplementation, ctx.GetService<ILogger<RedisHealthContributor>>()), ServiceLifetime.Singleton));
-            }
-            else
-            {
-                var str = factory.GetConnectionString();
-                healthChecksBuilder.AddRedis(str);
             }
         }
     }

--- a/src/Connectors/src/ConnectorCore/Steeltoe.CloudFoundry.ConnectorCore.csproj
+++ b/src/Connectors/src/ConnectorCore/Steeltoe.CloudFoundry.ConnectorCore.csproj
@@ -10,15 +10,11 @@
   <Import Project="..\..\..\..\sharedproject.props" />
 
   <ItemGroup>
-    <PackageReference Include="AspNetCore.HealthChecks.MongoDb" Version="2.2.2" />
-    <PackageReference Include="AspNetCore.HealthChecks.MySql" Version="2.2.0" />
-    <PackageReference Include="AspNetCore.HealthChecks.NpgSql" Version="2.2.0" />
-    <PackageReference Include="AspNetCore.HealthChecks.Rabbitmq" Version="2.2.1" />
-    <PackageReference Include="AspNetCore.HealthChecks.Redis" Version="2.2.3" />
-    <PackageReference Include="AspNetCore.HealthChecks.SqlServer" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="$(DiagnosticsExtensionsVersion)" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="$(SourceLinkGitHubVersion)" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="$(ExtensionsVersion)" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="$(ExtensionsVersion)" />
+    
   </ItemGroup>
 
   <ItemGroup Condition="'$(CI_BUILD)' == ''">

--- a/src/Connectors/test/ConnectorCore.Test/ConnectionStringManagerTest.cs
+++ b/src/Connectors/test/ConnectorCore.Test/ConnectionStringManagerTest.cs
@@ -1,0 +1,92 @@
+﻿// Copyright 2017 the original author or authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Microsoft.Extensions.Configuration;
+using Steeltoe.CloudFoundry.Connector.PostgreSql;
+using Steeltoe.CloudFoundry.Connector.RabbitMQ;
+using Steeltoe.CloudFoundry.Connector.Redis;
+using Steeltoe.CloudFoundry.Connector.SqlServer;
+using Xunit;
+
+namespace Steeltoe.CloudFoundry.Connector.Test
+{
+    public class ConnectionStringManagerTest
+    {
+        [Fact]
+        public void MysqlConnectionInfo()
+        {
+            var cm = new ConnectionStringManager(new ConfigurationBuilder().Build());
+            var connInfo = cm.Get<MySqlConnectionInfo>();
+
+            Assert.NotNull(connInfo);
+            Assert.Equal("Server=localhost;Port=3306;", connInfo.ConnectionString);
+            Assert.Equal("MySql", connInfo.Name);
+        }
+
+        [Fact]
+        public void PostgresConnectionInfo()
+        {
+            var cm = new ConnectionStringManager(new ConfigurationBuilder().Build());
+            var connInfo = cm.Get<PostgresConnectionInfo>();
+
+            Assert.NotNull(connInfo);
+            Assert.Equal("Host=localhost;Port=5432;", connInfo.ConnectionString);
+            Assert.Equal("Postgres", connInfo.Name);
+        }
+
+        [Fact]
+        public void SqlServerConnectionInfo()
+        {
+            var cm = new ConnectionStringManager(new ConfigurationBuilder().Build());
+            var connInfo = cm.Get<SqlServerConnectionInfo>();
+
+            Assert.NotNull(connInfo);
+            Assert.Equal("Data Source=localhost,1433;", connInfo.ConnectionString);
+            Assert.Equal("SqlServer", connInfo.Name);
+        }
+
+        [Fact]
+        public void RedisConnectionInfo()
+        {
+            var cm = new ConnectionStringManager(new ConfigurationBuilder().Build());
+            var connInfo = cm.Get<RedisConnectionInfo>();
+
+            Assert.NotNull(connInfo);
+            Assert.Equal("localhost:6379,allowAdmin=false,abortConnect=true,resolveDns=false,ssl=false", connInfo.ConnectionString);
+            Assert.Equal("Redis", connInfo.Name);
+        }
+
+        [Fact]
+        public void RabbitMQConnectionInfo()
+        {
+            var cm = new ConnectionStringManager(new ConfigurationBuilder().Build());
+            var connInfo = cm.Get<RabbitMQConnectionInfo>();
+
+            Assert.NotNull(connInfo);
+            Assert.Equal("amqp://127.0.0.1:5672/", connInfo.ConnectionString);
+            Assert.Equal("RabbitMQ", connInfo.Name);
+        }
+
+        [Fact]
+        public void MongoDbConnectionInfo()
+        {
+            var cm = new ConnectionStringManager(new ConfigurationBuilder().Build());
+            var connInfo = cm.Get<MongoDbConnectionInfo>();
+
+            Assert.NotNull(connInfo);
+            Assert.Equal("mongodb://localhost:27017", connInfo.ConnectionString);
+            Assert.Equal("MongoDb", connInfo.Name);
+        }
+    }
+}

--- a/src/Connectors/test/ConnectorCore.Test/ConnectionStringManagerTest.cs
+++ b/src/Connectors/test/ConnectorCore.Test/ConnectionStringManagerTest.cs
@@ -13,10 +13,17 @@
 // limitations under the License.
 
 using Microsoft.Extensions.Configuration;
+using Steeltoe.CloudFoundry.Connector.MongoDb.Test;
+using Steeltoe.CloudFoundry.Connector.MySql.Test;
 using Steeltoe.CloudFoundry.Connector.PostgreSql;
+using Steeltoe.CloudFoundry.Connector.PostgreSql.Test;
 using Steeltoe.CloudFoundry.Connector.RabbitMQ;
 using Steeltoe.CloudFoundry.Connector.Redis;
+using Steeltoe.CloudFoundry.Connector.Redis.Test;
 using Steeltoe.CloudFoundry.Connector.SqlServer;
+using Steeltoe.CloudFoundry.Connector.SqlServer.Test;
+using Steeltoe.Extensions.Configuration.CloudFoundry;
+using System;
 using Xunit;
 
 namespace Steeltoe.CloudFoundry.Connector.Test
@@ -35,6 +42,19 @@ namespace Steeltoe.CloudFoundry.Connector.Test
         }
 
         [Fact]
+        public void MysqlConnectionInfoByName()
+        {
+            Environment.SetEnvironmentVariable("VCAP_SERVICES", MySqlTestHelpers.TwoServerVCAP);
+            var config = new ConfigurationBuilder().AddCloudFoundry().Build();
+
+            var cm = new ConnectionStringManager(config);
+            var connInfo = cm.Get<MySqlConnectionInfo>("spring-cloud-broker-db");
+
+            Assert.NotNull(connInfo);
+            Assert.Equal("MySql-spring-cloud-broker-db", connInfo.Name);
+        }
+
+        [Fact]
         public void PostgresConnectionInfo()
         {
             var cm = new ConnectionStringManager(new ConfigurationBuilder().Build());
@@ -43,6 +63,17 @@ namespace Steeltoe.CloudFoundry.Connector.Test
             Assert.NotNull(connInfo);
             Assert.Equal("Host=localhost;Port=5432;", connInfo.ConnectionString);
             Assert.Equal("Postgres", connInfo.Name);
+        }
+
+        [Fact]
+        public void PostgresConnectionInfoByName()
+        {
+            Environment.SetEnvironmentVariable("VCAP_SERVICES", PostgresTestHelpers.TwoServerVCAP_EDB);
+            var cm = new ConnectionStringManager(new ConfigurationBuilder().AddCloudFoundry().Build());
+            var connInfo = cm.Get<PostgresConnectionInfo>("myPostgres");
+
+            Assert.NotNull(connInfo);
+            Assert.Equal("Postgres-myPostgres", connInfo.Name);
         }
 
         [Fact]
@@ -57,6 +88,18 @@ namespace Steeltoe.CloudFoundry.Connector.Test
         }
 
         [Fact]
+        public void SqlServerConnectionInfo_ByName()
+        {
+            Environment.SetEnvironmentVariable("VCAP_SERVICES", SqlServerTestHelpers.TwoServerVCAP);
+
+            var cm = new ConnectionStringManager(new ConfigurationBuilder().AddCloudFoundry().Build());
+            var connInfo = cm.Get<SqlServerConnectionInfo>("mySqlServerService");
+
+            Assert.NotNull(connInfo);
+            Assert.Equal("SqlServer-mySqlServerService", connInfo.Name);
+        }
+
+        [Fact]
         public void RedisConnectionInfo()
         {
             var cm = new ConnectionStringManager(new ConfigurationBuilder().Build());
@@ -65,6 +108,18 @@ namespace Steeltoe.CloudFoundry.Connector.Test
             Assert.NotNull(connInfo);
             Assert.Equal("localhost:6379,allowAdmin=false,abortConnect=true,resolveDns=false,ssl=false", connInfo.ConnectionString);
             Assert.Equal("Redis", connInfo.Name);
+        }
+
+        [Fact]
+        public void RedisConnectionInfoByName()
+        {
+            Environment.SetEnvironmentVariable("VCAP_SERVICES", RedisCacheTestHelpers.TwoServerVCAP);
+
+            var cm = new ConnectionStringManager(new ConfigurationBuilder().AddCloudFoundry().Build());
+            var connInfo = cm.Get<RedisConnectionInfo>("myRedisService1");
+
+            Assert.NotNull(connInfo);
+            Assert.Equal("Redis-myRedisService1", connInfo.Name);
         }
 
         [Fact]
@@ -87,6 +142,18 @@ namespace Steeltoe.CloudFoundry.Connector.Test
             Assert.NotNull(connInfo);
             Assert.Equal("mongodb://localhost:27017", connInfo.ConnectionString);
             Assert.Equal("MongoDb", connInfo.Name);
+        }
+
+        [Fact]
+        public void MongoDbConnectionInfoByName()
+        {
+            Environment.SetEnvironmentVariable("VCAP_SERVICES", MongoDbTestHelpers.DoubleBinding_Enterprise_VCAP);
+
+            var cm = new ConnectionStringManager(new ConfigurationBuilder().AddCloudFoundry().Build());
+            var connInfo = cm.Get<MongoDbConnectionInfo>("steeltoe");
+
+            Assert.NotNull(connInfo);
+            Assert.Equal("MongoDb-steeltoe", connInfo.Name);
         }
     }
 }

--- a/src/Connectors/test/ConnectorCore.Test/MySqlProviderServiceCollectionExtensionsTest.cs
+++ b/src/Connectors/test/ConnectorCore.Test/MySqlProviderServiceCollectionExtensionsTest.cs
@@ -222,5 +222,47 @@ namespace Steeltoe.CloudFoundry.Connector.MySql.Test
             // Assert
             Assert.NotNull(healthContributor);
         }
+
+        [Fact]
+        public void AddMySqlConnection_DoesntAddRelationalHealthContributor_WhenCommunityHealthExists()
+        {
+            // Arrange
+            IServiceCollection services = new ServiceCollection();
+            ConfigurationBuilder builder = new ConfigurationBuilder();
+            builder.AddCloudFoundry();
+            var config = builder.Build();
+
+            var cm = new ConnectionStringManager(config);
+            var ci = cm.Get<MySqlConnectionInfo>();
+            services.AddHealthChecks().AddMySql(ci.ConnectionString, name: ci.Name);
+
+            // Act
+            MySqlProviderServiceCollectionExtensions.AddMySqlConnection(services, config);
+            var healthContributor = services.BuildServiceProvider().GetService<IHealthContributor>() as RelationalHealthContributor;
+
+            // Assert
+            Assert.Null(healthContributor);
+        }
+
+        [Fact]
+        public void AddMySqlConnection_AddsRelationalHealthContributor_WhenCommunityHealthExistsAndForced()
+        {
+            // Arrange
+            IServiceCollection services = new ServiceCollection();
+            ConfigurationBuilder builder = new ConfigurationBuilder();
+            builder.AddCloudFoundry();
+            var config = builder.Build();
+
+            var cm = new ConnectionStringManager(config);
+            var ci = cm.Get<MySqlConnectionInfo>();
+            services.AddHealthChecks().AddMySql(ci.ConnectionString, name: ci.Name);
+
+            // Act
+            MySqlProviderServiceCollectionExtensions.AddMySqlConnection(services, config, addSteeltoeHealthChecks: true);
+            var healthContributor = services.BuildServiceProvider().GetService<IHealthContributor>() as RelationalHealthContributor;
+
+            // Assert
+            Assert.NotNull(healthContributor);
+        }
     }
 }

--- a/src/Connectors/test/ConnectorCore.Test/PostgresProviderServiceCollectionExtensionsTest.cs
+++ b/src/Connectors/test/ConnectorCore.Test/PostgresProviderServiceCollectionExtensionsTest.cs
@@ -225,5 +225,47 @@ namespace Steeltoe.CloudFoundry.Connector.PostgreSql.Test
             // Assert
             Assert.NotNull(healthContributor);
         }
+
+        [Fact]
+        public void AddPosgreSqlConnection_DoesntAddRelationalHealthContributor_WhenCommunityHealthCheckExists()
+        {
+            // Arrange
+            IServiceCollection services = new ServiceCollection();
+            ConfigurationBuilder builder = new ConfigurationBuilder();
+            builder.AddCloudFoundry();
+            var config = builder.Build();
+
+            var cm = new ConnectionStringManager(config);
+            var ci = cm.Get<PostgresConnectionInfo>();
+            services.AddHealthChecks().AddNpgSql(ci.ConnectionString, name: ci.Name);
+
+            // Act
+            PostgresProviderServiceCollectionExtensions.AddPostgresConnection(services, config);
+            var healthContributor = services.BuildServiceProvider().GetService<IHealthContributor>() as RelationalHealthContributor;
+
+            // Assert
+            Assert.Null(healthContributor);
+        }
+
+        [Fact]
+        public void AddPosgreSqlConnection_AddsRelationalHealthContributor_WhenCommunityHealthCheckExistsAndForced()
+        {
+            // Arrange
+            IServiceCollection services = new ServiceCollection();
+            ConfigurationBuilder builder = new ConfigurationBuilder();
+            builder.AddCloudFoundry();
+            var config = builder.Build();
+
+            var cm = new ConnectionStringManager(config);
+            var ci = cm.Get<PostgresConnectionInfo>();
+            services.AddHealthChecks().AddNpgSql(ci.ConnectionString, name: ci.Name);
+
+            // Act
+            PostgresProviderServiceCollectionExtensions.AddPostgresConnection(services, config, addSteeltoeHealthChecks: true);
+            var healthContributor = services.BuildServiceProvider().GetService<IHealthContributor>() as RelationalHealthContributor;
+
+            // Assert
+            Assert.NotNull(healthContributor);
+        }
     }
 }

--- a/src/Connectors/test/ConnectorCore.Test/RabbitMQServiceCollectionExtensionsTest.cs
+++ b/src/Connectors/test/ConnectorCore.Test/RabbitMQServiceCollectionExtensionsTest.cs
@@ -291,5 +291,47 @@ namespace Steeltoe.CloudFoundry.Connector.RabbitMQ.Test
             // Assert
             Assert.NotNull(healthContributor);
         }
+
+        [Fact]
+        public void AddRabbitMQConnection_DoesntAddsRabbitMQHealthContributor_WhenCommunityHealthCheckExists()
+        {
+            // Arrange
+            IServiceCollection services = new ServiceCollection();
+            ConfigurationBuilder builder = new ConfigurationBuilder();
+            builder.AddCloudFoundry();
+            var config = builder.Build();
+
+            var cm = new ConnectionStringManager(config);
+            var ci = cm.Get<RabbitMQConnectionInfo>();
+            services.AddHealthChecks().AddRabbitMQ(ci.ConnectionString, name: ci.Name);
+
+            // Act
+            RabbitMQProviderServiceCollectionExtensions.AddRabbitMQConnection(services, config);
+            var healthContributor = services.BuildServiceProvider().GetService<IHealthContributor>() as RabbitMQHealthContributor;
+
+            // Assert
+            Assert.Null(healthContributor);
+        }
+
+        [Fact]
+        public void AddRabbitMQConnection_AddsRabbitMQHealthContributor_WhenCommunityHealthCheckExistsAndForced()
+        {
+            // Arrange
+            IServiceCollection services = new ServiceCollection();
+            ConfigurationBuilder builder = new ConfigurationBuilder();
+            builder.AddCloudFoundry();
+            var config = builder.Build();
+
+            var cm = new ConnectionStringManager(config);
+            var ci = cm.Get<RabbitMQConnectionInfo>();
+            services.AddHealthChecks().AddRabbitMQ(ci.ConnectionString, name: ci.Name);
+
+            // Act
+            RabbitMQProviderServiceCollectionExtensions.AddRabbitMQConnection(services, config, addSteeltoeHealthChecks: true);
+            var healthContributor = services.BuildServiceProvider().GetService<IHealthContributor>() as RabbitMQHealthContributor;
+
+            // Assert
+            Assert.NotNull(healthContributor);
+        }
     }
 }

--- a/src/Connectors/test/ConnectorCore.Test/RedisCacheServiceCollectionExtensionsTest.cs
+++ b/src/Connectors/test/ConnectorCore.Test/RedisCacheServiceCollectionExtensionsTest.cs
@@ -118,6 +118,48 @@ namespace Steeltoe.CloudFoundry.Connector.Redis.Test
         }
 
         [Fact]
+        public void AddDistributedRedisCache_DoesntAddRedisHealthContributor_WhenCommunityHealthCheckExists()
+        {
+            // Arrange
+            IServiceCollection services = new ServiceCollection();
+            ConfigurationBuilder builder = new ConfigurationBuilder();
+            builder.AddCloudFoundry();
+            var config = builder.Build();
+
+            var cm = new ConnectionStringManager(config);
+            var ci = cm.Get<RedisConnectionInfo>();
+            services.AddHealthChecks().AddRedis(ci.ConnectionString, name: ci.Name);
+
+            // Act
+            RedisCacheServiceCollectionExtensions.AddDistributedRedisCache(services, config);
+            var healthContributor = services.BuildServiceProvider().GetService<IHealthContributor>() as RedisHealthContributor;
+
+            // Assert
+            Assert.Null(healthContributor);
+        }
+
+        [Fact]
+        public void AddDistributedRedisCache_AddsRedisHealthContributor_WhenCommunityHealthCheckExistsAndForced()
+        {
+            // Arrange
+            IServiceCollection services = new ServiceCollection();
+            ConfigurationBuilder builder = new ConfigurationBuilder();
+            builder.AddCloudFoundry();
+            var config = builder.Build();
+
+            var cm = new ConnectionStringManager(config);
+            var ci = cm.Get<RedisConnectionInfo>();
+            services.AddHealthChecks().AddRedis(ci.ConnectionString, name: ci.Name);
+
+            // Act
+            RedisCacheServiceCollectionExtensions.AddDistributedRedisCache(services, config, addSteeltoeHealthChecks: true);
+            var healthContributor = services.BuildServiceProvider().GetService<IHealthContributor>() as RedisHealthContributor;
+
+            // Assert
+            Assert.NotNull(healthContributor);
+        }
+
+        [Fact]
         public void AddDistributedRedisCache_WithServiceName_NoVCAPs_ThrowsConnectorException()
         {
             // Arrange

--- a/src/Connectors/test/ConnectorCore.Test/SqlServerProviderServiceCollectionExtensionsTest.cs
+++ b/src/Connectors/test/ConnectorCore.Test/SqlServerProviderServiceCollectionExtensionsTest.cs
@@ -196,5 +196,47 @@ namespace Steeltoe.CloudFoundry.Connector.SqlServer.Test
             // Assert
             Assert.NotNull(healthContributor);
         }
+
+        [Fact]
+        public void AddSqlServerConnection_DoesntAddsRelationalHealthContributor_WhenCommunityHealthCheckExists()
+        {
+            // Arrange
+            IServiceCollection services = new ServiceCollection();
+            ConfigurationBuilder builder = new ConfigurationBuilder();
+            builder.AddCloudFoundry();
+            var config = builder.Build();
+
+            var cm = new ConnectionStringManager(config);
+            var ci = cm.Get<SqlServerConnectionInfo>();
+            services.AddHealthChecks().AddSqlServer(ci.ConnectionString, name: ci.Name);
+
+            // Act
+            SqlServerProviderServiceCollectionExtensions.AddSqlServerConnection(services, config);
+            var healthContributor = services.BuildServiceProvider().GetService<IHealthContributor>() as RelationalHealthContributor;
+
+            // Assert
+            Assert.Null(healthContributor);
+        }
+
+        [Fact]
+        public void AddSqlServerConnection_AddsRelationalHealthContributor_WhenCommunityHealthCheckExistsAndForced()
+        {
+            // Arrange
+            IServiceCollection services = new ServiceCollection();
+            ConfigurationBuilder builder = new ConfigurationBuilder();
+            builder.AddCloudFoundry();
+            var config = builder.Build();
+
+            var cm = new ConnectionStringManager(config);
+            var ci = cm.Get<SqlServerConnectionInfo>();
+            services.AddHealthChecks().AddSqlServer(ci.ConnectionString, name: ci.Name);
+
+            // Act
+            SqlServerProviderServiceCollectionExtensions.AddSqlServerConnection(services, config, addSteeltoeHealthChecks: true);
+            var healthContributor = services.BuildServiceProvider().GetService<IHealthContributor>() as RelationalHealthContributor;
+
+            // Assert
+            Assert.NotNull(healthContributor);
+        }
     }
 }

--- a/src/Connectors/test/ConnectorCore.Test/Steeltoe.CloudFoundry.ConnectorCore.Test.csproj
+++ b/src/Connectors/test/ConnectorCore.Test/Steeltoe.CloudFoundry.ConnectorCore.Test.csproj
@@ -28,6 +28,13 @@
     <!--<PackageReference Include="MySql.Data" Version="$(MySqlV8)" /> -->
     <PackageReference Include="MySql.Data" Version="$(MySqlV6)" />
 
+    <PackageReference Include="AspNetCore.HealthChecks.MySql" Version="$(HealthChecksMySqlVersion)" />
+    <PackageReference Include="AspNetCore.HealthChecks.MongoDb" Version="$(HealthChecksMongoDbVersion)" />
+    <PackageReference Include="AspNetCore.HealthChecks.NpgSql" Version="$(HealthChecksNpgSqlVersion)" />
+    <PackageReference Include="AspNetCore.HealthChecks.Rabbitmq" Version="$(HealthChecksRabbitmqVersion)" />
+    <PackageReference Include="AspNetCore.HealthChecks.Redis" Version="$(HealthChecksRedisVersion)" />
+    <PackageReference Include="AspNetCore.HealthChecks.SqlServer" Version="$(HealthChecksSqlServerVersion)" />
+
     <PackageReference Include="RabbitMQ.Client" Version="$(RabbitClientVersion)" />
     <PackageReference Include="StackExchange.Redis" Version="$(StackExchangeVersion)" />
     <PackageReference Include="System.Data.SqlClient" Version="$(SqlClientVersion)" />

--- a/versions.props
+++ b/versions.props
@@ -49,6 +49,7 @@
     <CoverletVersion>2.6.0</CoverletVersion>
     <HdrHistogramVersion>2.0.0</HdrHistogramVersion>
     <HttpExtensionsVersion>2.1.0</HttpExtensionsVersion>
+    <DiagnosticsExtensionsVersion>2.2.5</DiagnosticsExtensionsVersion>
     <JsonNetVersion>11.0.2</JsonNetVersion>
     <MockHttpVersion>4.0.0</MockHttpVersion>
     <MoqVersion>4.8.2</MoqVersion>
@@ -60,6 +61,13 @@
     <XunitAnalyzersVersion>0.9.0</XunitAnalyzersVersion>
     <XunitVersion>2.4.1</XunitVersion>
     <XunitStudioVersion>2.4.1</XunitStudioVersion>
+
+    <HealthChecksMySqlVersion>2.2.0</HealthChecksMySqlVersion>
+    <HealthChecksMongoDbVersion>2.2.2</HealthChecksMongoDbVersion>
+    <HealthChecksNpgSqlVersion>2.2.0</HealthChecksNpgSqlVersion>
+    <HealthChecksRabbitmqVersion>2.2.1</HealthChecksRabbitmqVersion>
+    <HealthChecksRedisVersion>2.2.3</HealthChecksRedisVersion>
+    <HealthChecksSqlServerVersion>2.2.0</HealthChecksSqlServerVersion>
 
     <SourceLinkGitHubVersion>1.0.0-beta2-18618-05</SourceLinkGitHubVersion>
     <SecurityCodeScanVersion>3.0.0</SecurityCodeScanVersion>


### PR DESCRIPTION
Prevents dependency on AspnetCore.HealthChecks.*  packages, while still allowing integration for health endpoint to work with community health checks. 