### PR TITLE
remove redundant state machines

### DIFF
--- a/src/Discovery/src/ConsulBase/Discovery/ConsulHealthContributor.cs
+++ b/src/Discovery/src/ConsulBase/Discovery/ConsulHealthContributor.cs
@@ -89,10 +89,9 @@ namespace Steeltoe.Discovery.Consul.Discovery
             return result;
         }
 
-        internal async Task<string> GetLeaderStatusAsync()
+        internal Task<string> GetLeaderStatusAsync()
         {
-            var result = await _client.Status.Leader().ConfigureAwait(false);
-            return result;
+            return _client.Status.Leader();
         }
 
         internal async Task<Dictionary<string, string[]>> GetCatalogServicesAsync()

--- a/src/Discovery/src/ConsulBase/Discovery/TtlScheduler.cs
+++ b/src/Discovery/src/ConsulBase/Discovery/TtlScheduler.cs
@@ -102,7 +102,7 @@ namespace Steeltoe.Discovery.Consul.Discovery
                     checkId = "service:" + checkId;
                 }
 
-                var timer = new Timer(async s => { await PassTtl(s.ToString()).ConfigureAwait(false); }, checkId, TimeSpan.Zero, interval);
+                var timer = new Timer(s => { PassTtl(s.ToString()); }, checkId, TimeSpan.Zero, interval);
                 _serviceHeartbeats.AddOrUpdate(instanceId, timer, (key, oldTimer) =>
                 {
                     oldTimer.Dispose();

--- a/src/Discovery/src/ConsulBase/Registry/ConsulServiceRegistry.cs
+++ b/src/Discovery/src/ConsulBase/Registry/ConsulServiceRegistry.cs
@@ -130,7 +130,7 @@ namespace Steeltoe.Discovery.Consul.Registry
             return DeregisterAsyncInternal(registration);
         }
 
-        private async Task DeregisterAsyncInternal(IConsulRegistration registration)
+        private Task DeregisterAsyncInternal(IConsulRegistration registration)
         {
             if (Options.IsHeartBeatEnabled && _scheduler != null)
             {
@@ -139,7 +139,7 @@ namespace Steeltoe.Discovery.Consul.Registry
 
             _logger?.LogInformation("Deregistering service with consul {instanceId} ", registration.InstanceId);
 
-            await _client.Agent.ServiceDeregister(registration.InstanceId).ConfigureAwait(false);
+            return _client.Agent.ServiceDeregister(registration.InstanceId);
         }
 
         /// <inheritdoc/>
@@ -153,20 +153,19 @@ namespace Steeltoe.Discovery.Consul.Registry
             return SetStatusAsyncInternal(registration, status);
         }
 
-        private async Task SetStatusAsyncInternal(IConsulRegistration registration, string status)
+        private Task SetStatusAsyncInternal(IConsulRegistration registration, string status)
         {
             if (OUT_OF_SERVICE.Equals(status, StringComparison.OrdinalIgnoreCase))
             {
-                await _client.Agent.EnableServiceMaintenance(registration.InstanceId, OUT_OF_SERVICE).ConfigureAwait(false);
+                return _client.Agent.EnableServiceMaintenance(registration.InstanceId, OUT_OF_SERVICE);
             }
-            else if (UP.Equals(status, StringComparison.OrdinalIgnoreCase))
+
+            if (UP.Equals(status, StringComparison.OrdinalIgnoreCase))
             {
-                await _client.Agent.DisableServiceMaintenance(registration.InstanceId).ConfigureAwait(false);
+                return _client.Agent.DisableServiceMaintenance(registration.InstanceId);
             }
-            else
-            {
-                throw new ArgumentException($"Unknown status: {status}");
-            }
+
+            throw new ArgumentException($"Unknown status: {status}");
         }
 
         /// <inheritdoc/>

--- a/src/Discovery/src/EurekaBase/Transport/EurekaHttpClient.cs
+++ b/src/Discovery/src/EurekaBase/Transport/EurekaHttpClient.cs
@@ -272,14 +272,14 @@ namespace Steeltoe.Discovery.Eureka.Transport
             throw new EurekaTransportException("Retry limit reached; giving up on completing the SendHeartBeatAsync request");
         }
 
-        public virtual async Task<EurekaHttpResponse<Applications>> GetApplicationsAsync(ISet<string> regions = null)
+        public virtual Task<EurekaHttpResponse<Applications>> GetApplicationsAsync(ISet<string> regions = null)
         {
-            return await DoGetApplicationsAsync("apps/", regions).ConfigureAwait(false);
+            return DoGetApplicationsAsync("apps/", regions);
         }
 
-        public virtual async Task<EurekaHttpResponse<Applications>> GetDeltaAsync(ISet<string> regions = null)
+        public virtual Task<EurekaHttpResponse<Applications>> GetDeltaAsync(ISet<string> regions = null)
         {
-            return await DoGetApplicationsAsync("apps/delta", regions).ConfigureAwait(false);
+            return DoGetApplicationsAsync("apps/delta", regions);
         }
 
         public virtual Task<EurekaHttpResponse<Applications>> GetVipAsync(string vipAddress, ISet<string> regions = null)
@@ -292,9 +292,9 @@ namespace Steeltoe.Discovery.Eureka.Transport
             return GetVipAsyncInternal(vipAddress, regions);
         }
 
-        private async Task<EurekaHttpResponse<Applications>> GetVipAsyncInternal(string vipAddress, ISet<string> regions)
+        private Task<EurekaHttpResponse<Applications>> GetVipAsyncInternal(string vipAddress, ISet<string> regions)
         {
-            return await DoGetApplicationsAsync("vips/" + vipAddress, regions).ConfigureAwait(false);
+            return DoGetApplicationsAsync("vips/" + vipAddress, regions);
         }
 
         public virtual Task<EurekaHttpResponse<Applications>> GetSecureVipAsync(string secureVipAddress, ISet<string> regions = null)
