### PR TITLE
Add HostBuilder extensions for easier dynamic logging #122

### DIFF
--- a/src/Common/test/Common.TestResources/Steeltoe.Common.TestResources.csproj
+++ b/src/Common/test/Common.TestResources/Steeltoe.Common.TestResources.csproj
@@ -2,6 +2,7 @@
   <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+    <IsPackable>False</IsPackable>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="$(AspNetCoreVersion)" />

--- a/src/Logging/src/DynamicLogger/DynamicLoggerHostBuilderExtensions.cs
+++ b/src/Logging/src/DynamicLogger/DynamicLoggerHostBuilderExtensions.cs
@@ -23,6 +23,11 @@ namespace Steeltoe.Extensions.Logging.DynamicLogger
 {
     public static class DynamicLoggerHostBuilderExtensions
     {
+        /// <summary>
+        /// Adds Dynamic Console Logging to your application. Removes ConsoleLoggerProvider if found (to prevent duplicate console log entries)<para />
+        /// Also calls ILoggingBuilder.AddConfiguration() if not previously called.
+        /// </summary>
+        /// <param name="hostBuilder">Your HostBuilder</param>
         public static IHostBuilder AddDynamicLogging(this IHostBuilder hostBuilder)
         {
             return hostBuilder

--- a/src/Logging/src/DynamicLogger/DynamicLoggerHostBuilderExtensions.cs
+++ b/src/Logging/src/DynamicLogger/DynamicLoggerHostBuilderExtensions.cs
@@ -1,0 +1,48 @@
+﻿// Copyright 2017 the original author or authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Configuration;
+using Microsoft.Extensions.Logging.Console;
+using System.Linq;
+
+namespace Steeltoe.Extensions.Logging.DynamicLogger
+{
+    public static class DynamicLoggerHostBuilderExtensions
+    {
+        public static IHostBuilder AddDynamicLogging(this IHostBuilder hostBuilder)
+        {
+            return hostBuilder
+                .ConfigureLogging(ilb =>
+                {
+                    // remove the original ConsoleLoggerProvider to prevent duplicate logging
+                    var serviceDescriptor = ilb.Services.FirstOrDefault(descriptor => descriptor.ImplementationType == typeof(ConsoleLoggerProvider));
+                    if (serviceDescriptor != null)
+                    {
+                        ilb.Services.Remove(serviceDescriptor);
+                    }
+
+                    // make sure logger provider configurations are available
+                    if (!ilb.Services.Any(descriptor => descriptor.ServiceType == typeof(ILoggerProviderConfiguration<ConsoleLoggerProvider>)))
+                    {
+                        ilb.AddConfiguration();
+                    }
+
+                    ilb.AddDynamicConsole();
+                });
+        }
+    }
+}

--- a/src/Logging/src/DynamicLogger/Steeltoe.Extensions.Logging.DynamicLogger.csproj
+++ b/src/Logging/src/DynamicLogger/Steeltoe.Extensions.Logging.DynamicLogger.csproj
@@ -9,14 +9,8 @@
   </PropertyGroup>
   <Import Project="..\..\..\..\sharedproject.props" />
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="$(LoggingVersion)" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
-    <FrameworkReference Include="Microsoft.AspNetCore.App" />
-  </ItemGroup>
-
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="$(LoggingVersion)" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="$(LoggingVersion)" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="$(LoggingVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="$(LoggingVersion)" />

--- a/src/Logging/src/DynamicLogger/Steeltoe.Extensions.Logging.DynamicLogger.csproj
+++ b/src/Logging/src/DynamicLogger/Steeltoe.Extensions.Logging.DynamicLogger.csproj
@@ -2,16 +2,23 @@
   <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup>
     <Description>Steeltoe Dynamic Console Logger</Description>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netcoreapp3.0</TargetFrameworks>
     <AssemblyName>Steeltoe.Extensions.Logging.DynamicLogger</AssemblyName>
     <PackageId>Steeltoe.Extensions.Logging.DynamicLogger</PackageId>
     <PackageTags>Spring Cloud;Logging;Management</PackageTags>
   </PropertyGroup>
   <Import Project="..\..\..\..\sharedproject.props" />
 
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="$(LoggingVersion)" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="$(ExtensionsVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="$(ExtensionsVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="$(LoggingVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="$(LoggingVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="$(LoggingVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="$(LoggingVersion)" />
   </ItemGroup>

--- a/src/Logging/test/DynamicLogger.Test/DynamicLoggerHostBuilderExtensionsTest.cs
+++ b/src/Logging/test/DynamicLogger.Test/DynamicLoggerHostBuilderExtensionsTest.cs
@@ -1,0 +1,77 @@
+﻿// Copyright 2017 the original author or authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Console;
+using System.Linq;
+using Xunit;
+
+namespace Steeltoe.Extensions.Logging.DynamicLogger.Test
+{
+    public class DynamicLoggerHostBuilderExtensionsTest
+    {
+        [Fact]
+        public void AddDynamicLogging_IHostBuilder_AddsDynamicLogging()
+        {
+            // Arrange
+            var hostBuilder = new HostBuilder().AddDynamicLogging();
+
+            // Act
+            var host = hostBuilder.Build();
+            var loggerProviders = host.Services.GetServices<ILoggerProvider>();
+
+            // Assert
+            Assert.Single(loggerProviders);
+            Assert.IsType<DynamicConsoleLoggerProvider>(loggerProviders.First());
+        }
+
+        [Fact]
+        public void AddDynamicLogging_IHostBuilder_RemovesConsoleLogging()
+        {
+            // Arrange
+            var hostBuilder = new HostBuilder()
+                .ConfigureLogging(ilb => ilb.AddConsole())
+                .AddDynamicLogging();
+
+            // Act
+            var host = hostBuilder.Build();
+            var loggerProviders = host.Services.GetServices<ILoggerProvider>();
+
+            // Assert
+            Assert.Single(loggerProviders);
+            Assert.IsType<DynamicConsoleLoggerProvider>(loggerProviders.First());
+        }
+
+#if NETCOREAPP3_0
+        [Fact]
+        public void AddDynamicLogging_IHostBuilder_RemovesConsoleLoggingDefaultBuilder()
+        {
+            // Arrange
+            var hostBuilder = Host.CreateDefaultBuilder()
+                .ConfigureLogging(ilb => ilb.AddConsole())
+                .AddDynamicLogging();
+
+            // Act
+            var host = hostBuilder.Build();
+            var loggerProviders = host.Services.GetServices<ILoggerProvider>();
+
+            // Assert
+            Assert.DoesNotContain(loggerProviders, lp => lp is ConsoleLoggerProvider);
+            Assert.Contains(loggerProviders, lp => lp is DynamicConsoleLoggerProvider);
+        }
+#endif
+    }
+}

--- a/src/Logging/test/DynamicLogger.Test/Steeltoe.Extensions.Logging.DynamicLogger.Test.csproj
+++ b/src/Logging/test/DynamicLogger.Test/Steeltoe.Extensions.Logging.DynamicLogger.Test.csproj
@@ -16,12 +16,10 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.0'">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="$(AspNetCoreVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="$(AspNetCoreVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore" Version="$(AspNetCoreVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="$(LoggingVersion)" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="$(AspNetCoreVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="$(LoggingVersion)" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Provides an extension for HostBuilder that removes the ConsoleLoggerProvider (if present) and adds Steeltoe's dynamic console logging 

also don't package TestResources