### PR TITLE
updates to align with breaking changes in credhub api  #152

### DIFF
--- a/src/Security/src/DataProtection.CredHubBase/CredHubClient.cs
+++ b/src/Security/src/DataProtection.CredHubBase/CredHubClient.cs
@@ -334,21 +334,6 @@ namespace Steeltoe.Security.DataProtection.CredHub
             }
         }
 
-        public async Task<List<CredentialPath>> FindAllPathsAsync()
-        {
-            HttpClientHelper.ConfigureCertificateValidation(_validateCertificates, out SecurityProtocolType protocolType, out RemoteCertificateValidationCallback prevValidator);
-            try
-            {
-                _logger?.LogTrace($"About to GET {_baseCredHubUrl}/v1/data?paths=true");
-                var response = await _httpClient.GetAsync($"{_baseCredHubUrl}/v1/data?paths=true").ConfigureAwait(false);
-                return (await HandleErrorParseResponse<CredentialPathsResponse>(response, "Find all Paths").ConfigureAwait(false)).Paths;
-            }
-            finally
-            {
-                HttpClientHelper.RestoreCertificateValidation(_validateCertificates, protocolType, prevValidator);
-            }
-        }
-
         public Task<bool> DeleteByNameAsync(string name)
         {
             if (string.IsNullOrEmpty(name))

--- a/src/Security/src/DataProtection.CredHubBase/CredHubGenerateRequest.cs
+++ b/src/Security/src/DataProtection.CredHubBase/CredHubGenerateRequest.cs
@@ -12,9 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using Newtonsoft.Json;
-using System.Collections.Generic;
-
 namespace Steeltoe.Security.DataProtection.CredHub
 {
     public abstract class CredHubGenerateRequest : CredHubBaseObject
@@ -22,17 +19,11 @@ namespace Steeltoe.Security.DataProtection.CredHub
         /// <summary>
         /// Gets or sets a value indicating the overwrite interaction mode
         /// </summary>
-        public OverwiteMode Mode { get; set; } = OverwiteMode.noOverwrite;
+        public OverwiteMode Mode { get; set; } = OverwiteMode.converge;
 
         /// <summary>
         /// Gets or sets parameters for generating credential
         /// </summary>
         public object Parameters { get; set; }
-
-        /// <summary>
-        /// Gets or sets optionally set permissions on the credential
-        /// </summary>
-        [JsonProperty("additional_permissions")]
-        public List<CredentialPermission> AdditionalPermissions { get; set; }
     }
 }

--- a/src/Security/src/DataProtection.CredHubBase/Credentials/Certificate/CertificateGenerationRequest.cs
+++ b/src/Security/src/DataProtection.CredHubBase/Credentials/Certificate/CertificateGenerationRequest.cs
@@ -25,9 +25,8 @@ namespace Steeltoe.Security.DataProtection.CredHub
         /// </summary>
         /// <param name="credentialName">Name of the credential</param>
         /// <param name="parameters">Variables for certificate generation</param>
-        /// <param name="additionalPermissions">List of additional permissions to set on credential</param>
         /// <param name="overwriteMode">Overwrite existing credential (default: no-overwrite)</param>
-        public CertificateGenerationRequest(string credentialName, CertificateGenerationParameters parameters, List<CredentialPermission> additionalPermissions = null, OverwiteMode overwriteMode = OverwiteMode.noOverwrite)
+        public CertificateGenerationRequest(string credentialName, CertificateGenerationParameters parameters, OverwiteMode overwriteMode = OverwiteMode.converge)
         {
             var subjects = new List<string> { parameters.CommonName, parameters.Organization, parameters.OrganizationUnit, parameters.Locality, parameters.State, parameters.Country };
             if (!AtLeastOneProvided(subjects))
@@ -43,7 +42,6 @@ namespace Steeltoe.Security.DataProtection.CredHub
             Name = credentialName;
             Type = CredentialType.Certificate;
             Parameters = parameters;
-            AdditionalPermissions = additionalPermissions;
             Mode = overwriteMode;
         }
 

