### PR TITLE
Drop netcoreapp3.0 from tests

### DIFF
--- a/src/CircuitBreaker/test/Hystrix.MetricsEventsCore.Test/Steeltoe.CircuitBreaker.Hystrix.MetricsEventsCore.Test.csproj
+++ b/src/CircuitBreaker/test/Hystrix.MetricsEventsCore.Test/Steeltoe.CircuitBreaker.Hystrix.MetricsEventsCore.Test.csproj
@@ -1,8 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.0;netcoreapp3.1;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;</TargetFrameworks>
   </PropertyGroup>
+  
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedtest.props" />
 
   <ItemGroup>

--- a/src/CircuitBreaker/test/Hystrix.MetricsStreamCore.Test/Steeltoe.CircuitBreaker.Hystrix.MetricsStreamCore.Test.csproj
+++ b/src/CircuitBreaker/test/Hystrix.MetricsStreamCore.Test/Steeltoe.CircuitBreaker.Hystrix.MetricsStreamCore.Test.csproj
@@ -1,8 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.0;netcoreapp3.1;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;</TargetFrameworks>
   </PropertyGroup>
+  
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedtest.props" />
 
   <ItemGroup>

--- a/src/CircuitBreaker/test/HystrixBase.Test/Steeltoe.CircuitBreaker.HystrixBase.Test.csproj
+++ b/src/CircuitBreaker/test/HystrixBase.Test/Steeltoe.CircuitBreaker.HystrixBase.Test.csproj
@@ -1,8 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.0;netcoreapp3.1;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;</TargetFrameworks>
   </PropertyGroup>
+  
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedtest.props" />
 
   <PropertyGroup>

--- a/src/CircuitBreaker/test/HystrixCore.Test/Steeltoe.CircuitBreaker.HystrixCore.Test.csproj
+++ b/src/CircuitBreaker/test/HystrixCore.Test/Steeltoe.CircuitBreaker.HystrixCore.Test.csproj
@@ -1,8 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.0;netcoreapp3.1;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;</TargetFrameworks>
   </PropertyGroup>
+  
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedtest.props" />
 
   <ItemGroup>

--- a/src/Common/test/Common.Hosting.Test/Steeltoe.Common.Hosting.Test.csproj
+++ b/src/Common/test/Common.Hosting.Test/Steeltoe.Common.Hosting.Test.csproj
@@ -1,8 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.0;netcoreapp3.1;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;</TargetFrameworks>
   </PropertyGroup>
+  
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedtest.props" />
 
   <ItemGroup>

--- a/src/Common/test/Common.Http.Test/Steeltoe.Common.Http.Test.csproj
+++ b/src/Common/test/Common.Http.Test/Steeltoe.Common.Http.Test.csproj
@@ -1,8 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;</TargetFrameworks>
   </PropertyGroup>
+  
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedtest.props" />
 
   <ItemGroup>

--- a/src/Common/test/Common.Net.Test/Steeltoe.Common.Net.Test.csproj
+++ b/src/Common/test/Common.Net.Test/Steeltoe.Common.Net.Test.csproj
@@ -1,8 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.0;netcoreapp3.1;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;</TargetFrameworks>
   </PropertyGroup>
+  
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedtest.props" />
 
   <ItemGroup>

--- a/src/Common/test/Common.Test/Steeltoe.Common.Test.csproj
+++ b/src/Common/test/Common.Test/Steeltoe.Common.Test.csproj
@@ -1,8 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.0;netcoreapp3.1;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;</TargetFrameworks>
   </PropertyGroup>
+  
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedtest.props" />
 
   <ItemGroup>

--- a/src/Configuration/test/CloudFoundryBase.Test/Steeltoe.Extensions.Configuration.CloudFoundryBase.Test.csproj
+++ b/src/Configuration/test/CloudFoundryBase.Test/Steeltoe.Extensions.Configuration.CloudFoundryBase.Test.csproj
@@ -1,8 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.0;netcoreapp3.1;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;</TargetFrameworks>
   </PropertyGroup>
+  
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedtest.props" />
 
   <ItemGroup>

--- a/src/Configuration/test/CloudFoundryCore.Test/Steeltoe.Extensions.Configuration.CloudFoundryCore.Test.csproj
+++ b/src/Configuration/test/CloudFoundryCore.Test/Steeltoe.Extensions.Configuration.CloudFoundryCore.Test.csproj
@@ -1,8 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.0;netcoreapp3.1;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;</TargetFrameworks>
   </PropertyGroup>