@@ -307,9 +307,9 @@ namespace Steeltoe.Discovery.Eureka.Transport
             return GetSecureVipAsyncInternal(secureVipAddress, regions);
         }
 
-        private async Task<EurekaHttpResponse<Applications>> GetSecureVipAsyncInternal(string secureVipAddress, ISet<string> regions = null)
+        private Task<EurekaHttpResponse<Applications>> GetSecureVipAsyncInternal(string secureVipAddress, ISet<string> regions = null)
         {
-            return await DoGetApplicationsAsync("vips/" + secureVipAddress, regions).ConfigureAwait(false);
+            return DoGetApplicationsAsync("vips/" + secureVipAddress, regions);
         }
 
         public virtual Task<EurekaHttpResponse<Application>> GetApplicationAsync(string appName)
@@ -416,14 +416,14 @@ namespace Steeltoe.Discovery.Eureka.Transport
             return GetInstanceAsyncInternal(appName, id);
         }
 
-        private async Task<EurekaHttpResponse<InstanceInfo>> GetInstanceAsyncInternal(string id)
+        private Task<EurekaHttpResponse<InstanceInfo>> GetInstanceAsyncInternal(string id)
         {
-            return await DoGetInstanceAsync("instances/" + id).ConfigureAwait(false);
+            return DoGetInstanceAsync("instances/" + id);
         }
 
-        private async Task<EurekaHttpResponse<InstanceInfo>> GetInstanceAsyncInternal(string appName, string id)
+        private Task<EurekaHttpResponse<InstanceInfo>> GetInstanceAsyncInternal(string appName, string id)
         {
-            return await DoGetInstanceAsync($"apps/{appName}/{id}").ConfigureAwait(false);
+            return DoGetInstanceAsync($"apps/{appName}/{id}");
         }
 
         public virtual Task<EurekaHttpResponse> CancelAsync(string appName, string id)

--- a/src/Integration/src/Base/Endpoint/AbstractEndpoint.cs
+++ b/src/Integration/src/Base/Endpoint/AbstractEndpoint.cs
@@ -55,7 +55,7 @@ namespace Steeltoe.Integration.Endpoint
 
         public int Phase { get; set; } = 0;
 
-        public async Task Start()
+        public Task Start()
         {
             var doTheStart = false;
             lock (_lifecyclelock)
@@ -69,11 +69,13 @@ namespace Steeltoe.Integration.Endpoint
 
             if (doTheStart)
             {
-                await DoStart();
+                return DoStart();
             }
+
+            return Task.CompletedTask;
         }
 
-        public async Task Stop(Action callback)
+        public Task Stop(Action callback)
         {
             var doTheStop = false;
 
@@ -88,15 +90,14 @@ namespace Steeltoe.Integration.Endpoint
 
             if (doTheStop)
             {
-                await DoStop(callback);
+                return DoStop(callback);
             }
-            else
-            {
-                callback();
-            }
+
+            callback();
+            return Task.CompletedTask;
         }
 
-        public async Task Stop()
+        public Task Stop()
         {
             var doTheStop = false;
             lock (_lifecyclelock)
@@ -110,8 +111,10 @@ namespace Steeltoe.Integration.Endpoint
 
             if (doTheStop)
             {
-                await DoStop();
+                return DoStop();
             }
+
+            return Task.CompletedTask;
         }
 
         protected virtual async Task DoStop(Action callback)

--- a/src/Integration/src/Base/Endpoint/EventDrivenConsumerEndpoint.cs
+++ b/src/Integration/src/Base/Endpoint/EventDrivenConsumerEndpoint.cs
@@ -56,22 +56,26 @@ namespace Steeltoe.Integration.Endpoint
             }
         }
 
-        protected override async Task DoStart()
+        protected override Task DoStart()
         {
             _inputChannel.Subscribe(_handler);
             if (_handler is ILifecycle)
             {
-                await ((ILifecycle)_handler).Start();
+                return ((ILifecycle)_handler).Start();
             }
+
+            return Task.CompletedTask;
         }
 
-        protected override async Task DoStop()
+        protected override Task DoStop()
         {
             _inputChannel.Unsubscribe(_handler);
             if (_handler is ILifecycle)
             {
-                await ((ILifecycle)_handler).Stop();
+                return ((ILifecycle)_handler).Stop();
             }
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/Integration/src/Base/Handler/ServiceActivatingHandler.cs
+++ b/src/Integration/src/Base/Handler/ServiceActivatingHandler.cs
@@ -49,20 +49,24 @@ namespace Steeltoe.Integration.Handler
 
         public virtual bool IsRunning => !(_processor is ILifecycle) || ((ILifecycle)_processor).IsRunning;
 
-        public virtual async Task Start()
+        public virtual Task Start()
         {
             if (_processor is ILifecycle)
             {
-                await ((ILifecycle)_processor).Start();
+                return ((ILifecycle)_processor).Start();
             }
+
+            return Task.CompletedTask;
         }
 
-        public virtual async Task Stop()
+        public virtual Task Stop()
         {
             if (_processor is ILifecycle)
             {
-                await ((ILifecycle)_processor).Stop();
+                return ((ILifecycle)_processor).Stop();
             }
+
+            return Task.CompletedTask;
         }
 
         public override string ToString()

--- a/src/Management/src/EndpointCore/CloudFoundry/CloudFoundryEndpointMiddleware.cs
+++ b/src/Management/src/EndpointCore/CloudFoundry/CloudFoundryEndpointMiddleware.cs
@@ -41,27 +41,27 @@ namespace Steeltoe.Management.Endpoint.CloudFoundry
             _options = endpoint.Options as ICloudFoundryOptions;
         }
 
-        public async Task Invoke(HttpContext context)
+        public Task Invoke(HttpContext context)
         {
             _logger?.LogDebug("Invoke({0} {1})", context.Request.Method, context.Request.Path.Value);
 
             if (RequestVerbAndPathMatch(context.Request.Method, context.Request.Path.Value))
             {
-                await HandleCloudFoundryRequestAsync(context).ConfigureAwait(false);
+                return HandleCloudFoundryRequestAsync(context);
             }
             else
             {
-                await _next(context).ConfigureAwait(false);
+                return _next(context);
             }
         }
 
