### PR TITLE
Health async interfaces poc

### DIFF
--- a/src/Common/src/Abstractions/HealthChecks/IAsyncHealthAggregator.cs
+++ b/src/Common/src/Abstractions/HealthChecks/IAsyncHealthAggregator.cs
@@ -12,18 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using Microsoft.Extensions.Diagnostics.HealthChecks;
-using Microsoft.Extensions.Options;
-using Steeltoe.Common.HealthChecks;
-using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using HealthCheckResult = Steeltoe.Common.HealthChecks.HealthCheckResult;
 
-namespace Steeltoe.Management.Endpoint.Health
+namespace Steeltoe.Common.HealthChecks
 {
-    public interface IHealthRegistrationsAggregator
+    public interface IAsyncHealthAggregator
     {
-        Task<HealthCheckResult> Aggregate(IEnumerable<IHealthContributor> contributors, IEnumerable<IAsyncHealthContributor> asyncContributors, IOptionsMonitor<HealthCheckServiceOptions> healthServiceOptions, IServiceProvider serviceProvider);
+        Task<HealthCheckResult> Aggregate(IEnumerable<IAsyncHealthContributor> contributors);
     }
 }

--- a/src/Common/src/Abstractions/HealthChecks/IAsyncHealthContributor.cs
+++ b/src/Common/src/Abstractions/HealthChecks/IAsyncHealthContributor.cs
@@ -12,18 +12,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using Microsoft.Extensions.Diagnostics.HealthChecks;
-using Microsoft.Extensions.Options;
-using Steeltoe.Common.HealthChecks;
-using System;
-using System.Collections.Generic;
 using System.Threading.Tasks;
-using HealthCheckResult = Steeltoe.Common.HealthChecks.HealthCheckResult;
 
-namespace Steeltoe.Management.Endpoint.Health
+namespace Steeltoe.Common.HealthChecks
 {
-    public interface IHealthRegistrationsAggregator
+    /// <summary>
+    /// Implement this interface and add to DI to be included in health checks
+    /// </summary>
+    public interface IAsyncHealthContributor
     {
-        Task<HealthCheckResult> Aggregate(IEnumerable<IHealthContributor> contributors, IEnumerable<IAsyncHealthContributor> asyncContributors, IOptionsMonitor<HealthCheckServiceOptions> healthServiceOptions, IServiceProvider serviceProvider);
+        /// <summary>
+        /// Gets an identifier for the type of check being performed
+        /// </summary>
+        string Id { get; }
+
+        /// <summary>
+        /// Check the health of a resource
+        /// </summary>
+        /// <returns>The result of checking the health of a resource</returns>
+        Task<HealthCheckResult> CheckHealthAsync();
     }
 }

--- a/src/Management/src/EndpointBase/Health/Contributor/DiskSpaceAsyncContributor.cs
+++ b/src/Management/src/EndpointBase/Health/Contributor/DiskSpaceAsyncContributor.cs
@@ -1,0 +1,33 @@
+﻿// Copyright 2017 the original author or authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Steeltoe.Common.HealthChecks;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace Steeltoe.Management.Endpoint.Health.Contributor
+{
+    public class DiskSpaceAsyncContributor : DiskSpaceContributor, IAsyncHealthContributor
+    {
+        public DiskSpaceAsyncContributor(DiskSpaceContributorOptions options = null)
+            : base(options)
+        {
+        }
+
+        public async Task<HealthCheckResult> CheckHealthAsync()
+        {
+            return await Task.Run(() => Health());
+        }
+    }
+}