+  
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedtest.props" />
 
   <ItemGroup>

--- a/src/Configuration/test/ConfigServer.ITest/Steeltoe.Extensions.Configuration.ConfigServer.ITest.csproj
+++ b/src/Configuration/test/ConfigServer.ITest/Steeltoe.Extensions.Configuration.ConfigServer.ITest.csproj
@@ -1,8 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.0;netcoreapp3.1;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;</TargetFrameworks>
   </PropertyGroup>
+  
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedtest.props" />
 
   <ItemGroup>

--- a/src/Configuration/test/ConfigServerBase.Test/Steeltoe.Extensions.Configuration.ConfigServerBase.Test.csproj
+++ b/src/Configuration/test/ConfigServerBase.Test/Steeltoe.Extensions.Configuration.ConfigServerBase.Test.csproj
@@ -1,8 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.0;netcoreapp3.1;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;</TargetFrameworks>
   </PropertyGroup>
+  
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedtest.props" />
 
   <ItemGroup>

--- a/src/Configuration/test/ConfigServerCore.Test/Steeltoe.Extensions.Configuration.ConfigServerCore.Test.csproj
+++ b/src/Configuration/test/ConfigServerCore.Test/Steeltoe.Extensions.Configuration.ConfigServerCore.Test.csproj
@@ -1,8 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.0;netcoreapp3.1;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;</TargetFrameworks>
   </PropertyGroup>
+  
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedtest.props" />
 
   <ItemGroup>

--- a/src/Configuration/test/PlaceholderBase.Test/Steeltoe.Extensions.Configuration.PlaceholderBase.Test.csproj
+++ b/src/Configuration/test/PlaceholderBase.Test/Steeltoe.Extensions.Configuration.PlaceholderBase.Test.csproj
@@ -1,8 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.0;netcoreapp3.1;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;</TargetFrameworks>
   </PropertyGroup>
+  
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedtest.props" />
 
   <ItemGroup>

--- a/src/Configuration/test/PlaceholderCore.Test/Steeltoe.Extensions.Configuration.PlaceholderCore.Test.csproj
+++ b/src/Configuration/test/PlaceholderCore.Test/Steeltoe.Extensions.Configuration.PlaceholderCore.Test.csproj
@@ -1,8 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.0;netcoreapp3.1;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;</TargetFrameworks>
   </PropertyGroup>
+  
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedtest.props" />
 
   <ItemGroup>

--- a/src/Configuration/test/RandomValuesBase.Test/Steeltoe.Extensions.Configuration.RandomValueBase.Test.csproj
+++ b/src/Configuration/test/RandomValuesBase.Test/Steeltoe.Extensions.Configuration.RandomValueBase.Test.csproj
@@ -1,8 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.0;netcoreapp3.1;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;</TargetFrameworks>
   </PropertyGroup>
+  
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedtest.props" />
 
   <ItemGroup>

--- a/src/Connectors/test/Connector.EF6Core.Net4Test/Steeltoe.CloudFoundry.Connector.EF6Core.Test.csproj
+++ b/src/Connectors/test/Connector.EF6Core.Net4Test/Steeltoe.CloudFoundry.Connector.EF6Core.Test.csproj
@@ -1,8 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;</TargetFrameworks>
   </PropertyGroup>
+  
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedtest.props" />
 
   <ItemGroup>

--- a/src/Connectors/test/Connector.EFCore.Test/Steeltoe.CloudFoundry.Connector.EFCore.Test.csproj
+++ b/src/Connectors/test/Connector.EFCore.Test/Steeltoe.CloudFoundry.Connector.EFCore.Test.csproj
@@ -1,8 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.0;netcoreapp3.1;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;</TargetFrameworks>
   </PropertyGroup>
+  
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedtest.props" />
 
   <ItemGroup>

--- a/src/Connectors/test/ConnectorBase.Test/Steeltoe.CloudFoundry.ConnectorBase.Test.csproj
+++ b/src/Connectors/test/ConnectorBase.Test/Steeltoe.CloudFoundry.ConnectorBase.Test.csproj
@@ -1,8 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.0;netcoreapp3.1;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;</TargetFrameworks>
   </PropertyGroup>
+  
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedtest.props" />
 
   <ItemGroup>