-        protected internal async Task HandleCloudFoundryRequestAsync(HttpContext context)
+        protected internal Task HandleCloudFoundryRequestAsync(HttpContext context)
         {
             var serialInfo = HandleRequest(GetRequestUri(context.Request));
             _logger?.LogDebug("Returning: {0}", serialInfo);
 
             context.HandleContentNegotiation(_logger);
-            await context.Response.WriteAsync(serialInfo).ConfigureAwait(false);
+            return context.Response.WriteAsync(serialInfo);
         }
 
         protected internal string GetRequestUri(HttpRequest request)

--- a/src/Management/src/EndpointCore/CloudFoundry/CloudFoundrySecurityMiddleware.cs
+++ b/src/Management/src/EndpointCore/CloudFoundry/CloudFoundrySecurityMiddleware.cs
@@ -103,10 +103,10 @@ namespace Steeltoe.Management.Endpoint.CloudFoundry
             return null;
         }
 
-        internal async Task<SecurityResult> GetPermissions(HttpContext context)
+        internal Task<SecurityResult> GetPermissions(HttpContext context)
         {
             string token = GetAccessToken(context.Request);
-            return await _base.GetPermissionsAsync(token).ConfigureAwait(false);
+            return _base.GetPermissionsAsync(token);
         }
 
         private IEndpointOptions FindTargetEndpoint(PathString path)
@@ -132,12 +132,12 @@ namespace Steeltoe.Management.Endpoint.CloudFoundry
             return null;
         }
 
-        private async Task ReturnError(HttpContext context, SecurityResult error)
+        private Task ReturnError(HttpContext context, SecurityResult error)
         {
             LogError(context, error);
             context.Response.Headers.Add("Content-Type", "application/json;charset=UTF-8");
             context.Response.StatusCode = (int)error.Code;
-            await context.Response.WriteAsync(_base.Serialize(error)).ConfigureAwait(false);
+            return context.Response.WriteAsync(_base.Serialize(error));
         }
 
         private void LogError(HttpContext context, SecurityResult error)

--- a/src/Management/src/EndpointCore/DbMigrations/DbMigrationsEndpointMiddleware.cs
+++ b/src/Management/src/EndpointCore/DbMigrations/DbMigrationsEndpointMiddleware.cs
@@ -31,25 +31,23 @@ namespace Steeltoe.Management.Endpoint.DbMigrations
             _next = next;
         }
 
-        public async Task Invoke(HttpContext context)
+        public Task Invoke(HttpContext context)
         {
             if (RequestVerbAndPathMatch(context.Request.Method, context.Request.Path.Value))
             {
-                await HandleEntityFrameworkRequestAsync(context);
+                return HandleEntityFrameworkRequestAsync(context);
             }
-            else
-            {
-                await _next(context);
-            }
+
+            return _next(context);
         }
 
-        protected internal async Task HandleEntityFrameworkRequestAsync(HttpContext context)
+        protected internal Task HandleEntityFrameworkRequestAsync(HttpContext context)
         {
             var serialInfo = HandleRequest();
             _logger?.LogDebug("Returning: {0}", serialInfo);
 
             context.HandleContentNegotiation(_logger);
-            await context.Response.WriteAsync(serialInfo);
+            return context.Response.WriteAsync(serialInfo);
         }
     }
 }

--- a/src/Management/src/EndpointCore/Env/EnvEndpointMiddleware.cs
+++ b/src/Management/src/EndpointCore/Env/EnvEndpointMiddleware.cs
@@ -31,25 +31,23 @@ namespace Steeltoe.Management.Endpoint.Env
             _next = next;
         }
 
-        public async Task Invoke(HttpContext context)
+        public Task Invoke(HttpContext context)
         {
             if (RequestVerbAndPathMatch(context.Request.Method, context.Request.Path.Value))
             {
-                await HandleEnvRequestAsync(context).ConfigureAwait(false);
+                return HandleEnvRequestAsync(context);
             }
-            else
-            {
-                await _next(context).ConfigureAwait(false);
-            }
+
+            return _next(context);
         }
 
-        protected internal async Task HandleEnvRequestAsync(HttpContext context)
+        protected internal Task HandleEnvRequestAsync(HttpContext context)
         {
             var serialInfo = HandleRequest();
             _logger?.LogDebug("Returning: {0}", serialInfo);
 
             context.HandleContentNegotiation(_logger);
-            await context.Response.WriteAsync(serialInfo).ConfigureAwait(false);
+            return context.Response.WriteAsync(serialInfo);
         }
     }
 }

--- a/src/Management/src/EndpointCore/Health/HealthEndpointMiddleware.cs
+++ b/src/Management/src/EndpointCore/Health/HealthEndpointMiddleware.cs
@@ -35,27 +35,25 @@ namespace Steeltoe.Management.Endpoint.Health
             _next = next;
         }
 
-        public async Task Invoke(HttpContext context, HealthEndpointCore endpoint)
+        public Task Invoke(HttpContext context, HealthEndpointCore endpoint)
         {
             _endpoint = endpoint;
 
             if (RequestVerbAndPathMatch(context.Request.Method, context.Request.Path.Value))
             {
-                await HandleHealthRequestAsync(context).ConfigureAwait(false);
+                return HandleHealthRequestAsync(context);
             }
-            else
-            {
-                await _next(context).ConfigureAwait(false);
-            }
+
+            return _next(context);
         }
 
-        protected internal async Task HandleHealthRequestAsync(HttpContext context)
+        protected internal Task HandleHealthRequestAsync(HttpContext context)
         {
             var serialInfo = DoRequest(context);
             _logger?.LogDebug("Returning: {0}", serialInfo);
 
             context.HandleContentNegotiation(_logger);
-            await context.Response.WriteAsync(serialInfo).ConfigureAwait(false);
+            return context.Response.WriteAsync(serialInfo);
         }
 
         protected internal string DoRequest(HttpContext context)

