### PR TITLE
Bug: Token exchanger RequiredScopes

### DIFF
--- a/src/Security/src/Authentication.CloudFoundryBase/TokenExchanger.cs
+++ b/src/Security/src/Authentication.CloudFoundryBase/TokenExchanger.cs
@@ -172,7 +172,7 @@ namespace Steeltoe.Security.Authentication.CloudFoundry
             var scopes = "openid " + _options.AdditionalTokenScopes;
             if (_options.RequiredScopes != null)
             {
-                scopes = string.Join(" ", scopes, _options.RequiredScopes);
+                scopes += string.Join(" ", _options.RequiredScopes);
             }
 
             return new List<KeyValuePair<string, string>>


### PR DESCRIPTION
Scopes string is incorrectly formed when required RequiredScopes is specified