--- a/src/Management/src/EndpointBase/Health/DefaultAsyncHealthAggregator.cs
+++ b/src/Management/src/EndpointBase/Health/DefaultAsyncHealthAggregator.cs
@@ -1,0 +1,69 @@
+﻿// Copyright 2017 the original author or authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Steeltoe.Common.HealthChecks;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using HealthCheckResult = Steeltoe.Common.HealthChecks.HealthCheckResult;
+
+namespace Steeltoe.Management.Endpoint.Health
+{
+    public class DefaultAsyncHealthAggregator : IAsyncHealthAggregator
+    {
+        public async Task<HealthCheckResult> Aggregate(IEnumerable<IAsyncHealthContributor> contributors)
+        {
+            if (contributors == null)
+            {
+                return new HealthCheckResult();
+            }
+
+            var result = new HealthCheckResult();
+            foreach (var contributor in contributors)
+            {
+                HealthCheckResult h = null;
+                try
+                {
+                    h = await contributor.CheckHealthAsync();
+                }
+                catch (Exception)
+                {
+                    h = new HealthCheckResult();
+                }
+
+                if (h.Status > result.Status)
+                {
+                    result.Status = h.Status;
+                }
+
+                string key = GetKey(result, contributor.Id);
+                result.Details.Add(key, h.Details);
+            }
+
+            return result;
+        }
+
+        protected static string GetKey(HealthCheckResult result, string key)
+        {
+            // add the contribtor with a -n appended to the id
+            if (result.Details.ContainsKey(key))
+            {
+                return string.Concat(key, "-", result.Details.Count(k => k.Key == key));
+            }
+
+            return key;
+        }
+    }
+}

--- a/src/Management/src/EndpointBase/Metrics/MetricsObserverOptions.cs
+++ b/src/Management/src/EndpointBase/Metrics/MetricsObserverOptions.cs
@@ -72,6 +72,6 @@ namespace Steeltoe.Management.Endpoint.Metrics
 
         public bool HttpClientDesktop { get; set; } = false;
 
-        public bool HystrixEvents { get; set; } = false;
+        public bool HystrixEvents { get; set; } = true;
     }
 }

--- a/src/Management/src/EndpointBase/Metrics/MetricsObserverOptions.cs
+++ b/src/Management/src/EndpointBase/Metrics/MetricsObserverOptions.cs
@@ -72,6 +72,6 @@ namespace Steeltoe.Management.Endpoint.Metrics
 
         public bool HttpClientDesktop { get; set; } = false;
 
-        public bool HystrixEvents { get; set; } = true;
+        public bool HystrixEvents { get; set; } = false;
     }
 }

--- a/src/Management/src/EndpointBase/Metrics/Observer/EventSourceListener.cs
+++ b/src/Management/src/EndpointBase/Metrics/Observer/EventSourceListener.cs
@@ -47,7 +47,7 @@ namespace Steeltoe.Management.Endpoint.Metrics.Observer
         protected virtual void ExtractAndRecordMetric(
             string eventSourceName,
             EventWrittenEventArgs eventData,
-            IDictionary<string, string> labels,
+            IDictionary<string, string> labels = null,
             string[] ignorePayloadNames = null,
             string[] counterNames = null)
         {

--- a/src/Management/src/EndpointBase/Metrics/Observer/HystrixEventsListener.cs
+++ b/src/Management/src/EndpointBase/Metrics/Observer/HystrixEventsListener.cs
@@ -34,7 +34,7 @@ namespace Steeltoe.Management.Endpoint.Metrics.Observer
         };
 
         private readonly ILogger<EventSourceListener> _logger;
-        private readonly Dictionary<string, string> cktBreakerLabels = new Dictionary<string, string>();
+       // private readonly Dictionary<string, string> cktBreakerLabels = new Dictionary<string, string>();
 
         public HystrixEventsListener(IStats stats, ILogger<EventSourceListener> logger = null)
             : base(stats, logger)
@@ -53,7 +53,7 @@ namespace Steeltoe.Management.Endpoint.Metrics.Observer
             {
                 if (_allowedEvents.Any(e => e.Equals(eventData.EventName, StringComparison.InvariantCulture)))
                 {
-                    ExtractAndRecordMetric(EventSourceName, eventData, cktBreakerLabels);
+                    ExtractAndRecordMetric(EventSourceName, eventData);
                 }
             }
             catch (Exception ex)