--- a/src/Connectors/test/ConnectorCore.Test/Steeltoe.CloudFoundry.ConnectorCore.Test.csproj
+++ b/src/Connectors/test/ConnectorCore.Test/Steeltoe.CloudFoundry.ConnectorCore.Test.csproj
@@ -1,8 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.0;netcoreapp3.1;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;</TargetFrameworks>
   </PropertyGroup>
+  
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedtest.props" />
 
   <ItemGroup>

--- a/src/Discovery/test/ClientCore.Test/Steeltoe.Discovery.ClientCore.Test.csproj
+++ b/src/Discovery/test/ClientCore.Test/Steeltoe.Discovery.ClientCore.Test.csproj
@@ -1,8 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.0;netcoreapp3.1;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;</TargetFrameworks>
   </PropertyGroup>
+  
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedtest.props" />
 
   <ItemGroup>

--- a/src/Discovery/test/ConsulBase.Test/Steeltoe.Discovery.ConsulBase.Test.csproj
+++ b/src/Discovery/test/ConsulBase.Test/Steeltoe.Discovery.ConsulBase.Test.csproj
@@ -1,8 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.0;netcoreapp3.1;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;</TargetFrameworks>
   </PropertyGroup>
+  
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedtest.props" />
 
   <ItemGroup>

--- a/src/Discovery/test/EurekaBase.Test/Steeltoe.Discovery.EurekaBase.Test.csproj
+++ b/src/Discovery/test/EurekaBase.Test/Steeltoe.Discovery.EurekaBase.Test.csproj
@@ -1,8 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.0;netcoreapp3.1;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;</TargetFrameworks>
   </PropertyGroup>
+  
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedtest.props" />
 
   <ItemGroup>

--- a/src/Logging/test/DynamicLogger.Test/Steeltoe.Extensions.Logging.DynamicLogger.Test.csproj
+++ b/src/Logging/test/DynamicLogger.Test/Steeltoe.Extensions.Logging.DynamicLogger.Test.csproj
@@ -1,8 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.0;netcoreapp3.1;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;</TargetFrameworks>
   </PropertyGroup>
+  
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedtest.props" />
 
   <ItemGroup>

--- a/src/Logging/test/SerilogDynamicLoggerCore.Test/Steeltoe.Extensions.Logging.SerilogDynamicLoggerCore.Test.csproj
+++ b/src/Logging/test/SerilogDynamicLoggerCore.Test/Steeltoe.Extensions.Logging.SerilogDynamicLoggerCore.Test.csproj
@@ -1,8 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.0;netcoreapp3.1;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;</TargetFrameworks>
   </PropertyGroup>
+  
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedtest.props" />
 
   <ItemGroup>

--- a/src/Management/test/CloudFoundryCore.Test/Steeltoe.Management.CloudFoundryCore.Test.csproj
+++ b/src/Management/test/CloudFoundryCore.Test/Steeltoe.Management.CloudFoundryCore.Test.csproj
@@ -1,8 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.0;netcoreapp3.1;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;</TargetFrameworks>
   </PropertyGroup>
+  
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedtest.props" />
 
   <ItemGroup>

--- a/src/Management/test/EndpointBase.Test/Steeltoe.Management.EndpointBase.Test.csproj
+++ b/src/Management/test/EndpointBase.Test/Steeltoe.Management.EndpointBase.Test.csproj
@@ -1,8 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.0;netcoreapp3.1;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;</TargetFrameworks>
   </PropertyGroup>
+  
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedtest.props" />
 
   <ItemGroup>

--- a/src/Management/test/EndpointCore.Test/Steeltoe.Management.EndpointCore.Test.csproj
+++ b/src/Management/test/EndpointCore.Test/Steeltoe.Management.EndpointCore.Test.csproj
@@ -1,8 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.0;netcoreapp3.1;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;</TargetFrameworks>
   </PropertyGroup>
+  
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedtest.props" />
 
   <ItemGroup>

--- a/src/Security/test/DataProtection.RedisCore.Test/Steeltoe.Security.DataProtection.RedisCore.Test.csproj
+++ b/src/Security/test/DataProtection.RedisCore.Test/Steeltoe.Security.DataProtection.RedisCore.Test.csproj
@@ -1,8 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.0;netcoreapp3.1;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;</TargetFrameworks>
   </PropertyGroup>
+  
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedtest.props" />
 
   <ItemGroup>


### PR DESCRIPTION
.NET Core 3.0 hit "End of Life" today, this PR drops it from tests

https://devblogs.microsoft.com/dotnet/net-core-3-0-end-of-life/