### PR TITLE
EndpointWeb Fixes

### DIFF
--- a/src/Management/src/EndpointWeb/ActuatorConfigurator.cs
+++ b/src/Management/src/EndpointWeb/ActuatorConfigurator.cs
@@ -59,7 +59,7 @@ namespace Steeltoe.Management.Endpoint
 
         public static void UseCloudFoundryActuators(IConfiguration configuration, ILoggerProvider dynamicLogger, IEnumerable<IHealthContributor> healthContributors = null, IApiExplorer apiExplorer = null, ILoggerFactory loggerFactory = null)
         {
-            UseCloudFoundryActuators(configuration, dynamicLogger, MediaTypeVersion.V1, ActuatorContext.ActuatorAndCloudFoundry, healthContributors, apiExplorer);
+            UseCloudFoundryActuators(configuration, dynamicLogger, MediaTypeVersion.V1, ActuatorContext.ActuatorAndCloudFoundry, healthContributors, apiExplorer, loggerFactory);
         }
 
         public static void UseCloudFoundryActuators(IConfiguration configuration, ILoggerProvider dynamicLogger, MediaTypeVersion version, ActuatorContext context, IEnumerable<IHealthContributor> healthContributors = null, IApiExplorer apiExplorer = null, ILoggerFactory loggerFactory = null)
@@ -166,7 +166,7 @@ namespace Steeltoe.Management.Endpoint
             var options = new HeapDumpEndpointOptions(configuration);
             _mgmtOptions.RegisterEndpointOptions(configuration, options);
 
-            heapDumper = heapDumper ?? new HeapDumper(options);
+            heapDumper ??= new HeapDumper(options);
             var ep = new HeapDumpEndpoint(options, heapDumper, CreateLogger<HeapDumpEndpoint>(loggerFactory));
             var handler = new HeapDumpHandler(ep, SecurityServices, _mgmtOptions, CreateLogger<HeapDumpHandler>(loggerFactory));
             ConfiguredHandlers.Add(handler);
@@ -181,8 +181,8 @@ namespace Steeltoe.Management.Endpoint
                 return;
             }
 
-            healthAggregator = healthAggregator ?? new DefaultHealthAggregator();
-            contributors = contributors ?? new List<IHealthContributor>() { new DiskSpaceContributor(new DiskSpaceContributorOptions(configuration)) };
+            healthAggregator ??= new DefaultHealthAggregator();
+            contributors ??= new List<IHealthContributor>() { new DiskSpaceContributor(new DiskSpaceContributorOptions(configuration)) };
             var ep = new HealthEndpoint(options, healthAggregator, contributors, CreateLogger<HealthEndpoint>(loggerFactory));
             var handler = new HealthHandler(ep, SecurityServices, _mgmtOptions, CreateLogger<HealthHandler>(loggerFactory));
             ConfiguredHandlers.Add(handler);
@@ -198,7 +198,7 @@ namespace Steeltoe.Management.Endpoint
                 return;
             }
 
-            contributors = contributors ?? new List<IInfoContributor>() { new GitInfoContributor(), new AppSettingsInfoContributor(configuration) };
+            contributors ??= new List<IInfoContributor>() { new GitInfoContributor(), new AppSettingsInfoContributor(configuration) };
             var ep = new InfoEndpoint(options, contributors, CreateLogger<InfoEndpoint>(loggerFactory));
             var handler = new InfoHandler(ep, SecurityServices, _mgmtOptions, CreateLogger<InfoHandler>(loggerFactory));
             ConfiguredHandlers.Add(handler);
@@ -228,7 +228,7 @@ namespace Steeltoe.Management.Endpoint
             }
 
             _mgmtOptions.RegisterEndpointOptions(configuration, options);
-            threadDumper = threadDumper ?? new ThreadDumper(options);
+            threadDumper ??= new ThreadDumper(options);
             IActuatorHandler handler;
 
             switch (version)
