### PR TITLE
Service Discovery bugfix & minor feature

### DIFF
--- a/src/Discovery/src/ClientAutofac/DiscoveryContainerBuilderExtensions.cs
+++ b/src/Discovery/src/ClientAutofac/DiscoveryContainerBuilderExtensions.cs
@@ -200,7 +200,7 @@ namespace Steeltoe.Discovery.Client
             }).As<IConsulRegistration>().SingleInstance();
 
             container.RegisterType<ConsulServiceRegistrar>().As<IConsulServiceRegistrar>().SingleInstance();
-            container.RegisterType<ConsulDiscoveryClient>().As<IDiscoveryClient>().SingleInstance();
+            container.RegisterType<ConsulDiscoveryClient>().As<IDiscoveryClient>().As<IServiceInstanceProvider>().SingleInstance();
 
             container.RegisterType<ConsulHealthContributor>().As<IHealthContributor>().SingleInstance();
         }
@@ -237,7 +237,7 @@ namespace Steeltoe.Discovery.Client
         {
             container.RegisterType<EurekaApplicationInfoManager>().SingleInstance();
             container.RegisterType<EurekaDiscoveryManager>().SingleInstance();
-            container.RegisterType<EurekaDiscoveryClient>().AsSelf().As<IDiscoveryClient>().SingleInstance();
+            container.RegisterType<EurekaDiscoveryClient>().AsSelf().As<IDiscoveryClient>().As<IServiceInstanceProvider>().SingleInstance();
 
             if (lifecycle == null)
             {

--- a/src/Discovery/src/ClientCore/DiscoveryHostBuilderExtensions.cs
+++ b/src/Discovery/src/ClientCore/DiscoveryHostBuilderExtensions.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
@@ -26,12 +27,7 @@ namespace Steeltoe.Discovery.Client
         /// <param name="hostBuilder">Your HostBuilder</param>
         public static IWebHostBuilder AddServiceDiscovery(this IWebHostBuilder hostBuilder)
         {
-            return hostBuilder
-                .ConfigureServices((context, collection) =>
-                {
-                    collection.AddDiscoveryClient(context.Configuration);
-                    collection.AddTransient<IStartupFilter, DiscoveryClientStartupFilter>();
-                });
+            return hostBuilder.ConfigureServices((context, collection) => AddServices(collection, context.Configuration));
         }
 
         /// <summary>
@@ -40,12 +36,15 @@ namespace Steeltoe.Discovery.Client
         /// <param name="hostBuilder">Your HostBuilder</param>
         public static IHostBuilder AddServiceDiscovery(this IHostBuilder hostBuilder)
         {
-            return hostBuilder
-                .ConfigureServices((context, collection) =>
-                {
-                    collection.AddDiscoveryClient(context.Configuration);
-                    collection.AddTransient<IStartupFilter, DiscoveryClientStartupFilter>();
-                });
+            return hostBuilder.ConfigureServices((context, collection) => AddServices(collection, context.Configuration));
+        }
+
+        private static void AddServices(IServiceCollection collection, IConfiguration config)
+        {
+            collection.AddDiscoveryClient(config);
+            collection.AddTransient<IStartupFilter, DiscoveryClientStartupFilter>();
+            collection.AddHttpClient("DiscoveryRandom").AddRandomLoadBalancer();
+            collection.AddHttpClient("DiscoveryRoundRobin").AddRoundRobinLoadBalancer();
         }
     }
 }

--- a/src/Discovery/src/ClientCore/DiscoveryServiceCollectionExtensions.cs
+++ b/src/Discovery/src/ClientCore/DiscoveryServiceCollectionExtensions.cs
@@ -179,7 +179,7 @@ namespace Steeltoe.Discovery.Client
 
         private static void AddConsulServices(IServiceCollection services, IConfiguration config, IDiscoveryLifecycle lifecycle)
         {
-            services.AddSingleton<IConsulClient>((p) =>
+            services.AddSingleton((p) =>
             {
                 var consulOptions = p.GetRequiredService<IOptions<ConsulOptions>>();
                 return ConsulClientFactory.CreateClient(consulOptions.Value);
@@ -194,6 +194,7 @@ namespace Steeltoe.Discovery.Client
             });
             services.AddSingleton<IConsulServiceRegistrar, ConsulServiceRegistrar>();
             services.AddSingleton<IDiscoveryClient, ConsulDiscoveryClient>();
+            services.AddSingleton<IServiceInstanceProvider, ConsulDiscoveryClient>();
             services.AddSingleton<IHealthContributor, ConsulHealthContributor>();
         }
         #endregion Consul
@@ -252,6 +253,7 @@ namespace Steeltoe.Discovery.Client
                 return eurekaService;
             });
 
+            services.AddSingleton<IServiceInstanceProvider>(p => p.GetService<EurekaDiscoveryClient>());
             services.AddSingleton<IHealthContributor, EurekaServerHealthContributor>();
         }
 


### PR DESCRIPTION
Register `IDiscoveryClient`s as `IServiceInstanceProvider` so they work with the load balancers... also automatically register HttpClients that have load balancer schemes attached #170 #173