### PR TITLE
Fix DeregisterCriticalServiceAfter configuration on ttl healthchecks - Consul

### DIFF
--- a/src/Discovery/src/ConsulBase/Registry/ConsulRegistration.cs
+++ b/src/Discovery/src/ConsulBase/Registry/ConsulRegistration.cs
@@ -236,6 +236,12 @@ namespace Steeltoe.Discovery.Consul.Registry
         internal static AgentServiceCheck CreateCheck(int port, ConsulDiscoveryOptions options)
         {
             AgentServiceCheck check = new AgentServiceCheck();
+
+            if (!string.IsNullOrEmpty(options.HealthCheckCriticalTimeout))
+            {
+                check.DeregisterCriticalServiceAfter = DateTimeConversions.ToTimeSpan(options.HealthCheckCriticalTimeout);
+            }
+
             if (options.IsHeartBeatEnabled)
             {
                 check.TTL = DateTimeConversions.ToTimeSpan(options.Heartbeat.Ttl);
@@ -266,11 +272,6 @@ namespace Steeltoe.Discovery.Consul.Registry
             if (!string.IsNullOrEmpty(options.HealthCheckTimeout))
             {
                 check.Timeout = DateTimeConversions.ToTimeSpan(options.HealthCheckTimeout);
-            }
-
-            if (!string.IsNullOrEmpty(options.HealthCheckCriticalTimeout))
-            {
-                check.DeregisterCriticalServiceAfter = DateTimeConversions.ToTimeSpan(options.HealthCheckCriticalTimeout);
             }
 
             check.TLSSkipVerify = options.HealthCheckTlsSkipVerify;

--- a/src/Discovery/test/ConsulBase.Test/Registry/ConsulRegistrationTest.cs
+++ b/src/Discovery/test/ConsulBase.Test/Registry/ConsulRegistrationTest.cs
@@ -210,8 +210,8 @@ namespace Steeltoe.Discovery.Consul.Registry.Test
             ConsulDiscoveryOptions options = new ConsulDiscoveryOptions();
             var result = ConsulRegistration.CreateCheck(1234, options);
             Assert.NotNull(result);
-            var expectedTtl = DateTimeConversions.ToTimeSpan(options.Heartbeat.Ttl);
-            Assert.Equal(result.TTL, expectedTtl);
+            Assert.Equal(DateTimeConversions.ToTimeSpan(options.Heartbeat.Ttl), result.TTL);
+            Assert.Equal(DateTimeConversions.ToTimeSpan(options.HealthCheckCriticalTimeout), result.DeregisterCriticalServiceAfter);
 
             options.Heartbeat = null;
             Assert.Throws<ArgumentException>(() => ConsulRegistration.CreateCheck(0, options));


### PR DESCRIPTION
DeregisterCriticalServiceAfter property doesn't set properly if ttl healthcheck enabled.
I think it is not correct, because DeregisterCriticalServiceAfter feature work pretty well with ttl healthchecks too.
Note: this pr modify default behaviour and can broke backward compatibility a bit. I don't know if it is critical or not =)