--- a/src/Management/src/EndpointCore/HeapDump/HeapDumpEndpointMiddleware.cs
+++ b/src/Management/src/EndpointCore/HeapDump/HeapDumpEndpointMiddleware.cs
@@ -31,16 +31,14 @@ namespace Steeltoe.Management.Endpoint.HeapDump
             _next = next;
         }
 
-        public async Task Invoke(HttpContext context)
+        public Task Invoke(HttpContext context)
         {
             if (RequestVerbAndPathMatch(context.Request.Method, context.Request.Path.Value))
             {
-                await HandleHeapDumpRequestAsync(context).ConfigureAwait(false);
+                return HandleHeapDumpRequestAsync(context);
             }
-            else
-            {
-                await _next(context).ConfigureAwait(false);
-            }
+
+            return _next(context);
         }
 
         protected internal async Task HandleHeapDumpRequestAsync(HttpContext context)

--- a/src/Management/src/EndpointCore/Hypermedia/ActuatorHypermediaEndpointMiddleware.cs
+++ b/src/Management/src/EndpointCore/Hypermedia/ActuatorHypermediaEndpointMiddleware.cs
@@ -33,27 +33,25 @@ namespace Steeltoe.Management.Endpoint.Hypermedia
             _next = next;
         }
 
-        public async Task Invoke(HttpContext context)
+        public Task Invoke(HttpContext context)
         {
             _logger?.LogDebug("Invoke({0} {1})", context.Request.Method, context.Request.Path.Value);
 
             if (RequestVerbAndPathMatch(context.Request.Method, context.Request.Path.Value))
             {
-                await HandleCloudFoundryRequestAsync(context).ConfigureAwait(false);
+                return HandleCloudFoundryRequestAsync(context);
             }
-            else
-            {
-                await _next(context).ConfigureAwait(false);
-            }
+
+            return _next(context);
         }
 
-        protected internal async Task HandleCloudFoundryRequestAsync(HttpContext context)
+        protected internal Task HandleCloudFoundryRequestAsync(HttpContext context)
         {
             var serialInfo = HandleRequest(GetRequestUri(context.Request));
             _logger?.LogDebug("Returning: {0}", serialInfo);
 
             context.HandleContentNegotiation(_logger);
-            await context.Response.WriteAsync(serialInfo).ConfigureAwait(false);
+            return context.Response.WriteAsync(serialInfo);
         }
 
         protected internal string GetRequestUri(HttpRequest request)

--- a/src/Management/src/EndpointCore/Info/InfoEndpointMiddleware.cs
+++ b/src/Management/src/EndpointCore/Info/InfoEndpointMiddleware.cs
@@ -32,27 +32,25 @@ namespace Steeltoe.Management.Endpoint.Info
             _next = next;
         }
 
-        public async Task Invoke(HttpContext context)
+        public Task Invoke(HttpContext context)
         {
             _logger.LogDebug("Info middleware Invoke({0})", context.Request.Path.Value);
 
             if (RequestVerbAndPathMatch(context.Request.Method, context.Request.Path.Value))
             {
-                await HandleInfoRequestAsync(context).ConfigureAwait(false);
+                return HandleInfoRequestAsync(context);
             }
-            else
-            {
-                await _next(context).ConfigureAwait(false);
-            }
+
+            return _next(context);
         }
 
-        protected internal async Task HandleInfoRequestAsync(HttpContext context)
+        protected internal Task HandleInfoRequestAsync(HttpContext context)
         {
             var serialInfo = HandleRequest();
             _logger?.LogDebug("Returning: {0}", serialInfo);
 
             context.HandleContentNegotiation(_logger);
-            await context.Response.WriteAsync(serialInfo).ConfigureAwait(false);
+            return context.Response.WriteAsync(serialInfo);
         }
     }
 }

--- a/src/Management/src/EndpointCore/Loggers/LoggersEndpointMiddleware.cs
+++ b/src/Management/src/EndpointCore/Loggers/LoggersEndpointMiddleware.cs
@@ -35,16 +35,14 @@ namespace Steeltoe.Management.Endpoint.Loggers
             _next = next;
         }
 
-        public async Task Invoke(HttpContext context)
+        public Task Invoke(HttpContext context)
         {
             if (RequestVerbAndPathMatch(context.Request.Method, context.Request.Path.Value))
             {
-                await HandleLoggersRequestAsync(context).ConfigureAwait(false);
+                return HandleLoggersRequestAsync(context);
             }
-            else
-            {
-                await _next(context).ConfigureAwait(false);
-            }
+
+            return _next(context);
         }
 
         protected internal async Task HandleLoggersRequestAsync(HttpContext context)

--- a/src/Management/src/EndpointCore/Mappings/MappingsEndpointMiddleware.cs
+++ b/src/Management/src/EndpointCore/Mappings/MappingsEndpointMiddleware.cs
@@ -56,19 +56,17 @@ namespace Steeltoe.Management.Endpoint.Mappings
             _apiDescriptionProviders = apiDescriptionProviders;
         }
 
-        public async Task Invoke(HttpContext context)
+        public Task Invoke(HttpContext context)
         {
             if (IsMappingsRequest(context))
             {
-                await HandleMappingsRequestAsync(context).ConfigureAwait(false);
+                return HandleMappingsRequestAsync(context);
             }
-            else
-            {
-                await _next(context).ConfigureAwait(false);
-            }
+
+            return _next(context);
         }
 
-        protected internal async Task HandleMappingsRequestAsync(HttpContext context)
+        protected internal Task HandleMappingsRequestAsync(HttpContext context)
         {
             var result = GetApplicationMappings(context);
             var serialInfo = Serialize(result);
@@ -76,7 +74,7 @@ namespace Steeltoe.Management.Endpoint.Mappings
             _logger?.LogDebug("Returning: {0}", serialInfo);
 
             context.HandleContentNegotiation(_logger);
-            await context.Response.WriteAsync(serialInfo).ConfigureAwait(false);
+            return context.Response.WriteAsync(serialInfo);
         }
 
         protected internal ApplicationMappings GetApplicationMappings(HttpContext context)

