### PR TITLE
Adding spring placeholder resolution

### DIFF
--- a/src/Common/src/Common/Configuration/PropertyPlaceHolderHelper.cs
+++ b/src/Common/src/Common/Configuration/PropertyPlaceHolderHelper.cs
@@ -91,9 +91,6 @@ namespace Steeltoe.Common.Configuration
                 {
                     string placeholder = result.Substring(startIndex + PREFIX.Length, endIndex);
 
-                    // Replace Spring delimiters ('.') with MS-friendly delimiters (':') so Spring placeholders can also be resolved
-                    placeholder = placeholder.Replace(".", ":");
-
                     string originalPlaceholder = placeholder;
 
                     if (!visitedPlaceHolders.Add(originalPlaceholder))
@@ -126,6 +123,14 @@ namespace Steeltoe.Common.Configuration
                         {
                             propVal = string.Empty;
                         }
+                    }
+
+                    // Attempt to resolve as a spring-compatible placeholder
+                    if (propVal == null)
+                    {
+                        // Replace Spring delimiters ('.') with MS-friendly delimiters (':') so Spring placeholders can also be resolved
+                        lookup = placeholder.Replace(".", ":");
+                        propVal = config[lookup];
                     }
 
                     if (propVal != null)

--- a/src/Common/src/Common/Configuration/PropertyPlaceHolderHelper.cs
+++ b/src/Common/src/Common/Configuration/PropertyPlaceHolderHelper.cs
@@ -90,6 +90,10 @@ namespace Steeltoe.Common.Configuration
                 if (endIndex != -1)
                 {
                     string placeholder = result.Substring(startIndex + PREFIX.Length, endIndex);
+
+                    // Replace Spring period delimiters with MS-friendly delimiters so spring placeholders can also be resolved
+                    placeholder = placeholder.Replace(".", ":");
+
                     string originalPlaceholder = placeholder;
 
                     if (!visitedPlaceHolders.Add(originalPlaceholder))

--- a/src/Common/src/Common/Configuration/PropertyPlaceHolderHelper.cs
+++ b/src/Common/src/Common/Configuration/PropertyPlaceHolderHelper.cs
@@ -91,7 +91,7 @@ namespace Steeltoe.Common.Configuration
                 {
                     string placeholder = result.Substring(startIndex + PREFIX.Length, endIndex);
 
-                    // Replace Spring period delimiters with MS-friendly delimiters so spring placeholders can also be resolved
+                    // Replace Spring delimiters ('.') with MS-friendly delimiters (':') so Spring placeholders can also be resolved
                     placeholder = placeholder.Replace(".", ":");
 
                     string originalPlaceholder = placeholder;

--- a/src/Common/test/Common.Test/Configuration/PropertyPlaceholderHelperTest.cs
+++ b/src/Common/test/Common.Test/Configuration/PropertyPlaceholderHelperTest.cs
@@ -41,6 +41,24 @@ namespace Steeltoe.Common.Configuration.Test
         }
 
         [Fact]
+        public void ResolvePlaceholders_ResolvesSingleSpringPlaceholder()
+        {
+            // Arrange
+            var text = "foo=${foo.bar}";
+            var builder = new ConfigurationBuilder();
+            var dic1 = new Dictionary<string, string>()
+                {
+                    { "foo:bar", "bar" }
+                };
+            builder.AddInMemoryCollection(dic1);
+            var config = builder.Build();
+
+            // Act and Assert
+            var result = PropertyPlaceholderHelper.ResolvePlaceholders(text, config);
+            Assert.Equal("foo=bar", result);
+        }
+
+        [Fact]
         public void ResolvePlaceholders_ResolvesMultiplePlaceholders()
         {
             // Arrange
@@ -59,6 +77,24 @@ namespace Steeltoe.Common.Configuration.Test
         }
 
         [Fact]
+        public void ResolvePlaceholders_ResolvesMultipleSpringPlaceholders()
+        {
+            // Arrange
+            var text = "foo=${foo.boo},bar=${bar.far}";
+            var builder = new ConfigurationBuilder();
+            var dic1 = new Dictionary<string, string>()
+                {
+                    { "foo:boo", "bar" },
+                    { "bar:far", "baz" }
+                };
+            builder.AddInMemoryCollection(dic1);
+
+            // Act and Assert
+            var result = PropertyPlaceholderHelper.ResolvePlaceholders(text, builder.Build());
+            Assert.Equal("foo=bar,bar=baz", result);
+        }
+
+        [Fact]
         public void ResolvePlaceholders_ResolvesMultipleRecursivePlaceholders()
         {
             // Arrange
@@ -68,6 +104,25 @@ namespace Steeltoe.Common.Configuration.Test
                 {
                     { "bar", "${baz}" },
                     { "baz", "bar" }
+                };
+            builder.AddInMemoryCollection(dic1);
+            var config = builder.Build();
+
+            // Act and Assert
+            var result = PropertyPlaceholderHelper.ResolvePlaceholders(text, config);
+            Assert.Equal("foo=bar", result);
+        }
+
+        [Fact]
+        public void ResolvePlaceholders_ResolvesMultipleRecursiveSpringPlaceholders()
+        {
+            // Arrange
+            var text = "foo=${bar.boo}";
+            var builder = new ConfigurationBuilder();
+            var dic1 = new Dictionary<string, string>()
+                {
+                    { "bar:boo", "${baz.faz}" },
+                    { "baz:faz", "bar" }
                 };
             builder.AddInMemoryCollection(dic1);
             var config = builder.Build();
@@ -99,6 +154,39 @@ namespace Steeltoe.Common.Configuration.Test
                     { "child", "${${differentiator}.grandchild}" },
                     { "differentiator", "first" },
                     { "first.grandchild", "actualValue" }
+                };
+            builder2.AddInMemoryCollection(dic2);
+            var config2 = builder2.Build();
+
+            // Act and Assert
+            var result1 = PropertyPlaceholderHelper.ResolvePlaceholders(text1, config1);
+            Assert.Equal("foo=bar", result1);
+            var result2 = PropertyPlaceholderHelper.ResolvePlaceholders(text2, config2);
+            Assert.Equal("actualValue+actualValue", result2);
+        }
+
+        [Fact]
+        public void ResolvePlaceholders_ResolvesMultipleRecursiveInSpringPlaceholders()
+        {
+            // Arrange
+            var text1 = "foo=${b${inner.placeholder}}";
+            var builder1 = new ConfigurationBuilder();
+            var dic1 = new Dictionary<string, string>()
+                {
+                    { "bar", "bar" },
+                    { "inner:placeholder", "ar" }
+                };
+            builder1.AddInMemoryCollection(dic1);
+            var config1 = builder1.Build();
+
+            var text2 = "${top}";
+            var builder2 = new ConfigurationBuilder();
+            var dic2 = new Dictionary<string, string>()
+                {
+                    { "top", "${child}+${child}" },
+                    { "child", "${${differentiator}.grandchild}" },
+                    { "differentiator", "first" },
+                    { "first:grandchild", "actualValue" }
                 };
             builder2.AddInMemoryCollection(dic2);
             var config2 = builder2.Build();


### PR DESCRIPTION
Added a '.' to ':' replacement on identified placeholder before resolution to ensure that spring placeholders can be resolved. Attempted only after other resolution attempts have failed.