### PR TITLE
Don't add LoadBalancerDelegatingHandler directly

### DIFF
--- a/src/Common/src/Common.Http/LoadBalancer/LoadBalancerHttpClientBuilderExtensions.cs
+++ b/src/Common/src/Common.Http/LoadBalancer/LoadBalancerHttpClientBuilderExtensions.cs
@@ -77,7 +77,6 @@ namespace Microsoft.Extensions.DependencyInjection
                 throw new ArgumentNullException(nameof(httpClientBuilder));
             }
 
-            httpClientBuilder.Services.TryAddTransient<LoadBalancerDelegatingHandler>();
             httpClientBuilder.AddHttpMessageHandler((services) => new LoadBalancerDelegatingHandler(services.GetRequiredService<T>()));
             return httpClientBuilder;
         }

--- a/src/Discovery/src/ClientCore/DiscoveryServiceCollectionExtensions.cs
+++ b/src/Discovery/src/ClientCore/DiscoveryServiceCollectionExtensions.cs
@@ -159,6 +159,7 @@ namespace Steeltoe.Discovery.Client
             }
 
             services.TryAddTransient<DiscoveryHttpMessageHandler>();
+            services.AddSingleton<IServiceInstanceProvider>(p => p.GetService<IDiscoveryClient>());
         }
 
         #region Consul
@@ -194,7 +195,6 @@ namespace Steeltoe.Discovery.Client
             });
             services.AddSingleton<IConsulServiceRegistrar, ConsulServiceRegistrar>();
             services.AddSingleton<IDiscoveryClient, ConsulDiscoveryClient>();
-            services.AddSingleton<IServiceInstanceProvider, ConsulDiscoveryClient>();
             services.AddSingleton<IHealthContributor, ConsulHealthContributor>();
         }
         #endregion Consul
@@ -253,7 +253,6 @@ namespace Steeltoe.Discovery.Client
                 return eurekaService;
             });
 
-            services.AddSingleton<IServiceInstanceProvider>(p => p.GetService<EurekaDiscoveryClient>());
             services.AddSingleton<IHealthContributor, EurekaServerHealthContributor>();
         }
 


### PR DESCRIPTION
Address #293 in 2.x
Also consolidates the mechanism for supplying `IServiceInstanceProvider`