### PR TITLE
Implement CertificateSource.OptionsConfigurer

### DIFF
--- a/src/Common/src/Common.Http/ClientCertificateHttpHandlerProvider.cs
+++ b/src/Common/src/Common.Http/ClientCertificateHttpHandlerProvider.cs
@@ -28,6 +28,7 @@ namespace Steeltoe.Common.Http
         {
             certificateOptions = certOptions;
             certificateOptions.OnChange(RotateCert);
+            RotateCert(certificateOptions.CurrentValue);
         }
 
         public HttpClientHandler GetHttpClientHandler()

--- a/src/Common/src/Common.Security/CertificateSource.cs
+++ b/src/Common/src/Common.Security/CertificateSource.cs
@@ -27,7 +27,7 @@ namespace Steeltoe.Common.Security
             _certFilePath = Path.GetFullPath(certFilePath);
         }
 
-        public Type OptionsConfigurer => throw new NotImplementedException();
+        public Type OptionsConfigurer => typeof(ConfigureCertificateOptions);
 
         public IConfigurationProvider Build(IConfigurationBuilder builder)
         {

--- a/src/Common/src/Common.Security/CertificateSource.cs
+++ b/src/Common/src/Common.Security/CertificateSource.cs
@@ -42,15 +42,11 @@ namespace Steeltoe.Common.Security
                 Path = Path.GetFileName(_certFilePath),
                 Optional = false,
                 ReloadOnChange = true,
-                ReloadDelay = 1000
+                ReloadDelay = 1000,
+                BasePath = Path.GetDirectoryName(_certFilePath)
             };
 
-            var certProvider = new ConfigurationBuilder()
-                .SetBasePath(Path.GetDirectoryName(_certFilePath))
-                .Add(certSource)
-                .Build();
-
-            return new CertificateProvider(certProvider);
+            return new CertificateProvider(certSource);
         }
     }
 }

--- a/src/Common/src/Common.Security/ConfigureCertificateOptions.cs
+++ b/src/Common/src/Common.Security/ConfigureCertificateOptions.cs
@@ -50,7 +50,7 @@ namespace Steeltoe.Common.Security
                 return;
             }
 
-            options.Certificate = new X509Certificate2(certPath);
+            options.Certificate = new X509Certificate2(certPath, string.Empty, X509KeyStorageFlags.EphemeralKeySet);
         }
 
         public void Configure(CertificateOptions options)

--- a/src/Common/src/Common.Security/PemCertificateSource.cs
+++ b/src/Common/src/Common.Security/PemCertificateSource.cs
@@ -68,6 +68,8 @@ namespace Steeltoe.Common.Security
 #pragma warning disable SA1402 // File may only contain a single class
     internal class FileSource : FileConfigurationSource
     {
+        internal string BasePath { get; set; }
+
         internal string Key { get; }
 
         public FileSource(string key)

--- a/src/Common/test/Common.Security.Test/CertificateSourceTest.cs
+++ b/src/Common/test/Common.Security.Test/CertificateSourceTest.cs
@@ -1,0 +1,27 @@
+﻿// Copyright 2017 the original author or authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Xunit;
+
+namespace Steeltoe.Common.Security.Test
+{
+    public class CertificateSourceTest
+    {
+        [Fact]
+        public void CertificateSource_HasOptionsConfigurer()
+        {
+            Assert.NotNull(new CertificateSource("somePath").OptionsConfigurer);
+        }
+    }
+}

--- a/src/Common/test/Common.Security.Test/ConfigurationExtensionsTest.cs
+++ b/src/Common/test/Common.Security.Test/ConfigurationExtensionsTest.cs
@@ -106,7 +106,7 @@ namespace Steeltoe.Common.Security.Test
             var config = new ConfigurationBuilder()
                 .AddCertificateFile("instance.p12")
                 .Build();
-            Assert.Equal("instance.p12", config["certificate"]);
+            Assert.Equal(Path.GetFullPath("instance.p12"), config["certificate"]);
         }
 
         [Fact]

--- a/src/Common/test/Common.Security.Test/PemCertificateSourceTest.cs
+++ b/src/Common/test/Common.Security.Test/PemCertificateSourceTest.cs
@@ -1,0 +1,27 @@
+﻿// Copyright 2017 the original author or authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Xunit;
+
+namespace Steeltoe.Common.Security.Test
+{
+    public class PemCertificateSourceTest
+    {
+        [Fact]
+        public void PemCertificateSource_HasOptionsConfigurer()
+        {
+            Assert.NotNull(new PemCertificateSource("somePath", "somePath").OptionsConfigurer);
+        }
+    }
+}


### PR DESCRIPTION
Fixes oversight of `CertificateSource.OptionsConfigurer` not being set, add a tests to validate it is set on both implementations of ICertificateSource. Also several bugfixes for ASC