--- a/src/Security/src/DataProtection.CredHubBase/Credentials/Certificate/CertificateSetRequest.cs
+++ b/src/Security/src/DataProtection.CredHubBase/Credentials/Certificate/CertificateSetRequest.cs
@@ -28,10 +28,8 @@ namespace Steeltoe.Security.DataProtection.CredHub
         /// <param name="certificate">Certificate value of credential to set</param>
         /// <param name="certificateAuthority">Certificate authority value of credential to set</param>
         /// <param name="certificateAuthorityName">Name of CA credential in credhub that has signed this certificate</param>
-        /// <param name="additionalPermissions">List of additional permissions to set on credential</param>
-        /// <param name="overwriteMode">Overwrite existing credential (default: no-overwrite)</param>
         /// <remarks>Must include either the CA or CA Name</remarks>
-        public CertificateSetRequest(string credentialName, string privateKey, string certificate, string certificateAuthority = null, string certificateAuthorityName = null, List<CredentialPermission> additionalPermissions = null, OverwiteMode overwriteMode = OverwiteMode.noOverwrite)
+        public CertificateSetRequest(string credentialName, string privateKey, string certificate, string certificateAuthority = null, string certificateAuthorityName = null)
         {
             if (!string.IsNullOrEmpty(certificateAuthority) && !string.IsNullOrEmpty(certificateAuthorityName))
             {
@@ -47,8 +45,6 @@ namespace Steeltoe.Security.DataProtection.CredHub
                 CertificateAuthority = certificateAuthority,
                 CertificateAuthorityName = certificateAuthorityName
             };
-            AdditionalPermissions = additionalPermissions;
-            Mode = overwriteMode;
         }
     }
 }

--- a/src/Security/src/DataProtection.CredHubBase/Credentials/CredentialSetRequest.cs
+++ b/src/Security/src/DataProtection.CredHubBase/Credentials/CredentialSetRequest.cs
@@ -12,9 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using Newtonsoft.Json;
-using System.Collections.Generic;
-
 namespace Steeltoe.Security.DataProtection.CredHub
 {
     public class CredentialSetRequest : CredHubBaseObject
@@ -23,16 +20,5 @@ namespace Steeltoe.Security.DataProtection.CredHub
         /// Gets or sets value of the credential to be set
         /// </summary>
         public ICredentialValue Value { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating the overwrite interaction mode
-        /// </summary>
-        public OverwiteMode Mode { get; set; } = OverwiteMode.noOverwrite;
-
-        /// <summary>
-        /// Gets or sets optionally set permissions on the credential
-        /// </summary>
-        [JsonProperty("additional_permissions")]
-        public List<CredentialPermission> AdditionalPermissions { get; set; }
     }
 }

--- a/src/Security/src/DataProtection.CredHubBase/Credentials/JSON/JsonSetRequest.cs
+++ b/src/Security/src/DataProtection.CredHubBase/Credentials/JSON/JsonSetRequest.cs
@@ -24,15 +24,11 @@ namespace Steeltoe.Security.DataProtection.CredHub
         /// </summary>
         /// <param name="credentialName">Name of credential</param>
         /// <param name="value">Value of the credential to set</param>
-        /// <param name="additionalPermissions">List of additional permissions to set on credential</param>
-        /// <param name="overwriteMode">Overwrite existing credential (default: no-overwrite)</param>
-        public JsonSetRequest(string credentialName, JObject value, List<CredentialPermission> additionalPermissions = null, OverwiteMode overwriteMode = OverwiteMode.noOverwrite)
+        public JsonSetRequest(string credentialName, JObject value)
         {
             Name = credentialName;
             Type = CredentialType.JSON;
             Value = new JsonCredential(value);
-            AdditionalPermissions = additionalPermissions;
-            Mode = overwriteMode;
         }
 
         /// <summary>
@@ -40,15 +36,11 @@ namespace Steeltoe.Security.DataProtection.CredHub
         /// </summary>
         /// <param name="credentialName">Name of credential</param>
         /// <param name="value">Value of the credential to set</param>