--- a/src/Management/src/EndpointCore/Metrics/MetricsEndpointMiddleware.cs
+++ b/src/Management/src/EndpointCore/Metrics/MetricsEndpointMiddleware.cs
@@ -34,16 +34,14 @@ namespace Steeltoe.Management.Endpoint.Metrics
             _next = next;
         }
 
-        public async Task Invoke(HttpContext context)
+        public Task Invoke(HttpContext context)
         {
             if (RequestVerbAndPathMatch(context.Request.Method, context.Request.Path.Value))
             {
-                await HandleMetricsRequestAsync(context).ConfigureAwait(false);
+                return HandleMetricsRequestAsync(context);
             }
-            else
-            {
-                await _next(context).ConfigureAwait(false);
-            }
+
+            return _next(context);
         }
 
         public override string HandleRequest(MetricsRequest arg)

--- a/src/Management/src/EndpointCore/Metrics/Prometheus/PrometheusScraperEndpointMiddleware.cs
+++ b/src/Management/src/EndpointCore/Metrics/Prometheus/PrometheusScraperEndpointMiddleware.cs
@@ -31,16 +31,14 @@ namespace Steeltoe.Management.Endpoint.Metrics
             _next = next;
         }
 
-        public async Task Invoke(HttpContext context)
+        public Task Invoke(HttpContext context)
         {
             if (RequestVerbAndPathMatch(context.Request.Method, context.Request.Path.Value))
             {
-                await HandleMetricsRequestAsync(context).ConfigureAwait(false);
+                return HandleMetricsRequestAsync(context);
             }
-            else
-            {
-                await _next(context).ConfigureAwait(false);
-            }
+
+            return _next(context);
         }
 
         public override string HandleRequest()
@@ -49,7 +47,7 @@ namespace Steeltoe.Management.Endpoint.Metrics
             return result;
         }
 
-        protected internal async Task HandleMetricsRequestAsync(HttpContext context)
+        protected internal Task HandleMetricsRequestAsync(HttpContext context)
         {
             HttpRequest request = context.Request;
             HttpResponse response = context.Response;
@@ -59,16 +57,15 @@ namespace Steeltoe.Management.Endpoint.Metrics
             // GET /metrics/{metricName}?tag=key:value&tag=key:value
             var serialInfo = HandleRequest();
 
-            if (serialInfo != null)
+            if (serialInfo == null)
             {
-                response.StatusCode = (int)HttpStatusCode.OK;
-                response.ContentType = "text/plain; version=0.0.4;";
-                await context.Response.WriteAsync(serialInfo).ConfigureAwait(false);
+                response.StatusCode = (int) HttpStatusCode.NotFound;
+                return Task.CompletedTask;
             }
-            else
-            {
-                response.StatusCode = (int)HttpStatusCode.NotFound;
-            }
+
+            response.StatusCode = (int)HttpStatusCode.OK;
+            response.ContentType = "text/plain; version=0.0.4;";
+            return context.Response.WriteAsync(serialInfo);
         }
     }
 }

--- a/src/Management/src/EndpointCore/Metrics/Prometheus/PrometheusScraperEndpointMiddleware.cs
+++ b/src/Management/src/EndpointCore/Metrics/Prometheus/PrometheusScraperEndpointMiddleware.cs
@@ -59,7 +59,7 @@ namespace Steeltoe.Management.Endpoint.Metrics
 
             if (serialInfo == null)
             {
-                response.StatusCode = (int) HttpStatusCode.NotFound;
+                response.StatusCode = (int)HttpStatusCode.NotFound;
                 return Task.CompletedTask;
             }
 

--- a/src/Management/src/EndpointCore/Refresh/RefreshEndpointMiddleware.cs
+++ b/src/Management/src/EndpointCore/Refresh/RefreshEndpointMiddleware.cs
@@ -32,25 +32,23 @@ namespace Steeltoe.Management.Endpoint.Refresh
             _next = next;
         }
 
-        public async Task Invoke(HttpContext context)
+        public Task Invoke(HttpContext context)
         {
             if (RequestVerbAndPathMatch(context.Request.Method, context.Request.Path.Value))
             {
-                await HandleRefreshRequestAsync(context).ConfigureAwait(false);
+                return HandleRefreshRequestAsync(context);
             }
-            else
-            {
-                await _next(context).ConfigureAwait(false);
-            }
+
+            return _next(context);
         }
 
-        protected internal async Task HandleRefreshRequestAsync(HttpContext context)
+        protected internal Task HandleRefreshRequestAsync(HttpContext context)
         {
             var serialInfo = HandleRequest();
             _logger?.LogDebug("Returning: {0}", serialInfo);
 
             context.HandleContentNegotiation(_logger);
-            await context.Response.WriteAsync(serialInfo).ConfigureAwait(false);
+            return context.Response.WriteAsync(serialInfo);
         }
     }
 }

--- a/src/Management/src/EndpointCore/ThreadDump/ThreadDumpEndpointMiddleware.cs
+++ b/src/Management/src/EndpointCore/ThreadDump/ThreadDumpEndpointMiddleware.cs
@@ -31,25 +31,23 @@ namespace Steeltoe.Management.Endpoint.ThreadDump
             _next = next;
         }
 
-        public async Task Invoke(HttpContext context)
+        public Task Invoke(HttpContext context)
         {
             if (RequestVerbAndPathMatch(context.Request.Method, context.Request.Path.Value))
             {
-                await HandleThreadDumpRequestAsync(context).ConfigureAwait(false);
+                return HandleThreadDumpRequestAsync(context);
             }
-            else
-            {
-                await _next(context).ConfigureAwait(false);
-            }
+
+            return _next(context);
         }
 