--- a/src/Management/src/EndpointCore/Health/EndpointServiceCollectionExtensions.cs
+++ b/src/Management/src/EndpointCore/Health/EndpointServiceCollectionExtensions.cs
@@ -82,7 +82,41 @@ namespace Steeltoe.Management.Endpoint.Health
             services.TryAddSingleton<IHealthAggregator>(aggregator);
             services.TryAddScoped<HealthEndpointCore>();
         }
+        /// <summary>
+        /// Adds components of the Health actuator to Microsoft-DI
+        /// </summary>
+        /// <param name="services">Service collection to add health to</param>
+        /// <param name="config">Application configuration (this actuator looks for a settings starting with management:endpoints:health)</param>
+        /// <param name="aggregator">Custom health aggregator</param>
+        /// <param name="contributors">Contributors to application health</param>
+        public static void AddHealthActuator(this IServiceCollection services, IConfiguration config, IHealthRegistrationsAggregator aggregator, params Type[] contributors)
+        {
+            if (services == null)
+            {
+                throw new ArgumentNullException(nameof(services));
+            }
 
+            if (config == null)
+            {
+                throw new ArgumentNullException(nameof(config));
+            }
+
+            if (aggregator == null)
+            {
+                throw new ArgumentNullException(nameof(aggregator));
+            }
+
+            services.TryAddEnumerable(ServiceDescriptor.Singleton<IManagementOptions>(new ActuatorManagementOptions(config)));
+            services.TryAddEnumerable(ServiceDescriptor.Singleton<IManagementOptions>(new CloudFoundryManagementOptions(config)));
+
+            var options = new HealthEndpointOptions(config);
+            services.TryAddSingleton<IHealthOptions>(options);
+            services.RegisterEndpointOptions(options);
+            AddHealthContributors(services, contributors);
+
+            services.TryAddSingleton<IHealthRegistrationsAggregator>(aggregator);
+            services.TryAddScoped<HealthEndpointCore>();
+        }
         public static void AddHealthContributors(IServiceCollection services, params Type[] contributors)
         {
             List<ServiceDescriptor> descriptors = new List<ServiceDescriptor>();

--- a/src/Management/src/EndpointCore/Health/EndpointServiceCollectionExtensions.cs
+++ b/src/Management/src/EndpointCore/Health/EndpointServiceCollectionExtensions.cs
@@ -82,6 +82,7 @@ namespace Steeltoe.Management.Endpoint.Health
             services.TryAddSingleton<IHealthAggregator>(aggregator);
             services.TryAddScoped<HealthEndpointCore>();
         }
+
         /// <summary>
         /// Adds components of the Health actuator to Microsoft-DI
         /// </summary>
@@ -117,12 +118,20 @@ namespace Steeltoe.Management.Endpoint.Health
             services.TryAddSingleton<IHealthRegistrationsAggregator>(aggregator);
             services.TryAddScoped<HealthEndpointCore>();
         }
+
         public static void AddHealthContributors(IServiceCollection services, params Type[] contributors)
         {
             List<ServiceDescriptor> descriptors = new List<ServiceDescriptor>();
             foreach (var c in contributors)
             {
-                descriptors.Add(new ServiceDescriptor(typeof(IHealthContributor), c, ServiceLifetime.Scoped));
+                if (typeof(IAsyncHealthContributor).IsAssignableFrom(c))
+                {
+                    descriptors.Add(new ServiceDescriptor(typeof(IAsyncHealthContributor), c, ServiceLifetime.Scoped));
+                }
+                else
+                {
+                    descriptors.Add(new ServiceDescriptor(typeof(IHealthContributor), c, ServiceLifetime.Scoped));
+                }
             }
 
             services.TryAddEnumerable(descriptors);
@@ -132,7 +141,7 @@ namespace Steeltoe.Management.Endpoint.Health
         {
             return new Type[]
             {
-                typeof(DiskSpaceContributor)
+                typeof(DiskSpaceAsyncContributor)
             };
         }
     }