@@ -268,7 +268,7 @@ namespace Steeltoe.Management.Endpoint
         {
             var options = new HttpTraceEndpointOptions(configuration);
             _mgmtOptions.RegisterEndpointOptions(configuration, options);
-            traceRepository = traceRepository ?? new HttpTraceDiagnosticObserver(options, CreateLogger<HttpTraceDiagnosticObserver>(loggerFactory));
+            traceRepository ??= new HttpTraceDiagnosticObserver(options, CreateLogger<HttpTraceDiagnosticObserver>(loggerFactory));
             DiagnosticsManager.Instance.Observers.Add((IDiagnosticObserver)traceRepository);
             var ep = new HttpTraceEndpoint(options, traceRepository, CreateLogger<HttpTraceEndpoint>(loggerFactory));
             var handler = new HttpTraceHandler(ep, SecurityServices, _mgmtOptions, CreateLogger<HttpTraceHandler>(loggerFactory));
@@ -288,7 +288,7 @@ namespace Steeltoe.Management.Endpoint
         {
             var options = new EnvEndpointOptions(configuration);
             _mgmtOptions.RegisterEndpointOptions(configuration, options);
-            hostingEnvironment = hostingEnvironment ?? new DefaultHostingEnvironment("development");
+            hostingEnvironment ??= new DefaultHostingEnvironment("development");
             var ep = new EnvEndpoint(options, configuration, hostingEnvironment, CreateLogger<EnvEndpoint>(loggerFactory));
             var handler = new EnvHandler(ep, SecurityServices, _mgmtOptions, CreateLogger<EnvHandler>(loggerFactory));
             ConfiguredHandlers.Add(handler);
@@ -359,7 +359,7 @@ namespace Steeltoe.Management.Endpoint
         {
             var options = new TraceEndpointOptions(configuration);
             _mgmtOptions.RegisterEndpointOptions(configuration, options);
-            traceRepository = traceRepository ?? new TraceDiagnosticObserver(options, CreateLogger<TraceDiagnosticObserver>(loggerFactory));
+            traceRepository ??= new TraceDiagnosticObserver(options, CreateLogger<TraceDiagnosticObserver>(loggerFactory));
             DiagnosticsManager.Instance.Observers.Add((IDiagnosticObserver)traceRepository);
             var ep = new TraceEndpoint(options, traceRepository, CreateLogger<TraceEndpoint>(loggerFactory));
             var handler = new TraceHandler(ep, SecurityServices, _mgmtOptions, CreateLogger<TraceHandler>(loggerFactory));

--- a/src/Management/src/EndpointWeb/Handler/LoggersHandler.cs
+++ b/src/Management/src/EndpointWeb/Handler/LoggersHandler.cs
@@ -17,6 +17,7 @@ using Steeltoe.Management.Endpoint.Loggers;
 using Steeltoe.Management.Endpoint.Security;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Web;
@@ -57,9 +58,9 @@ namespace Steeltoe.Management.Endpoint.Handler
                 var psPath = context.Request.Path;
                 var epPath = _endpoint.Path;
 
-                if (psPath.StartsWithSegments(epPath, out string remaining) && !string.IsNullOrEmpty(remaining))
+                if (psPath.StartsWithSegments(epPath, _mgmtOptions.Select(p => p.Path), out var remaining) && !string.IsNullOrEmpty(remaining))
                 {
-                    string loggerName = remaining.TrimStart('/');
+                    var loggerName = remaining.TrimStart('/');
 
                     var change = ((LoggersEndpoint)_endpoint).DeserializeRequest(context.Request.InputStream);
 

--- a/src/Management/src/EndpointWeb/Handler/MetricsHandler.cs
+++ b/src/Management/src/EndpointWeb/Handler/MetricsHandler.cs
@@ -89,7 +89,7 @@ namespace Steeltoe.Management.Endpoint.Handler
             foreach (var epPath in epPaths)
             {
                 var psPath = request.Path;
-                if (psPath.StartsWithSegments(epPath, out string remaining) && !string.IsNullOrEmpty(remaining))
+                if (psPath.StartsWithSegments(epPath, _mgmtOptions.Select(p => p.Path), out var remaining) && !string.IsNullOrEmpty(remaining))
                 {
                     return remaining.TrimStart('/');
                 }

--- a/src/Management/src/EndpointWeb/StringExtensions.cs
+++ b/src/Management/src/EndpointWeb/StringExtensions.cs
@@ -13,19 +13,42 @@
 // limitations under the License.
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Steeltoe.Management.Endpoint
 {
     public static class StringExtensions
     {
-        public static bool StartsWithSegments(this string incoming, string other, out string remaining)
+        /// <summary>
+        /// Evaluate if a path starts with a given segment, including optional base paths
+        /// </summary>
+        /// <param name="incoming">path to evaluate</param>
+        /// <param name="other">path to search for</param>
+        /// <param name="baseSegments">base segments that should be considered separately</param>
+        /// <param name="remaining">the result</param>
+        /// <returns>remainder of path after base segment(s) and searched-for segment have been considered</returns>
+        public static bool StartsWithSegments(this string incoming, string other, IEnumerable<string> baseSegments, out string remaining)
         {
-            string value1 = incoming ?? string.Empty;
-            string value2 = other ?? string.Empty;
+            var value1 = incoming ?? string.Empty;
+            var value2 = other ?? string.Empty;
             if (value1.StartsWith(value2, StringComparison.OrdinalIgnoreCase) && (value1.Length == value2.Length || value1[value2.Length] == '/'))
             {
                 remaining = value1.Substring(value2.Length);
                 return true;
+            }
+
+            if (baseSegments?.Any() == true)
+            {
+                foreach (var pathBase in baseSegments.Distinct())
+                {
+                    var testPath = string.Concat(pathBase, '/', value2);
+                    if (value1.StartsWith(testPath, StringComparison.OrdinalIgnoreCase) && (value1.Length == testPath.Length || value1[testPath.Length] == '/'))
+                    {
+                        remaining = value1.Substring(testPath.Length);
+                        return true;
+                    }
+                }
             }
 
             remaining = string.Empty;

--- a/src/Management/test/EndpointWeb.Net4Test/StringExtensionsTest.cs
+++ b/src/Management/test/EndpointWeb.Net4Test/StringExtensionsTest.cs
@@ -1,0 +1,78 @@
+﻿// Copyright 2017 the original author or authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Steeltoe.Management.Endpoint;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Steeltoe.Management.EndpointWeb.Test
+{
+    public class StringExtensionsTest
+    {
+        [Fact]
+        public void StartsWithSegments_ReturnsFalseWithNoMatch()
+        {
+            // arrange
+            var incomingPath = "ShouldNotBeFound";
+            var configuredPath = "notconfigured";
+
+            // act
+            var result = incomingPath.StartsWithSegments(configuredPath, null, out var remnant);
+
+            // assert
+            Assert.False(result);
+            Assert.Equal(string.Empty, remnant);
+        }
+
+        [Fact]
+        public void StartsWithSegments_ReturnsTrueAndSetsRemnantWithMatch()
+        {
+            // arrange
+            var configuredPath = "found";
+            var incomingPath = "found/something";
+
+            // act
+            var result = incomingPath.StartsWithSegments(configuredPath, null, out var remnant);
+
+            // assert
+            Assert.True(result);
+            Assert.Equal("/something", remnant);
+        }
+
+        [Fact]
+        public void StartsWithSegments_WithBasePath_ReturnsTrueAndSetsRemnantWithMatch()
+        {
+            // arrange
+            var configuredPath1 = "cloudfoundryapplication/loggers";
+            var incomingPath1 = "cloudfoundryapplication/loggers/something";
+            var configuredPath2 = "actuator/metrics";
+            var incomingPath2 = "actuator/metrics/something";
+            var basePaths = new List<string> { "actuator", "cloudfoundryapplication" };
+
+            // act
+            var result1 = incomingPath1.StartsWithSegments(configuredPath1, basePaths, out var remnant1);
+            var result2 = incomingPath2.StartsWithSegments(configuredPath2, basePaths, out var remnant2);
+
+            // assert
+            Assert.True(result1);
+            Assert.Equal("/something", remnant1);
+            Assert.True(result2);
+            Assert.Equal("/something", remnant2);
+        }
+    }
+}


### PR DESCRIPTION
POST requests recently stopped working for loggers (and presumably metrics as well) apparently due to hypermedia-related changes. This PR updates the code to consider configured actuator base path(s) (eg: /actuator and /cloudfoundryapplication)

I also fixed an instance where a `LoggerFactory` param didn't make it down to a lower level method call