### PR TITLE
Consistent token validation params

### DIFF
--- a/src/Security/src/Authentication.CloudFoundryBase/CloudFoundryHelper.cs
+++ b/src/Security/src/Authentication.CloudFoundryBase/CloudFoundryHelper.cs
@@ -73,7 +73,12 @@ namespace Steeltoe.Security.Authentication.CloudFoundry
         {
             if (parameters == null)
             {
-                parameters = new TokenValidationParameters();
+                parameters = new TokenValidationParameters
+                {
+                    ValidateAudience = false,
+                    ValidateIssuer = true,
+                    ValidateLifetime = true
+                };
             }
 
             var tokenValidator = new CloudFoundryTokenValidator(options ?? new AuthServerOptions());

--- a/src/Security/src/Authentication.CloudFoundryCore/CloudFoundryJwtBearerConfigurer.cs
+++ b/src/Security/src/Authentication.CloudFoundryCore/CloudFoundryJwtBearerConfigurer.cs
@@ -34,11 +34,7 @@ namespace Steeltoe.Security.Authentication.CloudFoundry
 
             jwtOptions.ClaimsIssuer = options.ClaimsIssuer;
             jwtOptions.BackchannelHttpHandler = CloudFoundryHelper.GetBackChannelHandler(options.ValidateCertificates);
-            jwtOptions.TokenValidationParameters = jwtOptions.TokenValidationParameters ?? new TokenValidationParameters();
-            jwtOptions.TokenValidationParameters.ValidateAudience = options.TokenValidationParameters.ValidateAudience;
-            jwtOptions.TokenValidationParameters.ValidateIssuer = options.TokenValidationParameters.ValidateIssuer;
-            jwtOptions.TokenValidationParameters.ValidateLifetime = options.TokenValidationParameters.ValidateLifetime;
-            jwtOptions.TokenValidationParameters = CloudFoundryHelper.GetTokenValidationParameters(jwtOptions.TokenValidationParameters, options.JwtKeyUrl, jwtOptions.BackchannelHttpHandler, options.ValidateCertificates);
+            jwtOptions.TokenValidationParameters = CloudFoundryHelper.GetTokenValidationParameters(options.TokenValidationParameters, options.JwtKeyUrl, jwtOptions.BackchannelHttpHandler, options.ValidateCertificates);
             jwtOptions.SaveToken = options.SaveToken;
         }
     }

--- a/src/Security/src/Authentication.CloudFoundryCore/CloudFoundryOpenIdConnectConfigurer.cs
+++ b/src/Security/src/Authentication.CloudFoundryCore/CloudFoundryOpenIdConnectConfigurer.cs
@@ -73,14 +73,12 @@ namespace Steeltoe.Security.Authentication.CloudFoundry
                 }
             }
 
-            // http://irisclasson.com/2018/09/18/asp-net-core-openidconnect-why-is-the-claimsprincipal-name-null/
-            oidcOptions.TokenValidationParameters.NameClaimType = cfOptions.TokenValidationParameters.NameClaimType;
-
-            // main objective here is to set the IssuerSigningKeyResolver to work around an issue parsing the N value of the signing key in FullFramework
-            oidcOptions.TokenValidationParameters = CloudFoundryHelper.GetTokenValidationParameters(oidcOptions.TokenValidationParameters, oidcOptions.Authority + CloudFoundryDefaults.JwtTokenUri, oidcOptions.BackchannelHttpHandler, cfOptions.ValidateCertificates, cfOptions.BaseOptions(oidcOptions.ClientId));
-
-            oidcOptions.TokenValidationParameters.ValidateAudience = cfOptions.TokenValidationParameters.ValidateAudience;
-            oidcOptions.TokenValidationParameters.ValidateLifetime = cfOptions.TokenValidationParameters.ValidateLifetime;
+            oidcOptions.TokenValidationParameters = CloudFoundryHelper.GetTokenValidationParameters(
+                cfOptions.TokenValidationParameters,
+                oidcOptions.Authority + CloudFoundryDefaults.JwtTokenUri,
+                oidcOptions.BackchannelHttpHandler,
+                cfOptions.ValidateCertificates,
+                cfOptions.BaseOptions(oidcOptions.ClientId));
 
             // the ClaimsIdentity is built off the id_token, but scopes are returned in the access_token. Copy them as claims
             oidcOptions.Events.OnTokenValidated = MapScopesToClaims;

--- a/src/Security/src/Authentication.CloudFoundryCore/CloudFoundryOpenIdConnectOptions.cs
+++ b/src/Security/src/Authentication.CloudFoundryCore/CloudFoundryOpenIdConnectOptions.cs
@@ -33,7 +33,12 @@ namespace Steeltoe.Security.Authentication.CloudFoundry
             ClientSecret = CloudFoundryDefaults.ClientSecret;
             ResponseType = OpenIdConnectResponseType.Code;
             SignInScheme = CookieAuthenticationDefaults.AuthenticationScheme;
+
+            // http://irisclasson.com/2018/09/18/asp-net-core-openidconnect-why-is-the-claimsprincipal-name-null/
             TokenValidationParameters.NameClaimType = "user_name";
+            TokenValidationParameters.ValidateAudience = true;
+            TokenValidationParameters.ValidateIssuer = true;
+            TokenValidationParameters.ValidateLifetime = true;
         }
 
         /// <summary>

--- a/src/Security/test/Authentication.CloudFoundryBase.Test/CloudFoundryHelperTest.cs
+++ b/src/Security/test/Authentication.CloudFoundryBase.Test/CloudFoundryHelperTest.cs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 using Newtonsoft.Json.Linq;
-using Steeltoe.Common;
 using System;
 using Xunit;
 
@@ -35,12 +34,10 @@ namespace Steeltoe.Security.Authentication.CloudFoundry.Test
         public void GetTokenValidationParameters_ReturnsExpected()
         {
             var parameters = CloudFoundryHelper.GetTokenValidationParameters(null, "https://foo.bar.com/keyurl", null, false);
-            Assert.True(parameters.ValidateAudience);
-            Assert.True(parameters.ValidateIssuer);
+            Assert.False(parameters.ValidateAudience, "Audience validation should not be enabled by default");
+            Assert.True(parameters.ValidateIssuer, "Issuer validation should be enabled by default");
             Assert.NotNull(parameters.IssuerValidator);
-
-            // Assert.Equal(cftv.ValidateIssuer, parameters.IssuerValidator);
-            Assert.True(parameters.ValidateLifetime);
+            Assert.True(parameters.ValidateLifetime, "Token lifetime validation should be enabled by default");
             Assert.NotNull(parameters.IssuerSigningKeyResolver);
         }
 


### PR DESCRIPTION
Token validation params should match for JWT between OWIN and Core. Audience validation should be applied by default with OpenID Connect, but not with JWT scenarios as the user token is commonly passed to backing service from front-end applications