--- a/src/Management/src/EndpointCore/Health/HealthCheckExtensions.cs
+++ b/src/Management/src/EndpointCore/Health/HealthCheckExtensions.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Linq;
 using System.Threading.Tasks;
@@ -60,7 +61,7 @@ namespace Steeltoe.Management.Endpoint.Health
             };
         }
 
-        public static async Task<HealthCheckResult> HealthCheck(this HealthCheckRegistration registration, IServiceProvider provider)
+        public static async Task<HealthCheckResult> CheckHealthAsync(this HealthCheckRegistration registration, IServiceProvider provider)
         {
             var context = new HealthCheckContext { Registration = registration };
             var healthCheckResult = new HealthCheckResult();
@@ -88,6 +89,28 @@ namespace Steeltoe.Management.Endpoint.Health
 #pragma warning restore CA1031 // Do not catch general exception types
 
             return healthCheckResult;
+        }
+
+        public static HealthCheckResult Merge(this HealthCheckResult result, HealthCheckResult next, ILogger logger = null)
+        {
+            if (result == null)
+            {
+                throw new ArgumentNullException(nameof(result));
+            }
+
+            if (next == null)
+            {
+                throw new ArgumentNullException(nameof(next));
+            }
+
+            result.Status = result.Status > next.Status ? result.Status : next.Status;
+            foreach (var detail in next.Details)
+            {
+                result.Details.Add(detail.Key, detail.Value);
+            }
+
+            result.Description += next.Description;
+            return result;
         }
     }
 }

--- a/src/Management/src/EndpointCore/Health/HealthEndpointCore.cs
+++ b/src/Management/src/EndpointCore/Health/HealthEndpointCore.cs
@@ -20,16 +20,16 @@ using Steeltoe.Management.Endpoint.Security;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using HealthCheckResult = Steeltoe.Common.HealthChecks.HealthCheckResult;
 
 namespace Steeltoe.Management.Endpoint.Health
 {
     public class HealthEndpointCore : HealthEndpoint
     {
+        private readonly IHealthRegistrationsAggregator _registrationsAggregator;
         private readonly IOptionsMonitor<HealthCheckServiceOptions> _serviceOptions;
         private readonly IServiceProvider _provider;
-        private readonly IHealthAggregator _aggregator;
-        private readonly IList<IHealthContributor> _contributors;
         private readonly ILogger<HealthEndpoint> _logger;
 
         public HealthEndpointCore(IHealthOptions options, IHealthAggregator aggregator, IEnumerable<IHealthContributor> contributors, IOptionsMonitor<HealthCheckServiceOptions> serviceOptions, IServiceProvider provider, ILogger<HealthEndpoint> logger = null)
@@ -40,15 +40,35 @@ namespace Steeltoe.Management.Endpoint.Health
                 throw new ArgumentNullException(nameof(options));
             }
 
-            if (contributors == null)
-            {
-                throw new ArgumentNullException(nameof(contributors));
-            }
-
-            _aggregator = aggregator ?? throw new ArgumentNullException(nameof(aggregator));
             _serviceOptions = serviceOptions ?? throw new ArgumentNullException(nameof(serviceOptions));
             _provider = provider ?? throw new ArgumentNullException(nameof(provider));
-            _contributors = contributors.ToList();
+            _logger = logger;
+        }
+
+        public HealthEndpointCore(IHealthOptions options, IAsyncHealthAggregator aggregator, IEnumerable<IAsyncHealthContributor> asyncContributors, IOptionsMonitor<HealthCheckServiceOptions> serviceOptions, IServiceProvider provider, ILogger<HealthEndpoint> logger = null)
+          : base(options, aggregator, asyncContributors, logger)
+        {
+            if (options == null)
+            {
+                throw new ArgumentNullException(nameof(options));
+            }
+
+            _serviceOptions = serviceOptions ?? throw new ArgumentNullException(nameof(serviceOptions));
+            _provider = provider ?? throw new ArgumentNullException(nameof(provider));
+            _logger = logger;
+        }
+
+        public HealthEndpointCore(IHealthOptions options, IHealthRegistrationsAggregator registrationsAggregator, IEnumerable<IAsyncHealthContributor> asyncContributors, IOptionsMonitor<HealthCheckServiceOptions> serviceOptions, IServiceProvider provider, ILogger<HealthEndpoint> logger = null)
+        : base(options, null, asyncContributors, logger)
+        {
+            if (options == null)
+            {
+                throw new ArgumentNullException(nameof(options));
+            }
+
+            _registrationsAggregator = registrationsAggregator;
+            _serviceOptions = serviceOptions ?? throw new ArgumentNullException(nameof(serviceOptions));
+            _provider = provider ?? throw new ArgumentNullException(nameof(provider));
             _logger = logger;
         }
 