-        /// <param name="additionalPermissions">List of additional permissions to set on credential</param>
-        /// <param name="overwriteMode">Overwrite existing credential (default: no-overwrite)</param>
-        public JsonSetRequest(string credentialName, string value, List<CredentialPermission> additionalPermissions = null, OverwiteMode overwriteMode = OverwiteMode.noOverwrite)
+        public JsonSetRequest(string credentialName, string value)
         {
             Name = credentialName;
             Type = CredentialType.JSON;
             Value = new JsonCredential(value);
-            AdditionalPermissions = additionalPermissions;
-            Mode = overwriteMode;
         }
     }
 }

--- a/src/Security/src/DataProtection.CredHubBase/Credentials/Password/PasswordGenerationRequest.cs
+++ b/src/Security/src/DataProtection.CredHubBase/Credentials/Password/PasswordGenerationRequest.cs
@@ -24,14 +24,12 @@ namespace Steeltoe.Security.DataProtection.CredHub
         /// </summary>
         /// <param name="credentialName">Name of the credential</param>
         /// <param name="parameters">Variables for password generation</param>
-        /// <param name="additionalPermissions">List of additional permissions to set on credential</param>
         /// <param name="overwriteMode">Overwrite existing credential (default: no-overwrite)</param>
-        public PasswordGenerationRequest(string credentialName, PasswordGenerationParameters parameters, List<CredentialPermission> additionalPermissions = null, OverwiteMode overwriteMode = OverwiteMode.noOverwrite)
+        public PasswordGenerationRequest(string credentialName, PasswordGenerationParameters parameters, OverwiteMode overwriteMode = OverwiteMode.converge)
         {
             Name = credentialName;
             Type = CredentialType.Password;
             Parameters = parameters;
-            AdditionalPermissions = additionalPermissions;
             Mode = overwriteMode;
         }
     }

--- a/src/Security/src/DataProtection.CredHubBase/Credentials/Password/PasswordSetRequest.cs
+++ b/src/Security/src/DataProtection.CredHubBase/Credentials/Password/PasswordSetRequest.cs
@@ -23,15 +23,11 @@ namespace Steeltoe.Security.DataProtection.CredHub
         /// </summary>
         /// <param name="credentialName">Name of credential</param>
         /// <param name="password">Value of the credential to set</param>
-        /// <param name="additionalPermissions">List of additional permissions to set on credential</param>
-        /// <param name="overwriteMode">Overwrite existing credential (default: no-overwrite)</param>
-        public PasswordSetRequest(string credentialName, string password, List<CredentialPermission> additionalPermissions = null, OverwiteMode overwriteMode = OverwiteMode.noOverwrite)
+        public PasswordSetRequest(string credentialName, string password)
         {
             Name = credentialName;
             Type = CredentialType.Password;
             Value = new PasswordCredential(password);
-            AdditionalPermissions = additionalPermissions;
-            Mode = overwriteMode;
         }
     }
 }

--- a/src/Security/src/DataProtection.CredHubBase/Credentials/RSA/RsaGenerationRequest.cs
+++ b/src/Security/src/DataProtection.CredHubBase/Credentials/RSA/RsaGenerationRequest.cs
@@ -24,14 +24,12 @@ namespace Steeltoe.Security.DataProtection.CredHub
         /// </summary>
         /// <param name="credentialName">Name of credential</param>
         /// <param name="keyLength">Optional Key Length (default: 2048)</param>
-        /// <param name="additionalPermissions">List of additional permissions to set on credential</param>
         /// <param name="overwriteMode">Overwrite existing credential (default: no-overwrite)</param>
-        public RsaGenerationRequest(string credentialName, CertificateKeyLength keyLength = CertificateKeyLength.Length_2048, List<CredentialPermission> additionalPermissions = null, OverwiteMode overwriteMode = OverwiteMode.noOverwrite)
+        public RsaGenerationRequest(string credentialName, CertificateKeyLength keyLength = CertificateKeyLength.Length_2048, OverwiteMode overwriteMode = OverwiteMode.converge)
         {
             Name = credentialName;
             Type = CredentialType.RSA;
             Parameters = new KeyParameters { KeyLength = keyLength };
-            AdditionalPermissions = additionalPermissions;
             Mode = overwriteMode;
         }
     }