-        protected internal async Task HandleThreadDumpRequestAsync(HttpContext context)
+        protected internal Task HandleThreadDumpRequestAsync(HttpContext context)
         {
             var serialInfo = HandleRequest();
             _logger?.LogDebug("Returning: {0}", serialInfo);
 
             context.HandleContentNegotiation(_logger);
-            await context.Response.WriteAsync(serialInfo).ConfigureAwait(false);
+            return context.Response.WriteAsync(serialInfo);
         }
     }
 }

--- a/src/Management/src/EndpointCore/ThreadDump/ThreadDumpEndpointMiddleware_v2.cs
+++ b/src/Management/src/EndpointCore/ThreadDump/ThreadDumpEndpointMiddleware_v2.cs
@@ -30,24 +30,22 @@ namespace Steeltoe.Management.Endpoint.ThreadDump
             _next = next;
         }
 
-        public async Task Invoke(HttpContext context)
+        public Task Invoke(HttpContext context)
         {
             if (RequestVerbAndPathMatch(context.Request.Method, context.Request.Path.Value))
             {
-                await HandleThreadDumpRequestAsync(context).ConfigureAwait(false);
+                return HandleThreadDumpRequestAsync(context);
             }
-            else
-            {
-                await _next(context).ConfigureAwait(false);
-            }
+
+            return _next(context);
         }
 
-        protected internal async Task HandleThreadDumpRequestAsync(HttpContext context)
+        protected internal Task HandleThreadDumpRequestAsync(HttpContext context)
         {
             var serialInfo = HandleRequest();
             _logger?.LogDebug("Returning: {0}", serialInfo);
             context.Response.Headers.Add("Content-Type", "application/vnd.spring-boot.actuator.v2+json");
-            await context.Response.WriteAsync(serialInfo).ConfigureAwait(false);
+            return context.Response.WriteAsync(serialInfo);
         }
     }
 }

--- a/src/Management/src/EndpointCore/Trace/HttpTraceEndpointMiddleware.cs
+++ b/src/Management/src/EndpointCore/Trace/HttpTraceEndpointMiddleware.cs
@@ -31,25 +31,23 @@ namespace Steeltoe.Management.Endpoint.Trace
             _next = next;
         }
 
-        public async Task Invoke(HttpContext context)
+        public Task Invoke(HttpContext context)
         {
             if (RequestVerbAndPathMatch(context.Request.Method, context.Request.Path.Value))
             {
-                await HandleTraceRequestAsync(context).ConfigureAwait(false);
+                return HandleTraceRequestAsync(context);
             }
-            else
-            {
-                await _next(context).ConfigureAwait(false);
-            }
+
+            return _next(context);
         }
 
-        protected internal async Task HandleTraceRequestAsync(HttpContext context)
+        protected internal Task HandleTraceRequestAsync(HttpContext context)
         {
             var serialInfo = HandleRequest();
             _logger?.LogDebug("Returning: {0}", serialInfo);
 
             context.HandleContentNegotiation(_logger);
-            await context.Response.WriteAsync(serialInfo).ConfigureAwait(false);
+            return context.Response.WriteAsync(serialInfo);
         }
     }
 }

--- a/src/Management/src/EndpointCore/Trace/TraceEndpointMiddleware.cs
+++ b/src/Management/src/EndpointCore/Trace/TraceEndpointMiddleware.cs
@@ -31,25 +31,23 @@ namespace Steeltoe.Management.Endpoint.Trace
             _next = next;
         }
 
-        public async Task Invoke(HttpContext context)
+        public Task Invoke(HttpContext context)
         {
             if (RequestVerbAndPathMatch(context.Request.Method, context.Request.Path.Value))
             {
-                await HandleTraceRequestAsync(context).ConfigureAwait(false);
+                return HandleTraceRequestAsync(context);
             }
-            else
-            {
-                await _next(context).ConfigureAwait(false);
-            }
+
+            return _next(context);
         }
 
-        protected internal async Task HandleTraceRequestAsync(HttpContext context)
+        protected internal Task HandleTraceRequestAsync(HttpContext context)
         {
             var serialInfo = HandleRequest();
             _logger?.LogDebug("Returning: {0}", serialInfo);
 
             context.HandleContentNegotiation(_logger);
-            await context.Response.WriteAsync(serialInfo).ConfigureAwait(false);
+            return context.Response.WriteAsync(serialInfo);
         }
     }
 }

--- a/src/Messaging/src/Base/Core/AbstractDestinationResolvingMessagingTemplate.cs
+++ b/src/Messaging/src/Base/Core/AbstractDestinationResolvingMessagingTemplate.cs
@@ -74,58 +74,58 @@ namespace Steeltoe.Messaging.Core
             return ConvertAndSendAsync(destinationName, payload, null, postProcessor, cancellationToken);
         }
 
-        public virtual async Task ConvertAndSendAsync<T>(string destinationName, T payload, IDictionary<string, object> headers, IMessagePostProcessor postProcessor, CancellationToken cancellationToken = default)
+        public virtual Task ConvertAndSendAsync<T>(string destinationName, T payload, IDictionary<string, object> headers, IMessagePostProcessor postProcessor, CancellationToken cancellationToken = default)
         {
             var destination = ResolveDestination(destinationName);
-            await ConvertAndSendAsync(destination, payload, headers, postProcessor, cancellationToken);
+            return ConvertAndSendAsync(destination, payload, headers, postProcessor, cancellationToken);
         }
 
-        public virtual async Task<T> ConvertSendAndReceiveAsync<T>(string destinationName, object request, CancellationToken cancellationToken = default)
+        public virtual Task<T> ConvertSendAndReceiveAsync<T>(string destinationName, object request, CancellationToken cancellationToken = default)
         {
             var destination = ResolveDestination(destinationName);
-            return await ConvertSendAndReceiveAsync<T>(destination, request, cancellationToken);
+            return ConvertSendAndReceiveAsync<T>(destination, request, cancellationToken);
         }
 