@@ -62,16 +82,28 @@ namespace Steeltoe.Management.Endpoint.Health
 
         public override HealthCheckResult Invoke(ISecurityContext securityContext)
         {
-            return BuildHealth(_aggregator, _contributors, securityContext, _serviceOptions, _provider);
+            return BuildHealth(securityContext, _serviceOptions, _provider).Result;
         }
 
-        protected virtual HealthCheckResult BuildHealth(IHealthAggregator aggregator, IList<IHealthContributor> contributors, ISecurityContext securityContext, IOptionsMonitor<HealthCheckServiceOptions> svcOptions, IServiceProvider provider)
+        protected virtual async Task<HealthCheckResult> BuildHealth(ISecurityContext securityContext, IOptionsMonitor<HealthCheckServiceOptions> svcOptions, IServiceProvider provider)
         {
-            var registrationAggregator = _aggregator as IHealthRegistrationsAggregator;
+            HealthCheckResult result;
 
-            var result = registrationAggregator == null
-                ? _aggregator.Aggregate(contributors)
-                : registrationAggregator.Aggregate(contributors, svcOptions, provider);
+            if (_registrationsAggregator == null)
+            {
+                if (_aggregator != null)
+                {
+                    result = _aggregator.Aggregate(_contributors.ToList());
+                }
+                else
+                {
+                    result = await _asyncAggregator.Aggregate(_asyncContributors.ToList());
+                }
+            }
+            else
+            {
+                result = await _registrationsAggregator.Aggregate(_contributors, _asyncContributors, svcOptions, provider);
+            }
 
             var showDetails = Options.ShowDetails;
 

--- a/src/Management/src/EndpointCore/Health/HealthEndpointCore.cs
+++ b/src/Management/src/EndpointCore/Health/HealthEndpointCore.cs
@@ -59,7 +59,7 @@ namespace Steeltoe.Management.Endpoint.Health
         }
 
         public HealthEndpointCore(IHealthOptions options, IHealthRegistrationsAggregator registrationsAggregator, IEnumerable<IAsyncHealthContributor> asyncContributors, IOptionsMonitor<HealthCheckServiceOptions> serviceOptions, IServiceProvider provider, ILogger<HealthEndpoint> logger = null)
