### PR TITLE
Address "BAD NET NAME" with Windows file shares #202

### DIFF
--- a/src/Common/src/Common.Net/WindowsNetworkFileShare.cs
+++ b/src/Common/src/Common.Net/WindowsNetworkFileShare.cs
@@ -264,12 +264,17 @@ namespace Steeltoe.Common.Net
             public ResourceType ResourceType;
             public ResourceDisplaytype DisplayType;
             public int Usage;
+
+            [MarshalAs(UnmanagedType.LPTStr)]
             public string LocalName;
 
             [MarshalAs(UnmanagedType.LPTStr)]
             public string RemoteName;
 
+            [MarshalAs(UnmanagedType.LPTStr)]
             public string Comment;
+
+            [MarshalAs(UnmanagedType.LPTStr)]
             public string Provider;
         }
     }

--- a/src/Common/src/Common.Net/WindowsNetworkFileShare.cs
+++ b/src/Common/src/Common.Net/WindowsNetworkFileShare.cs
@@ -257,24 +257,16 @@ namespace Steeltoe.Common.Net
         /// The NETRESOURCE structure contains information about a network resource.
         /// More info on NetResource: <seealso href="https://msdn.microsoft.com/en-us/c53d078e-188a-4371-bdb9-fc023bc0c1ba"/>
         /// </summary>
-        [StructLayout(LayoutKind.Sequential)]
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
         public class NetResource
         {
             public ResourceScope Scope;
             public ResourceType ResourceType;
             public ResourceDisplaytype DisplayType;
             public int Usage;
-
-            [MarshalAs(UnmanagedType.LPTStr)]
             public string LocalName;
-
-            [MarshalAs(UnmanagedType.LPTStr)]
             public string RemoteName;
-
-            [MarshalAs(UnmanagedType.LPTStr)]
             public string Comment;
-
-            [MarshalAs(UnmanagedType.LPTStr)]
             public string Provider;
         }
     }

--- a/src/Common/src/Common.Net/WindowsNetworkFileShare.cs
+++ b/src/Common/src/Common.Net/WindowsNetworkFileShare.cs
@@ -265,7 +265,10 @@ namespace Steeltoe.Common.Net
             public ResourceDisplaytype DisplayType;
             public int Usage;
             public string LocalName;
+
+            [MarshalAs(UnmanagedType.LPTStr)]
             public string RemoteName;
+
             public string Comment;
             public string Provider;
         }


### PR DESCRIPTION
DLL Imports were changed to use CharSet.Unicode, resulting in unwanted alterations to the remote paths of remote file shares... this change allows the path to passed through to the underlying p/invoke call correctly #202 