### PR TITLE
(WCF) Always GetTokenValidationParameters, now before checking serviceinfo

### DIFF
--- a/src/Security/src/Authentication.CloudFoundryWcf/CloudFoundryExtensions.cs
+++ b/src/Security/src/Authentication.CloudFoundryWcf/CloudFoundryExtensions.cs
@@ -22,7 +22,20 @@ namespace Steeltoe.Security.Authentication.CloudFoundry.Wcf
         /// <param name="httpClient">Provide your own http client for interacting with the security server</param>
         /// <param name="loggerFactory">For logging within the library</param>
         /// <returns>Your service</returns>
+        [Obsolete("The httpClient parameter has never actually been used, please remove it")]
         public static ServiceHost AddJwtAuthorization(this ServiceHost serviceHost, IConfiguration configuration, HttpClient httpClient = null, LoggerFactory loggerFactory = null)
+        {
+            return serviceHost.AddJwtAuthorization(configuration, loggerFactory);
+        }
+
+        /// <summary>
+        /// Adds the <see cref="JwtAuthorizationManager"/> to a <see cref="ServiceHost"/>
+        /// </summary>
+        /// <param name="serviceHost">Your service to be secured with JWT Auth</param>
+        /// <param name="configuration">Your application configuration, including VCAP_SERVICES</param>
+        /// <param name="loggerFactory">For logging within the library</param>
+        /// <returns>Your service</returns>
+        public static ServiceHost AddJwtAuthorization(this ServiceHost serviceHost, IConfiguration configuration, LoggerFactory loggerFactory = null)
         {
             if (serviceHost == null)
             {
@@ -42,7 +55,7 @@ namespace Steeltoe.Security.Authentication.CloudFoundry.Wcf
             securitySection.Bind(cloudFoundryOptions);
 
             // get and apply service binding info
-            SsoServiceInfo info = configuration.GetSingletonServiceInfo<SsoServiceInfo>();
+            var info = configuration.GetSingletonServiceInfo<SsoServiceInfo>();
             CloudFoundryOptionsConfigurer.Configure(info, cloudFoundryOptions);
 
             var authManager = new JwtAuthorizationManager(cloudFoundryOptions);

--- a/src/Security/src/Authentication.CloudFoundryWcf/CloudFoundryOptions.cs
+++ b/src/Security/src/Authentication.CloudFoundryWcf/CloudFoundryOptions.cs
@@ -89,16 +89,14 @@ namespace Steeltoe.Security.Authentication.CloudFoundry.Wcf
                 AuthorizationUrl = Environment.GetEnvironmentVariable("sso_auth_domain");
                 ClientId = Environment.GetEnvironmentVariable("sso_client_id");
                 ClientSecret = Environment.GetEnvironmentVariable("sso_client_secret");
+
+                // not using ILogger because an app using environment variable here could predate inclusion of ILogger in this class
                 Console.Error.WriteLine("sso_* variables were detected in your environment! Future releases of Steeltoe will not uses them for configuration");
                 Debug.WriteLine("sso_* variables were detected in your environment! Future releases of Steeltoe will not uses them for configuration");
             }
 
-            TokenKeyResolver = TokenKeyResolver ??
-                new CloudFoundry.CloudFoundryTokenKeyResolver(
-                    AuthorizationUrl + CloudFoundryDefaults.JwtTokenUri,
-                    null,
-                    ValidateCertificates);
-            TokenValidator = TokenValidator ?? new CloudFoundryWcfTokenValidator(this, LoggerFactory?.CreateLogger<CloudFoundryWcfTokenValidator>());
+            TokenKeyResolver ??= new CloudFoundry.CloudFoundryTokenKeyResolver(AuthorizationUrl + CloudFoundryDefaults.JwtTokenUri, null, ValidateCertificates);
+            TokenValidator ??= new CloudFoundryWcfTokenValidator(this, LoggerFactory?.CreateLogger<CloudFoundryWcfTokenValidator>());
         }
 
         [Obsolete("This constructor is expected to be removed in a future release. Please reach out if this constructor is important to you!")]
@@ -128,13 +126,9 @@ namespace Steeltoe.Security.Authentication.CloudFoundry.Wcf
             AuthorizationUrl = info.AuthDomain;
             ClientId = info.ClientId;
             ClientSecret = info.ClientSecret;