-        public virtual async Task<T> ConvertSendAndReceiveAsync<T>(string destinationName, object request, IDictionary<string, object> headers, CancellationToken cancellationToken = default)
+        public virtual Task<T> ConvertSendAndReceiveAsync<T>(string destinationName, object request, IDictionary<string, object> headers, CancellationToken cancellationToken = default)
         {
             var destination = ResolveDestination(destinationName);
-            return await ConvertSendAndReceiveAsync<T>(destination, request, headers, cancellationToken);
+            return ConvertSendAndReceiveAsync<T>(destination, request, headers, cancellationToken);
         }
 
-        public virtual async Task<T> ConvertSendAndReceiveAsync<T>(string destinationName, object request, IMessagePostProcessor requestPostProcessor, CancellationToken cancellationToken = default)
+        public virtual Task<T> ConvertSendAndReceiveAsync<T>(string destinationName, object request, IMessagePostProcessor requestPostProcessor, CancellationToken cancellationToken = default)
         {
             var destination = ResolveDestination(destinationName);
-            return await ConvertSendAndReceiveAsync<T>(destination, request, requestPostProcessor, cancellationToken);
+            return ConvertSendAndReceiveAsync<T>(destination, request, requestPostProcessor, cancellationToken);
         }
 
-        public virtual async Task<T> ConvertSendAndReceiveAsync<T>(string destinationName, object request, IDictionary<string, object> headers, IMessagePostProcessor requestPostProcessor, CancellationToken cancellationToken = default)
+        public virtual Task<T> ConvertSendAndReceiveAsync<T>(string destinationName, object request, IDictionary<string, object> headers, IMessagePostProcessor requestPostProcessor, CancellationToken cancellationToken = default)
         {
             var destination = ResolveDestination(destinationName);
-            return await ConvertSendAndReceiveAsync<T>(destination, request, headers, requestPostProcessor, cancellationToken);
+            return ConvertSendAndReceiveAsync<T>(destination, request, headers, requestPostProcessor, cancellationToken);
         }
 
-        public virtual async Task<IMessage> ReceiveAsync(string destinationName, CancellationToken cancellationToken = default)
+        public virtual Task<IMessage> ReceiveAsync(string destinationName, CancellationToken cancellationToken = default)
         {
             var destination = ResolveDestination(destinationName);
-            return await ReceiveAsync(destination, cancellationToken);
+            return ReceiveAsync(destination, cancellationToken);
         }
 
-        public virtual async Task<T> ReceiveAndConvertAsync<T>(string destinationName, CancellationToken cancellationToken = default)
+        public virtual Task<T> ReceiveAndConvertAsync<T>(string destinationName, CancellationToken cancellationToken = default)
         {
             var destination = ResolveDestination(destinationName);
-            return await ReceiveAndConvertAsync<T>(destination, cancellationToken);
+            return ReceiveAndConvertAsync<T>(destination, cancellationToken);
         }
 
-        public virtual async Task SendAsync(string destinationName, IMessage message, CancellationToken cancellationToken = default)
+        public virtual Task SendAsync(string destinationName, IMessage message, CancellationToken cancellationToken = default)
         {
             var destination = ResolveDestination(destinationName);
-            await SendAsync(destination, message, cancellationToken);
+            return SendAsync(destination, message, cancellationToken);
         }
 
-        public virtual async Task<IMessage> SendAndReceiveAsync(string destinationName, IMessage requestMessage, CancellationToken cancellationToken = default)
+        public virtual Task<IMessage> SendAndReceiveAsync(string destinationName, IMessage requestMessage, CancellationToken cancellationToken = default)
         {
             var destination = ResolveDestination(destinationName);
-            return await SendAndReceiveAsync(destination, requestMessage, cancellationToken);
+            return SendAndReceiveAsync(destination, requestMessage, cancellationToken);
         }
 
         public virtual void ConvertAndSend<T>(string destinationName, T payload)

--- a/src/Messaging/src/Base/Core/AbstractMessageSendingTemplate.cs
+++ b/src/Messaging/src/Base/Core/AbstractMessageSendingTemplate.cs
@@ -79,10 +79,10 @@ namespace Steeltoe.Messaging.Core
             return ConvertAndSendAsync(destination, payload, null, postProcessor, cancellationToken);
         }
 
-        public virtual async Task ConvertAndSendAsync(D destination, object payload, IDictionary<string, object> headers, IMessagePostProcessor postProcessor, CancellationToken cancellationToken = default)
+        public virtual Task ConvertAndSendAsync(D destination, object payload, IDictionary<string, object> headers, IMessagePostProcessor postProcessor, CancellationToken cancellationToken = default)
         {
             var message = DoConvert(payload, headers, postProcessor);
-            await SendAsync(destination, message, cancellationToken);
+            return SendAsync(destination, message, cancellationToken);
         }
 
         public virtual Task SendAsync(IMessage message, CancellationToken cancellationToken = default)

--- a/src/Messaging/src/RabbitMQ/Core/RabbitTemplate.cs
+++ b/src/Messaging/src/RabbitMQ/Core/RabbitTemplate.cs
@@ -383,12 +383,12 @@ namespace Steeltoe.Messaging.Rabbit.Core
                     .Sum();
         }
 
-        public async Task Start()
+        public Task Start()
         {
-            await DoStart();
+            return DoStart();
         }
 
-        public async Task Stop()
+        public Task Stop()
         {
             lock (_directReplyToContainers)
             {
@@ -403,7 +403,7 @@ namespace Steeltoe.Messaging.Rabbit.Core
                 _directReplyToContainers.Clear();
             }
 
-            await DoStop();
+            return DoStop();
         }
 
         public async Task Destroy() => await Stop();

--- a/src/Messaging/test/Base.Test/Core/DestinationResolvingMessagingTemplateTest.cs
+++ b/src/Messaging/test/Base.Test/Core/DestinationResolvingMessagingTemplateTest.cs
@@ -67,10 +67,10 @@ namespace Steeltoe.Messaging.Core.Test
         }
 
         [Fact]
-        public async Task SendAsyncNoDestinationResolver()
+        public Task SendAsyncNoDestinationResolver()
         {
             var template = new TestDestinationResolvingMessagingTemplate();
-            await Assert.ThrowsAsync<InvalidOperationException>(() => template.SendAsync("myChannel", new GenericMessage("payload")));
+            return Assert.ThrowsAsync<InvalidOperationException>(() => template.SendAsync("myChannel", new GenericMessage("payload")));
         }
 
         [Fact]

