### PR TITLE
Fix IApplicationInstanceInfo bug with Zipkin tracing

### DIFF
--- a/src/Management/src/TracingCore/Steeltoe.Management.TracingCore.csproj
+++ b/src/Management/src/TracingCore/Steeltoe.Management.TracingCore.csproj
@@ -17,12 +17,14 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(CI_BUILD)' == ''">
+    <ProjectReference Include="..\..\..\Common\src\Common\Steeltoe.Common.csproj" />
     <ProjectReference Include="..\..\..\Logging\src\DynamicLogger\Steeltoe.Extensions.Logging.DynamicLogger.csproj" />
     <ProjectReference Include="..\TracingBase\Steeltoe.Management.TracingBase.csproj" />
     <ProjectReference Include="..\Abstractions\Steeltoe.Management.Abstractions.csproj" />
     <ProjectReference Include="..\OpenTelemetryBase\Steeltoe.Management.OpenTelemetryBase.csproj" />
   </ItemGroup>
   <ItemGroup Condition="'$(CI_BUILD)' == 'True'">
+    <PackageReference Include="Steeltoe.Common" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
     <PackageReference Include="Steeltoe.Extensions.Logging.DynamicLogger" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
     <PackageReference Include="Steeltoe.Management.TracingBase" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
     <PackageReference Include="Steeltoe.Management.Abstractions" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />

--- a/src/Management/src/TracingCore/TracingServiceCollectionExtensions.cs
+++ b/src/Management/src/TracingCore/TracingServiceCollectionExtensions.cs
@@ -41,7 +41,7 @@ namespace Steeltoe.Management.Tracing
                 throw new ArgumentNullException(nameof(config));
             }
 
-            var appInstanceInfo = services.BuildServiceProvider().GetService<IApplicationInstanceInfo>();
+            var appInstanceInfo = services.GetApplicationInstanceInfo();
 
             services.TryAddSingleton<IDiagnosticsManager, DiagnosticsManager>();
             services.TryAddEnumerable(ServiceDescriptor.Singleton<IHostedService, TracingService>());

--- a/src/Management/test/TaskCore.Test/Steeltoe.Management.TaskCore.Test.csproj
+++ b/src/Management/test/TaskCore.Test/Steeltoe.Management.TaskCore.Test.csproj
@@ -1,8 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.0;netcoreapp3.1;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;</TargetFrameworks>
   </PropertyGroup>
+
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedtest.props" />
 
   <ItemGroup>

--- a/src/Management/test/TracingBase.Test/Steeltoe.Management.TracingBase.Test.csproj
+++ b/src/Management/test/TracingBase.Test/Steeltoe.Management.TracingBase.Test.csproj
@@ -1,8 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.0;netcoreapp3.1;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;</TargetFrameworks>
   </PropertyGroup>
+
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedtest.props" />
 
   <ItemGroup>

--- a/src/Management/test/TracingCore.Test/Steeltoe.Management.TracingCore.Test.csproj
+++ b/src/Management/test/TracingCore.Test/Steeltoe.Management.TracingCore.Test.csproj
@@ -1,8 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.0;netcoreapp3.1;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;</TargetFrameworks>
   </PropertyGroup>
+
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedtest.props" />
 
   <ItemGroup>

--- a/src/Management/test/TracingCore.Test/TracingServiceCollectionExtensionsTest.cs
+++ b/src/Management/test/TracingCore.Test/TracingServiceCollectionExtensionsTest.cs
@@ -47,7 +47,7 @@ namespace Steeltoe.Management.Tracing.Test
         {
             var services = new ServiceCollection();
             var config = GetConfiguration();
-
+            services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
             services.AddOptions();
             services.AddSingleton(HostingHelpers.GetHostingEnvironment());
             services.AddDistributedTracing(config);


### PR DESCRIPTION
Use GetApplicationInstanceInfo helper so that a generic `IApplicationInstanceInfo` is added if no other is found  #323