--- a/src/Security/src/DataProtection.CredHubBase/Credentials/RSA/RsaSetRequest.cs
+++ b/src/Security/src/DataProtection.CredHubBase/Credentials/RSA/RsaSetRequest.cs
@@ -24,15 +24,11 @@ namespace Steeltoe.Security.DataProtection.CredHub
         /// <param name="credentialName">Name of credential</param>
         /// <param name="privateKey">Private key for the credential</param>
         /// <param name="publicKey">Public key for the credential</param>
-        /// <param name="additionalPermissions">List of additional permissions to set on credential</param>
-        /// <param name="overwriteMode">Overwrite existing credential (default: no-overwrite)</param>
-        public RsaSetRequest(string credentialName, string privateKey, string publicKey, List<CredentialPermission> additionalPermissions = null, OverwiteMode overwriteMode = OverwiteMode.noOverwrite)
+        public RsaSetRequest(string credentialName, string privateKey, string publicKey)
         {
             Name = credentialName;
             Type = CredentialType.RSA;
             Value = new RsaCredential { PrivateKey = privateKey, PublicKey = publicKey };
-            AdditionalPermissions = additionalPermissions;
-            Mode = overwriteMode;
         }
     }
 }

--- a/src/Security/src/DataProtection.CredHubBase/Credentials/SSH/SshGenerationRequest.cs
+++ b/src/Security/src/DataProtection.CredHubBase/Credentials/SSH/SshGenerationRequest.cs
@@ -26,15 +26,13 @@ namespace Steeltoe.Security.DataProtection.CredHub
         /// </summary>
         /// <param name="credentialName">Name of credential</param>
         /// <param name="parameters">Optional parameters (defaults to key length 2048 and no SSH Comment)</param>
-        /// <param name="additionalPermissions">List of additional permissions to set on credential</param>
         /// <param name="overwriteMode">Overwrite existing credential (default: no-overwrite)</param>
-        public SshGenerationRequest(string credentialName, SshGenerationParameters parameters = null, List<CredentialPermission> additionalPermissions = null, OverwiteMode overwriteMode = OverwiteMode.noOverwrite)
+        public SshGenerationRequest(string credentialName, SshGenerationParameters parameters = null, OverwiteMode overwriteMode = OverwiteMode.converge)
         {
             Name = credentialName;
             Type = CredentialType.SSH;
             Parameters = parameters ?? defaultParams;
             Mode = overwriteMode;
-            AdditionalPermissions = additionalPermissions;
         }
     }
 }

--- a/src/Security/src/DataProtection.CredHubBase/Credentials/SSH/SshSetRequest.cs
+++ b/src/Security/src/DataProtection.CredHubBase/Credentials/SSH/SshSetRequest.cs
@@ -24,15 +24,11 @@ namespace Steeltoe.Security.DataProtection.CredHub
         /// <param name="credentialName">Name of credential</param>
         /// <param name="privateKey">Private key for the credential</param>
         /// <param name="publicKey">Public key for the credential</param>
-        /// <param name="additionalPermissions">List of additional permissions to set on credential</param>
-        /// <param name="overwriteMode">Overwrite existing credential (default: no-overwrite)</param>
-        public SshSetRequest(string credentialName, string privateKey, string publicKey, List<CredentialPermission> additionalPermissions = null, OverwiteMode overwriteMode = OverwiteMode.noOverwrite)
+        public SshSetRequest(string credentialName, string privateKey, string publicKey)
         {
             Name = credentialName;
             Type = CredentialType.SSH;
             Value = new SshCredential { PrivateKey = privateKey, PublicKey = publicKey };
-            AdditionalPermissions = additionalPermissions;
-            Mode = overwriteMode;
         }
     }
 }

--- a/src/Security/src/DataProtection.CredHubBase/Credentials/User/UserGenerationRequest.cs
+++ b/src/Security/src/DataProtection.CredHubBase/Credentials/User/UserGenerationRequest.cs
@@ -24,14 +24,12 @@ namespace Steeltoe.Security.DataProtection.CredHub
         /// </summary>
         /// <param name="credentialName">Name of credential</param>
         /// <param name="parameters">Variables for username and password generation</param>
