### PR TITLE
Fix CloudFoundryApplicationOptions binding

### DIFF
--- a/src/Configuration/src/CloudFoundryCore/CloudFoundryServiceCollectionExtensions.cs
+++ b/src/Configuration/src/CloudFoundryCore/CloudFoundryServiceCollectionExtensions.cs
@@ -45,7 +45,7 @@ namespace Steeltoe.Extensions.Configuration.CloudFoundry
 
             services.AddOptions();
 
-            var appSection = config.GetSection(CloudFoundryApplicationOptions.PlatformConfigRoot);
+            var appSection = config.GetSection(CloudFoundryApplicationOptions.PlatformConfigRoot + ":" + CloudFoundryApplicationOptions.ApplicationRoot);
             services.Configure<CloudFoundryApplicationOptions>(appSection);
 
             var serviceSection = config.GetSection(CloudFoundryServicesOptions.ServicesConfigRoot);

--- a/src/Configuration/test/CloudFoundryCore.Test/CloudFoundryServiceCollectionExtensionsTest.cs
+++ b/src/Configuration/test/CloudFoundryCore.Test/CloudFoundryServiceCollectionExtensionsTest.cs
@@ -52,6 +52,7 @@ namespace Steeltoe.Extensions.Configuration.CloudFoundry.Test
         {
             // Arrange
             var services = new ServiceCollection();
+            Environment.SetEnvironmentVariable("VCAP_APPLICATION", @"{ ""cf_api"": ""https://api.run.pcfone.io"", ""limits"": { ""fds"": 16384 }, ""application_name"": ""foo"", ""application_uris"": [ ""foo-unexpected-serval-iy.apps.pcfone.io"" ], ""name"": ""foo"", ""space_name"": ""playground"", ""space_id"": ""f03f2ab0-cf33-416b-999c-fb01c1247753"", ""organization_id"": ""d7afe5cb-2d42-487b-a415-f47c0665f1ba"", ""organization_name"": ""pivot-thess"", ""uris"": [ ""foo-unexpected-serval-iy.apps.pcfone.io"" ], ""users"": null, ""application_id"": ""f69a6624-7669-43e3-a3c8-34d23a17e3db"" }");
 
             // Act and Assert
             var builder = new ConfigurationBuilder().AddCloudFoundry();
@@ -61,6 +62,8 @@ namespace Steeltoe.Extensions.Configuration.CloudFoundry.Test
             var serviceProvider = services.BuildServiceProvider();
             var app = serviceProvider.GetService<IOptions<CloudFoundryApplicationOptions>>();
             Assert.NotNull(app.Value);
+            Assert.Equal("foo", app.Value.ApplicationName);
+            Assert.Equal("playground", app.Value.SpaceName);
             var service = serviceProvider.GetService<IOptions<CloudFoundryServicesOptions>>();
             Assert.NotNull(service.Value);
         }


### PR DESCRIPTION
As a consequence of the ApplicationOptions refactoring this was binding to the wrong key/section... fix the binding and update the relevant test to actually check that some values were bound