### PR TITLE
Fix heartbeat interval calculation

### DIFF
--- a/src/Discovery/src/ConsulBase/Discovery/ConsulHeartbeatOptions.cs
+++ b/src/Discovery/src/ConsulBase/Discovery/ConsulHeartbeatOptions.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Steeltoe.Discovery.Consul.Util;
 using System;
 
 namespace Steeltoe.Discovery.Consul.Discovery
@@ -54,14 +55,16 @@ namespace Steeltoe.Discovery.Consul.Discovery
 
         internal TimeSpan ComputeHearbeatInterval()
         {
+            var second = TimeSpan.FromSeconds(1);
+            var ttl = DateTimeConversions.ToTimeSpan(TtlValue, TtlUnit);
+
             // heartbeat rate at ratio * ttl, but no later than ttl -1s and, (under lesser priority),
             // no sooner than 1s from now
-            double interval = TtlValue * IntervalRatio;
-            double max = Math.Max(interval, 1);
-            int ttlMinus1 = TtlValue - 1;
-            double min = Math.Min(ttlMinus1, max);
-            double heartbeatInterval = (int)Math.Round(1000 * min);
-            return TimeSpan.FromMilliseconds(heartbeatInterval);
+            var interval = ttl * IntervalRatio;
+            var max = interval > second ? interval : second;
+            var ttlMinus1sec = ttl - second;
+            var min = ttlMinus1sec < max ? ttlMinus1sec : max;
+            return min;
         }
     }
 }

--- a/src/Discovery/test/ConsulBase.Test/Discovery/ConsulHeartbeatOptionsTest.cs
+++ b/src/Discovery/test/ConsulBase.Test/Discovery/ConsulHeartbeatOptionsTest.cs
@@ -30,21 +30,23 @@ namespace Steeltoe.Discovery.Consul.Discovery.Test
             Assert.Equal("30s", opts.Ttl);
         }
 
-        [Fact]
-        public void ComputeHeartbeatIntervalWorks()
+        [Theory]
+        [InlineData(30, "s", 2.0 / 3.0, 20000)]
+        [InlineData(30, "s", 1.0 / 3.0, 10000)]
+        [InlineData(10, "m", 0.1, 60000)]
+        [InlineData(1, "h", 0.1, 360000)]
+        [InlineData(2, "s", 2.0 / 3.0, 1000)]
+        [InlineData(1, "s", 2.0 / 3.0, 0)]
+        [InlineData(0, "s", 2.0 / 3.0, -1000)]
+        public void ComputeHeartbeatIntervalWorks(int ttl, string unit, double ratio, int expected)
         {
             ConsulHeartbeatOptions opts = new ConsulHeartbeatOptions();
-            var period = opts.ComputeHearbeatInterval();
-            Assert.Equal(TimeSpan.FromSeconds(20), period);
-        }
+            opts.TtlValue = ttl;
+            opts.TtlUnit = unit;
+            opts.IntervalRatio = ratio;
 
-        [Fact]
-        public void ComputeShortHeartbeat()
-        {
-            ConsulHeartbeatOptions opts = new ConsulHeartbeatOptions();
-            opts.TtlValue = 2;
             var period = opts.ComputeHearbeatInterval();
-            Assert.Equal(TimeSpan.FromSeconds(1), period);
+            Assert.Equal(TimeSpan.FromMilliseconds(expected), period);
         }
     }
 }


### PR DESCRIPTION
It seems like interval calculations for consul's heartbeat does not respect TtlUnit parameter.
F.e. ttl "10m" with ratio 0.1 will produce 1 second interval instead of 1 minute.
Also I've merged multiple tests into one theory and extent cases a bit.