-        /// <param name="additionalPermissions">List of additional permissions to set on credential</param>
         /// <param name="overwriteMode">Overwrite existing credential (default: no-overwrite)</param>
-        public UserGenerationRequest(string credentialName, UserGenerationParameters parameters, List<CredentialPermission> additionalPermissions = null, OverwiteMode overwriteMode = OverwiteMode.noOverwrite)
+        public UserGenerationRequest(string credentialName, UserGenerationParameters parameters, OverwiteMode overwriteMode = OverwiteMode.converge)
         {
             Name = credentialName;
             Type = CredentialType.User;
             Parameters = parameters;
-            AdditionalPermissions = additionalPermissions;
             Mode = overwriteMode;
         }
     }

--- a/src/Security/src/DataProtection.CredHubBase/Credentials/User/UserSetRequest.cs
+++ b/src/Security/src/DataProtection.CredHubBase/Credentials/User/UserSetRequest.cs
@@ -24,15 +24,11 @@ namespace Steeltoe.Security.DataProtection.CredHub
         /// <param name="credentialName">Name of credential</param>
         /// <param name="userName">Name of the user</param>
         /// <param name="password">Password of the user</param>
-        /// <param name="additionalPermissions">List of additional permissions to set on credential</param>
-        /// <param name="overwriteMode">Overwrite existing credential (default: no-overwrite)</param>
-        public UserSetRequest(string credentialName, string userName, string password, List<CredentialPermission> additionalPermissions = null, OverwiteMode overwriteMode = OverwiteMode.noOverwrite)
+        public UserSetRequest(string credentialName, string userName, string password)
         {
             Name = credentialName;
             Type = CredentialType.User;
             Value = new UserCredential { Username = userName, Password = password };
-            AdditionalPermissions = additionalPermissions;
-            Mode = overwriteMode;
         }
     }
 }

--- a/src/Security/src/DataProtection.CredHubBase/Credentials/Value/ValueSetRequest.cs
+++ b/src/Security/src/DataProtection.CredHubBase/Credentials/Value/ValueSetRequest.cs
@@ -23,15 +23,11 @@ namespace Steeltoe.Security.DataProtection.CredHub
         /// </summary>
         /// <param name="credentialName">Name of credential</param>
         /// <param name="value">Value of the credential to set</param>
-        /// <param name="additionalPermissions">List of additional permissions to set on credential</param>
-        /// <param name="overwriteMode">Overwrite existing credential (default: no-overwrite)</param>
-        public ValueSetRequest(string credentialName, string value, List<CredentialPermission> additionalPermissions = null, OverwiteMode overwriteMode = OverwiteMode.noOverwrite)
+        public ValueSetRequest(string credentialName, string value)
         {
             Name = credentialName;
             Type = CredentialType.Value;
             Value = new ValueCredential(value);
-            AdditionalPermissions = additionalPermissions;
-            Mode = overwriteMode;
         }
     }
 }

--- a/src/Security/src/DataProtection.CredHubBase/ICredHubClient.cs
+++ b/src/Security/src/DataProtection.CredHubBase/ICredHubClient.cs
@@ -92,12 +92,6 @@ namespace Steeltoe.Security.DataProtection.CredHub
         Task<List<FoundCredential>> FindByPathAsync(string path);
 
         /// <summary>
-        /// Retrieves a list of all paths which contain credentials
-        /// </summary>
-        /// <returns>List of paths that contain credentials</returns>
-        Task<List<CredentialPath>> FindAllPathsAsync();
-
-        /// <summary>
         /// Delete a credential by its full name.
         /// </summary>
         /// <param name="name">the name of the credential; must not be <see langword="null" /></param>

--- a/src/Security/test/DataProtection.CredHubBase.Test/CredHubClientTests.cs
+++ b/src/Security/test/DataProtection.CredHubBase.Test/CredHubClientTests.cs
@@ -120,10 +120,10 @@ namespace Steeltoe.Security.DataProtection.CredHub.Test
             var mockHttpMessageHandler = InitializedHandlerWithLogin();
             var mockRequest = mockHttpMessageHandler
                 .Expect(HttpMethod.Put, credHubBase + "/v1/data")
