### PR TITLE
Support Postgres cert-related properties (GCP) #199

### DIFF
--- a/src/Common/src/Common/Extensions/UriExtensions.cs
+++ b/src/Common/src/Common/Extensions/UriExtensions.cs
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 using System;
+using System.Collections.Generic;
+using System.Net;
 
 namespace Steeltoe.Common.Extensions
 {
@@ -49,6 +51,26 @@ namespace Steeltoe.Common.Extensions
             };
 
             return builder.Uri;
+        }
+
+        /// <summary>
+        /// Parse a querystring into a dictionary of key value pairs
+        /// </summary>
+        /// <param name="querystring">The querystring to parse</param>
+        /// <returns>Pairs of keys and values</returns>
+        public static Dictionary<string, string> ParseQuerystring(string querystring)
+        {
+            var result = new Dictionary<string, string>();
+            foreach (var pair in querystring.Split('&'))
+            {
+                if (!string.IsNullOrEmpty(pair))
+                {
+                    var kvp = pair.Split('=');
+                    result.Add(kvp[0], WebUtility.UrlDecode(kvp[1]));
+                }
+            }
+
+            return result;
         }
     }
 }

--- a/src/Configuration/test/ConfigServerBase.Test/ConfigServerConfigurationProviderTest.cs
+++ b/src/Configuration/test/ConfigServerBase.Test/ConfigServerConfigurationProviderTest.cs
@@ -286,6 +286,7 @@ namespace Steeltoe.Extensions.Configuration.ConfigServer.Test
         }
 
         [Fact]
