### PR TITLE
Removed code that removes the "X-Forwarded-Proto" header.

### DIFF
--- a/src/Security/src/Authentication.CloudFoundryOwin/ForwardedProtocolMiddleware.cs
+++ b/src/Security/src/Authentication.CloudFoundryOwin/ForwardedProtocolMiddleware.cs
@@ -29,7 +29,6 @@ namespace Steeltoe.Security.Authentication.CloudFoundry.Owin
             if (context.Request.Headers["X-Forwarded-Proto"] == "https" && context.Request.Scheme != "https")
             {
                 context.Request.Scheme = "https";
-                context.Request.Headers.Remove("X-Forwarded-Proto");
             }
 
             await Next.Invoke(context);


### PR DESCRIPTION
For some reason in an ASP.Net WebForms application, the OWIN pipeline appears to restart before a response is generated after the OpenIdConnectAuthenticationHandler.InvokeAsync. This results in ForwardedProtocolMiddleware being executed twice. Being as Steeltoe removes the "X-Forwarded-Proto" header, the scheme ends up being http instead of https resulting in a bad request_uri querystring parameter. It works fine in an ASP.NET MVC application. I can reproduce this and I am still working to isolate why the OWIN pipeline appears to restart. There is no harm in leaving "X-Forwarded-Proto" header and it resolves this issue.