### PR TITLE
Change wrong log level from Error to Trace

### DIFF
--- a/src/Management/src/EndpointCore/ContentNegotiation/ContentNegotiationExtensions.cs
+++ b/src/Management/src/EndpointCore/ContentNegotiation/ContentNegotiationExtensions.cs
@@ -34,7 +34,7 @@ namespace Steeltoe.Management.EndpointCore.ContentNegotiation
 
         public static void LogContentType(this ILogger logger, IHeaderDictionary requestHeaders,  string contentType)
         {
-            logger?.LogError("setting contentType to {0}", contentType);
+            logger?.LogTrace("setting contentType to {0}", contentType);
             var logTrace = logger?.IsEnabled(LogLevel.Trace);
 
             if (logTrace.GetValueOrDefault())


### PR DESCRIPTION
Change the log level from error to trace when setting the content type response header for management endpoints.

See Issue #197