-                .WithContent("{\"value\":{\"username\":\"testUser\",\"password\":\"testPassword\"},\"mode\":\"no-overwrite\",\"additional_permissions\":[{\"actor\":\"test\",\"operations\":[\"read\",\"write\"]}],\"name\":\"example-user\",\"type\":\"User\"}")
+                .WithContent("{\"value\":{\"username\":\"testUser\",\"password\":\"testPassword\"},\"name\":\"example-user\",\"type\":\"User\"}")
                 .Respond("application/json", "{\"type\":\"user\",\"version_created_at\":\"2017-11-22T21:49:09Z\",\"id\":\"b6dffbd6-ccca-4703-a4fd-8d39ca7b564a\",\"name\":\"/example-user\",\"value\":{\"username\":\"testUser\",\"password\":\"testPassword\",\"password_hash\":\"$6$rzwQOeLD$uuZp.sh9mT/bUGSB9i9x8pr.MG8hvo7bsUf2BNEKMVUErzEtYxGdmG6AfHtM1s087DUE1NeC01LOwtDLg3tLb/\"}}");
             var client = await InitializeClientAsync(mockHttpMessageHandler);
-            var request = new UserSetRequest("example-user", "testUser", "testPassword", new List<CredentialPermission> { new CredentialPermission { Actor = "test", Operations = new List<OperationPermissions> { OperationPermissions.read, OperationPermissions.write } } });
+            var request = new UserSetRequest("example-user", "testUser", "testPassword");
 
             // act
             var response = await client.WriteAsync<UserCredential>(request);
@@ -346,7 +346,7 @@ namespace Steeltoe.Security.DataProtection.CredHub.Test
             var mockHttpMessageHandler = InitializedHandlerWithLogin();
             var mockRequest = mockHttpMessageHandler
                 .Expect(HttpMethod.Post, credHubBase + "/v1/data")
-                .WithContent("{\"mode\":\"no-overwrite\",\"parameters\":{\"length\":40},\"name\":\"generated-password\",\"type\":\"Password\"}")
+                .WithContent("{\"mode\":\"converge\",\"parameters\":{\"length\":40},\"name\":\"generated-password\",\"type\":\"Password\"}")
                 .Respond("application/json", "{\"type\":\"password\",\"version_created_at\":\"2017-11-21T18:18:28Z\",\"id\":\"1a129eff-f467-42bc-b959-772f4dec1f5e\",\"name\":\"/generated-password\",\"value\":\"W9VwGfI3gvV0ypMDUaFvYDnui84elZPtfGaKaILO\"}");
             var client = await InitializeClientAsync(mockHttpMessageHandler);
             var request = new PasswordGenerationRequest("generated-password", new PasswordGenerationParameters { Length = 40 });
@@ -371,10 +371,10 @@ namespace Steeltoe.Security.DataProtection.CredHub.Test
             var mockHttpMessageHandler = InitializedHandlerWithLogin();
             var mockRequest = mockHttpMessageHandler
                 .Expect(HttpMethod.Post, credHubBase + "/v1/data")
-                .WithContent("{\"mode\":\"no-overwrite\",\"parameters\":{\"length\":40},\"additional_permissions\":[{\"actor\":\"test\",\"operations\":[\"read\",\"write\"]}],\"name\":\"generated-password\",\"type\":\"Password\"}")
+                .WithContent("{\"mode\":\"converge\",\"parameters\":{\"length\":40},\"name\":\"generated-password\",\"type\":\"Password\"}")
                 .Respond("application/json", "{\"type\":\"password\",\"version_created_at\":\"2017-11-21T18:18:28Z\",\"id\":\"1a129eff-f467-42bc-b959-772f4dec1f5e\",\"name\":\"/generated-password\",\"value\":\"W9VwGfI3gvV0ypMDUaFvYDnui84elZPtfGaKaILO\"}");
             var client = await InitializeClientAsync(mockHttpMessageHandler);