+        [Obsolete]
         public void AddPropertySource_ChangesDataDictionary()
         {
             // Arrange

--- a/src/Connectors/src/ConnectorBase/ConnectionStringManager.cs
+++ b/src/Connectors/src/ConnectorBase/ConnectionStringManager.cs
@@ -13,8 +13,6 @@
 // limitations under the License.
 
 using Microsoft.Extensions.Configuration;
-using System;
-using System.Reflection;
 
 namespace Steeltoe.CloudFoundry.Connector
 {

--- a/src/Connectors/src/ConnectorBase/Relational/PostgreSQL/PostgresConnectionInfo.cs
+++ b/src/Connectors/src/ConnectorBase/Relational/PostgreSQL/PostgresConnectionInfo.cs
@@ -17,7 +17,7 @@ using Steeltoe.CloudFoundry.Connector.Services;
 
 namespace Steeltoe.CloudFoundry.Connector.PostgreSql
 {
-    public class PostgresConnectionInfo : IConnectionInfo
+    public class PostgresConnectionInfo : Connection, IConnectionInfo
     {
         public Connection Get(IConfiguration configuration, string serviceName)
         {
@@ -27,11 +27,23 @@ namespace Steeltoe.CloudFoundry.Connector.PostgreSql
 
             var postgresConfig = new PostgresProviderConnectorOptions(configuration);
             var configurer = new PostgresProviderConfigurer();
-            return new Connection
-            {
-                ConnectionString = configurer.Configure(info, postgresConfig),
-                Name = "Postgres" + serviceName?.Insert(0, "-")
-            };
+
+            var connectionString = configurer.Configure(info, postgresConfig);
+
+            ClientCertificate = postgresConfig.ClientCertificate;
+            ClientKey = postgresConfig.ClientKey;
+            SslRootCertificate = postgresConfig.SslRootCertificate;
+
+            ConnectionString = connectionString;
+            Name = "Postgres" + serviceName?.Insert(0, "-");
+
+            return this;
         }
+
+        public string ClientCertificate { get; set; }
+
+        public string ClientKey { get; set; }
+
+        public string SslRootCertificate { get; set; }
     }
 }

--- a/src/Connectors/src/ConnectorBase/Relational/PostgreSQL/PostgresProviderConnectorOptions.cs
+++ b/src/Connectors/src/ConnectorBase/Relational/PostgreSQL/PostgresProviderConnectorOptions.cs
@@ -14,6 +14,8 @@
 
 using Microsoft.Extensions.Configuration;
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 
 namespace Steeltoe.CloudFoundry.Connector.PostgreSql
@@ -57,6 +59,18 @@ namespace Steeltoe.CloudFoundry.Connector.PostgreSql
 
         public string SearchPath { get; set; }
 
+        public string SslMode { get; set; }
+
+        public string ClientCertificate { get; set; }
+
+        public string ClientKey { get; set; }
+
+        public string SslRootCertificate { get; set; }
+
+        public bool? TrustServerCertificate { get; set; } = null;
+
+        internal Dictionary<string, string> Options { get; set; } = new Dictionary<string, string>();
+
         public override string ToString()
         {
             StringBuilder sb;
@@ -76,6 +90,16 @@ namespace Steeltoe.CloudFoundry.Connector.PostgreSql
             }
 
             AddKeyValue(sb, "Search Path", SearchPath);
+            AddKeyValue(sb, "sslmode", SslMode);
+            AddKeyValue(sb, "Trust Server Certificate", TrustServerCertificate);
+
+            if (Options != null && Options.Any())
+            {
+                foreach (var o in Options)
+                {
+                    AddKeyValue(sb, o.Key, o.Value);
+                }
+            }
 
             return sb.ToString();
         }

--- a/src/Connectors/src/ConnectorBase/Relational/SqlServer/SqlServerProviderConfigurer.cs
+++ b/src/Connectors/src/ConnectorBase/Relational/SqlServer/SqlServerProviderConfigurer.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using Steeltoe.CloudFoundry.Connector.Services;
+using Steeltoe.Common.Extensions;
 using System;
 using System.Net;
 
@@ -44,24 +45,23 @@ namespace Steeltoe.CloudFoundry.Connector.SqlServer
 
                 if (si.Query != null)
                 {
-                    foreach (var piece in si.Query.Split('&'))
+                    foreach (var kvp in UriExtensions.ParseQuerystring(si.Query))
                     {
-                        var kvp = piece.Split('=');
-                        if (kvp[0].EndsWith("database", StringComparison.InvariantCultureIgnoreCase) || kvp[0].EndsWith("databaseName", StringComparison.InvariantCultureIgnoreCase))
+                        if (kvp.Key.EndsWith("database", StringComparison.InvariantCultureIgnoreCase) || kvp.Key.EndsWith("databaseName", StringComparison.InvariantCultureIgnoreCase))
                         {
-                            configuration.Database = kvp[1];
+                            configuration.Database = kvp.Value;
                         }
-                        else if (kvp[0].EndsWith("instancename", StringComparison.InvariantCultureIgnoreCase))
+                        else if (kvp.Key.EndsWith("instancename", StringComparison.InvariantCultureIgnoreCase))
                         {
-                            configuration.InstanceName = kvp[1];
+                            configuration.InstanceName = kvp.Value;
                         }
-                        else if (kvp[0].StartsWith("hostnameincertificate", StringComparison.InvariantCultureIgnoreCase))
+                        else if (kvp.Key.StartsWith("hostnameincertificate", StringComparison.InvariantCultureIgnoreCase))
                         {
                             // adding this key could result in "System.ArgumentException : Keyword not supported: 'hostnameincertificate'" later
                         }
                         else
                         {
-                            configuration.Options.Add(kvp[0], kvp[1]);
+                            configuration.Options.Add(kvp.Key, kvp.Value);
                         }
                     }
                 }

--- a/src/Connectors/test/ConnectorCore.Test/PostgresProviderServiceCollectionExtensionsTest.cs
+++ b/src/Connectors/test/ConnectorCore.Test/PostgresProviderServiceCollectionExtensionsTest.cs
@@ -207,6 +207,8 @@ namespace Steeltoe.CloudFoundry.Connector.PostgreSql.Test
             Assert.Contains("Database=postgresample;", connString);
             Assert.Contains("Username=steeltoe7b59f5b8a34bce2a3cf873061cfb5815;", connString);
             Assert.Contains("Password=!DQ4Wm!r4omt$h1929!$;", connString);
+            Assert.Contains("sslmode=Require;", connString);
+            Assert.Contains("pooling=true;", connString);
         }
 
         [Fact]

--- a/src/Connectors/test/ConnectorCore.Test/PostgresTestHelpers.cs
+++ b/src/Connectors/test/ConnectorCore.Test/PostgresTestHelpers.cs
@@ -84,7 +84,7 @@ namespace Steeltoe.CloudFoundry.Connector.PostgreSql.Test
                         ""read_uri"": ""postgresql://steeltoe7b59f5b8a34bce2a3cf873061cfb5815:%21DQ4Wm%21r4omt%24h1929%21%24@10.194.45.174:5432/postgresample"",
                         ""service_id"": ""service-instance_9d294ea3-4745-4115-8ef2-0ee28f42bc78"",
                         ""service_role"": ""steeltoe"",
-                        ""uri"": ""postgresql://steeltoe7b59f5b8a34bce2a3cf873061cfb5815:%21DQ4Wm%21r4omt%24h1929%21%24@10.194.45.174:5432/postgresample"",
+                        ""uri"": ""postgresql://steeltoe7b59f5b8a34bce2a3cf873061cfb5815:%21DQ4Wm%21r4omt%24h1929%21%24@10.194.45.174:5432/postgresample?sslmode=require&pooling=true"",
                         ""username"": ""steeltoe7b59f5b8a34bce2a3cf873061cfb5815""
                     },
                     ""syslog_drain_url"": null,


### PR DESCRIPTION
Partial support for #199 -- does not address configuring cert callbacks, but provides a way for downstream developers to do so via `ConnectionStringManager`