-            TokenKeyResolver = TokenKeyResolver ??
-                new CloudFoundry.CloudFoundryTokenKeyResolver(
-                    AuthorizationUrl + CloudFoundryDefaults.JwtTokenUri,
-                    null,
-                    ValidateCertificates);
-            TokenValidator = TokenValidator ?? new CloudFoundryWcfTokenValidator(this);
-            TokenValidationParameters = TokenValidationParameters ?? GetTokenValidationParameters();
+            TokenKeyResolver ??= new CloudFoundry.CloudFoundryTokenKeyResolver(AuthorizationUrl + CloudFoundryDefaults.JwtTokenUri, null, ValidateCertificates);
+            TokenValidator ??= new CloudFoundryWcfTokenValidator(this);
+            TokenValidationParameters ??= GetTokenValidationParameters();
         }
 
         internal TokenValidationParameters GetTokenValidationParameters()
@@ -145,12 +139,8 @@ namespace Steeltoe.Security.Authentication.CloudFoundry.Wcf
             }
 
             var parameters = new TokenValidationParameters();
-            TokenKeyResolver = TokenKeyResolver ??
-                new Steeltoe.Security.Authentication.CloudFoundry.CloudFoundryTokenKeyResolver(
-                    AuthorizationUrl + CloudFoundryDefaults.JwtTokenUri,
-                    null,
-                    ValidateCertificates);
-            TokenValidator = TokenValidator ?? new CloudFoundryWcfTokenValidator(this, LoggerFactory?.CreateLogger<CloudFoundryWcfTokenValidator>());
+            TokenKeyResolver ??= new CloudFoundry.CloudFoundryTokenKeyResolver(AuthorizationUrl + CloudFoundryDefaults.JwtTokenUri, null, ValidateCertificates);
+            TokenValidator ??= new CloudFoundryWcfTokenValidator(this, LoggerFactory?.CreateLogger<CloudFoundryWcfTokenValidator>());
             TokenValidationParameters = parameters;
 
             parameters.ValidateAudience = ValidateAudience;

--- a/src/Security/src/Authentication.CloudFoundryWcf/CloudFoundryOptionsConfigurer.cs
+++ b/src/Security/src/Authentication.CloudFoundryWcf/CloudFoundryOptionsConfigurer.cs
@@ -21,6 +21,10 @@ namespace Steeltoe.Security.Authentication.CloudFoundry.Wcf
                 throw new ArgumentNullException(nameof(options));
             }
 
+            var backchannelHttpHandler = CloudFoundryHelper.GetBackChannelHandler(options.ValidateCertificates);
+            options.TokenValidationParameters ??= options.GetTokenValidationParameters();
+            options.TokenValidationParameters = CloudFoundryHelper.GetTokenValidationParameters(options.TokenValidationParameters, options.AuthorizationUrl + CloudFoundryDefaults.JwtTokenUri, backchannelHttpHandler, options.ValidateCertificates, options);
+
             if (si == null)
             {
                 return;
@@ -29,9 +33,6 @@ namespace Steeltoe.Security.Authentication.CloudFoundry.Wcf
             options.AuthorizationUrl = si.AuthDomain;
             options.ClientId = si.ClientId;
             options.ClientSecret = si.ClientSecret;
-
-            var backchannelHttpHandler = CloudFoundryHelper.GetBackChannelHandler(options.ValidateCertificates);
-            options.TokenValidationParameters = CloudFoundryHelper.GetTokenValidationParameters(options.TokenValidationParameters, options.AuthorizationUrl + CloudFoundryDefaults.JwtTokenUri, backchannelHttpHandler, options.ValidateCertificates, options);
         }
     }
 }

--- a/src/Security/test/Authentication.CloudFoundryWcf.Net4Test/CloudFoundryOptionsConfigurerTest.cs
+++ b/src/Security/test/Authentication.CloudFoundryWcf.Net4Test/CloudFoundryOptionsConfigurerTest.cs
@@ -55,5 +55,22 @@ namespace Steeltoe.Security.Authentication.CloudFoundry.Wcf.Test
             Assert.Equal(authURL + CloudFoundryDefaults.CheckTokenUri, opts.TokenInfoUrl);
             Assert.True(opts.ValidateCertificates);
         }
+
+        [Fact]
+        public void Configure_AlwaysSetsTokenValidationParameters()
+        {
+            // arrange
+            var opts = new CloudFoundryOptions() { ValidateAudience = false };
+
+            // this property isn't set in the constructor or exposed downstream, it should be false here:
+            Assert.Null(opts.TokenValidationParameters);
+
+            // act
+            CloudFoundryOptionsConfigurer.Configure(null, opts);
+
+            // assert
+            Assert.NotNull(opts.TokenValidationParameters);
+            Assert.False(opts.TokenValidationParameters.ValidateAudience);
+        }
     }
 }


### PR DESCRIPTION
Code & test to make sure token validation parameters are always set for WCF + JWT in `CloudFoundryOptionsConfigurer.cs`.

Also removes an unused param from `AddJwtAuthorization` and makes several mostly cosmetic changes to related files