### PR TITLE
Fix usages of IPAddress.Parse.

### DIFF
--- a/src/Common/src/Common/Net/InetUtils.cs
+++ b/src/Common/src/Common/Net/InetUtils.cs
@@ -102,13 +102,7 @@ namespace Steeltoe.Common.Net
                 return result;
             }
 
-            string localHost = GetHostAddress();
-            if (!string.IsNullOrEmpty(localHost))
-            {
-                return IPAddress.Parse(localHost);
-            }
-
-            return null;
+            return GetHostAddress();
         }
 
         internal bool IsInet4Address(IPAddress address)
@@ -194,9 +188,9 @@ namespace Steeltoe.Common.Net
             return hostInfo;
         }
 
-        internal string ResolveHostAddress(string hostName)
+        internal IPAddress ResolveHostAddress(string hostName)
         {
-            string result = null;
+            IPAddress result = null;
             try
             {
                 var results = Dns.GetHostAddresses(hostName);
@@ -206,7 +200,7 @@ namespace Steeltoe.Common.Net
                     {
                         if (addr.AddressFamily.Equals(AddressFamily.InterNetwork))
                         {
-                            result = addr.ToString();
+                            result = addr;
                             break;
                         }
                     }
@@ -248,7 +242,7 @@ namespace Steeltoe.Common.Net
             return ResolveHostName();
         }
 
-        internal string GetHostAddress()
+        internal IPAddress GetHostAddress()
         {
             string hostName = GetHostName();
             if (!string.IsNullOrEmpty(hostName))

--- a/src/Discovery/src/ConsulBase/Util/ConsulServerUtils.cs
+++ b/src/Discovery/src/ConsulBase/Util/ConsulServerUtils.cs
@@ -43,24 +43,21 @@ namespace Steeltoe.Discovery.Consul.Util
 
         public static string FixIPv6Address(string address)
         {
-            try
+            if (IPAddress.TryParse(address, out IPAddress parsed) &&
+                parsed.AddressFamily == AddressFamily.InterNetworkV6)
             {
-                var parsed = IPAddress.Parse(address);
-                if (parsed.AddressFamily == AddressFamily.InterNetworkV6)
+                var bytes = parsed.GetAddressBytes();
+                StringBuilder sb = new StringBuilder("[");
+                for (int i = 0; i < bytes.Length; i = i + 2)
                 {
-                    var bytes = parsed.GetAddressBytes();
-                    StringBuilder sb = new StringBuilder("[");
-                    for (int i = 0; i < bytes.Length; i = i + 2)
-                    {
-                        ushort num = (ushort)((bytes[i] << 8) | bytes[i + 1]);
-                        sb.Append(num.ToString("x") + ":");
-                    }
-
-                    sb.Replace(':', ']', sb.Length - 1, 1);
-                    return sb.ToString();
+                    ushort num = (ushort)((bytes[i] << 8) | bytes[i + 1]);
+                    sb.Append(num.ToString("x") + ":");
                 }
+
+                sb.Replace(':', ']', sb.Length - 1, 1);
+                return sb.ToString();
             }
-            catch (Exception)
+            else
             {
                 // Log
             }


### PR DESCRIPTION
In ConsulServerUtils.FixIPv6Address, it is possible to get a non-valid IPAddress - ex. "localhost". This would cause an unnecessary exception, which was caught and discarded. Changed to use TryParse instead.

In InetUtils, the underlying method has an IPAddress, which it ToStrings, only to parse it again later. The change is to simply flow the IPAddress object.