--- a/src/Security/src/Authentication.CloudFoundryBase/TokenExchanger.cs
+++ b/src/Security/src/Authentication.CloudFoundryBase/TokenExchanger.cs
@@ -60,17 +60,14 @@ namespace Steeltoe.Security.Authentication.CloudFoundry
                 out SecurityProtocolType protocolType,
                 out RemoteCertificateValidationCallback prevValidator);
 
-            HttpResponseMessage response;
             try
             {
-                response = await _httpClient.SendAsync(requestMessage, cancellationToken).ConfigureAwait(false);
+                return await _httpClient.SendAsync(requestMessage, cancellationToken).ConfigureAwait(false);
             }
             finally
             {
                 HttpClientHelper.RestoreCertificateValidation(_options.ValidateCertificates, protocolType, prevValidator);
             }
-
-            return response;
         }
 
         /// <summary>
@@ -115,17 +112,14 @@ namespace Steeltoe.Security.Authentication.CloudFoundry
 
             HttpClientHelper.ConfigureCertificateValidation(_options.ValidateCertificates, out SecurityProtocolType protocolType, out RemoteCertificateValidationCallback prevValidator);
 
-            HttpResponseMessage response;
             try
             {
-                response = await _httpClient.SendAsync(requestMessage).ConfigureAwait(false);
+                return await _httpClient.SendAsync(requestMessage).ConfigureAwait(false);
             }
             finally
             {
                 HttpClientHelper.RestoreCertificateValidation(_options.ValidateCertificates, protocolType, prevValidator);
             }
-
-            return response;
         }
 
         /// <summary>

--- a/src/Stream/src/Base/Binder/AbstractMessageChannelBinder.cs
+++ b/src/Stream/src/Base/Binder/AbstractMessageChannelBinder.cs
@@ -613,20 +613,24 @@ namespace Steeltoe.Stream.Binder
                 this.useNativeEncoding = useNativeEncoding;
             }
 
-            public async Task Start()
+            public Task Start()
             {
                 if (handler is ILifecycle)
                 {
-                    await ((ILifecycle)handler).Start();
+                    return ((ILifecycle)handler).Start();
                 }
+
+                return Task.CompletedTask;
             }
 
-            public async Task Stop()
+            public Task Stop()
             {
                 if (handler is ILifecycle)
                 {
-                    await ((ILifecycle)handler).Stop();
+                    return ((ILifecycle)handler).Stop();
                 }
+
+                return Task.CompletedTask;
             }
 
             public bool IsRunning

--- a/src/Stream/src/Base/Binder/DefaultBinding.cs
+++ b/src/Stream/src/Base/Binder/DefaultBinding.cs
@@ -85,15 +85,10 @@ namespace Steeltoe.Stream.Binder
 
         public override Task Start()
         {
-            if (!IsRunning)
+            if (!IsRunning && _lifecycle != null && _restartable)
             {
-                if (_lifecycle != null && _restartable)
-                {
-                    return _lifecycle.Start();
-                }
-
-                // this.logger.warn("Can not re-bind an anonymous binding");
-            }
+                return _lifecycle.Start();
+            }  // else this.logger.warn("Can not re-bind an anonymous binding");
 
             return Task.CompletedTask;
         }

--- a/src/Stream/src/Base/Binder/DefaultBinding.cs
+++ b/src/Stream/src/Base/Binder/DefaultBinding.cs
@@ -83,27 +83,29 @@ namespace Steeltoe.Stream.Binder
             get { return _lifecycle is IPausable; }
         }
 
-        public override async Task Start()
+        public override Task Start()
         {
             if (!IsRunning)
             {
                 if (_lifecycle != null && _restartable)
                 {
-                    await _lifecycle.Start();
+                    return _lifecycle.Start();
                 }
-                else
-                {
-                    // this.logger.warn("Can not re-bind an anonymous binding");
-                }
+
+                // this.logger.warn("Can not re-bind an anonymous binding");
             }
+
+            return Task.CompletedTask;
         }
 
-        public override async Task Stop()
+        public override Task Stop()
         {
             if (IsRunning)
             {
-                await _lifecycle.Stop();
+                return _lifecycle.Stop();
             }
+
+            return Task.CompletedTask;
         }
 
         public override async Task Pause()

--- a/src/Stream/src/Base/Binder/DefaultBinding.cs
+++ b/src/Stream/src/Base/Binder/DefaultBinding.cs
@@ -89,7 +89,6 @@ namespace Steeltoe.Stream.Binder
             {
                 return _lifecycle.Start();
             }  // else this.logger.warn("Can not re-bind an anonymous binding");
-
             return Task.CompletedTask;
         }
 

--- a/src/Stream/src/Base/Binder/DefaultPollableMessageSource.cs
+++ b/src/Stream/src/Base/Binder/DefaultPollableMessageSource.cs
@@ -95,20 +95,24 @@ namespace Steeltoe.Stream.Binder
             _interceptors.Insert(index, interceptor);
         }
 
-        public async Task Start()
+        public Task Start()
         {
             if (Interlocked.CompareExchange(ref _running, 1, 0) == 0 && Source is ILifecycle)
             {
-                await ((ILifecycle)Source).Start();
+                return ((ILifecycle)Source).Start();
             }
+
+            return Task.CompletedTask;
         }
 
-        public async Task Stop()
+        public Task Stop()
         {
             if (Interlocked.CompareExchange(ref _running, 0, 1) == 1 && Source is ILifecycle)
             {
-                await ((ILifecycle)Source).Stop();
+                return ((ILifecycle)Source).Stop();
             }
+
+            return Task.CompletedTask;
         }
 
         public override bool Poll(IMessageHandler handler)


### PR DESCRIPTION
returning a task directly avoids the compiler needing the generate an async state machine. resulting in less garbage collection