-            var request = new PasswordGenerationRequest("generated-password", new PasswordGenerationParameters { Length = 40 }, new List<CredentialPermission> { new CredentialPermission { Actor = "test", Operations = new List<OperationPermissions> { OperationPermissions.read, OperationPermissions.write } } });
+            var request = new PasswordGenerationRequest("generated-password", new PasswordGenerationParameters { Length = 40 });
 
             // assert
             var response = await client.GenerateAsync<PasswordCredential>(request);
@@ -396,7 +396,7 @@ namespace Steeltoe.Security.DataProtection.CredHub.Test
             var mockHttpMessageHandler = InitializedHandlerWithLogin();
             var mockRequest = mockHttpMessageHandler
                 .Expect(HttpMethod.Post, credHubBase + "/v1/data")
-                .WithContent("{\"mode\":\"no-overwrite\",\"parameters\":{\"length\":40},\"name\":\"generated-user\",\"type\":\"User\"}")
+                .WithContent("{\"mode\":\"converge\",\"parameters\":{\"length\":40},\"name\":\"generated-user\",\"type\":\"User\"}")
                 .Respond("application/json", "{\"type\":\"user\",\"version_created_at\":\"2017-11-21T18:18:28Z\",\"id\":\"1a129eff-f467-42bc-b959-772f4dec1f5e\",\"name\":\"/generated-user\",\"value\":{\"username\":\"HzFFMbHuRbtImAWdGmML\",\"password\":\"zVNmqtSHakqRCMb2OtUFtwnoOSJ0T4NCSaaYdIku\",\"password_hash\":\"$6$8Oq5Fmmr$dVjMXUCk.r9I6jpQYapnwtoK80qrpSSCBqezyeB7AFJFPvQQy.tw0LBHSBJjaT9L9W3u1nodrDol8U.knd17y0\"}}");
             var client = await InitializeClientAsync(mockHttpMessageHandler);
             var request = new UserGenerationRequest("generated-user", new UserGenerationParameters { Length = 40 });
@@ -423,7 +423,7 @@ namespace Steeltoe.Security.DataProtection.CredHub.Test
             var mockHttpMessageHandler = InitializedHandlerWithLogin();
             var mockRequest = mockHttpMessageHandler
                 .Expect(HttpMethod.Post, credHubBase + "/v1/data")
-                .WithContent("{\"mode\":\"no-overwrite\",\"parameters\":{\"common_name\":\"TestCA\",\"duration\":365,\"is_ca\":true,\"self_sign\":false,\"key_length\":2048},\"name\":\"example-ca\",\"type\":\"Certificate\"}")
+                .WithContent("{\"mode\":\"converge\",\"parameters\":{\"common_name\":\"TestCA\",\"duration\":365,\"is_ca\":true,\"self_sign\":false,\"key_length\":2048},\"name\":\"example-ca\",\"type\":\"Certificate\"}")
                 .Respond("application/json", "{\"type\":\"certificate\",\"transitional\":false,\"version_created_at\":\"2017-11-20T15:55:24Z\",\"id\":\"0d698309-cca6-4626-aae3-a72ed664304a\",\"name\":\"/example-ca\",\"value\":{\"ca\":null,\"certificate\":\"-----BEGIN CERTIFICATE-----\\nFakeCertificateText\\n-----END CERTIFICATE-----\\n\",\"private_key\":\"-----BEGIN RSA PRIVATE KEY-----\\nFakePrivateKeyTextEAAQ==\\n-----END RSA PRIVATE KEY-----\\n\"}}");
             var client = await InitializeClientAsync(mockHttpMessageHandler);
             var parms = new CertificateGenerationParameters { CommonName = "TestCA", IsCertificateAuthority = true };
@@ -451,7 +451,7 @@ namespace Steeltoe.Security.DataProtection.CredHub.Test
             var mockHttpMessageHandler = InitializedHandlerWithLogin();
             var mockRequest = mockHttpMessageHandler
                 .Expect(HttpMethod.Post, credHubBase + "/v1/data")
