### PR TITLE
Disable console logging color automatically on PCF. Addresses #196

### DIFF
--- a/src/Logging/Logging.sln
+++ b/src/Logging/Logging.sln
@@ -34,6 +34,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "dependencies", "dependencie
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Steeltoe.Common.TestResources", "..\Common\test\Common.TestResources\Steeltoe.Common.TestResources.csproj", "{B78BAA02-862A-4DD3-8E9F-407FEDA3C950}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Steeltoe.Common", "..\Common\src\Common\Steeltoe.Common.csproj", "{A393D6DA-492C-45C5-90E2-A32D43DE1C52}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -60,6 +62,10 @@ Global
 		{B78BAA02-862A-4DD3-8E9F-407FEDA3C950}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B78BAA02-862A-4DD3-8E9F-407FEDA3C950}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B78BAA02-862A-4DD3-8E9F-407FEDA3C950}.Release|Any CPU.Build.0 = Release|Any CPU
+        {A393D6DA-492C-45C5-90E2-A32D43DE1C52}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A393D6DA-492C-45C5-90E2-A32D43DE1C52}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A393D6DA-492C-45C5-90E2-A32D43DE1C52}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A393D6DA-492C-45C5-90E2-A32D43DE1C52}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -70,6 +76,7 @@ Global
 		{DF66D833-EAC4-4C84-A80F-74CFBD2BF78F} = {EEF15943-96DB-44B5-BA4A-1D11171AD74F}
 		{8F0B1896-E147-4516-A032-1043A4C1EB23} = {26E1A61B-FA79-41BF-9C3B-5A04299F356A}
 		{B78BAA02-862A-4DD3-8E9F-407FEDA3C950} = {6F22E520-D148-4A22-9B56-64840656D1F8}
+        {A393D6DA-492C-45C5-90E2-A32D43DE1C52} = {6F22E520-D148-4A22-9B56-64840656D1F8}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {F03D9805-6C7E-411E-A8D5-191ABE8D2F66}

--- a/src/Logging/src/DynamicLogger/DynamicLoggingBuilder.cs
+++ b/src/Logging/src/DynamicLogger/DynamicLoggingBuilder.cs
@@ -19,6 +19,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Configuration;
 using Microsoft.Extensions.Logging.Console;
 using Microsoft.Extensions.Options;
+using Steeltoe.Common;
 using System;
 using System.Linq;
 
@@ -67,6 +68,16 @@ namespace Steeltoe.Extensions.Logging
             public ConsoleLoggerOptionsSetup(ILoggerProviderConfiguration<ConsoleLoggerProvider> providerConfiguration)
                 : base(providerConfiguration.Configuration)
             {
+            }
+
+            public override void Configure(ConsoleLoggerOptions options)
+            {
+                if (Platform.IsCloudFoundry)
+                {
+                    options.DisableColors = true;
+                }
+
+                base.Configure(options);
             }
         }
     }

--- a/src/Logging/src/DynamicLogger/Steeltoe.Extensions.Logging.DynamicLogger.csproj
+++ b/src/Logging/src/DynamicLogger/Steeltoe.Extensions.Logging.DynamicLogger.csproj
@@ -18,13 +18,11 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(CI_BUILD)' == ''">
+    <ProjectReference Include="..\..\..\Common\src\Common\Steeltoe.Common.csproj" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(CI_BUILD)' == 'True'">
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\..\..\Common\src\Common\Steeltoe.Common.csproj" />
+    <PackageReference Include="Steeltoe.Common" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
   </ItemGroup>
 
 </Project>

--- a/src/Logging/src/DynamicLogger/Steeltoe.Extensions.Logging.DynamicLogger.csproj
+++ b/src/Logging/src/DynamicLogger/Steeltoe.Extensions.Logging.DynamicLogger.csproj
@@ -23,4 +23,8 @@
   <ItemGroup Condition="'$(CI_BUILD)' == 'True'">
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\Common\src\Common\Steeltoe.Common.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/versions.props
+++ b/versions.props
@@ -73,6 +73,6 @@
     <EF6Version>6.2.0</EF6Version>
     <ExtensionsVersion>2.2.0</ExtensionsVersion>
     <HealthChecksVersion>2.2.0</HealthChecksVersion>
-    <LoggingVersion>2.1.0</LoggingVersion>
+    <LoggingVersion>2.2.0</LoggingVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Guys, made the suggested modifications to solve #196. However, I was unable to find a way to unit test it, because I couldn't find a way to retrieve the DisableColors property. If you think it is extremely necessary to generate a unit test for this change, I'd ask you to help me find a way.

Additionally, as it was necessary to reference Platform, I had to add a reference to Steeltoe.Common, which also required to upgrade LoggingVersion from 2.1.0 to 2.20.