### PR TITLE
Address "BAD NET NAME" with Windows file shares

### DIFF
--- a/src/Common/src/Common.Net/WindowsNetworkFileShare.cs
+++ b/src/Common/src/Common.Net/WindowsNetworkFileShare.cs
@@ -234,7 +234,7 @@ namespace Steeltoe.Common.Net
         /// The NETRESOURCE structure contains information about a network resource.
         /// More info on NetResource: <seealso href="https://msdn.microsoft.com/en-us/c53d078e-188a-4371-bdb9-fc023bc0c1ba"/>
         /// </summary>
-        [StructLayout(LayoutKind.Sequential)]
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
         public class NetResource
         {
             public ResourceScope Scope;


### PR DESCRIPTION
* Fix string marshaling issues on P/Invoke calls by using CharSet.Unicode on NetResource
 to prevent error "BAD NET NAME" with Windows file shares #202