-        : base(options, null, asyncContributors, logger)
+        : base(options, new DefaultAsyncHealthAggregator(), asyncContributors, logger)
         {
             if (options == null)
             {

--- a/src/Management/test/EndpointBase.Test/Health/HealthEndpointTest.cs
+++ b/src/Management/test/EndpointBase.Test/Health/HealthEndpointTest.cs
@@ -26,9 +26,12 @@ namespace Steeltoe.Management.Endpoint.Health.Test
         [Fact]
         public void Constructor_ThrowsOptionsNull()
         {
-            Assert.Throws<ArgumentNullException>(() => new HealthEndpoint(null, null, null));
-            Assert.Throws<ArgumentNullException>(() => new HealthEndpoint(new HealthEndpointOptions(), null, null));
+            Assert.Throws<ArgumentNullException>(() => new HealthEndpoint(null, new DefaultHealthAggregator(), null));
+            Assert.Throws<ArgumentNullException>(() => new HealthEndpoint(null, new DefaultAsyncHealthAggregator(), null));
+            Assert.Throws<ArgumentNullException>(() => new HealthEndpoint(new HealthEndpointOptions(), null as DefaultAsyncHealthAggregator, null));
+            Assert.Throws<ArgumentNullException>(() => new HealthEndpoint(new HealthEndpointOptions(), null as DefaultHealthAggregator, null));
             Assert.Throws<ArgumentNullException>(() => new HealthEndpoint(new HealthEndpointOptions(), new DefaultHealthAggregator(), null));
+            Assert.Throws<ArgumentNullException>(() => new HealthEndpoint(new HealthEndpointOptions(), new DefaultAsyncHealthAggregator(), null));
         }
 
         [Fact]

--- a/src/Management/test/EndpointCore.Test/Health/HealthEndpointTest.cs
+++ b/src/Management/test/EndpointCore.Test/Health/HealthEndpointTest.cs
@@ -26,12 +26,15 @@ namespace Steeltoe.Management.Endpoint.Health.Test
         [Fact]
         public void Constructor_ThrowsOptionsNull()
         {
-            Assert.Throws<ArgumentNullException>(() => new HealthEndpointCore(null, null, null, null, null));
-            Assert.Throws<ArgumentNullException>(() => new HealthEndpointCore(new HealthEndpointOptions(), null, null, null, null));
+            Assert.Throws<ArgumentNullException>(() => new HealthEndpointCore(null, null as IHealthAggregator, null, null, null));
+            Assert.Throws<ArgumentNullException>(() => new HealthEndpointCore(null, null as IAsyncHealthAggregator, null, null, null));
+            Assert.Throws<ArgumentNullException>(() => new HealthEndpointCore(new HealthEndpointOptions(), null as IHealthAggregator, null, null, null));
+            Assert.Throws<ArgumentNullException>(() => new HealthEndpointCore(new HealthEndpointOptions(), null as IAsyncHealthAggregator, null, null, null));
             Assert.Throws<ArgumentNullException>(() => new HealthEndpointCore(new HealthEndpointOptions(), new HealthRegistrationsAggregator(), null, null, null));
-            Assert.Throws<ArgumentNullException>(() => new HealthEndpointCore(new HealthEndpointOptions(), new HealthRegistrationsAggregator(), new List<IHealthContributor>(), null, null));
+            Assert.Throws<ArgumentNullException>(() => new HealthEndpointCore(new HealthEndpointOptions(), new HealthRegistrationsAggregator(), new List<IAsyncHealthContributor>(), null, null));
+            Assert.Throws<ArgumentNullException>(() => new HealthEndpointCore(new HealthEndpointOptions(), new HealthRegistrationsAggregator(), new List<IAsyncHealthContributor>(), null, null));
             var svcOptions = default(IOptionsMonitor<Microsoft.Extensions.Diagnostics.HealthChecks.HealthCheckServiceOptions>);
-            Assert.Throws<ArgumentNullException>(() => new HealthEndpointCore(new HealthEndpointOptions(), new HealthRegistrationsAggregator(), new List<IHealthContributor>(), svcOptions, null));
+            Assert.Throws<ArgumentNullException>(() => new HealthEndpointCore(new HealthEndpointOptions(), new HealthRegistrationsAggregator(), new List<IAsyncHealthContributor>(), svcOptions, null));
         }
     }
 }


### PR DESCRIPTION
Draft for adding a new IAsyncHealthContributor with CheckHealthAsync() method. Steeltoe already supports adding IHealthContributor implementations in addition to Microsoft HealthCheckRegistrations. In order to be flexible to Steeltoe consumers, who want to continue using IHealthContributor, we want to support IAsyncHealthContributor in addition to the other options.