-                .WithContent("{\"mode\":\"no-overwrite\",\"parameters\":{\"key_length\":2048},\"name\":\"example-rsa\",\"type\":\"RSA\"}")
+                .WithContent("{\"mode\":\"converge\",\"parameters\":{\"key_length\":2048},\"name\":\"example-rsa\",\"type\":\"RSA\"}")
                 .Respond("application/json", "{\"type\":\"rsa\",\"version_created_at\":\"2017-11-10T15:55:24Z\",\"id\":\"2af5191f-9c05-4746-b72c-78b3283aef46\",\"name\":\"/example-rsa\",\"value\":{\"public_key\":\"-----BEGIN PUBLIC KEY-----\\nFakePublicKeyTextEAAQ==\\n-----END PUBLIC KEY-----\\n\",\"private_key\":\"-----BEGIN RSA PRIVATE KEY-----\\nFakePrivateKeyTextEAAQ==\\n-----END RSA PRIVATE KEY-----\\n\"}}");
             var client = await InitializeClientAsync(mockHttpMessageHandler);
             var request = new RsaGenerationRequest("example-rsa", CertificateKeyLength.Length_2048);
@@ -477,7 +477,7 @@ namespace Steeltoe.Security.DataProtection.CredHub.Test
             var mockHttpMessageHandler = InitializedHandlerWithLogin();
             var mockRequest = mockHttpMessageHandler
                 .Expect(HttpMethod.Post, credHubBase + "/v1/data")
-                .WithContent("{\"mode\":\"no-overwrite\",\"parameters\":{\"key_length\":2048},\"name\":\"example-ssh\",\"type\":\"SSH\"}")
+                .WithContent("{\"mode\":\"converge\",\"parameters\":{\"key_length\":2048},\"name\":\"example-ssh\",\"type\":\"SSH\"}")
                 .Respond("application/json", "{\"type\":\"ssh\",\"version_created_at\":\"2017-11-10T15:55:24Z\",\"id\":\"2af5191f-9c05-4746-b72c-78b3283aef46\",\"name\":\"/example-ssh\",\"value\":{\"public_key\":\"ssh-rsa FakePublicKeyText asdf\",\"private_key\":\"-----BEGIN RSA PRIVATE KEY-----\\nFakePrivateKeyTextEAAQ==\\n-----END RSA PRIVATE KEY-----\\n\",\"public_key_fingerprint\":\"mkiqcOCEUhYsp/0Uu5ZsJlLkKt74/lV4Yz/FKslHxR8\"}}");
             var client = await InitializeClientAsync(mockHttpMessageHandler);
             var request = new SshGenerationRequest("example-ssh");
@@ -693,28 +693,6 @@ namespace Steeltoe.Security.DataProtection.CredHub.Test
 
             // act & assert
             await Assert.ThrowsAsync<ArgumentException>(() => client.FindByPathAsync(string.Empty));
-        }
-
-        [Fact]
-        public async void FindAllPathsAsync_Returns_ListOfPaths()
-        {
-            // arrange
-            var mockHttpMessageHandler = InitializedHandlerWithLogin();
-            var mockRequest = mockHttpMessageHandler
-                .Expect(HttpMethod.Get, $"{credHubBase}/v1/data?paths=true")
-                .Respond("application/json", "{\"paths\":[{\"path\":\"/\"},{\"path\":\"/example/\"},{\"path\":\"/example2/\"}]}");
-            var client = await InitializeClientAsync(mockHttpMessageHandler);
-
-            // act
-            var response = await client.FindAllPathsAsync();
-
-            // assert
-            mockHttpMessageHandler.VerifyNoOutstandingExpectation();
-            Assert.Equal(1, mockHttpMessageHandler.GetMatchCount(mockRequest));
-            Assert.Equal(3, response.Count);
-            Assert.Contains(response, i => i.Path == "/");
-            Assert.Contains(response, i => i.Path == "/example/");
-            Assert.Contains(response, i => i.Path == "/example2/");
         }
 
         [Fact]


### PR DESCRIPTION
This PR is a reaction to breaking changes in [CredHub 2.0.0](https://github.com/pivotal-cf/credhub-release/releases/tag/2.0.0)

- Removes support for finding all paths with GET /v1/data?paths=true
- Removes AdditionalPermissions params on Set and Generate requests
- Removes `mode` on Set requests
- Changes default `mode` to `converge`