### PR TITLE
Skip InetUtils tests on hosted Mac, target netcoreapp3.1

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,7 +1,3 @@
-# ASP.NET Core
-# Build and test ASP.NET Core projects targeting .NET Core.
-# Add steps that run tests, create a NuGet package, deploy, and more:
-# https://docs.microsoft.com/azure/devops/pipelines/languages/dotnet-core
 trigger:
   branches:
     include:
@@ -13,125 +9,118 @@ trigger:
     - project-docs/*
     - roadmaps/*
 
-variables:
-  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
-  DOTNET_CLI_TELEMETRY_OPTOUT: 1
-  PackageVersion: $[format('2.5.0-ci{0}', variables['Build.BuildId'])]
-strategy:
-  matrix:
-    Linux_Build_and_Test:
-      imageName: ubuntu-latest
-      skipFilter: '--filter "Category!=Integration&Category!=SkipOnLinux"'
-    MacOS_Build_and_Test:
-      imageName: macOS-latest
-      skipFilter: '--filter "Category!=Integration&Category!=SkipOnMacOS"'
-    Windows_Build_Test_and_Package:
-      imageName: windows-latest
-      skipFilter: '--filter "Category!=Integration"'
-pool:
-  vmImage: $(imageName)
-
-steps:
-- pwsh: |
-    if ($env:PackageVersionOverride){
-        $env:PackageVersion = $env:PackageVersionOverride
-    }
-    Write-Host "##vso[build.updatebuildnumber]$env:PackageVersion"
-    Write-Host "##vso[task.setvariable variable=PackageVersion;]$env:PackageVersion"
-    $prefix = $env:PackageVersion.Split('-')[0]
-    $suffix = $env:PackageVersion.Split('-')[1]
-    Write-Host "##vso[task.setvariable variable=VersionPrefix;]$prefix"
-    Write-Host "##vso[task.setvariable variable=VersionSuffix;]$suffix"
-  displayName: Set Build Variables
-  env:
-    PackageVersion: $(PackageVersion)
-    PackageVersionOverride: $(PackageVersionOverride)
-- task: PowerShell@2
-  displayName: 'Get GemFire NativeClient assemblies'
-  inputs:
-    filePath: src/Connectors/EnableGemFire.ps1
-    arguments: $(PivNetAPIToken)
-- task: DotNetCoreCLI@2
-  displayName: dotnet restore
-  inputs:
-    command: restore
-    projects: src/Steeltoe.All.sln
-    feedsToUse: config
-    nugetConfigPath: nuget.config
-- task: SonarSource.sonarcloud.14d9cde6-c1da-4d55-aa01-2965cd301255.SonarCloudPrepare@1
-  condition: eq( variables['Agent.OS'], 'Windows_NT' )
-  displayName: 'Prepare analysis on SonarCloud'
-  inputs:
-    SonarCloud: SonarCloud
-    organization: 'steeltoeoss'
-    projectKey: 'SteeltoeOSS_steeltoe'
-    extraProperties: |
-      sonar.cs.opencover.reportsPaths=$(Build.SourcesDirectory)\**\*opencover.xml
-      sonar.cs.vstest.reportsPaths=$(Agent.TempDirectory)\*.trx
-      sonar.exclusions=$(Build.SourcesDirectory)\src\Management\OpenCensus*
-      sonar.coverage.exclusions=**/*Test*/**/*
-- task: DotNetCoreCLI@2
-  displayName: dotnet build
-  inputs:
-    command: build
-    projects: 'src/Steeltoe.All.sln'
-    arguments: '--no-restore -c $(buildConfiguration) -v n /p:TreatWarningsAsErrors=True /p:VersionPrefix=$(VersionPrefix) /p:VersionSuffix=$(VersionSuffix)'
-- task: DotNetCoreCLI@2
-  displayName: dotnet test
-  inputs:
-    command: test
-    projects: '**/*.Test/*.csproj'
-    arguments: '--no-build -c $(buildConfiguration) -maxcpucount:1 /p:CopyLocalLockFileAssemblies=true $(skipFilter) /p:CollectCoverage=true /p:CoverletOutputFormat="opencover" /p:Include="[Steeltoe.*]*" /p:Exclude="[*.Test*]*%2c[*]Microsoft.Diagnostics*"'
-- pwsh: dotnet tool install -g dotnet-reportgenerator-globaltool; reportgenerator "-reports:**\*.opencover.xml" "-targetdir:$(Build.SourcesDirectory)\CodeCoverage" -reporttypes:Cobertura
-  condition: eq( variables['Agent.OS'], 'Windows_NT' )
-  displayName: Create Code coverage report
-- task: PublishCodeCoverageResults@1
-  condition: eq( variables['Agent.OS'], 'Windows_NT' )
-  displayName: 'Publish code coverage'
-  inputs:
-    codeCoverageTool: Cobertura
-    summaryFileLocation: '$(Build.SourcesDirectory)\CodeCoverage\Cobertura.xml'
-    reportDirectory: '$(Build.SourcesDirectory)\CodeCoverage'
-- bash: bash <(curl -s https://codecov.io/bash)
-  condition: eq( variables['Agent.OS'], 'Windows_NT' )
-  displayName: 'Upload to codecov.io'
-- task: SonarSource.sonarcloud.ce096e50-6155-4de8-8800-4221aaeed4a1.SonarCloudAnalyze@1
-  condition: eq( variables['Agent.OS'], 'Windows_NT' )
-  displayName: Run Code Analysis
-- task: SonarSource.sonarcloud.38b27399-a642-40af-bb7d-9971f69712e8.SonarCloudPublish@1
-  condition: eq( variables['Agent.OS'], 'Windows_NT' )
-  displayName: Publish Quality Gate Result
-- task: DotNetCoreCLI@2
-  condition: eq( variables['Agent.OS'], 'Windows_NT' )
-  displayName: dotnet pack
-  inputs:
-    command: pack
-    feedsToUse: select
-    packagesToPack: src/Steeltoe.All.sln
-    versioningScheme: byEnvVar
-    versionEnvVar: PackageVersion
-    nobuild: true
-- task: PowerShell@2
-  condition: and(succeeded(), not(eq(variables['build.reason'], 'PullRequest')), not(eq(variables['SignClientSecret'], '')), not(eq(variables['SignClientUser'], '')), eq( variables['Agent.OS'], 'Windows_NT' ))
-  displayName: Authenticode Sign Packages
-  inputs:
-    filePath: build/sign-packages.ps1
-  env:
-    SignClientUser: $(SignClientUser)
-    SignClientSecret: $(SignClientSecret)
-    ArtifactDirectory: $(Build.ArtifactStagingDirectory)
-- task: PublishBuildArtifacts@1
-  condition: always()
-  inputs:
-    PathtoPublish: $(Build.ArtifactStagingDirectory)
-    ArtifactName: Packages
-    publishLocation: Container
-
-
-
-
-  # Generate the report using ReportGenerator (https://github.com/danielpalme/ReportGenerator)
-  # First install the tool on the machine, then run it
-  # Publish the code coverage result (summary and web site)
-  # The summary allows to view the coverage percentage in the summary tab
-  # The web site allows to view which lines are covered directly in Azure Pipeline
+jobs:
+- job:
+  variables:
+    DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+    DOTNET_CLI_TELEMETRY_OPTOUT: 1
+    PackageVersion: $[format('2.5.0-ci{0}', variables['Build.BuildId'])]
+  strategy:
+    matrix:
+      Linux_Build_and_Test:
+        imageName: ubuntu-latest
+        skipFilter: '--filter "Category!=Integration&Category!=SkipOnLinux"'
+      MacOS_Build_and_Test:
+        imageName: macOS-latest
+        skipFilter: '--filter "Category!=Integration&Category!=SkipOnMacOS"'
+      Windows_Build_Test_and_Package:
+        imageName: windows-latest
+        skipFilter: '--filter "Category!=Integration"'
+  pool:
+    vmImage: $(imageName) 
+  timeoutInMinutes: 0
+  steps:
+  - pwsh: |
+      if ($env:PackageVersionOverride){
+          $env:PackageVersion = $env:PackageVersionOverride
+      }
+      Write-Host "##vso[build.updatebuildnumber]$env:PackageVersion"
+      Write-Host "##vso[task.setvariable variable=PackageVersion;]$env:PackageVersion"
+      $prefix = $env:PackageVersion.Split('-')[0]
+      $suffix = $env:PackageVersion.Split('-')[1]
+      Write-Host "##vso[task.setvariable variable=VersionPrefix;]$prefix"
+      Write-Host "##vso[task.setvariable variable=VersionSuffix;]$suffix"
+    displayName: Set Build Variables
+    env:
+      PackageVersion: $(PackageVersion)
+      PackageVersionOverride: $(PackageVersionOverride)
+  - task: PowerShell@2
+    displayName: 'Get GemFire NativeClient assemblies'
+    inputs:
+      filePath: src/Connectors/EnableGemFire.ps1
+      arguments: $(PivNetAPIToken)
+  - task: DotNetCoreCLI@2
+    displayName: dotnet restore
+    inputs:
+      command: restore
+      projects: src/Steeltoe.All.sln
+      feedsToUse: config
+      nugetConfigPath: nuget.config
+  - task: SonarCloudPrepare@1
+    condition: eq( variables['Agent.OS'], 'Windows_NT' )
+    displayName: 'Prepare analysis on SonarCloud'
+    inputs:
+      SonarCloud: SonarCloud
+      organization: 'steeltoeoss'
+      projectKey: 'SteeltoeOSS_steeltoe'
+      extraProperties: |
+        sonar.cs.opencover.reportsPaths=$(Build.SourcesDirectory)\**\*opencover.xml
+        sonar.cs.vstest.reportsPaths=$(Agent.TempDirectory)\*.trx
+        sonar.exclusions=$(Build.SourcesDirectory)\src\Management\OpenCensus*
+        sonar.coverage.exclusions=**/*Test*/**/*
+  - task: DotNetCoreCLI@2
+    displayName: dotnet build
+    inputs:
+      command: build
+      projects: 'src/Steeltoe.All.sln'
+      arguments: '--no-restore -c $(buildConfiguration) -v n /p:TreatWarningsAsErrors=True /p:VersionPrefix=$(VersionPrefix) /p:VersionSuffix=$(VersionSuffix)'
+  - task: DotNetCoreCLI@2
+    displayName: dotnet test
+    inputs:
+      command: test
+      projects: '**/*.Test/*.csproj'
+      arguments: '--no-build -c $(buildConfiguration) -maxcpucount:1 /p:CopyLocalLockFileAssemblies=true $(skipFilter) /p:CollectCoverage=true /p:CoverletOutputFormat="opencover" /p:Include="[Steeltoe.*]*" /p:Exclude="[*.Test*]*%2c[*]Microsoft.Diagnostics*"'
+  - pwsh: dotnet tool install -g dotnet-reportgenerator-globaltool; reportgenerator "-reports:**\*.opencover.xml" "-targetdir:$(Build.SourcesDirectory)\CodeCoverage" -reporttypes:Cobertura
+    condition: eq( variables['Agent.OS'], 'Windows_NT' )
+    displayName: Create Code coverage report
+  - task: PublishCodeCoverageResults@1
+    condition: eq( variables['Agent.OS'], 'Windows_NT' )
+    displayName: 'Publish code coverage'
+    inputs:
+      codeCoverageTool: Cobertura
+      summaryFileLocation: '$(Build.SourcesDirectory)\CodeCoverage\Cobertura.xml'
+      reportDirectory: '$(Build.SourcesDirectory)\CodeCoverage'
+  - bash: bash <(curl -s https://codecov.io/bash)
+    condition: eq( variables['Agent.OS'], 'Windows_NT' )
+    displayName: 'Upload to codecov.io'
+  - task: SonarCloudAnalyze@1
+    condition: eq( variables['Agent.OS'], 'Windows_NT' )
+    displayName: Run Code Analysis
+  - task: SonarCloudPublish@1
+    condition: eq( variables['Agent.OS'], 'Windows_NT' )
+    displayName: Publish Quality Gate Result
+  - task: DotNetCoreCLI@2
+    condition: eq( variables['Agent.OS'], 'Windows_NT' )
+    displayName: dotnet pack
+    inputs:
+      command: pack
+      feedsToUse: select
+      packagesToPack: src/Steeltoe.All.sln
+      versioningScheme: byEnvVar
+      versionEnvVar: PackageVersion
+      nobuild: true
+  - task: PowerShell@2
+    condition: and(succeeded(), not(eq(variables['build.reason'], 'PullRequest')), not(eq(variables['SignClientSecret'], '')), not(eq(variables['SignClientUser'], '')), eq( variables['Agent.OS'], 'Windows_NT' ))
+    displayName: Authenticode Sign Packages
+    inputs:
+      filePath: build/sign-packages.ps1
+    env:
+      SignClientUser: $(SignClientUser)
+      SignClientSecret: $(SignClientSecret)
+      ArtifactDirectory: $(Build.ArtifactStagingDirectory)
+  - task: PublishBuildArtifacts@1
+    condition: always()
+    inputs:
+      PathtoPublish: $(Build.ArtifactStagingDirectory)
+      ArtifactName: Packages
+      publishLocation: Container

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,189 +17,121 @@ variables:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
   DOTNET_CLI_TELEMETRY_OPTOUT: 1
   PackageVersion: $[format('2.5.0-ci{0}', variables['Build.BuildId'])]
+strategy:
+  matrix:
+    Linux_Build_and_Test:
+      imageName: ubuntu-latest
+      skipFilter: '--filter "Category!=Integration&Category!=SkipOnLinux"'
+    MacOS_Build_and_Test:
+      imageName: macOS-latest
+      skipFilter: '--filter "Category!=Integration&Category!=SkipOnMacOS"'
+    Windows_Build_Test_and_Package:
+      imageName: windows-latest
+      skipFilter: '--filter "Category!=Integration"'
+pool:
+  vmImage: $(imageName)
 
-jobs:
-- job: Linux_Build_and_Test
-  pool:
-    vmImage: 'ubuntu-latest'
-  steps:
-  - task: PowerShell@2
-    displayName: 'Get GemFire NativeClient assemblies'
-    inputs:
-      filePath: src/Connectors/EnableGemFire.ps1
-      arguments: $(PivNetAPIToken)
-  - task: UseDotNet@2
-    displayName: 'Install .NET Core 2.x SDK'
-    inputs:
-      packageType: sdk
-      version: 2.1.806
-  - task: UseDotNet@2
-    displayName: 'Install .NET Core 3.x SDK'
-    inputs:
-      packageType: sdk
-      version: 3.1.300
-  - task: DotNetCoreCLI@2
-    displayName: dotnet restore
-    inputs:
-      command: restore
-      projects: 'src/Steeltoe.All.sln'
-  - task: DotNetCoreCLI@2
-    displayName: dotnet build
-    inputs:
-      command: build
-      projects: 'src/Steeltoe.All.sln'
-      arguments: '--no-restore -c $(buildConfiguration) -v n /p:TreatWarningsAsErrors=True'
-  - task: DotNetCoreCLI@2
-    displayName: dotnet test
-    inputs:
-      command: test
-      projects: '**/*.Test/*.csproj'
-      arguments: '--no-build -c $(buildConfiguration) -maxcpucount:1 --filter "Category!=SkipOnLinux"'
-- job: MacOS_Build_and_Test
-  pool:
-    vmImage: 'macOS-latest'
-  steps:
-  - task: PowerShell@2
-    displayName: 'Get GemFire NativeClient assemblies'
-    inputs:
-      filePath: src/Connectors/EnableGemFire.ps1
-      arguments: $(PivNetAPIToken)
-  - task: UseDotNet@2
-    displayName: 'Install .NET Core 2.x SDK'
-    inputs:
-      packageType: sdk
-      version: 2.1.806
-  - task: UseDotNet@2
-    displayName: 'Install .NET Core 3.x SDK'
-    inputs:
-      packageType: sdk
-      version: 3.1.300
-  - task: DotNetCoreCLI@2
-    displayName: dotnet restore
-    inputs:
-      command: restore
-      projects: 'src/Steeltoe.All.sln'
-  - task: DotNetCoreCLI@2
-    displayName: dotnet build
-    inputs:
-      command: build
-      projects: 'src/Steeltoe.All.sln'
-      arguments: '--no-restore -c $(buildConfiguration) -v n /p:TreatWarningsAsErrors=True'
-  - task: DotNetCoreCLI@2
-    displayName: dotnet test
-    inputs:
-      command: test
-      projects: '**/*.Test/*.csproj'
-      arguments: '--no-build -c $(buildConfiguration) -maxcpucount:1 --filter "Category!=SkipOnMacOS"'
-- job: Windows_Build_Test_and_Package
-  timeoutInMinutes: 90
-  pool:
-    vmImage: 'windows-latest'
-  steps:
-  - pwsh: |
-      if ($env:PackageVersionOverride){
-          $env:PackageVersion = $env:PackageVersionOverride
-      }
-      Write-Host "##vso[build.updatebuildnumber]$env:PackageVersion"
-      Write-Host "##vso[task.setvariable variable=PackageVersion;]$env:PackageVersion"
-      $prefix = $env:PackageVersion.Split('-')[0]
-      $suffix = $env:PackageVersion.Split('-')[1]
-      Write-Host "##vso[task.setvariable variable=VersionPrefix;]$prefix"
-      Write-Host "##vso[task.setvariable variable=VersionSuffix;]$suffix"
-    displayName: Set Build Variables
-    env:
-      PackageVersion: $(PackageVersion)
-      PackageVersionOverride: $(PackageVersionOverride)
-  - task: PowerShell@2
-    displayName: 'Get GemFire NativeClient assemblies'
-    inputs:
-      filePath: src/Connectors/EnableGemFire.ps1
-      arguments: $(PivNetAPIToken)
-  - task: UseDotNet@2
-    displayName: 'Install .NET Core 2.x SDK'
-    inputs:
-      packageType: sdk
-      version: 2.1.806
-  - task: UseDotNet@2
-    displayName: 'Install .NET Core 3.x SDK'
-    inputs:
-      packageType: sdk
-      version: 3.1.300
-  - task: DotNetCoreCLI@2
-    displayName: dotnet restore
-    inputs:
-      command: 'restore'
-      projects: 'src/Steeltoe.All.sln'
-  - task: SonarSource.sonarcloud.14d9cde6-c1da-4d55-aa01-2965cd301255.SonarCloudPrepare@1
-    displayName: 'Prepare analysis on SonarCloud'
-    inputs:
-      SonarCloud: SonarCloud
-      organization: 'steeltoeoss'
-      projectKey: 'SteeltoeOSS_steeltoe'
-      extraProperties: |
-        sonar.cs.opencover.reportsPaths=$(Build.SourcesDirectory)\**\*opencover.xml
-        sonar.cs.vstest.reportsPaths=$(Agent.TempDirectory)\*.trx
-        sonar.exclusions=$(Build.SourcesDirectory)\src\Management\OpenCensus*
-        sonar.coverage.exclusions=**/*Test*/**/*
-  - task: DotNetCoreCLI@2
-    displayName: dotnet build
-    inputs:
-      command: 'build'
-      feedsToUse: 'select'
-      arguments: '--no-restore -c $(buildConfiguration) /p:VersionPrefix=$(VersionPrefix) /p:VersionSuffix=$(VersionSuffix)'
-      projects: 'src/Steeltoe.All.sln'
-      versioningScheme: 'byEnvVar'
-      versionEnvVar: PackageVersion
-  - task: DotNetCoreCLI@2
-    displayName: dotnet test
-    inputs:
-      command: test
-      projects: 'src/Steeltoe.All.sln'
-      arguments: '--no-build -c $(buildConfiguration) -maxcpucount:1 /p:CopyLocalLockFileAssemblies=true --filter "Category!=Integration" /p:CollectCoverage=true /p:CoverletOutputFormat="opencover" /p:Include="[Steeltoe.*]*" /p:Exclude="[*.Test*]*%2c[*]Microsoft.Diagnostics*"'
+steps:
+- pwsh: |
+    if ($env:PackageVersionOverride){
+        $env:PackageVersion = $env:PackageVersionOverride
+    }
+    Write-Host "##vso[build.updatebuildnumber]$env:PackageVersion"
+    Write-Host "##vso[task.setvariable variable=PackageVersion;]$env:PackageVersion"
+    $prefix = $env:PackageVersion.Split('-')[0]
+    $suffix = $env:PackageVersion.Split('-')[1]
+    Write-Host "##vso[task.setvariable variable=VersionPrefix;]$prefix"
+    Write-Host "##vso[task.setvariable variable=VersionSuffix;]$suffix"
+  displayName: Set Build Variables
+  env:
+    PackageVersion: $(PackageVersion)
+    PackageVersionOverride: $(PackageVersionOverride)
+- task: PowerShell@2
+  displayName: 'Get GemFire NativeClient assemblies'
+  inputs:
+    filePath: src/Connectors/EnableGemFire.ps1
+    arguments: $(PivNetAPIToken)
+- task: DotNetCoreCLI@2
+  displayName: dotnet restore
+  inputs:
+    command: restore
+    projects: src/Steeltoe.All.sln
+    feedsToUse: config
+    nugetConfigPath: nuget.config
+- task: SonarSource.sonarcloud.14d9cde6-c1da-4d55-aa01-2965cd301255.SonarCloudPrepare@1
+  condition: eq( variables['Agent.OS'], 'Windows_NT' )
+  displayName: 'Prepare analysis on SonarCloud'
+  inputs:
+    SonarCloud: SonarCloud
+    organization: 'steeltoeoss'
+    projectKey: 'SteeltoeOSS_steeltoe'
+    extraProperties: |
+      sonar.cs.opencover.reportsPaths=$(Build.SourcesDirectory)\**\*opencover.xml
+      sonar.cs.vstest.reportsPaths=$(Agent.TempDirectory)\*.trx
+      sonar.exclusions=$(Build.SourcesDirectory)\src\Management\OpenCensus*
+      sonar.coverage.exclusions=**/*Test*/**/*
+- task: DotNetCoreCLI@2
+  displayName: dotnet build
+  inputs:
+    command: build
+    projects: 'src/Steeltoe.All.sln'
+    arguments: '--no-restore -c $(buildConfiguration) -v n /p:TreatWarningsAsErrors=True /p:VersionPrefix=$(VersionPrefix) /p:VersionSuffix=$(VersionSuffix)'
+- task: DotNetCoreCLI@2
+  displayName: dotnet test
+  inputs:
+    command: test
+    projects: '**/*.Test/*.csproj'
+    arguments: '--no-build -c $(buildConfiguration) -maxcpucount:1 /p:CopyLocalLockFileAssemblies=true $(skipFilter) /p:CollectCoverage=true /p:CoverletOutputFormat="opencover" /p:Include="[Steeltoe.*]*" /p:Exclude="[*.Test*]*%2c[*]Microsoft.Diagnostics*"'
+- pwsh: dotnet tool install -g dotnet-reportgenerator-globaltool; reportgenerator "-reports:**\*.opencover.xml" "-targetdir:$(Build.SourcesDirectory)\CodeCoverage" -reporttypes:Cobertura
+  condition: eq( variables['Agent.OS'], 'Windows_NT' )
+  displayName: Create Code coverage report
+- task: PublishCodeCoverageResults@1
+  condition: eq( variables['Agent.OS'], 'Windows_NT' )
+  displayName: 'Publish code coverage'
+  inputs:
+    codeCoverageTool: Cobertura
+    summaryFileLocation: '$(Build.SourcesDirectory)\CodeCoverage\Cobertura.xml'
+    reportDirectory: '$(Build.SourcesDirectory)\CodeCoverage'
+- bash: bash <(curl -s https://codecov.io/bash)
+  condition: eq( variables['Agent.OS'], 'Windows_NT' )
+  displayName: 'Upload to codecov.io'
+- task: SonarSource.sonarcloud.ce096e50-6155-4de8-8800-4221aaeed4a1.SonarCloudAnalyze@1
+  condition: eq( variables['Agent.OS'], 'Windows_NT' )
+  displayName: Run Code Analysis
+- task: SonarSource.sonarcloud.38b27399-a642-40af-bb7d-9971f69712e8.SonarCloudPublish@1
+  condition: eq( variables['Agent.OS'], 'Windows_NT' )
+  displayName: Publish Quality Gate Result
+- task: DotNetCoreCLI@2
+  condition: eq( variables['Agent.OS'], 'Windows_NT' )
+  displayName: dotnet pack
+  inputs:
+    command: pack
+    feedsToUse: select
+    packagesToPack: src/Steeltoe.All.sln
+    versioningScheme: byEnvVar
+    versionEnvVar: PackageVersion
+    nobuild: true
+- task: PowerShell@2
+  condition: and(succeeded(), not(eq(variables['build.reason'], 'PullRequest')), not(eq(variables['SignClientSecret'], '')), not(eq(variables['SignClientUser'], '')), eq( variables['Agent.OS'], 'Windows_NT' ))
+  displayName: Authenticode Sign Packages
+  inputs:
+    filePath: build/sign-packages.ps1
+  env:
+    SignClientUser: $(SignClientUser)
+    SignClientSecret: $(SignClientSecret)
+    ArtifactDirectory: $(Build.ArtifactStagingDirectory)
+- task: PublishBuildArtifacts@1
+  condition: always()
+  inputs:
+    PathtoPublish: $(Build.ArtifactStagingDirectory)
+    ArtifactName: Packages
+    publishLocation: Container
+
+
+
+
   # Generate the report using ReportGenerator (https://github.com/danielpalme/ReportGenerator)
   # First install the tool on the machine, then run it
-  - pwsh: dotnet tool install -g dotnet-reportgenerator-globaltool; reportgenerator "-reports:**\*.opencover.xml" "-targetdir:$(Build.SourcesDirectory)\CodeCoverage" -reporttypes:Cobertura
-    displayName: Create Code coverage report
-    condition: always()
   # Publish the code coverage result (summary and web site)
   # The summary allows to view the coverage percentage in the summary tab
   # The web site allows to view which lines are covered directly in Azure Pipeline
-  - task: PublishCodeCoverageResults@1
-    displayName: 'Publish code coverage'
-    inputs:
-      codeCoverageTool: Cobertura
-      summaryFileLocation: '$(Build.SourcesDirectory)\CodeCoverage\Cobertura.xml'
-      reportDirectory: '$(Build.SourcesDirectory)\CodeCoverage'
-    condition: always()
-  - bash: bash <(curl -s https://codecov.io/bash)
-    displayName: 'Upload to codecov.io'
-    condition: always()
-  - task: SonarSource.sonarcloud.ce096e50-6155-4de8-8800-4221aaeed4a1.SonarCloudAnalyze@1
-    displayName: Run Code Analysis
-    condition: always()
-  - task: SonarSource.sonarcloud.38b27399-a642-40af-bb7d-9971f69712e8.SonarCloudPublish@1
-    displayName: Publish Quality Gate Result
-    condition: always()
-  - task: DotNetCoreCLI@2
-    displayName: dotnet pack
-    inputs:
-      command: 'pack'
-      feedsToUse: 'select'
-      packagesToPack: 'src/Steeltoe.All.sln'
-      versioningScheme: 'byEnvVar'
-      versionEnvVar: PackageVersion
-  - task: PowerShell@2
-    displayName: Authenticode Sign Packages
-    inputs:
-      filePath: build/sign-packages.ps1
-    env:
-      SignClientUser: $(SignClientUser)
-      SignClientSecret: $(SignClientSecret)
-      ArtifactDirectory: $(Build.ArtifactStagingDirectory)
-    condition: and(succeeded(), not(eq(variables['build.reason'], 'PullRequest')), not(eq(variables['SignClientSecret'], '')), not(eq(variables['SignClientUser'], '')))
-  - task: PublishBuildArtifacts@1
-    inputs:
-      PathtoPublish: $(Build.ArtifactStagingDirectory)
-      ArtifactName: Packages
-      publishLocation: Container
-    condition: always()

--- a/src/CircuitBreaker/src/Hystrix.MetricsEventsCore/Steeltoe.CircuitBreaker.Hystrix.MetricsEventsCore.csproj
+++ b/src/CircuitBreaker/src/Hystrix.MetricsEventsCore/Steeltoe.CircuitBreaker.Hystrix.MetricsEventsCore.csproj
@@ -1,30 +1,29 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
- <Import Project="..\..\..\..\versions.props" />
-
   <PropertyGroup>
     <Description>Steeltoe Neflix Hystrix Metrics Event Stream ASP.NET Core</Description>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
     <AssemblyName>Steeltoe.CircuitBreaker.Hystrix.MetricsEventsCore</AssemblyName>
     <PackageId>Steeltoe.CircuitBreaker.Hystrix.MetricsEventsCore</PackageId>
     <PackageTags>ASPNET Core;Circuit Breaker;Spring;Spring Cloud;Spring Cloud Hystrix;Hystrix</PackageTags>
   </PropertyGroup>
+
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedproject.props" />
 
-  <ItemGroup Condition="'$(CI_BUILD)' == ''">
+  <ItemGroup Condition="'$(TF_BUILD)' == ''">
       <ProjectReference Include="..\HystrixBase\Steeltoe.CircuitBreaker.HystrixBase.csproj" />
   </ItemGroup>
-
-  <ItemGroup Condition="'$(CI_BUILD)' == 'True'">
+  <ItemGroup Condition="'$(TF_BUILD)' == 'True'">
       <PackageReference Include="Steeltoe.CircuitBreaker.HystrixBase" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="$(AspNetCoreVersion)" />
   </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="System.Reactive" Version="$(ReactiveVersion)" />
     <PackageReference Include="System.Reactive.Observable.Aliases" Version="$(ReactiveVersion)" />

--- a/src/CircuitBreaker/src/Hystrix.MetricsEventsCore/Steeltoe.CircuitBreaker.Hystrix.MetricsEventsCore.csproj
+++ b/src/CircuitBreaker/src/Hystrix.MetricsEventsCore/Steeltoe.CircuitBreaker.Hystrix.MetricsEventsCore.csproj
@@ -10,11 +10,8 @@
   <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedproject.props" />
 
-  <ItemGroup Condition="'$(TF_BUILD)' == ''">
-      <ProjectReference Include="..\HystrixBase\Steeltoe.CircuitBreaker.HystrixBase.csproj" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TF_BUILD)' == 'True'">
-      <PackageReference Include="Steeltoe.CircuitBreaker.HystrixBase" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
+  <ItemGroup>
+    <ProjectReference Include="..\HystrixBase\Steeltoe.CircuitBreaker.HystrixBase.csproj" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">

--- a/src/CircuitBreaker/src/Hystrix.MetricsStreamAutofac/Steeltoe.CircuitBreaker.Hystrix.MetricsStreamAutofac.csproj
+++ b/src/CircuitBreaker/src/Hystrix.MetricsStreamAutofac/Steeltoe.CircuitBreaker.Hystrix.MetricsStreamAutofac.csproj
@@ -11,15 +11,10 @@
   <Import Project="..\..\..\..\sharedproject.props" />
   <Import Project="..\..\..\..\targetframework.props" />
 
-  <ItemGroup Condition="'$(TF_BUILD)' == ''">
+  <ItemGroup>
     <ProjectReference Include="..\..\..\Common\src\Common.Autofac\Steeltoe.Common.Autofac.csproj" />
     <ProjectReference Include="..\..\..\Connectors\src\ConnectorAutofac\Steeltoe.CloudFoundry.ConnectorAutofac.csproj" />
     <ProjectReference Include="..\HystrixBase\Steeltoe.CircuitBreaker.HystrixBase.csproj" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TF_BUILD)' == 'True'">
-    <PackageReference Include="Steeltoe.Common.Autofac" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
-    <PackageReference Include="Steeltoe.CloudFoundry.ConnectorAutofac" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
-    <PackageReference Include="Steeltoe.CircuitBreaker.HystrixBase" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CircuitBreaker/src/Hystrix.MetricsStreamAutofac/Steeltoe.CircuitBreaker.Hystrix.MetricsStreamAutofac.csproj
+++ b/src/CircuitBreaker/src/Hystrix.MetricsStreamAutofac/Steeltoe.CircuitBreaker.Hystrix.MetricsStreamAutofac.csproj
@@ -1,7 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
- <Import Project="..\..\..\..\versions.props" />
-
   <PropertyGroup>
     <Description>Steeltoe Neflix Hystrix Metrics Event Stream Autofac</Description>
     <TargetFramework>net461</TargetFramework>
@@ -9,17 +6,17 @@
     <PackageId>Steeltoe.CircuitBreaker.Hystrix.MetricsStreamAutofac</PackageId>
     <PackageTags>ASPNET;Autofac;Circuit Breaker;Spring;Spring Cloud;Spring Cloud Hystrix;Hystrix</PackageTags>
   </PropertyGroup>
-  <Import Project="..\..\..\..\sharedproject.props" />
 
+  <Import Project="..\..\..\..\versions.props" />
+  <Import Project="..\..\..\..\sharedproject.props" />
   <Import Project="..\..\..\..\targetframework.props" />
 
-  <ItemGroup Condition="'$(CI_BUILD)' == ''">
+  <ItemGroup Condition="'$(TF_BUILD)' == ''">
     <ProjectReference Include="..\..\..\Common\src\Common.Autofac\Steeltoe.Common.Autofac.csproj" />
     <ProjectReference Include="..\..\..\Connectors\src\ConnectorAutofac\Steeltoe.CloudFoundry.ConnectorAutofac.csproj" />
     <ProjectReference Include="..\HystrixBase\Steeltoe.CircuitBreaker.HystrixBase.csproj" />
   </ItemGroup>
-
-  <ItemGroup Condition="'$(CI_BUILD)' == 'True'">
+  <ItemGroup Condition="'$(TF_BUILD)' == 'True'">
     <PackageReference Include="Steeltoe.Common.Autofac" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
     <PackageReference Include="Steeltoe.CloudFoundry.ConnectorAutofac" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
     <PackageReference Include="Steeltoe.CircuitBreaker.HystrixBase" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />

--- a/src/CircuitBreaker/src/Hystrix.MetricsStreamCore/Steeltoe.CircuitBreaker.Hystrix.MetricsStreamCore.csproj
+++ b/src/CircuitBreaker/src/Hystrix.MetricsStreamCore/Steeltoe.CircuitBreaker.Hystrix.MetricsStreamCore.csproj
@@ -10,13 +10,9 @@
   <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedproject.props" />
 
-  <ItemGroup Condition="'$(TF_BUILD)' == ''">
+  <ItemGroup>
     <ProjectReference Include="..\..\..\Connectors\src\ConnectorCore\Steeltoe.CloudFoundry.ConnectorCore.csproj" />
     <ProjectReference Include="..\HystrixBase\Steeltoe.CircuitBreaker.HystrixBase.csproj" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TF_BUILD)' == 'True'">
-    <PackageReference Include="Steeltoe.CloudFoundry.ConnectorCore" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
-    <PackageReference Include="Steeltoe.CircuitBreaker.HystrixBase" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CircuitBreaker/src/Hystrix.MetricsStreamCore/Steeltoe.CircuitBreaker.Hystrix.MetricsStreamCore.csproj
+++ b/src/CircuitBreaker/src/Hystrix.MetricsStreamCore/Steeltoe.CircuitBreaker.Hystrix.MetricsStreamCore.csproj
@@ -1,5 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
- <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup>
     <Description>Steeltoe Neflix Hystrix Metrics Event Stream ASP.NET Core</Description>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
@@ -7,14 +6,15 @@
     <PackageId>Steeltoe.CircuitBreaker.Hystrix.MetricsStreamCore</PackageId>
     <PackageTags>ASPNET Core;Circuit Breaker;Spring;Spring Cloud;Spring Cloud Hystrix;Hystrix</PackageTags>
   </PropertyGroup>
+  
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedproject.props" />
 
-  <ItemGroup Condition="'$(CI_BUILD)' == ''">
+  <ItemGroup Condition="'$(TF_BUILD)' == ''">
     <ProjectReference Include="..\..\..\Connectors\src\ConnectorCore\Steeltoe.CloudFoundry.ConnectorCore.csproj" />
     <ProjectReference Include="..\HystrixBase\Steeltoe.CircuitBreaker.HystrixBase.csproj" />
   </ItemGroup>
-
-  <ItemGroup Condition="'$(CI_BUILD)' == 'True'">
+  <ItemGroup Condition="'$(TF_BUILD)' == 'True'">
     <PackageReference Include="Steeltoe.CloudFoundry.ConnectorCore" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
     <PackageReference Include="Steeltoe.CircuitBreaker.HystrixBase" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
   </ItemGroup>

--- a/src/CircuitBreaker/src/HystrixAutofac/Steeltoe.CircuitBreaker.HystrixAutofac.csproj
+++ b/src/CircuitBreaker/src/HystrixAutofac/Steeltoe.CircuitBreaker.HystrixAutofac.csproj
@@ -11,14 +11,9 @@
   <Import Project="..\..\..\..\sharedproject.props" />
   <Import Project="..\..\..\..\targetframework.props" />
 
-  <ItemGroup Condition="'$(TF_BUILD)' == ''">
+  <ItemGroup>
     <ProjectReference Include="..\..\..\Common\src\Common.Autofac\Steeltoe.Common.Autofac.csproj" />
     <ProjectReference Include="..\HystrixBase\Steeltoe.CircuitBreaker.HystrixBase.csproj" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TF_BUILD)' == 'True'">
-    <PackageReference Include="Steeltoe.Common.Autofac" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
-    <PackageReference Include="Steeltoe.CircuitBreaker.HystrixBase" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CircuitBreaker/src/HystrixAutofac/Steeltoe.CircuitBreaker.HystrixAutofac.csproj
+++ b/src/CircuitBreaker/src/HystrixAutofac/Steeltoe.CircuitBreaker.HystrixAutofac.csproj
@@ -1,7 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
- <Import Project="..\..\..\..\versions.props" />
- 
   <PropertyGroup>
     <Description>Steeltoe Neflix Hystrix Client Autofac</Description>
     <TargetFramework>net461</TargetFramework>
@@ -9,21 +6,19 @@
     <PackageId>Steeltoe.CircuitBreaker.HystrixAutofac</PackageId>
     <PackageTags>Autofac;ASPNET;Spring Cloud;Netflix;Hystrix Client;Circuit Breaker</PackageTags>
   </PropertyGroup>
-  <Import Project="..\..\..\..\sharedproject.props" />
 
+  <Import Project="..\..\..\..\versions.props" />
+  <Import Project="..\..\..\..\sharedproject.props" />
   <Import Project="..\..\..\..\targetframework.props" />
 
-  <ItemGroup Condition="'$(CI_BUILD)' == ''">
+  <ItemGroup Condition="'$(TF_BUILD)' == ''">
     <ProjectReference Include="..\..\..\Common\src\Common.Autofac\Steeltoe.Common.Autofac.csproj" />
     <ProjectReference Include="..\HystrixBase\Steeltoe.CircuitBreaker.HystrixBase.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(CI_BUILD)' == 'True'">
+  <ItemGroup Condition="'$(TF_BUILD)' == 'True'">
     <PackageReference Include="Steeltoe.Common.Autofac" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
     <PackageReference Include="Steeltoe.CircuitBreaker.HystrixBase" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
-  </ItemGroup>
-
-  <ItemGroup>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CircuitBreaker/src/HystrixBase/Steeltoe.CircuitBreaker.HystrixBase.csproj
+++ b/src/CircuitBreaker/src/HystrixBase/Steeltoe.CircuitBreaker.HystrixBase.csproj
@@ -1,5 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup>
     <Description>Steeltoe Neflix Hystrix Client - Base Package</Description>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
@@ -7,6 +6,8 @@
     <PackageId>Steeltoe.CircuitBreaker.HystrixBase</PackageId>
     <PackageTags>Spring Cloud;Netflix;Hystrix Client;Circuit Breaker</PackageTags>
   </PropertyGroup>
+
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedproject.props" />
 
   <ItemGroup>
@@ -16,10 +17,10 @@
     <PackageReference Include="System.Reactive.Observable.Aliases" Version="$(ReactiveVersion)" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(CI_BUILD)' == ''">
+  <ItemGroup Condition="'$(TF_BUILD)' == ''">
     <ProjectReference Include="..\..\..\Common\src\Common\Steeltoe.Common.csproj" />
   </ItemGroup>
-  <ItemGroup Condition="'$(CI_BUILD)' == 'True'">
+  <ItemGroup Condition="'$(TF_BUILD)' == 'True'">
     <PackageReference Include="Steeltoe.Common" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
   </ItemGroup>
 

--- a/src/CircuitBreaker/src/HystrixBase/Steeltoe.CircuitBreaker.HystrixBase.csproj
+++ b/src/CircuitBreaker/src/HystrixBase/Steeltoe.CircuitBreaker.HystrixBase.csproj
@@ -17,11 +17,8 @@
     <PackageReference Include="System.Reactive.Observable.Aliases" Version="$(ReactiveVersion)" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TF_BUILD)' == ''">
+  <ItemGroup>
     <ProjectReference Include="..\..\..\Common\src\Common\Steeltoe.Common.csproj" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TF_BUILD)' == 'True'">
-    <PackageReference Include="Steeltoe.Common" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
   </ItemGroup>
 
 </Project>

--- a/src/CircuitBreaker/src/HystrixCore/Steeltoe.CircuitBreaker.HystrixCore.csproj
+++ b/src/CircuitBreaker/src/HystrixCore/Steeltoe.CircuitBreaker.HystrixCore.csproj
@@ -1,21 +1,19 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
- <Import Project="..\..\..\..\versions.props" />
- 
   <PropertyGroup>
     <Description>Steeltoe Neflix Hystrix Client - ASPNET Core</Description>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
     <AssemblyName>Steeltoe.CircuitBreaker.HystrixCore</AssemblyName>
     <PackageId>Steeltoe.CircuitBreaker.HystrixCore</PackageId>
     <PackageTags>ASPNET Core;Spring Cloud;Netflix;Hystrix Client;Circuit Breaker</PackageTags>
   </PropertyGroup>
+ 
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedproject.props" />
 
-  <ItemGroup Condition="'$(CI_BUILD)' == ''">
+  <ItemGroup Condition="'$(TF_BUILD)' == ''">
       <ProjectReference Include="..\HystrixBase\Steeltoe.CircuitBreaker.HystrixBase.csproj" />
   </ItemGroup>
-
-  <ItemGroup Condition="'$(CI_BUILD)' == 'True'">
+  <ItemGroup Condition="'$(TF_BUILD)' == 'True'">
       <PackageReference Include="Steeltoe.CircuitBreaker.HystrixBase" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
   </ItemGroup>
 
@@ -23,7 +21,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="$(AspNetCoreVersion)" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 </Project>

--- a/src/CircuitBreaker/src/HystrixCore/Steeltoe.CircuitBreaker.HystrixCore.csproj
+++ b/src/CircuitBreaker/src/HystrixCore/Steeltoe.CircuitBreaker.HystrixCore.csproj
@@ -10,11 +10,8 @@
   <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedproject.props" />
 
-  <ItemGroup Condition="'$(TF_BUILD)' == ''">
-      <ProjectReference Include="..\HystrixBase\Steeltoe.CircuitBreaker.HystrixBase.csproj" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TF_BUILD)' == 'True'">
-      <PackageReference Include="Steeltoe.CircuitBreaker.HystrixBase" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
+  <ItemGroup>
+    <ProjectReference Include="..\HystrixBase\Steeltoe.CircuitBreaker.HystrixBase.csproj" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">

--- a/src/CircuitBreaker/test/Hystrix.MetricsEventsCore.Test/Startup.cs
+++ b/src/CircuitBreaker/test/Hystrix.MetricsEventsCore.Test/Startup.cs
@@ -35,7 +35,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix.MetricsEvents.Test
         public void Configure(IApplicationBuilder app)
         {
             app.UseHystrixRequestContext();
-#if NETCOREAPP3_0
+#if NETCOREAPP3_1
             app.UseRouting();
             app.UseEndpoints(endpoints =>
             {

--- a/src/CircuitBreaker/test/Hystrix.MetricsEventsCore.Test/Steeltoe.CircuitBreaker.Hystrix.MetricsEventsCore.Test.csproj
+++ b/src/CircuitBreaker/test/Hystrix.MetricsEventsCore.Test/Steeltoe.CircuitBreaker.Hystrix.MetricsEventsCore.Test.csproj
@@ -1,11 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
+
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedtest.props" />
   <Import Project="..\..\..\..\targetframework.props" />
 
@@ -15,12 +16,13 @@
     </None>
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.0'">
+  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.1'">
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="$(AspNetCoreVersion)" />
   </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="$(ExtensionsVersion)" />

--- a/src/CircuitBreaker/test/Hystrix.MetricsStreamAutofac.Net4Test/Steeltoe.CircuitBreaker.Hystrix.MetricsStreamAutofac.Test.csproj
+++ b/src/CircuitBreaker/test/Hystrix.MetricsStreamAutofac.Net4Test/Steeltoe.CircuitBreaker.Hystrix.MetricsStreamAutofac.Test.csproj
@@ -1,12 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
- <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup>
     <TargetFrameworks>net461</TargetFrameworks>
-    <!-- <SignAssembly>true</SignAssembly>
-    <AssemblyOriginatorKeyFile>..\..\..\..\steeltoe.snk</AssemblyOriginatorKeyFile> -->
   </PropertyGroup>
-  <Import Project="..\..\..\..\sharedtest.props" />
 
+  <Import Project="..\..\..\..\versions.props" />
+  <Import Project="..\..\..\..\sharedtest.props" />
   <Import Project="..\..\..\..\targetframework.props" />
 
   <ItemGroup>

--- a/src/CircuitBreaker/test/Hystrix.MetricsStreamCore.Test/Steeltoe.CircuitBreaker.Hystrix.MetricsStreamCore.Test.csproj
+++ b/src/CircuitBreaker/test/Hystrix.MetricsStreamCore.Test/Steeltoe.CircuitBreaker.Hystrix.MetricsStreamCore.Test.csproj
@@ -1,11 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
+
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedtest.props" />
   <Import Project="..\..\..\..\targetframework.props" />
 
@@ -15,7 +16,7 @@
     </None>
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.0'">
+  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.1'">
     <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="$(AspNetCoreVersion)" />
   </ItemGroup>
   <ItemGroup>

--- a/src/CircuitBreaker/test/HystrixAutofac.Net4Test/Steeltoe.CircuitBreaker.HystrixAutofac.Test.csproj
+++ b/src/CircuitBreaker/test/HystrixAutofac.Net4Test/Steeltoe.CircuitBreaker.HystrixAutofac.Test.csproj
@@ -1,12 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
- <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup>
     <TargetFramework>net461</TargetFramework>
-    <!-- <SignAssembly>true</SignAssembly>
-    <AssemblyOriginatorKeyFile>..\..\..\..\steeltoe.snk</AssemblyOriginatorKeyFile> -->
   </PropertyGroup>
+
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedtest.props" />
-   <Import Project="..\..\..\..\targetframework.props" />
+  <Import Project="..\..\..\..\targetframework.props" />
  
   <ItemGroup>
     <ProjectReference Include="..\..\src\HystrixAutofac\Steeltoe.CircuitBreaker.HystrixAutofac.csproj" />

--- a/src/CircuitBreaker/test/HystrixBase.Test/Steeltoe.CircuitBreaker.HystrixBase.Test.csproj
+++ b/src/CircuitBreaker/test/HystrixBase.Test/Steeltoe.CircuitBreaker.HystrixBase.Test.csproj
@@ -1,11 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
     <TargetFrameworks>net461;netcoreapp2.1</TargetFrameworks>
   </PropertyGroup>
+
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedtest.props" />
   <Import Project="..\..\..\..\targetframework.props" />
 

--- a/src/CircuitBreaker/test/HystrixCore.Test/Steeltoe.CircuitBreaker.HystrixCore.Test.csproj
+++ b/src/CircuitBreaker/test/HystrixCore.Test/Steeltoe.CircuitBreaker.HystrixCore.Test.csproj
@@ -1,20 +1,22 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
+
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedtest.props" />
   <Import Project="..\..\..\..\targetframework.props" />
 
-  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.0'">
+  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.1'">
     <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="$(AspNetCoreVersion)" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(ExtensionsVersion)" />
   </ItemGroup>

--- a/src/Common/src/Common.Autofac/Steeltoe.Common.Autofac.csproj
+++ b/src/Common/src/Common.Autofac/Steeltoe.Common.Autofac.csproj
@@ -1,5 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup>
     <Description>Steeltoe Common Library for Autofac</Description>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
@@ -7,6 +6,8 @@
     <PackageId>Steeltoe.Common.Autofac</PackageId>
     <PackageTags>NET Core;NET Framework;Autofac</PackageTags>
   </PropertyGroup>
+
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedproject.props" />
 
   <ItemGroup>

--- a/src/Common/src/Common.Hosting/HostBuilderExtensions.cs
+++ b/src/Common/src/Common.Hosting/HostBuilderExtensions.cs
@@ -29,7 +29,7 @@ namespace Steeltoe.Common.Hosting
             return webHostBuilder.BindToPorts(runLocalHttpPort, runLocalHttpsPort);
         }
 
-#if NETCOREAPP3_0
+#if NETCOREAPP3_1
         /// <summary>
         /// Configure the application to listen on port(s) provided by the environment at runtime. Defaults to port 8080.
         /// </summary>

--- a/src/Common/src/Common.Hosting/Steeltoe.Common.Hosting.csproj
+++ b/src/Common/src/Common.Hosting/Steeltoe.Common.Hosting.csproj
@@ -1,17 +1,19 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup>
     <Description>Steeltoe Library for common hosting-related utilities</Description>
-    <TargetFrameworks>netcoreapp3.0;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;netstandard2.0</TargetFrameworks>
     <AssemblyName>Steeltoe.Common.Hosting</AssemblyName>
     <PackageId>Steeltoe.Common.Hosting</PackageId>
     <PackageTags>NET Core;Cloud Hosting;</PackageTags>
   </PropertyGroup>
+
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedproject.props" />
+
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="$(AspNetCoreVersion)" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 </Project>

--- a/src/Common/src/Common.Http/Steeltoe.Common.Http.csproj
+++ b/src/Common/src/Common.Http/Steeltoe.Common.Http.csproj
@@ -1,5 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup>
     <Description>Steeltoe Common Library</Description>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
@@ -7,6 +6,8 @@
     <PackageId>Steeltoe.Common.Http</PackageId>
     <PackageTags>NET Core;NET Framework</PackageTags>
   </PropertyGroup>
+
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedproject.props" />
 
   <ItemGroup>
@@ -18,11 +19,11 @@
     </PackageReference>    
   </ItemGroup>
 
-  <ItemGroup Condition="'$(CI_BUILD)' == ''">
+  <ItemGroup Condition="'$(TF_BUILD)' == ''">
     <ProjectReference Include="..\Common\Steeltoe.Common.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(CI_BUILD)' == 'True'">
+  <ItemGroup Condition="'$(TF_BUILD)' == 'True'">
     <PackageReference Include="Steeltoe.Common" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
   </ItemGroup>
 </Project>

--- a/src/Common/src/Common.Http/Steeltoe.Common.Http.csproj
+++ b/src/Common/src/Common.Http/Steeltoe.Common.Http.csproj
@@ -19,11 +19,7 @@
     </PackageReference>    
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TF_BUILD)' == ''">
+  <ItemGroup>
     <ProjectReference Include="..\Common\Steeltoe.Common.csproj" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TF_BUILD)' == 'True'">
-    <PackageReference Include="Steeltoe.Common" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
   </ItemGroup>
 </Project>

--- a/src/Common/src/Common.Net/Steeltoe.Common.Net.csproj
+++ b/src/Common/src/Common.Net/Steeltoe.Common.Net.csproj
@@ -10,14 +10,8 @@
   <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedproject.props" />
 
-  <ItemGroup Condition="'$(TF_BUILD)' == ''">
+  <ItemGroup>
     <ProjectReference Include="..\Common\Steeltoe.Common.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TF_BUILD)' == 'True'">
-    <PackageReference Include="Steeltoe.Common" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
-  </ItemGroup>
-
-  <ItemGroup>
-  </ItemGroup>
 </Project>

--- a/src/Common/src/Common.Net/Steeltoe.Common.Net.csproj
+++ b/src/Common/src/Common.Net/Steeltoe.Common.Net.csproj
@@ -1,5 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup>
     <Description>Steeltoe Common Library</Description>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
@@ -7,12 +6,15 @@
     <PackageId>Steeltoe.Common.Net</PackageId>
     <PackageTags>NET Core;NET Framework</PackageTags>
   </PropertyGroup>
+
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedproject.props" />
-  <ItemGroup Condition="'$(CI_BUILD)' == ''">
+
+  <ItemGroup Condition="'$(TF_BUILD)' == ''">
     <ProjectReference Include="..\Common\Steeltoe.Common.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(CI_BUILD)' == 'True'">
+  <ItemGroup Condition="'$(TF_BUILD)' == 'True'">
     <PackageReference Include="Steeltoe.Common" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
   </ItemGroup>
 

--- a/src/Common/src/Common.Security/Steeltoe.Common.Security.csproj
+++ b/src/Common/src/Common.Security/Steeltoe.Common.Security.csproj
@@ -1,5 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup>
     <Description>Steeltoe Common Security Library</Description>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
@@ -7,7 +6,10 @@
     <PackageId>Steeltoe.Common.Security</PackageId>
     <PackageTags>NET Core;NET Framework</PackageTags>
   </PropertyGroup>
+
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedproject.props" />
+
   <ItemGroup>
     <PackageReference Include="Portable.BouncyCastle" Version="$(BouncyCastleVersion)" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="$(ExtensionsVersion)" />

--- a/src/Common/src/Common/Net/InetUtils.cs
+++ b/src/Common/src/Common/Net/InetUtils.cs
@@ -4,7 +4,6 @@
 
 using Microsoft.Extensions.Logging;
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.NetworkInformation;
@@ -32,9 +31,11 @@ namespace Steeltoe.Common.Net
                 return ConvertAddress(address);
             }
 
-            HostInfo hostInfo = new HostInfo();
-            hostInfo.Hostname = _options.DefaultHostname;
-            hostInfo.IpAddress = _options.DefaultIpAddress;
+            var hostInfo = new HostInfo
+            {
+                Hostname = _options.DefaultHostname,
+                IpAddress = _options.DefaultIpAddress
+            };
             return hostInfo;
         }
 
@@ -43,9 +44,9 @@ namespace Steeltoe.Common.Net
             IPAddress result = null;
             try
             {
-                int lowest = int.MaxValue;
+                var lowest = int.MaxValue;
                 var ifaces = NetworkInterface.GetAllNetworkInterfaces();
-                for (int i = 0; i < ifaces.Length; i++)
+                for (var i = 0; i < ifaces.Length; i++)
                 {
                     var ifc = ifaces[i];
 
@@ -109,24 +110,24 @@ namespace Steeltoe.Common.Net
         {
             if (_options.UseOnlySiteLocalInterfaces)
             {
-                bool siteLocalAddress = IsSiteLocalAddress(address);
+                var siteLocalAddress = IsSiteLocalAddress(address);
                 if (!siteLocalAddress)
                 {
-                    _logger?.LogTrace("Ignoring address: {address} ", address.ToString());
+                    _logger?.LogTrace("Ignoring address: {address} [UseOnlySiteLocalInterfaces=true, this address is not]", address.ToString());
                 }
 
                 return siteLocalAddress;
             }
 
-            IEnumerable<string> preferredNetworks = _options.GetPreferredNetworks();
+            var preferredNetworks = _options.GetPreferredNetworks();
             if (!preferredNetworks.Any())
             {
                 return true;
             }
 
-            foreach (string regex in preferredNetworks)
+            foreach (var regex in preferredNetworks)
             {
-                string hostAddress = address.ToString();
+                var hostAddress = address.ToString();
                 var matcher = new Regex(regex);
                 if (matcher.IsMatch(hostAddress) || hostAddress.StartsWith(regex))
                 {
@@ -145,7 +146,7 @@ namespace Steeltoe.Common.Net
                 return false;
             }
 
-            foreach (string regex in _options.GetIgnoredInterfaces())
+            foreach (var regex in _options.GetIgnoredInterfaces())
             {
                 var matcher = new Regex(regex);
                 if (matcher.IsMatch(interfaceName))
@@ -160,7 +161,7 @@ namespace Steeltoe.Common.Net
 
         internal HostInfo ConvertAddress(IPAddress address)
         {
-            HostInfo hostInfo = new HostInfo();
+            var hostInfo = new HostInfo();
             if (!_options.SkipReverseDnsLookup)
             {
                 string hostname;
@@ -243,7 +244,7 @@ namespace Steeltoe.Common.Net
 
         internal IPAddress GetHostAddress()
         {
-            string hostName = GetHostName();
+            var hostName = GetHostName();
             if (!string.IsNullOrEmpty(hostName))
             {
                 return ResolveHostAddress(hostName);
@@ -254,7 +255,7 @@ namespace Steeltoe.Common.Net
 
         internal bool IsSiteLocalAddress(IPAddress address)
         {
-            string addr = address.ToString();
+            var addr = address.ToString();
             return addr.StartsWith("10.") ||
                 addr.StartsWith("172.16.") ||
                 addr.StartsWith("192.168.");

--- a/src/Common/src/Common/Steeltoe.Common.csproj
+++ b/src/Common/src/Common/Steeltoe.Common.csproj
@@ -1,5 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup>
     <Description>Steeltoe Common Library</Description>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
@@ -7,6 +6,8 @@
     <PackageId>Steeltoe.Common</PackageId>
     <PackageTags>NET Core;NET Framework</PackageTags>
   </PropertyGroup>
+
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedproject.props" />
   
   <ItemGroup>

--- a/src/Common/test/Common.Autofac.Test/Steeltoe.Common.Autofac.Test.csproj
+++ b/src/Common/test/Common.Autofac.Test/Steeltoe.Common.Autofac.Test.csproj
@@ -1,15 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
-  <Import Project="..\..\..\..\versions.props" />
-
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
     <TargetFrameworks>netcoreapp2.1;</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
     <TargetFrameworks>netcoreapp2.1;net461</TargetFrameworks>
   </PropertyGroup>
-  <Import Project="..\..\..\..\sharedtest.props" />
 
+  <Import Project="..\..\..\..\versions.props" />
+  <Import Project="..\..\..\..\sharedtest.props" />
   <Import Project="..\..\..\..\targetframework.props" />
 
   <ItemGroup>

--- a/src/Common/test/Common.Hosting.Test/HostBuilderExtensionsTest.cs
+++ b/src/Common/test/Common.Hosting.Test/HostBuilderExtensionsTest.cs
@@ -100,7 +100,7 @@ namespace Steeltoe.Common.Hosting.Test
             Assert.Contains("https://*:5001", addresses.Addresses);
         }
 
-#if NETCOREAPP3_0
+#if NETCOREAPP3_1
         [Fact]
         public void UseCloudHosting_GenericHost_Default8080()
         {

--- a/src/Common/test/Common.Hosting.Test/Steeltoe.Common.Hosting.Test.csproj
+++ b/src/Common/test/Common.Hosting.Test/Steeltoe.Common.Hosting.Test.csproj
@@ -1,11 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp3.0;net461;netcoreapp2.1;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net461;netcoreapp2.1;</TargetFrameworks>
   </PropertyGroup>
+
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedtest.props" />
   <Import Project="..\..\..\..\targetframework.props" />
 
@@ -19,7 +20,7 @@
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="$(AspNetCoreVersion)" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.0'">
+  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.1'">
     <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="$(AspNetCoreVersion)" />
   </ItemGroup>

--- a/src/Common/test/Common.Http.Test/Steeltoe.Common.Http.Test.csproj
+++ b/src/Common/test/Common.Http.Test/Steeltoe.Common.Http.Test.csproj
@@ -1,11 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
+
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedtest.props" />
   <Import Project="..\..\..\..\targetframework.props" />
 

--- a/src/Common/test/Common.Net.Test/Steeltoe.Common.Net.Test.csproj
+++ b/src/Common/test/Common.Net.Test/Steeltoe.Common.Net.Test.csproj
@@ -1,11 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
+
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedtest.props" />
   <Import Project="..\..\..\..\targetframework.props" />
 

--- a/src/Common/test/Common.Security.Test/Steeltoe.Common.Security.Test.csproj
+++ b/src/Common/test/Common.Security.Test/Steeltoe.Common.Security.Test.csproj
@@ -1,11 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
+
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedtest.props" />
   <Import Project="..\..\..\..\targetframework.props" />
 

--- a/src/Common/test/Common.Test/Net/InetUtilsTest.cs
+++ b/src/Common/test/Common.Test/Net/InetUtilsTest.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.Extensions.Logging;
 using System.Net;
 using Xunit;
 
@@ -12,41 +13,41 @@ namespace Steeltoe.Common.Net.Test
         [Fact]
         public void TestGetFirstNonLoopbackHostInfo()
         {
-            InetUtils utils = new InetUtils(new InetOptions());
+            var utils = new InetUtils(new InetOptions(), GetLogger());
             Assert.NotNull(utils.FindFirstNonLoopbackHostInfo());
         }
 
         [Fact]
         public void TestGetFirstNonLoopbackAddress()
         {
-            InetUtils utils = new InetUtils(new InetOptions());
+            var utils = new InetUtils(new InetOptions(), GetLogger());
             Assert.NotNull(utils.FindFirstNonLoopbackAddress());
         }
 
         [Fact]
         public void TestConvert()
         {
-            InetUtils utils = new InetUtils(new InetOptions());
+            var utils = new InetUtils(new InetOptions(), GetLogger());
             Assert.NotNull(utils.ConvertAddress(Dns.GetHostEntry("localhost").AddressList[0]));
         }
 
         [Fact]
         public void TestHostInfo()
         {
-            InetUtils utils = new InetUtils(new InetOptions());
-            HostInfo info = utils.FindFirstNonLoopbackHostInfo();
+            var utils = new InetUtils(new InetOptions(), GetLogger());
+            var info = utils.FindFirstNonLoopbackHostInfo();
             Assert.NotNull(info.IpAddress);
         }
 
         [Fact]
         public void TestIgnoreInterface()
         {
-            InetOptions properties = new InetOptions()
+            var properties = new InetOptions()
             {
                 IgnoredInterfaces = "docker0,veth.*"
             };
 
-            InetUtils inetUtils = new InetUtils(properties);
+            var inetUtils = new InetUtils(properties);
 
             Assert.True(inetUtils.IgnoreInterface("docker0"));
             Assert.True(inetUtils.IgnoreInterface("vethAQI2QT"));
@@ -56,19 +57,19 @@ namespace Steeltoe.Common.Net.Test
         [Fact]
         public void TestDefaultIgnoreInterface()
         {
-            InetUtils inetUtils = new InetUtils(new InetOptions());
+            var inetUtils = new InetUtils(new InetOptions(), GetLogger());
             Assert.False(inetUtils.IgnoreInterface("docker0"));
         }
 
         [Fact]
         public void TestSiteLocalAddresses()
         {
-            InetOptions properties = new InetOptions()
+            var properties = new InetOptions()
             {
                 UseOnlySiteLocalInterfaces = true
             };
 
-            InetUtils utils = new InetUtils(properties);
+            var utils = new InetUtils(properties);
             Assert.True(utils.IsPreferredAddress(IPAddress.Parse("192.168.0.1")));
             Assert.False(utils.IsPreferredAddress(IPAddress.Parse("5.5.8.1")));
         }
@@ -76,12 +77,12 @@ namespace Steeltoe.Common.Net.Test
         [Fact]
         public void TestPreferredNetworksRegex()
         {
-            InetOptions properties = new InetOptions()
+            var properties = new InetOptions()
             {
                 PreferredNetworks = "192.168.*,10.0.*"
             };
 
-            InetUtils utils = new InetUtils(properties);
+            var utils = new InetUtils(properties, GetLogger());
             Assert.True(utils.IsPreferredAddress(IPAddress.Parse("192.168.0.1")));
             Assert.False(utils.IsPreferredAddress(IPAddress.Parse("5.5.8.1")));
             Assert.True(utils.IsPreferredAddress(IPAddress.Parse("10.0.10.1")));
@@ -91,12 +92,12 @@ namespace Steeltoe.Common.Net.Test
         [Fact]
         public void TestPreferredNetworksSimple()
         {
-            InetOptions properties = new InetOptions()
+            var properties = new InetOptions()
             {
                 PreferredNetworks = "192,10.0"
             };
 
-            InetUtils utils = new InetUtils(properties);
+            var utils = new InetUtils(properties, GetLogger());
             Assert.True(utils.IsPreferredAddress(IPAddress.Parse("192.168.0.1")));
             Assert.False(utils.IsPreferredAddress(IPAddress.Parse("5.5.8.1")));
             Assert.False(utils.IsPreferredAddress(IPAddress.Parse("10.255.10.1")));
@@ -106,13 +107,19 @@ namespace Steeltoe.Common.Net.Test
         [Fact]
         public void TestPreferredNetworksListIsEmpty()
         {
-            InetOptions properties = new InetOptions();
+            var properties = new InetOptions();
 
-            InetUtils utils = new InetUtils(properties);
+            var utils = new InetUtils(properties, GetLogger());
             Assert.True(utils.IsPreferredAddress(IPAddress.Parse("192.168.0.1")));
             Assert.True(utils.IsPreferredAddress(IPAddress.Parse("5.5.8.1")));
             Assert.True(utils.IsPreferredAddress(IPAddress.Parse("10.255.10.1")));
             Assert.True(utils.IsPreferredAddress(IPAddress.Parse("10.0.10.1")));
         }
-    }
+
+        private ILogger GetLogger()
+        {
+            var loggerFactory = TestHelpers.GetLoggerFactory();
+            return loggerFactory.CreateLogger<InetOptions>();
+        }
+}
 }

--- a/src/Common/test/Common.Test/Net/InetUtilsTest.cs
+++ b/src/Common/test/Common.Test/Net/InetUtilsTest.cs
@@ -11,6 +11,7 @@ namespace Steeltoe.Common.Net.Test
     public class InetUtilsTest
     {
         [Fact]
+        [Trait("Category", "SkipOnMacOS")] // TODO: revisit running this on the MSFT-hosted MacOS agent
         public void TestGetFirstNonLoopbackHostInfo()
         {
             var utils = new InetUtils(new InetOptions(), GetLogger());
@@ -18,9 +19,10 @@ namespace Steeltoe.Common.Net.Test
         }
 
         [Fact]
+        [Trait("Category", "SkipOnMacOS")] // TODO: revisit running this on the MSFT-hosted MacOS agent
         public void TestGetFirstNonLoopbackAddress()
         {
-            var utils = new InetUtils(new InetOptions(), GetLogger());
+            var utils = new InetUtils(new InetOptions() { UseOnlySiteLocalInterfaces = true }, GetLogger());
             Assert.NotNull(utils.FindFirstNonLoopbackAddress());
         }
 
@@ -32,6 +34,7 @@ namespace Steeltoe.Common.Net.Test
         }
 
         [Fact]
+        [Trait("Category", "SkipOnMacOS")] // TODO: revisit running this on the MSFT-hosted MacOS agent
         public void TestHostInfo()
         {
             var utils = new InetUtils(new InetOptions(), GetLogger());

--- a/src/Common/test/Common.Test/Steeltoe.Common.Test.csproj
+++ b/src/Common/test/Common.Test/Steeltoe.Common.Test.csproj
@@ -1,11 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
+
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedtest.props" />
   <Import Project="..\..\..\..\targetframework.props" />
 

--- a/src/Common/test/Common.TestResources/Steeltoe.Common.TestResources.csproj
+++ b/src/Common/test/Common.TestResources/Steeltoe.Common.TestResources.csproj
@@ -1,15 +1,18 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <IsPackable>False</IsPackable>
   </PropertyGroup>
+
+  <Import Project="..\..\..\..\versions.props" />
+
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="$(AspNetCoreVersion)" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="$(ExtensionsVersion)" />
   </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="$(ExtensionsVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="$(ExtensionsVersion)" />

--- a/src/Configuration/src/CloudFoundryAutofac/Steeltoe.Extensions.Configuration.CloudFoundryAutofac.csproj
+++ b/src/Configuration/src/CloudFoundryAutofac/Steeltoe.Extensions.Configuration.CloudFoundryAutofac.csproj
@@ -1,5 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup>
     <Description>CloudFoundry Environment Variable Configuration Provider Autofac</Description>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -7,18 +6,20 @@
     <PackageId>Steeltoe.Extensions.Configuration.CloudFoundryAutofac</PackageId>
     <PackageTags>CloudFoundry;ASPNET;Autofac</PackageTags>
   </PropertyGroup>
+
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedproject.props" />
 
   <ItemGroup>
     <PackageReference Include="Autofac" Version="$(AutofacVersion)" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(CI_BUILD)' == ''">
+  <ItemGroup Condition="'$(TF_BUILD)' == ''">
     <ProjectReference Include="..\..\..\Common\src\Common.Autofac\Steeltoe.Common.Autofac.csproj" />
     <ProjectReference Include="..\CloudFoundryBase\Steeltoe.Extensions.Configuration.CloudFoundryBase.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(CI_BUILD)' == 'True'">
+  <ItemGroup Condition="'$(TF_BUILD)' == 'True'">
     <PackageReference Include="Steeltoe.Common.Autofac" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
     <PackageReference Include="Steeltoe.Extensions.Configuration.CloudFoundryBase" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
   </ItemGroup>

--- a/src/Configuration/src/CloudFoundryAutofac/Steeltoe.Extensions.Configuration.CloudFoundryAutofac.csproj
+++ b/src/Configuration/src/CloudFoundryAutofac/Steeltoe.Extensions.Configuration.CloudFoundryAutofac.csproj
@@ -14,13 +14,8 @@
     <PackageReference Include="Autofac" Version="$(AutofacVersion)" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TF_BUILD)' == ''">
+  <ItemGroup>
     <ProjectReference Include="..\..\..\Common\src\Common.Autofac\Steeltoe.Common.Autofac.csproj" />
     <ProjectReference Include="..\CloudFoundryBase\Steeltoe.Extensions.Configuration.CloudFoundryBase.csproj" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TF_BUILD)' == 'True'">
-    <PackageReference Include="Steeltoe.Common.Autofac" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
-    <PackageReference Include="Steeltoe.Extensions.Configuration.CloudFoundryBase" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
   </ItemGroup>
 </Project>

--- a/src/Configuration/src/CloudFoundryBase/Steeltoe.Extensions.Configuration.CloudFoundryBase.csproj
+++ b/src/Configuration/src/CloudFoundryBase/Steeltoe.Extensions.Configuration.CloudFoundryBase.csproj
@@ -16,11 +16,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="$(ExtensionsVersion)" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TF_BUILD)' == ''">
+  <ItemGroup>
     <ProjectReference Include="..\..\..\Common\src\Common\Steeltoe.Common.csproj" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TF_BUILD)' == 'True'">
-    <PackageReference Include="Steeltoe.Common" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
   </ItemGroup>
 </Project>

--- a/src/Configuration/src/CloudFoundryBase/Steeltoe.Extensions.Configuration.CloudFoundryBase.csproj
+++ b/src/Configuration/src/CloudFoundryBase/Steeltoe.Extensions.Configuration.CloudFoundryBase.csproj
@@ -1,5 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup>
     <Description>CloudFoundry Environment Variable Configuration Provider - Base Package</Description>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
@@ -7,6 +6,8 @@
     <PackageId>Steeltoe.Extensions.Configuration.CloudFoundryBase</PackageId>
     <PackageTags>CloudFoundry;NET Core;NET Framework</PackageTags>
   </PropertyGroup>
+
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedproject.props" />
   
   <ItemGroup>
@@ -15,11 +16,11 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="$(ExtensionsVersion)" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(CI_BUILD)' == ''">
+  <ItemGroup Condition="'$(TF_BUILD)' == ''">
     <ProjectReference Include="..\..\..\Common\src\Common\Steeltoe.Common.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(CI_BUILD)' == 'True'">
+  <ItemGroup Condition="'$(TF_BUILD)' == 'True'">
     <PackageReference Include="Steeltoe.Common" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
   </ItemGroup>
 </Project>

--- a/src/Configuration/src/CloudFoundryCore/CloudFoundryHostBuilderExtensions.cs
+++ b/src/Configuration/src/CloudFoundryCore/CloudFoundryHostBuilderExtensions.cs
@@ -49,7 +49,7 @@ namespace Steeltoe.Extensions.Configuration.CloudFoundry
             return webHostBuilder;
         }
 
-#if NETCOREAPP3_0
+#if NETCOREAPP3_1
         /// <summary>
         /// Enable the application to listen on port(s) provided by the environment at runtime
         /// </summary>

--- a/src/Configuration/src/CloudFoundryCore/Steeltoe.Extensions.Configuration.CloudFoundryCore.csproj
+++ b/src/Configuration/src/CloudFoundryCore/Steeltoe.Extensions.Configuration.CloudFoundryCore.csproj
@@ -1,12 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup>
     <Description>NET Core CloudFoundry Environment Variable Configuration Provider</Description>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
     <AssemblyName>Steeltoe.Extensions.Configuration.CloudFoundryCore</AssemblyName>
     <PackageId>Steeltoe.Extensions.Configuration.CloudFoundryCore</PackageId>
     <PackageTags>CloudFoundry;ASPNET Core;Spring;Spring Cloud</PackageTags>
   </PropertyGroup>
+
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedproject.props" />
   
   <ItemGroup>
@@ -15,14 +16,14 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="$(AspNetCoreVersion)" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(CI_BUILD)' == ''">
+  <ItemGroup Condition="'$(TF_BUILD)' == ''">
     <ProjectReference Include="..\CloudFoundryBase\Steeltoe.Extensions.Configuration.CloudFoundryBase.csproj" />
   </ItemGroup>
-  <ItemGroup Condition="'$(CI_BUILD)' == 'True'">
+  <ItemGroup Condition="'$(TF_BUILD)' == 'True'">
     <PackageReference Include="Steeltoe.Extensions.Configuration.CloudFoundryBase" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
   </ItemGroup>
 </Project>

--- a/src/Configuration/src/CloudFoundryCore/Steeltoe.Extensions.Configuration.CloudFoundryCore.csproj
+++ b/src/Configuration/src/CloudFoundryCore/Steeltoe.Extensions.Configuration.CloudFoundryCore.csproj
@@ -20,10 +20,7 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TF_BUILD)' == ''">
+  <ItemGroup>
     <ProjectReference Include="..\CloudFoundryBase\Steeltoe.Extensions.Configuration.CloudFoundryBase.csproj" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TF_BUILD)' == 'True'">
-    <PackageReference Include="Steeltoe.Extensions.Configuration.CloudFoundryBase" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
   </ItemGroup>
 </Project>

--- a/src/Configuration/src/ConfigServerAutofac/Steeltoe.Extensions.Configuration.ConfigServerAutofac.csproj
+++ b/src/Configuration/src/ConfigServerAutofac/Steeltoe.Extensions.Configuration.ConfigServerAutofac.csproj
@@ -14,13 +14,8 @@
     <PackageReference Include="Autofac" Version="$(AutofacVersion)" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TF_BUILD)' == ''">
+  <ItemGroup>
     <ProjectReference Include="..\..\..\Common\src\Common.Autofac\Steeltoe.Common.Autofac.csproj" />
     <ProjectReference Include="..\ConfigServerBase\Steeltoe.Extensions.Configuration.ConfigServerBase.csproj" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TF_BUILD)' == 'True'">
-    <PackageReference Include="Steeltoe.Common.Autofac" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
-    <PackageReference Include="Steeltoe.Extensions.Configuration.ConfigServerBase" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
   </ItemGroup>
 </Project>

--- a/src/Configuration/src/ConfigServerAutofac/Steeltoe.Extensions.Configuration.ConfigServerAutofac.csproj
+++ b/src/Configuration/src/ConfigServerAutofac/Steeltoe.Extensions.Configuration.ConfigServerAutofac.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup>
     <Description>Spring Cloud Config Server Configuration Provider Autofac</Description>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -7,18 +6,20 @@
     <PackageId>Steeltoe.Extensions.Configuration.ConfigServerAutofac</PackageId>
     <PackageTags>ASPNET;Autofac;Spring Cloud;Spring Cloud Config Server</PackageTags>
   </PropertyGroup>
+
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedproject.props" />
   
   <ItemGroup>
     <PackageReference Include="Autofac" Version="$(AutofacVersion)" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(CI_BUILD)' == ''">
+  <ItemGroup Condition="'$(TF_BUILD)' == ''">
     <ProjectReference Include="..\..\..\Common\src\Common.Autofac\Steeltoe.Common.Autofac.csproj" />
     <ProjectReference Include="..\ConfigServerBase\Steeltoe.Extensions.Configuration.ConfigServerBase.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(CI_BUILD)' == 'True'">
+  <ItemGroup Condition="'$(TF_BUILD)' == 'True'">
     <PackageReference Include="Steeltoe.Common.Autofac" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
     <PackageReference Include="Steeltoe.Extensions.Configuration.ConfigServerBase" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
   </ItemGroup>

--- a/src/Configuration/src/ConfigServerBase/Steeltoe.Extensions.Configuration.ConfigServerBase.csproj
+++ b/src/Configuration/src/ConfigServerBase/Steeltoe.Extensions.Configuration.ConfigServerBase.csproj
@@ -10,15 +10,9 @@
   <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedproject.props" />
   
-  <ItemGroup Condition="'$(TF_BUILD)' == ''">
+  <ItemGroup>
     <ProjectReference Include="..\..\..\Common\src\Common.Http\Steeltoe.Common.Http.csproj" />
     <ProjectReference Include="..\CloudFoundryBase\Steeltoe.Extensions.Configuration.CloudFoundryBase.csproj" />
     <ProjectReference Include="..\PlaceholderBase\Steeltoe.Extensions.Configuration.PlaceholderBase.csproj" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TF_BUILD)' == 'True'">
-    <PackageReference Include="Steeltoe.Common.Http" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
-    <PackageReference Include="Steeltoe.Extensions.Configuration.CloudFoundryBase" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
-    <PackageReference Include="Steeltoe.Extensions.Configuration.PlaceHolderBase" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
   </ItemGroup>
 </Project>

--- a/src/Configuration/src/ConfigServerBase/Steeltoe.Extensions.Configuration.ConfigServerBase.csproj
+++ b/src/Configuration/src/ConfigServerBase/Steeltoe.Extensions.Configuration.ConfigServerBase.csproj
@@ -1,5 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup>
     <Description>Spring Cloud Config Server Configuration Provider - Base Package</Description>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
@@ -7,15 +6,17 @@
     <PackageId>Steeltoe.Extensions.Configuration.ConfigServerBase</PackageId>
     <PackageTags>Spring Cloud;Spring Cloud Config Server</PackageTags>
   </PropertyGroup>
+
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedproject.props" />
   
-  <ItemGroup Condition="'$(CI_BUILD)' == ''">
+  <ItemGroup Condition="'$(TF_BUILD)' == ''">
     <ProjectReference Include="..\..\..\Common\src\Common.Http\Steeltoe.Common.Http.csproj" />
     <ProjectReference Include="..\CloudFoundryBase\Steeltoe.Extensions.Configuration.CloudFoundryBase.csproj" />
     <ProjectReference Include="..\PlaceholderBase\Steeltoe.Extensions.Configuration.PlaceholderBase.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(CI_BUILD)' == 'True'">
+  <ItemGroup Condition="'$(TF_BUILD)' == 'True'">
     <PackageReference Include="Steeltoe.Common.Http" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
     <PackageReference Include="Steeltoe.Extensions.Configuration.CloudFoundryBase" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
     <PackageReference Include="Steeltoe.Extensions.Configuration.PlaceHolderBase" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />

--- a/src/Configuration/src/ConfigServerCore/ConfigServerConfigurationBuilderExtensionsCore.cs
+++ b/src/Configuration/src/ConfigServerCore/ConfigServerConfigurationBuilderExtensionsCore.cs
@@ -14,7 +14,7 @@ namespace Steeltoe.Extensions.Configuration.ConfigServer
     /// </summary>
     public static class ConfigServerConfigurationBuilderExtensionsCore
     {
-#if NETCOREAPP3_0
+#if NETCOREAPP3_1
         [Obsolete("IHostingEnvironment is obsolete")]
 #endif
         public static IConfigurationBuilder AddConfigServer(this IConfigurationBuilder configurationBuilder, IHostingEnvironment environment, ILoggerFactory logFactory = null)
@@ -27,7 +27,7 @@ namespace Steeltoe.Extensions.Configuration.ConfigServer
             return DoAddConfigServer(configurationBuilder, environment.ApplicationName, environment.EnvironmentName, logFactory);
         }
 
-#if NETCOREAPP3_0
+#if NETCOREAPP3_1
         [Obsolete("IHostingEnvironment is obsolete")]
 #endif
         public static IConfigurationBuilder AddConfigServer(this IConfigurationBuilder configurationBuilder, Microsoft.AspNetCore.Hosting.IHostingEnvironment environment, ILoggerFactory logFactory = null)
@@ -40,7 +40,7 @@ namespace Steeltoe.Extensions.Configuration.ConfigServer
             return DoAddConfigServer(configurationBuilder, environment.ApplicationName, environment.EnvironmentName, logFactory);
         }
 
-#if NETCOREAPP3_0
+#if NETCOREAPP3_1
         public static IConfigurationBuilder AddConfigServer(this IConfigurationBuilder configurationBuilder, IHostEnvironment environment, ILoggerFactory logFactory = null)
         {
             if (environment == null)

--- a/src/Configuration/src/ConfigServerCore/Steeltoe.Extensions.Configuration.ConfigServerCore.csproj
+++ b/src/Configuration/src/ConfigServerCore/Steeltoe.Extensions.Configuration.ConfigServerCore.csproj
@@ -21,11 +21,7 @@
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="$(ExtensionsVersion)" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TF_BUILD)' == ''">
+  <ItemGroup>
     <ProjectReference Include="..\ConfigServerBase\Steeltoe.Extensions.Configuration.ConfigServerBase.csproj" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TF_BUILD)' == 'True'">
-    <PackageReference Include="Steeltoe.Extensions.Configuration.ConfigServerBase" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
   </ItemGroup>
 </Project>

--- a/src/Configuration/src/ConfigServerCore/Steeltoe.Extensions.Configuration.ConfigServerCore.csproj
+++ b/src/Configuration/src/ConfigServerCore/Steeltoe.Extensions.Configuration.ConfigServerCore.csproj
@@ -1,18 +1,19 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup>
     <Description>NET Core Spring Cloud Config Server Configuration Provider</Description>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
     <AssemblyName>Steeltoe.Extensions.Configuration.ConfigServerCore</AssemblyName>
     <PackageId>Steeltoe.Extensions.Configuration.ConfigServerCore</PackageId>
     <PackageTags>ASPNET Core;Spring;Spring Cloud;Config Server</PackageTags>
   </PropertyGroup>
+
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedproject.props" />
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="$(AspNetCoreVersion)" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
   <ItemGroup>
@@ -20,11 +21,11 @@
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="$(ExtensionsVersion)" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(CI_BUILD)' == ''">
+  <ItemGroup Condition="'$(TF_BUILD)' == ''">
     <ProjectReference Include="..\ConfigServerBase\Steeltoe.Extensions.Configuration.ConfigServerBase.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(CI_BUILD)' == 'True'">
+  <ItemGroup Condition="'$(TF_BUILD)' == 'True'">
     <PackageReference Include="Steeltoe.Extensions.Configuration.ConfigServerBase" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
   </ItemGroup>
 </Project>

--- a/src/Configuration/src/PlaceholderBase/Steeltoe.Extensions.Configuration.PlaceholderBase.csproj
+++ b/src/Configuration/src/PlaceholderBase/Steeltoe.Extensions.Configuration.PlaceholderBase.csproj
@@ -1,5 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup>
     <Description>Configuration Placeholder Resolver - Base Package</Description>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -7,16 +6,18 @@
     <PackageId>Steeltoe.Extensions.Configuration.PlaceholderBase</PackageId>
     <PackageTags>Configuration;Placeholders</PackageTags>
   </PropertyGroup>
+
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedproject.props" />
   
   <ItemGroup>
   </ItemGroup>
  
-  <ItemGroup Condition="'$(CI_BUILD)' == ''">
+  <ItemGroup Condition="'$(TF_BUILD)' == ''">
     <ProjectReference Include="..\..\..\Common\src\Common\Steeltoe.Common.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(CI_BUILD)' == 'True'">
+  <ItemGroup Condition="'$(TF_BUILD)' == 'True'">
     <PackageReference Include="Steeltoe.Common" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
   </ItemGroup>
 </Project>

--- a/src/Configuration/src/PlaceholderBase/Steeltoe.Extensions.Configuration.PlaceholderBase.csproj
+++ b/src/Configuration/src/PlaceholderBase/Steeltoe.Extensions.Configuration.PlaceholderBase.csproj
@@ -13,11 +13,7 @@
   <ItemGroup>
   </ItemGroup>
  
-  <ItemGroup Condition="'$(TF_BUILD)' == ''">
+  <ItemGroup>
     <ProjectReference Include="..\..\..\Common\src\Common\Steeltoe.Common.csproj" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TF_BUILD)' == 'True'">
-    <PackageReference Include="Steeltoe.Common" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
   </ItemGroup>
 </Project>

--- a/src/Configuration/src/PlaceholderCore/Steeltoe.Extensions.Configuration.PlaceholderCore.csproj
+++ b/src/Configuration/src/PlaceholderCore/Steeltoe.Extensions.Configuration.PlaceholderCore.csproj
@@ -17,11 +17,7 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TF_BUILD)' == ''">
+  <ItemGroup>
     <ProjectReference Include="..\PlaceholderBase\Steeltoe.Extensions.Configuration.PlaceholderBase.csproj" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TF_BUILD)' == 'True'">
-    <PackageReference Include="Steeltoe.Extensions.Configuration.PlaceholderBase" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
   </ItemGroup>
 </Project>

--- a/src/Configuration/src/PlaceholderCore/Steeltoe.Extensions.Configuration.PlaceholderCore.csproj
+++ b/src/Configuration/src/PlaceholderCore/Steeltoe.Extensions.Configuration.PlaceholderCore.csproj
@@ -1,26 +1,27 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup>
     <Description>Configuration Placeholder Resolver - Core Package</Description>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
     <AssemblyName>Steeltoe.Extensions.Configuration.PlaceholderCore</AssemblyName>
     <PackageId>Steeltoe.Extensions.Configuration.PlaceholderCore</PackageId>
     <PackageTags>Configuration;Placeholders</PackageTags>
   </PropertyGroup>
+
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedproject.props" />
   
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="$(AspNetCoreVersion)" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(CI_BUILD)' == ''">
+  <ItemGroup Condition="'$(TF_BUILD)' == ''">
     <ProjectReference Include="..\PlaceholderBase\Steeltoe.Extensions.Configuration.PlaceholderBase.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(CI_BUILD)' == 'True'">
+  <ItemGroup Condition="'$(TF_BUILD)' == 'True'">
     <PackageReference Include="Steeltoe.Extensions.Configuration.PlaceholderBase" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
   </ItemGroup>
 </Project>

--- a/src/Configuration/src/RandomValueBase/Steeltoe.Extensions.Configuration.RandomValueBase.csproj
+++ b/src/Configuration/src/RandomValueBase/Steeltoe.Extensions.Configuration.RandomValueBase.csproj
@@ -1,5 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup>
     <Description>Random Value Provider - Base Package</Description>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
@@ -7,6 +6,8 @@
     <PackageId>Steeltoe.Extensions.Configuration.RandomValueBase</PackageId>
     <PackageTags>Configuration;Random Values</PackageTags>
   </PropertyGroup>
+
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedproject.props" />
 
   <ItemGroup>

--- a/src/Configuration/test/CloudFoundryAutofac.Test/Steeltoe.Extensions.Configuration.CloudFoundryAutofac.Test.csproj
+++ b/src/Configuration/test/CloudFoundryAutofac.Test/Steeltoe.Extensions.Configuration.CloudFoundryAutofac.Test.csproj
@@ -1,13 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
     <TargetFrameworks>netcoreapp2.1;</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
     <TargetFrameworks>netcoreapp2.1;net461</TargetFrameworks>
   </PropertyGroup>
+
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedtest.props" />
   <Import Project="..\..\..\..\targetframework.props" />
+
   <ItemGroup>
     <None Update="xunit.runner.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/src/Configuration/test/CloudFoundryBase.Test/Steeltoe.Extensions.Configuration.CloudFoundryBase.Test.csproj
+++ b/src/Configuration/test/CloudFoundryBase.Test/Steeltoe.Extensions.Configuration.CloudFoundryBase.Test.csproj
@@ -1,11 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
+
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedtest.props" />
   <Import Project="..\..\..\..\targetframework.props" />
 

--- a/src/Configuration/test/CloudFoundryCore.Test/CloudFoundryHostBuilderExtensionsTest.cs
+++ b/src/Configuration/test/CloudFoundryCore.Test/CloudFoundryHostBuilderExtensionsTest.cs
@@ -61,7 +61,7 @@ namespace Steeltoe.Extensions.Configuration.CloudFoundry.Test
             Assert.Contains("http://*:42", addresses.Addresses);
         }
 
-#if NETCOREAPP3_0
+#if NETCOREAPP3_1
         [Fact]
         public void UseCloudFoundryHosting_GenericHost_DoNotSetUrlsIfNull()
         {

--- a/src/Configuration/test/CloudFoundryCore.Test/Steeltoe.Extensions.Configuration.CloudFoundryCore.Test.csproj
+++ b/src/Configuration/test/CloudFoundryCore.Test/Steeltoe.Extensions.Configuration.CloudFoundryCore.Test.csproj
@@ -1,11 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
+
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedtest.props" />
   <Import Project="..\..\..\..\targetframework.props" />
 
@@ -20,7 +21,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="$(AspNetCoreVersion)" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.0'">
+  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.1'">
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="$(AspNetCoreVersion)" />
   </ItemGroup>

--- a/src/Configuration/test/CloudFoundryCore.Test/TestServerStartup.cs
+++ b/src/Configuration/test/CloudFoundryCore.Test/TestServerStartup.cs
@@ -16,7 +16,7 @@ namespace Steeltoe.Extensions.Configuration.CloudFoundry.Test
 
         public void Configure(IApplicationBuilder app)
         {
-#if NETCOREAPP3_0
+#if NETCOREAPP3_1
             app.UseRouting();
 #else
             app.UseMvc();

--- a/src/Configuration/test/ConfigServer.ITest/Steeltoe.Extensions.Configuration.ConfigServer.ITest.csproj
+++ b/src/Configuration/test/ConfigServer.ITest/Steeltoe.Extensions.Configuration.ConfigServer.ITest.csproj
@@ -1,11 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
+
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedtest.props" />
   <Import Project="..\..\..\..\targetframework.props" />
 
@@ -19,11 +20,11 @@
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="$(ExtensionsVersion)" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.0'">
+  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.1'">
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="$(AspNetCoreVersion)" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 

--- a/src/Configuration/test/ConfigServer.ITest/TestServerStartup.cs
+++ b/src/Configuration/test/ConfigServer.ITest/TestServerStartup.cs
@@ -28,7 +28,7 @@ namespace Steeltoe.Extensions.Configuration.ConfigServer.ITest
         public void Configure(IApplicationBuilder app)
         {
             var config = app.ApplicationServices.GetServices<IConfiguration>();
-#if NETCOREAPP3_0
+#if NETCOREAPP3_1
             app.UseRouting();
             app.UseEndpoints(endpoints =>
             {

--- a/src/Configuration/test/ConfigServerAutofac.Test/Steeltoe.Extensions.Configuration.ConfigServerAutofac.Test.csproj
+++ b/src/Configuration/test/ConfigServerAutofac.Test/Steeltoe.Extensions.Configuration.ConfigServerAutofac.Test.csproj
@@ -1,11 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
     <TargetFrameworks>netcoreapp2.1;</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
     <TargetFrameworks>netcoreapp2.1;net461</TargetFrameworks>
   </PropertyGroup>
+
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedtest.props" />
   <Import Project="..\..\..\..\targetframework.props" />
 

--- a/src/Configuration/test/ConfigServerBase.Test/Steeltoe.Extensions.Configuration.ConfigServerBase.Test.csproj
+++ b/src/Configuration/test/ConfigServerBase.Test/Steeltoe.Extensions.Configuration.ConfigServerBase.Test.csproj
@@ -1,11 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
+
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedtest.props" />
   <Import Project="..\..\..\..\targetframework.props" />
 

--- a/src/Configuration/test/ConfigServerCore.Test/ConfigServerConfigurationBuilderExtensionsCoreTest.cs
+++ b/src/Configuration/test/ConfigServerCore.Test/ConfigServerConfigurationBuilderExtensionsCoreTest.cs
@@ -33,7 +33,7 @@ namespace Steeltoe.Extensions.Configuration.ConfigServerCore.Test
         {
             // Arrange
             IConfigurationBuilder configurationBuilder = new ConfigurationBuilder();
-#if NETCOREAPP3_0
+#if NETCOREAPP3_1
             IHostEnvironment env = null;
 #else
             IHostingEnvironment env = null;

--- a/src/Configuration/test/ConfigServerCore.Test/Steeltoe.Extensions.Configuration.ConfigServerCore.Test.csproj
+++ b/src/Configuration/test/ConfigServerCore.Test/Steeltoe.Extensions.Configuration.ConfigServerCore.Test.csproj
@@ -1,11 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
+
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedtest.props" />
   <Import Project="..\..\..\..\targetframework.props" />
 
@@ -20,7 +21,7 @@
     <ProjectReference Include="..\ConfigServerBase.Test\Steeltoe.Extensions.Configuration.ConfigServerBase.Test.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.0'">
+  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.1'">
     <PackageReference Include="Microsoft.AspNetCore" Version="$(AspNetCoreVersion)" />
   </ItemGroup>
 

--- a/src/Configuration/test/PlaceholderBase.Test/Steeltoe.Extensions.Configuration.PlaceholderBase.Test.csproj
+++ b/src/Configuration/test/PlaceholderBase.Test/Steeltoe.Extensions.Configuration.PlaceholderBase.Test.csproj
@@ -1,11 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
+
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedtest.props" />
   <Import Project="..\..\..\..\targetframework.props" />
 

--- a/src/Configuration/test/PlaceholderCore.Test/PlaceholderServiceCollectionExtensionsTest.cs
+++ b/src/Configuration/test/PlaceholderCore.Test/PlaceholderServiceCollectionExtensionsTest.cs
@@ -126,7 +126,7 @@ namespace Steeltoe.Extensions.Configuration.PlaceholderCore.Test
             }
         }
 
-#if NETCOREAPP3_0
+#if NETCOREAPP3_1
         [Fact]
         public void AddPlaceholderResolver_HostBuilder_WrapsApplicationsConfiguration()
         {

--- a/src/Configuration/test/PlaceholderCore.Test/Steeltoe.Extensions.Configuration.PlaceholderCore.Test.csproj
+++ b/src/Configuration/test/PlaceholderCore.Test/Steeltoe.Extensions.Configuration.PlaceholderCore.Test.csproj
@@ -1,11 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
+
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedtest.props" />
   <Import Project="..\..\..\..\targetframework.props" />
 

--- a/src/Configuration/test/RandomValuesBase.Test/Steeltoe.Extensions.Configuration.RandomValueBase.Test.csproj
+++ b/src/Configuration/test/RandomValuesBase.Test/Steeltoe.Extensions.Configuration.RandomValueBase.Test.csproj
@@ -1,11 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
+
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedtest.props" />
   <Import Project="..\..\..\..\targetframework.props" />
 

--- a/src/Connectors/src/Connector.EF6Autofac/Steeltoe.CloudFoundry.Connector.EF6Autofac.csproj
+++ b/src/Connectors/src/Connector.EF6Autofac/Steeltoe.CloudFoundry.Connector.EF6Autofac.csproj
@@ -10,13 +10,10 @@
   <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedproject.props" />
 
-  <ItemGroup Condition="'$(TF_BUILD)' == ''">
+  <ItemGroup>
     <ProjectReference Include="..\ConnectorBase\Steeltoe.CloudFoundry.ConnectorBase.csproj" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Autofac" Version="$(AutofacVersion)" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TF_BUILD)' == 'True'">
-    <PackageReference Include="Steeltoe.CloudFoundry.ConnectorBase" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
   </ItemGroup>
 </Project>

--- a/src/Connectors/src/Connector.EF6Autofac/Steeltoe.CloudFoundry.Connector.EF6Autofac.csproj
+++ b/src/Connectors/src/Connector.EF6Autofac/Steeltoe.CloudFoundry.Connector.EF6Autofac.csproj
@@ -1,5 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup>
     <Description>CloudFoundry Connector Extensions for Entity Framework 6 with Autofac</Description>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -7,15 +6,17 @@
     <PackageId>Steeltoe.CloudFoundry.Connector.EF6Autofac</PackageId>
     <PackageTags>CloudFoundry;ASPNET;Autofac;EntityFramework</PackageTags>
   </PropertyGroup>
+
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedproject.props" />
 
-  <ItemGroup Condition="'$(CI_BUILD)' == ''">
+  <ItemGroup Condition="'$(TF_BUILD)' == ''">
     <ProjectReference Include="..\ConnectorBase\Steeltoe.CloudFoundry.ConnectorBase.csproj" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Autofac" Version="$(AutofacVersion)" />
   </ItemGroup>
-  <ItemGroup Condition="'$(CI_BUILD)' == 'True'">
+  <ItemGroup Condition="'$(TF_BUILD)' == 'True'">
     <PackageReference Include="Steeltoe.CloudFoundry.ConnectorBase" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
   </ItemGroup>
 </Project>

--- a/src/Connectors/src/Connector.EF6Core/Steeltoe.CloudFoundry.Connector.EF6Core.csproj
+++ b/src/Connectors/src/Connector.EF6Core/Steeltoe.CloudFoundry.Connector.EF6Core.csproj
@@ -14,13 +14,8 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="$(ExtensionsVersion)" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TF_BUILD)' == ''">
+  <ItemGroup>
     <ProjectReference Include="..\..\..\Configuration\src\CloudFoundryCore\Steeltoe.Extensions.Configuration.CloudFoundryCore.csproj" />
     <ProjectReference Include="..\ConnectorBase\Steeltoe.CloudFoundry.ConnectorBase.csproj" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TF_BUILD)' == 'True'">
-    <PackageReference Include="Steeltoe.Extensions.Configuration.CloudFoundryCore" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
-    <PackageReference Include="Steeltoe.CloudFoundry.ConnectorBase" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
   </ItemGroup>
 </Project>

--- a/src/Connectors/src/Connector.EF6Core/Steeltoe.CloudFoundry.Connector.EF6Core.csproj
+++ b/src/Connectors/src/Connector.EF6Core/Steeltoe.CloudFoundry.Connector.EF6Core.csproj
@@ -1,5 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup>
     <Description>CloudFoundry Connector Extensions for Entity Framework</Description>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
@@ -7,18 +6,20 @@
     <PackageId>Steeltoe.CloudFoundry.Connector.EF6Core</PackageId>
     <PackageTags>CloudFoundry;ASPNET Core;Connectors;EntityFramework</PackageTags>
   </PropertyGroup>
+
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedproject.props" />
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="$(ExtensionsVersion)" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(CI_BUILD)' == ''">
+  <ItemGroup Condition="'$(TF_BUILD)' == ''">
     <ProjectReference Include="..\..\..\Configuration\src\CloudFoundryCore\Steeltoe.Extensions.Configuration.CloudFoundryCore.csproj" />
     <ProjectReference Include="..\ConnectorBase\Steeltoe.CloudFoundry.ConnectorBase.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(CI_BUILD)' == 'True'">
+  <ItemGroup Condition="'$(TF_BUILD)' == 'True'">
     <PackageReference Include="Steeltoe.Extensions.Configuration.CloudFoundryCore" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
     <PackageReference Include="Steeltoe.CloudFoundry.ConnectorBase" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
   </ItemGroup>

--- a/src/Connectors/src/Connector.EFCore/Steeltoe.CloudFoundry.Connector.EFCore.csproj
+++ b/src/Connectors/src/Connector.EFCore/Steeltoe.CloudFoundry.Connector.EFCore.csproj
@@ -1,5 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup>
     <Description>CloudFoundry Connector Extensions for Entity Framework Core</Description>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -7,6 +6,8 @@
     <PackageId>Steeltoe.CloudFoundry.Connector.EFCore</PackageId>
     <PackageTags>CloudFoundry;ASPNET Core;Connectors;EntityFrameworkCore</PackageTags>
   </PropertyGroup>
+
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedproject.props" />
 
   <ItemGroup>
@@ -15,13 +16,13 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="$(EFCoreVersion)" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(CI_BUILD)' == ''">
+  <ItemGroup Condition="'$(TF_BUILD)' == ''">
     <ProjectReference Include="..\..\..\Common\src\Common\Steeltoe.Common.csproj" />
     <ProjectReference Include="..\..\..\Configuration\src\CloudFoundryCore\Steeltoe.Extensions.Configuration.CloudFoundryCore.csproj" />
     <ProjectReference Include="..\ConnectorBase\Steeltoe.CloudFoundry.ConnectorBase.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(CI_BUILD)' == 'True'">
+  <ItemGroup Condition="'$(TF_BUILD)' == 'True'">
     <PackageReference Include="Steeltoe.Common" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
     <PackageReference Include="Steeltoe.Extensions.Configuration.CloudFoundryCore" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
     <PackageReference Include="Steeltoe.CloudFoundry.ConnectorBase" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />

--- a/src/Connectors/src/Connector.EFCore/Steeltoe.CloudFoundry.Connector.EFCore.csproj
+++ b/src/Connectors/src/Connector.EFCore/Steeltoe.CloudFoundry.Connector.EFCore.csproj
@@ -16,15 +16,9 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="$(EFCoreVersion)" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TF_BUILD)' == ''">
+  <ItemGroup>
     <ProjectReference Include="..\..\..\Common\src\Common\Steeltoe.Common.csproj" />
     <ProjectReference Include="..\..\..\Configuration\src\CloudFoundryCore\Steeltoe.Extensions.Configuration.CloudFoundryCore.csproj" />
     <ProjectReference Include="..\ConnectorBase\Steeltoe.CloudFoundry.ConnectorBase.csproj" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TF_BUILD)' == 'True'">
-    <PackageReference Include="Steeltoe.Common" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
-    <PackageReference Include="Steeltoe.Extensions.Configuration.CloudFoundryCore" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
-    <PackageReference Include="Steeltoe.CloudFoundry.ConnectorBase" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
   </ItemGroup>
 </Project>

--- a/src/Connectors/src/ConnectorAutofac/Steeltoe.CloudFoundry.ConnectorAutofac.csproj
+++ b/src/Connectors/src/ConnectorAutofac/Steeltoe.CloudFoundry.ConnectorAutofac.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup>
     <Description>CloudFoundry Connector Extensions for Autofac</Description>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -7,15 +6,17 @@
     <PackageId>Steeltoe.CloudFoundry.ConnectorAutofac</PackageId>
     <PackageTags>CloudFoundry;ASPNET;Autofac</PackageTags>
   </PropertyGroup>
+
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedproject.props" />
 
-  <ItemGroup Condition="'$(CI_BUILD)' == ''">
+  <ItemGroup Condition="'$(TF_BUILD)' == ''">
     <ProjectReference Include="..\ConnectorBase\Steeltoe.CloudFoundry.ConnectorBase.csproj" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Autofac" Version="$(AutofacVersion)" />
   </ItemGroup>
-  <ItemGroup Condition="'$(CI_BUILD)' == 'True'">
+  <ItemGroup Condition="'$(TF_BUILD)' == 'True'">
     <PackageReference Include="Steeltoe.CloudFoundry.ConnectorBase" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
   </ItemGroup>
 </Project>

--- a/src/Connectors/src/ConnectorAutofac/Steeltoe.CloudFoundry.ConnectorAutofac.csproj
+++ b/src/Connectors/src/ConnectorAutofac/Steeltoe.CloudFoundry.ConnectorAutofac.csproj
@@ -10,13 +10,10 @@
   <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedproject.props" />
 
-  <ItemGroup Condition="'$(TF_BUILD)' == ''">
+  <ItemGroup>
     <ProjectReference Include="..\ConnectorBase\Steeltoe.CloudFoundry.ConnectorBase.csproj" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Autofac" Version="$(AutofacVersion)" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TF_BUILD)' == 'True'">
-    <PackageReference Include="Steeltoe.CloudFoundry.ConnectorBase" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
   </ItemGroup>
 </Project>

--- a/src/Connectors/src/ConnectorBase/Steeltoe.CloudFoundry.ConnectorBase.csproj
+++ b/src/Connectors/src/ConnectorBase/Steeltoe.CloudFoundry.ConnectorBase.csproj
@@ -16,11 +16,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="$(ExtensionsVersion)" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="$(ExtensionsVersion)" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TF_BUILD)' == ''">
+  <ItemGroup>
     <ProjectReference Include="..\..\..\Configuration\src\CloudFoundryBase\Steeltoe.Extensions.Configuration.CloudFoundryBase.csproj" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TF_BUILD)' == 'True'">
-    <PackageReference Include="Steeltoe.Extensions.Configuration.CloudFoundryBase" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
   </ItemGroup>
 </Project>

--- a/src/Connectors/src/ConnectorBase/Steeltoe.CloudFoundry.ConnectorBase.csproj
+++ b/src/Connectors/src/ConnectorBase/Steeltoe.CloudFoundry.ConnectorBase.csproj
@@ -1,5 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup>
     <Description>CloudFoundry Connectors for .NET, Base package</Description>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
@@ -8,6 +7,8 @@
     <PackageTags>CloudFoundry;Connectors</PackageTags>
     <RootNamespace>Steeltoe.CloudFoundry.Connector</RootNamespace>
   </PropertyGroup>
+
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedproject.props" />
 
   <ItemGroup>
@@ -15,11 +16,11 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="$(ExtensionsVersion)" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="$(ExtensionsVersion)" />
   </ItemGroup>
-  <ItemGroup Condition="'$(CI_BUILD)' == ''">
+  <ItemGroup Condition="'$(TF_BUILD)' == ''">
     <ProjectReference Include="..\..\..\Configuration\src\CloudFoundryBase\Steeltoe.Extensions.Configuration.CloudFoundryBase.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(CI_BUILD)' == 'True'">
+  <ItemGroup Condition="'$(TF_BUILD)' == 'True'">
     <PackageReference Include="Steeltoe.Extensions.Configuration.CloudFoundryBase" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
   </ItemGroup>
 </Project>

--- a/src/Connectors/src/ConnectorCore/Steeltoe.CloudFoundry.ConnectorCore.csproj
+++ b/src/Connectors/src/ConnectorCore/Steeltoe.CloudFoundry.ConnectorCore.csproj
@@ -15,12 +15,8 @@
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="$(SourceLinkGitHubVersion)" PrivateAssets="All" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TF_BUILD)' == ''">
+  <ItemGroup>
     <ProjectReference Include="..\..\..\Configuration\src\CloudFoundryCore\Steeltoe.Extensions.Configuration.CloudFoundryCore.csproj" />
     <ProjectReference Include="..\ConnectorBase\Steeltoe.CloudFoundry.ConnectorBase.csproj" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TF_BUILD)' == 'True'">
-    <PackageReference Include="Steeltoe.Extensions.Configuration.CloudFoundryCore" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
-    <PackageReference Include="Steeltoe.CloudFoundry.ConnectorBase" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
   </ItemGroup>
 </Project>

--- a/src/Connectors/src/ConnectorCore/Steeltoe.CloudFoundry.ConnectorCore.csproj
+++ b/src/Connectors/src/ConnectorCore/Steeltoe.CloudFoundry.ConnectorCore.csproj
@@ -1,5 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup>
     <Description>.NET Core CloudFoundry Connector Extensions</Description>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -7,6 +6,8 @@
     <PackageId>Steeltoe.CloudFoundry.ConnectorCore</PackageId>
     <PackageTags>CloudFoundry;ASPNET Core;Connectors</PackageTags>
   </PropertyGroup>
+
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedproject.props" />
 
   <ItemGroup>
@@ -14,11 +15,11 @@
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="$(SourceLinkGitHubVersion)" PrivateAssets="All" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(CI_BUILD)' == ''">
+  <ItemGroup Condition="'$(TF_BUILD)' == ''">
     <ProjectReference Include="..\..\..\Configuration\src\CloudFoundryCore\Steeltoe.Extensions.Configuration.CloudFoundryCore.csproj" />
     <ProjectReference Include="..\ConnectorBase\Steeltoe.CloudFoundry.ConnectorBase.csproj" />
   </ItemGroup>
-  <ItemGroup Condition="'$(CI_BUILD)' == 'True'">
+  <ItemGroup Condition="'$(TF_BUILD)' == 'True'">
     <PackageReference Include="Steeltoe.Extensions.Configuration.CloudFoundryCore" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
     <PackageReference Include="Steeltoe.CloudFoundry.ConnectorBase" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
   </ItemGroup>

--- a/src/Connectors/test/Connector.EF6Autofac.Net4Test/Steeltoe.CloudFoundry.Connector.EF6Autofac.Test.csproj
+++ b/src/Connectors/test/Connector.EF6Autofac.Net4Test/Steeltoe.CloudFoundry.Connector.EF6Autofac.Test.csproj
@@ -1,9 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup>
     <TargetFrameworks>net461</TargetFrameworks>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
   </PropertyGroup>
+
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedtest.props" />
   <Import Project="..\..\..\..\targetframework.props" />
 

--- a/src/Connectors/test/Connector.EF6Core.Net4Test/Steeltoe.CloudFoundry.Connector.EF6Core.Test.csproj
+++ b/src/Connectors/test/Connector.EF6Core.Net4Test/Steeltoe.CloudFoundry.Connector.EF6Core.Test.csproj
@@ -1,8 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup>
-    <TargetFrameworks>net461;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
+
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedtest.props" />
   <Import Project="..\..\..\..\targetframework.props" />
 

--- a/src/Connectors/test/Connector.EFCore.Test/Steeltoe.CloudFoundry.Connector.EFCore.Test.csproj
+++ b/src/Connectors/test/Connector.EFCore.Test/Steeltoe.CloudFoundry.Connector.EFCore.Test.csproj
@@ -1,11 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
+
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedtest.props" />
   <Import Project="..\..\..\..\targetframework.props" />
 

--- a/src/Connectors/test/ConnectorAutofac.Test/Steeltoe.CloudFoundry.ConnectorAutofac.Test.csproj
+++ b/src/Connectors/test/ConnectorAutofac.Test/Steeltoe.CloudFoundry.ConnectorAutofac.Test.csproj
@@ -1,11 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
     <TargetFrameworks>netcoreapp2.1;</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
     <TargetFrameworks>net461;netcoreapp2.1</TargetFrameworks>
   </PropertyGroup>
+
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedtest.props" />
   <Import Project="..\..\..\..\targetframework.props" />
 

--- a/src/Connectors/test/ConnectorBase.Test/Steeltoe.CloudFoundry.ConnectorBase.Test.csproj
+++ b/src/Connectors/test/ConnectorBase.Test/Steeltoe.CloudFoundry.ConnectorBase.Test.csproj
@@ -1,11 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
+
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedtest.props" />
   <Import Project="..\..\..\..\targetframework.props" />
 

--- a/src/Connectors/test/ConnectorCore.Test/Steeltoe.CloudFoundry.ConnectorCore.Test.csproj
+++ b/src/Connectors/test/ConnectorCore.Test/Steeltoe.CloudFoundry.ConnectorCore.Test.csproj
@@ -1,11 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
+
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedtest.props" />
   <Import Project="..\..\..\..\targetframework.props" />
 

--- a/src/Connectors/test/GemFireConnector.Net4Test/Steeltoe.CloudFoundry.GemFireConnector.Test.csproj
+++ b/src/Connectors/test/GemFireConnector.Net4Test/Steeltoe.CloudFoundry.GemFireConnector.Test.csproj
@@ -1,11 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup>
     <TargetFrameworks>net461</TargetFrameworks>
     <PlatformTarget>x64</PlatformTarget>
-    <!-- <SignAssembly>true</SignAssembly>
-    <AssemblyOriginatorKeyFile>..\..\..\..\steeltoe.snk</AssemblyOriginatorKeyFile> -->
   </PropertyGroup>
+
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedtest.props" />
   <Import Project="..\..\..\..\targetframework.props" />
 

--- a/src/Discovery/src/ClientAutofac/Steeltoe.Discovery.ClientAutofac.csproj
+++ b/src/Discovery/src/ClientAutofac/Steeltoe.Discovery.ClientAutofac.csproj
@@ -1,7 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
-  <Import Project="..\..\..\..\versions.props" />
-
   <PropertyGroup>
     <Description>Steeltoe Service Discovery Client Autofac</Description>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -9,16 +6,18 @@
     <PackageId>Steeltoe.Discovery.ClientAutofac</PackageId>
     <PackageTags>Eureka, Autofac, Spring, Spring Cloud</PackageTags>
   </PropertyGroup>
+
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedproject.props" />
 
-  <ItemGroup Condition="'$(CI_BUILD)' == ''">
+  <ItemGroup Condition="'$(TF_BUILD)' == ''">
     <ProjectReference Include="..\..\..\Common\src\Common\Steeltoe.Common.csproj" />
     <ProjectReference Include="..\..\..\Common\src\Common.Autofac\Steeltoe.Common.Autofac.csproj" />
     <ProjectReference Include="..\EurekaBase\Steeltoe.Discovery.EurekaBase.csproj" />
     <ProjectReference Include="..\ConsulBase\Steeltoe.Discovery.ConsulBase.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(CI_BUILD)' == 'True'">
+  <ItemGroup Condition="'$(TF_BUILD)' == 'True'">
     <PackageReference Include="Steeltoe.Common" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
     <PackageReference Include="Steeltoe.Common.Autofac" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
     <PackageReference Include="Steeltoe.Discovery.EurekaBase" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />

--- a/src/Discovery/src/ClientAutofac/Steeltoe.Discovery.ClientAutofac.csproj
+++ b/src/Discovery/src/ClientAutofac/Steeltoe.Discovery.ClientAutofac.csproj
@@ -10,20 +10,10 @@
   <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedproject.props" />
 
-  <ItemGroup Condition="'$(TF_BUILD)' == ''">
+  <ItemGroup>
     <ProjectReference Include="..\..\..\Common\src\Common\Steeltoe.Common.csproj" />
     <ProjectReference Include="..\..\..\Common\src\Common.Autofac\Steeltoe.Common.Autofac.csproj" />
     <ProjectReference Include="..\EurekaBase\Steeltoe.Discovery.EurekaBase.csproj" />
     <ProjectReference Include="..\ConsulBase\Steeltoe.Discovery.ConsulBase.csproj" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TF_BUILD)' == 'True'">
-    <PackageReference Include="Steeltoe.Common" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
-    <PackageReference Include="Steeltoe.Common.Autofac" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
-    <PackageReference Include="Steeltoe.Discovery.EurekaBase" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
-    <PackageReference Include="Steeltoe.Discovery.ConsulBase" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
-  </ItemGroup>
-
-  <ItemGroup>
   </ItemGroup>
 </Project>

--- a/src/Discovery/src/ClientCore/Steeltoe.Discovery.ClientCore.csproj
+++ b/src/Discovery/src/ClientCore/Steeltoe.Discovery.ClientCore.csproj
@@ -1,5 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup>
     <Description>Steeltoe Service Discovery Client</Description>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
@@ -7,15 +6,17 @@
     <PackageId>Steeltoe.Discovery.ClientCore</PackageId>
     <PackageTags>Eureka, ASPNET Core, Spring, Spring Cloud</PackageTags>
   </PropertyGroup>
+
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedproject.props" />
   
-  <ItemGroup Condition="'$(CI_BUILD)' == ''">
+  <ItemGroup Condition="'$(TF_BUILD)' == ''">
     <ProjectReference Include="..\..\..\Common\src\Common\Steeltoe.Common.csproj" />
     <ProjectReference Include="..\EurekaBase\Steeltoe.Discovery.EurekaBase.csproj" />
     <ProjectReference Include="..\ConsulBase\Steeltoe.Discovery.ConsulBase.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(CI_BUILD)' == 'True'">
+  <ItemGroup Condition="'$(TF_BUILD)' == 'True'">
     <PackageReference Include="Steeltoe.Common" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
     <PackageReference Include="Steeltoe.Discovery.EurekaBase" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
     <PackageReference Include="Steeltoe.Discovery.ConsulBase" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />

--- a/src/Discovery/src/ClientCore/Steeltoe.Discovery.ClientCore.csproj
+++ b/src/Discovery/src/ClientCore/Steeltoe.Discovery.ClientCore.csproj
@@ -10,16 +10,10 @@
   <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedproject.props" />
   
-  <ItemGroup Condition="'$(TF_BUILD)' == ''">
+  <ItemGroup>
     <ProjectReference Include="..\..\..\Common\src\Common\Steeltoe.Common.csproj" />
     <ProjectReference Include="..\EurekaBase\Steeltoe.Discovery.EurekaBase.csproj" />
     <ProjectReference Include="..\ConsulBase\Steeltoe.Discovery.ConsulBase.csproj" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TF_BUILD)' == 'True'">
-    <PackageReference Include="Steeltoe.Common" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
-    <PackageReference Include="Steeltoe.Discovery.EurekaBase" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
-    <PackageReference Include="Steeltoe.Discovery.ConsulBase" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Discovery/src/ConsulBase/Steeltoe.Discovery.ConsulBase.csproj
+++ b/src/Discovery/src/ConsulBase/Steeltoe.Discovery.ConsulBase.csproj
@@ -1,5 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup>
     <Description>Hashicorp Consul Client</Description>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
@@ -7,13 +6,15 @@
     <PackageId>Steeltoe.Discovery.ConsulBase</PackageId>
     <PackageTags>Consul, ASPNET Core, Spring, Spring Cloud</PackageTags>
   </PropertyGroup>
+
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedproject.props" />
 
-  <ItemGroup Condition="'$(CI_BUILD)' == ''">
+  <ItemGroup Condition="'$(TF_BUILD)' == ''">
     <ProjectReference Include="..\..\..\Common\src\Common.Http\Steeltoe.Common.Http.csproj" />
     <ProjectReference Include="..\..\..\Connectors\src\ConnectorBase\Steeltoe.CloudFoundry.ConnectorBase.csproj" />
   </ItemGroup>
-  <ItemGroup Condition="'$(CI_BUILD)' == 'True'">
+  <ItemGroup Condition="'$(TF_BUILD)' == 'True'">
     <PackageReference Include="Steeltoe.Common.Http" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
     <PackageReference Include="Steeltoe.CloudFoundry.ConnectorBase" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
   </ItemGroup>

--- a/src/Discovery/src/ConsulBase/Steeltoe.Discovery.ConsulBase.csproj
+++ b/src/Discovery/src/ConsulBase/Steeltoe.Discovery.ConsulBase.csproj
@@ -10,13 +10,9 @@
   <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedproject.props" />
 
-  <ItemGroup Condition="'$(TF_BUILD)' == ''">
+  <ItemGroup>
     <ProjectReference Include="..\..\..\Common\src\Common.Http\Steeltoe.Common.Http.csproj" />
     <ProjectReference Include="..\..\..\Connectors\src\ConnectorBase\Steeltoe.CloudFoundry.ConnectorBase.csproj" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TF_BUILD)' == 'True'">
-    <PackageReference Include="Steeltoe.Common.Http" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
-    <PackageReference Include="Steeltoe.CloudFoundry.ConnectorBase" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Discovery/src/EurekaBase/Steeltoe.Discovery.EurekaBase.csproj
+++ b/src/Discovery/src/EurekaBase/Steeltoe.Discovery.EurekaBase.csproj
@@ -10,13 +10,9 @@
   <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedproject.props" />
 
-  <ItemGroup Condition="'$(TF_BUILD)' == ''">
+  <ItemGroup>
     <ProjectReference Include="..\..\..\Common\src\Common.Http\Steeltoe.Common.Http.csproj" />
     <ProjectReference Include="..\..\..\Connectors\src\ConnectorBase\Steeltoe.CloudFoundry.ConnectorBase.csproj" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TF_BUILD)' == 'True'">
-    <PackageReference Include="Steeltoe.Common.Http" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
-    <PackageReference Include="Steeltoe.CloudFoundry.ConnectorBase" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Discovery/src/EurekaBase/Steeltoe.Discovery.EurekaBase.csproj
+++ b/src/Discovery/src/EurekaBase/Steeltoe.Discovery.EurekaBase.csproj
@@ -1,5 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup>
     <Description>Neflix Eureka Client</Description>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
@@ -7,13 +6,15 @@
     <PackageId>Steeltoe.Discovery.EurekaBase</PackageId>
     <PackageTags>Eureka, ASPNET Core, Spring, Spring Cloud</PackageTags>
   </PropertyGroup>
+
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedproject.props" />
 
-  <ItemGroup Condition="'$(CI_BUILD)' == ''">
+  <ItemGroup Condition="'$(TF_BUILD)' == ''">
     <ProjectReference Include="..\..\..\Common\src\Common.Http\Steeltoe.Common.Http.csproj" />
     <ProjectReference Include="..\..\..\Connectors\src\ConnectorBase\Steeltoe.CloudFoundry.ConnectorBase.csproj" />
   </ItemGroup>
-  <ItemGroup Condition="'$(CI_BUILD)' == 'True'">
+  <ItemGroup Condition="'$(TF_BUILD)' == 'True'">
     <PackageReference Include="Steeltoe.Common.Http" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
     <PackageReference Include="Steeltoe.CloudFoundry.ConnectorBase" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
   </ItemGroup>

--- a/src/Discovery/test/ClientAutofac.Test/Steeltoe.Discovery.ClientAutofac.Test.csproj
+++ b/src/Discovery/test/ClientAutofac.Test/Steeltoe.Discovery.ClientAutofac.Test.csproj
@@ -1,11 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
     <TargetFrameworks>netcoreapp2.1;</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
     <TargetFrameworks>netcoreapp2.1;net461</TargetFrameworks>
   </PropertyGroup>
+
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedtest.props" />
   <Import Project="..\..\..\..\targetframework.props" />
   

--- a/src/Discovery/test/ClientCore.Test/DiscoveryHostBuilderExtensionsTest.cs
+++ b/src/Discovery/test/ClientCore.Test/DiscoveryHostBuilderExtensionsTest.cs
@@ -68,7 +68,7 @@ namespace Steeltoe.Discovery.Client.Test
             Assert.IsType<DiscoveryClientStartupFilter>(filter);
         }
 
-#if NETCOREAPP3_0
+#if NETCOREAPP3_1
         [Fact]
         public async Task AddServiceDiscovery_IHostBuilder_IStartupFilterFires()
         {

--- a/src/Discovery/test/ClientCore.Test/DiscoveryServiceCollectionExtensionsTest.cs
+++ b/src/Discovery/test/ClientCore.Test/DiscoveryServiceCollectionExtensionsTest.cs
@@ -6,7 +6,7 @@ using Consul;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-#if NETCOREAPP3_0
+#if NETCOREAPP3_1
 using Microsoft.Extensions.Hosting;
 #endif
 using Steeltoe.CloudFoundry.Connector;
@@ -124,7 +124,7 @@ namespace Steeltoe.Discovery.Client.Test
 
             var services = new ServiceCollection();
             services.AddOptions();
-#if NETCOREAPP3_0
+#if NETCOREAPP3_1
             services.AddSingleton<IHostApplicationLifetime>(new TestApplicationLifetime());
 #else
             services.AddSingleton<IApplicationLifetime>(new TestApplicationLifetime());
@@ -153,7 +153,7 @@ namespace Steeltoe.Discovery.Client.Test
             var config = new ConfigurationBuilder().AddInMemoryCollection(appsettings).Build();
             var services = new ServiceCollection();
             services.AddOptions();
-#if NETCOREAPP3_0
+#if NETCOREAPP3_1
             services.AddSingleton<IHostApplicationLifetime>(new TestApplicationLifetime());
 #else
             services.AddSingleton<IApplicationLifetime>(new TestApplicationLifetime());
@@ -206,7 +206,7 @@ namespace Steeltoe.Discovery.Client.Test
             };
 
             var services = new ServiceCollection();
-#if NETCOREAPP3_0
+#if NETCOREAPP3_1
             services.AddSingleton<IHostApplicationLifetime>(new TestApplicationLifetime());
 #else
             services.AddSingleton<IApplicationLifetime>(new TestApplicationLifetime());
@@ -232,7 +232,7 @@ namespace Steeltoe.Discovery.Client.Test
             };
 
             var services = new ServiceCollection();
-#if NETCOREAPP3_0
+#if NETCOREAPP3_1
             services.AddSingleton<IHostApplicationLifetime>(new TestApplicationLifetime());
 #else
             services.AddSingleton<IApplicationLifetime>(new TestApplicationLifetime());
@@ -261,7 +261,7 @@ namespace Steeltoe.Discovery.Client.Test
             };
 
             var services = new ServiceCollection();
-#if NETCOREAPP3_0
+#if NETCOREAPP3_1
             services.AddSingleton<IHostApplicationLifetime>(new TestApplicationLifetime());
 #else
             services.AddSingleton<IApplicationLifetime>(new TestApplicationLifetime());
@@ -290,7 +290,7 @@ namespace Steeltoe.Discovery.Client.Test
             };
 
             var services = new ServiceCollection();
-#if NETCOREAPP3_0
+#if NETCOREAPP3_1
             services.AddSingleton<IHostApplicationLifetime>(new TestApplicationLifetime());
 #else
             services.AddSingleton<IApplicationLifetime>(new TestApplicationLifetime());
@@ -303,7 +303,7 @@ namespace Steeltoe.Discovery.Client.Test
         {
             // Arrange
             var services = new ServiceCollection();
-#if NETCOREAPP3_0
+#if NETCOREAPP3_1
             services.AddSingleton<IHostApplicationLifetime>(new TestApplicationLifetime());
 #else
             services.AddSingleton<IApplicationLifetime>(new TestApplicationLifetime());
@@ -343,7 +343,7 @@ namespace Steeltoe.Discovery.Client.Test
             var hprovider = new TestClientHandlerProvider();
             services.AddSingleton<IEurekaDiscoveryClientHandlerProvider>(hprovider);
 
-#if NETCOREAPP3_0
+#if NETCOREAPP3_1
             services.AddSingleton<IHostApplicationLifetime>(new TestApplicationLifetime());
 #else
             services.AddSingleton<IApplicationLifetime>(new TestApplicationLifetime());

--- a/src/Discovery/test/ClientCore.Test/Steeltoe.Discovery.ClientCore.Test.csproj
+++ b/src/Discovery/test/ClientCore.Test/Steeltoe.Discovery.ClientCore.Test.csproj
@@ -1,13 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
+
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedtest.props" />
   <Import Project="..\..\..\..\targetframework.props" />
+
   <ItemGroup>
     <None Update="xunit.runner.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
@@ -18,7 +20,7 @@
     <ProjectReference Include="..\..\src\ClientCore\Steeltoe.Discovery.ClientCore.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.0'">
+  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.1'">
     <PackageReference Include="Microsoft.AspNetCore" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="$(LoggingVersion)" />
   </ItemGroup>

--- a/src/Discovery/test/ClientCore.Test/TestApplicationLifetime.cs
+++ b/src/Discovery/test/ClientCore.Test/TestApplicationLifetime.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-#if NETCOREAPP3_0
+#if NETCOREAPP3_1
 using Microsoft.Extensions.Hosting;
 #else
 using Microsoft.AspNetCore.Hosting;
@@ -12,7 +12,7 @@ using System.Threading;
 
 namespace Steeltoe.Discovery.Client.Test
 {
-#if NETCOREAPP3_0
+#if NETCOREAPP3_1
     public class TestApplicationLifetime : IHostApplicationLifetime
     {
         public CancellationToken ApplicationStarted => throw new NotImplementedException();

--- a/src/Discovery/test/ConsulBase.Test/Steeltoe.Discovery.ConsulBase.Test.csproj
+++ b/src/Discovery/test/ConsulBase.Test/Steeltoe.Discovery.ConsulBase.Test.csproj
@@ -1,11 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
+
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedtest.props" />
   <Import Project="..\..\..\..\targetframework.props" />
 

--- a/src/Discovery/test/EurekaBase.Test/EurekaInstanceOptionsTest.cs
+++ b/src/Discovery/test/EurekaBase.Test/EurekaInstanceOptionsTest.cs
@@ -10,6 +10,7 @@ using Steeltoe.Discovery.Eureka.AppInfo;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Runtime.InteropServices;
 using System.Threading;
 using Xunit;
 
@@ -44,10 +45,14 @@ namespace Steeltoe.Discovery.Eureka.Test
             Assert.Null(opts.HealthCheckUrl);
             Assert.Null(opts.SecureHealthCheckUrl);
             Assert.Equal(DataCenterName.MyOwn, opts.DataCenterInfo.Name);
-            Assert.NotNull(opts.IpAddress); // TODO: this is null on MacOS
             Assert.Equal(opts.GetHostAddress(false), opts.IpAddress);
             Assert.Null(opts.DefaultAddressResolutionOrder);
             Assert.Null(opts.RegistrationMethod);
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                // TODO: this is null on MacOS
+                Assert.NotNull(opts.IpAddress);
+            }
         }
 
         [Fact]
@@ -188,17 +193,18 @@ namespace Steeltoe.Discovery.Eureka.Test
         }
 
         [Fact]
+        [Trait("Category", "SkipOnMacOS")] // for some reason this takes 25-ish seconds on the MSFT-hosted MacOS agent
         public void Options_CanUseInetUtilsWithoutReverseDnsOnIP()
         {
             // arrange
-            var noSlowReverseDNSQuery = new Stopwatch();
-            noSlowReverseDNSQuery.Start();
             var appSettings = new Dictionary<string, string> { { "eureka:instance:UseNetUtils", "true" }, { "spring:cloud:inet:SkipReverseDnsLookup", "true" } };
             var config = new ConfigurationBuilder().AddInMemoryCollection(appSettings).Build();
             var opts = new EurekaInstanceOptions() { NetUtils = new InetUtils(config.GetSection(InetOptions.PREFIX).Get<InetOptions>()) };
             config.GetSection(EurekaInstanceOptions.EUREKA_INSTANCE_CONFIGURATION_PREFIX).Bind(opts);
 
             // act
+            var noSlowReverseDNSQuery = new Stopwatch();
+            noSlowReverseDNSQuery.Start();
             opts.ApplyNetUtils();
             noSlowReverseDNSQuery.Stop();
 

--- a/src/Discovery/test/EurekaBase.Test/Steeltoe.Discovery.EurekaBase.Test.csproj
+++ b/src/Discovery/test/EurekaBase.Test/Steeltoe.Discovery.EurekaBase.Test.csproj
@@ -1,11 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
+
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedtest.props" />
   <Import Project="..\..\..\..\targetframework.props" />
 

--- a/src/Logging/src/DynamicLogger/Steeltoe.Extensions.Logging.DynamicLogger.csproj
+++ b/src/Logging/src/DynamicLogger/Steeltoe.Extensions.Logging.DynamicLogger.csproj
@@ -18,12 +18,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="$(LoggingVersion)" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TF_BUILD)' == ''">
+  <ItemGroup>
     <ProjectReference Include="..\..\..\Common\src\Common\Steeltoe.Common.csproj" />
   </ItemGroup>
-
-  <ItemGroup Condition="'$(TF_BUILD)' == 'True'">
-    <PackageReference Include="Steeltoe.Common" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
-  </ItemGroup>
-
 </Project>

--- a/src/Logging/src/DynamicLogger/Steeltoe.Extensions.Logging.DynamicLogger.csproj
+++ b/src/Logging/src/DynamicLogger/Steeltoe.Extensions.Logging.DynamicLogger.csproj
@@ -1,12 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup>
     <Description>Steeltoe Dynamic Console Logger</Description>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
     <AssemblyName>Steeltoe.Extensions.Logging.DynamicLogger</AssemblyName>
     <PackageId>Steeltoe.Extensions.Logging.DynamicLogger</PackageId>
     <PackageTags>Spring Cloud;Logging;Management</PackageTags>
   </PropertyGroup>
+
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedproject.props" />
 
   <ItemGroup>
@@ -17,11 +18,11 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="$(LoggingVersion)" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(CI_BUILD)' == ''">
+  <ItemGroup Condition="'$(TF_BUILD)' == ''">
     <ProjectReference Include="..\..\..\Common\src\Common\Steeltoe.Common.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(CI_BUILD)' == 'True'">
+  <ItemGroup Condition="'$(TF_BUILD)' == 'True'">
     <PackageReference Include="Steeltoe.Common" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
   </ItemGroup>
 

--- a/src/Logging/src/SerilogDynamicLoggerCore/Steeltoe.Extensions.Logging.SerilogDynamicLoggerCore.csproj
+++ b/src/Logging/src/SerilogDynamicLoggerCore/Steeltoe.Extensions.Logging.SerilogDynamicLoggerCore.csproj
@@ -1,12 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup>
     <Description>Steeltoe library for enabling dynamic management of Serilog</Description>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
     <AssemblyName>Steeltoe.Extensions.Logging.SerilogDynamicLogger</AssemblyName>
     <PackageId>Steeltoe.Extensions.Logging.SerilogDynamicLogger</PackageId>
     <PackageTags>Spring Cloud;Logging;Management</PackageTags>
   </PropertyGroup>
+
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedproject.props" />
 
   <ItemGroup>
@@ -20,10 +21,10 @@
     <PackageReference Include="Serilog.Settings.Configuration" Version="3.0.1" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
   </ItemGroup>
-  <ItemGroup Condition="'$(CI_BUILD)' == ''">
+  <ItemGroup Condition="'$(TF_BUILD)' == ''">
     <ProjectReference Include="..\DynamicLogger\Steeltoe.Extensions.Logging.DynamicLogger.csproj" />
   </ItemGroup>
-  <ItemGroup Condition="'$(CI_BUILD)' == 'True'">
+  <ItemGroup Condition="'$(TF_BUILD)' == 'True'">
     <PackageReference Include="Steeltoe.Extensions.Logging.DynamicLogger" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
   </ItemGroup>
 </Project>

--- a/src/Logging/src/SerilogDynamicLoggerCore/Steeltoe.Extensions.Logging.SerilogDynamicLoggerCore.csproj
+++ b/src/Logging/src/SerilogDynamicLoggerCore/Steeltoe.Extensions.Logging.SerilogDynamicLoggerCore.csproj
@@ -21,10 +21,7 @@
     <PackageReference Include="Serilog.Settings.Configuration" Version="3.0.1" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TF_BUILD)' == ''">
+  <ItemGroup>
     <ProjectReference Include="..\DynamicLogger\Steeltoe.Extensions.Logging.DynamicLogger.csproj" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TF_BUILD)' == 'True'">
-    <PackageReference Include="Steeltoe.Extensions.Logging.DynamicLogger" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
   </ItemGroup>
 </Project>

--- a/src/Logging/test/DynamicLogger.Test/DynamicLoggerHostBuilderExtensionsTest.cs
+++ b/src/Logging/test/DynamicLogger.Test/DynamicLoggerHostBuilderExtensionsTest.cs
@@ -45,7 +45,7 @@ namespace Steeltoe.Extensions.Logging.DynamicLogger.Test
             Assert.IsType<DynamicConsoleLoggerProvider>(loggerProviders.First());
         }
 
-#if NETCOREAPP3_0
+#if NETCOREAPP3_1
         [Fact]
         public void AddDynamicLogging_IHostBuilder_RemovesConsoleLoggingDefaultBuilder()
         {

--- a/src/Logging/test/DynamicLogger.Test/Steeltoe.Extensions.Logging.DynamicLogger.Test.csproj
+++ b/src/Logging/test/DynamicLogger.Test/Steeltoe.Extensions.Logging.DynamicLogger.Test.csproj
@@ -1,11 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
+
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedtest.props" />
   <Import Project="..\..\..\..\targetframework.props" />
 
@@ -15,11 +16,11 @@
     </None>
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.0'">
+  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.1'">
     <PackageReference Include="Microsoft.AspNetCore" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="$(LoggingVersion)" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Logging/test/SerilogDynamicLoggerCore.Test/Steeltoe.Extensions.Logging.SerilogDynamicLoggerCore.Test.csproj
+++ b/src/Logging/test/SerilogDynamicLoggerCore.Test/Steeltoe.Extensions.Logging.SerilogDynamicLoggerCore.Test.csproj
@@ -1,11 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
+
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedtest.props" />
   <Import Project="..\..\..\..\targetframework.props" />
 
@@ -23,10 +24,10 @@
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
     <PackageReference Include="Serilog.Exceptions" Version="5.0.0" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.0'">
+  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.1'">
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="$(AspNetCoreVersion)" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Management/src/CloudFoundryCore/Steeltoe.Management.CloudFoundryCore.csproj
+++ b/src/Management/src/CloudFoundryCore/Steeltoe.Management.CloudFoundryCore.csproj
@@ -1,12 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup>
     <Description>Steeltoe Management Extensions for Cloud Foundry with Microsoft DI</Description>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
     <AssemblyName>Steeltoe.Management.CloudFoundryCore</AssemblyName>
     <PackageId>Steeltoe.Management.CloudFoundryCore</PackageId>
     <PackageTags>Spring Cloud;Actuator;Management;Monitoring;CloudFoundry</PackageTags>
   </PropertyGroup>
+
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedproject.props" />
   
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
@@ -14,11 +15,11 @@
     <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="$(AspNetCoreVersion)" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(CI_BUILD)' == ''">
+  <ItemGroup Condition="'$(TF_BUILD)' == ''">
     <ProjectReference Include="..\EndpointCore\Steeltoe.Management.EndpointCore.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(CI_BUILD)' == 'True'">
+  <ItemGroup Condition="'$(TF_BUILD)' == 'True'">
     <PackageReference Include="Steeltoe.Management.EndpointCore" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
   </ItemGroup>
 </Project>

--- a/src/Management/src/CloudFoundryCore/Steeltoe.Management.CloudFoundryCore.csproj
+++ b/src/Management/src/CloudFoundryCore/Steeltoe.Management.CloudFoundryCore.csproj
@@ -15,11 +15,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="$(AspNetCoreVersion)" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TF_BUILD)' == ''">
+  <ItemGroup>
     <ProjectReference Include="..\EndpointCore\Steeltoe.Management.EndpointCore.csproj" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TF_BUILD)' == 'True'">
-    <PackageReference Include="Steeltoe.Management.EndpointCore" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
   </ItemGroup>
 </Project>

--- a/src/Management/src/Diagnostics/Steeltoe.Management.Diagnostics.csproj
+++ b/src/Management/src/Diagnostics/Steeltoe.Management.Diagnostics.csproj
@@ -1,5 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup>
     <Description>Steeltoe Management Runtime Diagnostics</Description>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
@@ -8,6 +7,8 @@
     <PackageTags>Spring Cloud;Actuator;Management;Monitoring</PackageTags>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
+
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedproject.props" />
   
   <ItemGroup>

--- a/src/Management/src/EndpointBase/Steeltoe.Management.EndpointBase.csproj
+++ b/src/Management/src/EndpointBase/Steeltoe.Management.EndpointBase.csproj
@@ -10,26 +10,17 @@
   <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedproject.props" />
 
-  <ItemGroup Condition="'$(TF_BUILD)' == ''">
+  <ItemGroup>
     <ProjectReference Include="..\..\..\Common\src\Common\Steeltoe.Common.csproj" />
     <ProjectReference Include="..\..\..\Common\src\Common.Http\Steeltoe.Common.Http.csproj" />
     <ProjectReference Include="..\..\..\Logging\src\DynamicLogger\Steeltoe.Extensions.Logging.DynamicLogger.csproj" />
     <ProjectReference Include="..\Diagnostics\Steeltoe.Management.Diagnostics.csproj" />
     <ProjectReference Include="..\OpenCensusBase\Steeltoe.Management.OpenCensusBase.csproj" />
   </ItemGroup>
-  
-  <ItemGroup Condition="'$(TF_BUILD)' == 'True'">
-    <PackageReference Include="Steeltoe.Common" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
-    <PackageReference Include="Steeltoe.Common.Http" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
-    <PackageReference Include="Steeltoe.Extensions.Logging.DynamicLogger" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
-    <PackageReference Include="Steeltoe.Management.Diagnostics" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
-    <PackageReference Include="Steeltoe.Management.OpenCensusBase" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
-  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="$(ExtensionsVersion)" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="$(ExtensionsVersion)" />
-    
     <PackageReference Include="Microsoft.DiaSymReader" Version="$(SymReaderVersion)" />
     <PackageReference Include="Microsoft.DiaSymReader.PortablePdb" Version="$(SymReaderPortableVersion)" />
     <PackageReference Include="System.IO.FileSystem.DriveInfo" Version="$(DriveInfoVersion)" />

--- a/src/Management/src/EndpointBase/Steeltoe.Management.EndpointBase.csproj
+++ b/src/Management/src/EndpointBase/Steeltoe.Management.EndpointBase.csproj
@@ -1,5 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup>
     <Description>Steeltoe Management Endpoints - Base Package</Description>
     <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
@@ -7,9 +6,11 @@
     <PackageId>Steeltoe.Management.EndpointBase</PackageId>
     <PackageTags>Spring Cloud;Actuator;Management;Monitoring</PackageTags>
   </PropertyGroup>
+
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedproject.props" />
 
-  <ItemGroup Condition="'$(CI_BUILD)' == ''">
+  <ItemGroup Condition="'$(TF_BUILD)' == ''">
     <ProjectReference Include="..\..\..\Common\src\Common\Steeltoe.Common.csproj" />
     <ProjectReference Include="..\..\..\Common\src\Common.Http\Steeltoe.Common.Http.csproj" />
     <ProjectReference Include="..\..\..\Logging\src\DynamicLogger\Steeltoe.Extensions.Logging.DynamicLogger.csproj" />
@@ -17,7 +18,7 @@
     <ProjectReference Include="..\OpenCensusBase\Steeltoe.Management.OpenCensusBase.csproj" />
   </ItemGroup>
   
-  <ItemGroup Condition="'$(CI_BUILD)' == 'True'">
+  <ItemGroup Condition="'$(TF_BUILD)' == 'True'">
     <PackageReference Include="Steeltoe.Common" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
     <PackageReference Include="Steeltoe.Common.Http" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
     <PackageReference Include="Steeltoe.Extensions.Logging.DynamicLogger" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />

--- a/src/Management/src/EndpointCore/Env/EndpointServiceCollectionExtensions.cs
+++ b/src/Management/src/EndpointCore/Env/EndpointServiceCollectionExtensions.cs
@@ -30,7 +30,7 @@ namespace Steeltoe.Management.Endpoint.Env
                 throw new ArgumentNullException(nameof(config));
             }
 
-#if NETCOREAPP3_0
+#if NETCOREAPP3_1
             services.TryAddSingleton<IHostEnvironment>((provider) =>
             {
                 var service = provider.GetRequiredService<IHostEnvironment>();

--- a/src/Management/src/EndpointCore/SpringBootAdminClient/BootAdminAppBuilderExtensions.cs
+++ b/src/Management/src/EndpointCore/SpringBootAdminClient/BootAdminAppBuilderExtensions.cs
@@ -77,7 +77,7 @@ namespace Steeltoe.Management.Endpoint.SpringBootAdminClient
                 var result = httpClient.DeleteAsync($"{options.Url}/instances/{RegistrationResult.Id}").Result;
             };
 
-#if NETCOREAPP3_0
+#if NETCOREAPP3_1
             var lifetime = builder.ApplicationServices.GetService<IHostApplicationLifetime>();
             lifetime.ApplicationStarted.Register(onStarted);
             lifetime.ApplicationStopped.Register(onStopped);

--- a/src/Management/src/EndpointCore/Steeltoe.Management.EndpointCore.csproj
+++ b/src/Management/src/EndpointCore/Steeltoe.Management.EndpointCore.csproj
@@ -26,14 +26,8 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TF_BUILD)' == ''">
+  <ItemGroup>
     <ProjectReference Include="..\..\..\Common\src\Common.Http\Steeltoe.Common.Http.csproj" />
     <ProjectReference Include="..\EndpointBase\Steeltoe.Management.EndpointBase.csproj" />
   </ItemGroup>
-
-  <ItemGroup Condition="'$(TF_BUILD)' == 'True'">
-    <PackageReference Include="Steeltoe.Common.Http" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
-    <PackageReference Include="Steeltoe.Management.EndpointBase" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
-  </ItemGroup>
-
 </Project>

--- a/src/Management/src/EndpointCore/Steeltoe.Management.EndpointCore.csproj
+++ b/src/Management/src/EndpointCore/Steeltoe.Management.EndpointCore.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
-
   <PropertyGroup>
     <Description>Steeltoe Management Endpoint Extensions for Microsoft DI</Description>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
     <AssemblyName>Steeltoe.Management.EndpointCore</AssemblyName>
     <PackageId>Steeltoe.Management.EndpointCore</PackageId>
     <PackageTags>Spring Cloud;Actuator;Management;Monitoring</PackageTags>
     <RootNamespace>Steeltoe.Management.Endpoint</RootNamespace>
   </PropertyGroup>
+
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedproject.props" />
   
   <ItemGroup>
@@ -23,15 +23,15 @@
     <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="$(AspNetCoreVersion)" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
-  <ItemGroup Condition="'$(CI_BUILD)' == ''">
+  <ItemGroup Condition="'$(TF_BUILD)' == ''">
     <ProjectReference Include="..\..\..\Common\src\Common.Http\Steeltoe.Common.Http.csproj" />
     <ProjectReference Include="..\EndpointBase\Steeltoe.Management.EndpointBase.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(CI_BUILD)' == 'True'">
+  <ItemGroup Condition="'$(TF_BUILD)' == 'True'">
     <PackageReference Include="Steeltoe.Common.Http" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
     <PackageReference Include="Steeltoe.Management.EndpointBase" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
   </ItemGroup>

--- a/src/Management/src/EndpointOwin/Steeltoe.Management.EndpointOwin.csproj
+++ b/src/Management/src/EndpointOwin/Steeltoe.Management.EndpointOwin.csproj
@@ -16,14 +16,9 @@
     <PackageReference Include="Microsoft.Owin" Version="$(OwinVersion)" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TF_BUILD)' == ''">
+  <ItemGroup>
     <ProjectReference Include="..\..\..\Common\src\Common.Http\Steeltoe.Common.Http.csproj" />
     <ProjectReference Include="..\EndpointBase\Steeltoe.Management.EndpointBase.csproj" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TF_BUILD)' == 'True'">
-    <PackageReference Include="Steeltoe.Common.Http" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
-    <PackageReference Include="Steeltoe.Management.EndpointBase" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Management/src/EndpointOwin/Steeltoe.Management.EndpointOwin.csproj
+++ b/src/Management/src/EndpointOwin/Steeltoe.Management.EndpointOwin.csproj
@@ -1,6 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
-
   <PropertyGroup>
     <Description>Steeltoe Management Endpoint Support for ASP.NET 4x via OWIN</Description>
     <TargetFrameworks>net461</TargetFrameworks>
@@ -8,8 +6,9 @@
     <PackageId>Steeltoe.Management.EndpointOwin</PackageId>
     <PackageTags>Spring Cloud;Actuator;Management;Monitoring</PackageTags>
   </PropertyGroup>
-  <Import Project="..\..\..\..\sharedproject.props" />
 
+  <Import Project="..\..\..\..\versions.props" />
+  <Import Project="..\..\..\..\sharedproject.props" />
   <Import Project="..\..\..\..\targetframework.props" />
   
   <ItemGroup>
@@ -17,12 +16,12 @@
     <PackageReference Include="Microsoft.Owin" Version="$(OwinVersion)" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(CI_BUILD)' == ''">
+  <ItemGroup Condition="'$(TF_BUILD)' == ''">
     <ProjectReference Include="..\..\..\Common\src\Common.Http\Steeltoe.Common.Http.csproj" />
     <ProjectReference Include="..\EndpointBase\Steeltoe.Management.EndpointBase.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(CI_BUILD)' == 'True'">
+  <ItemGroup Condition="'$(TF_BUILD)' == 'True'">
     <PackageReference Include="Steeltoe.Common.Http" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
     <PackageReference Include="Steeltoe.Management.EndpointBase" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
   </ItemGroup>

--- a/src/Management/src/EndpointOwinAutofac/Steeltoe.Management.EndpointOwinAutofac.csproj
+++ b/src/Management/src/EndpointOwinAutofac/Steeltoe.Management.EndpointOwinAutofac.csproj
@@ -1,6 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
-
   <PropertyGroup>
     <Description>Extensions for using Steeltoe Management OWIN Endpoints with Autofac</Description>
     <TargetFramework>net461</TargetFramework>
@@ -8,20 +6,21 @@
     <PackageId>Steeltoe.Management.EndpointOwinAutofac</PackageId>
     <PackageTags>Spring Cloud;Actuator;Management;Monitoring;OWIN</PackageTags>
   </PropertyGroup>
-  <Import Project="..\..\..\..\sharedproject.props" />
 
+  <Import Project="..\..\..\..\versions.props" />
+  <Import Project="..\..\..\..\sharedproject.props" />
   <Import Project="..\..\..\..\targetframework.props" />
   
   <ItemGroup>
     <PackageReference Include="Autofac" Version="$(AutofacVersion)" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(CI_BUILD)' == ''">
+  <ItemGroup Condition="'$(TF_BUILD)' == ''">
     <ProjectReference Include="..\..\..\Common\src\Common.Autofac\Steeltoe.Common.Autofac.csproj" />
     <ProjectReference Include="..\EndpointOwin\Steeltoe.Management.EndpointOwin.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(CI_BUILD)' == 'True'">
+  <ItemGroup Condition="'$(TF_BUILD)' == 'True'">
     <PackageReference Include="Steeltoe.Common.Autofac" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
     <PackageReference Include="Steeltoe.Management.EndpointOwin" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
   </ItemGroup>

--- a/src/Management/src/EndpointOwinAutofac/Steeltoe.Management.EndpointOwinAutofac.csproj
+++ b/src/Management/src/EndpointOwinAutofac/Steeltoe.Management.EndpointOwinAutofac.csproj
@@ -15,13 +15,8 @@
     <PackageReference Include="Autofac" Version="$(AutofacVersion)" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TF_BUILD)' == ''">
+  <ItemGroup>
     <ProjectReference Include="..\..\..\Common\src\Common.Autofac\Steeltoe.Common.Autofac.csproj" />
     <ProjectReference Include="..\EndpointOwin\Steeltoe.Management.EndpointOwin.csproj" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TF_BUILD)' == 'True'">
-    <PackageReference Include="Steeltoe.Common.Autofac" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
-    <PackageReference Include="Steeltoe.Management.EndpointOwin" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
   </ItemGroup>
 </Project>

--- a/src/Management/src/EndpointWeb/Steeltoe.Management.EndpointWeb.csproj
+++ b/src/Management/src/EndpointWeb/Steeltoe.Management.EndpointWeb.csproj
@@ -21,11 +21,7 @@
     <PackageReference Include="Microsoft.Web.Infrastructure" Version="$(WebInfrastructureVersion)" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TF_BUILD)' == ''">
+  <ItemGroup>
     <ProjectReference Include="..\EndpointBase\Steeltoe.Management.EndpointBase.csproj" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TF_BUILD)' == 'True'">
-    <PackageReference Include="Steeltoe.Management.EndpointBase" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
   </ItemGroup>
 </Project>

--- a/src/Management/src/EndpointWeb/Steeltoe.Management.EndpointWeb.csproj
+++ b/src/Management/src/EndpointWeb/Steeltoe.Management.EndpointWeb.csproj
@@ -1,5 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup>
     <Description>Steeltoe Management Endpoints for ASP.NET 4.x</Description>
     <TargetFrameworks>net461</TargetFrameworks>
@@ -7,6 +6,8 @@
     <PackageId>Steeltoe.Management.EndpointWeb</PackageId>
     <PackageTags>Spring Cloud;Actuator;Management;Monitoring;CloudFoundry;ASP.NET 4.x</PackageTags>
   </PropertyGroup>
+
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedproject.props" />
   <Import Project="..\..\..\..\targetframework.props" />
 
@@ -20,11 +21,11 @@
     <PackageReference Include="Microsoft.Web.Infrastructure" Version="$(WebInfrastructureVersion)" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(CI_BUILD)' == ''">
+  <ItemGroup Condition="'$(TF_BUILD)' == ''">
     <ProjectReference Include="..\EndpointBase\Steeltoe.Management.EndpointBase.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(CI_BUILD)' == 'True'">
+  <ItemGroup Condition="'$(TF_BUILD)' == 'True'">
     <PackageReference Include="Steeltoe.Management.EndpointBase" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
   </ItemGroup>
 </Project>

--- a/src/Management/src/ExporterBase/Steeltoe.Management.ExporterBase.csproj
+++ b/src/Management/src/ExporterBase/Steeltoe.Management.ExporterBase.csproj
@@ -1,6 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
-  
   <PropertyGroup>
     <Description>Steeltoe Management ExporterBase - Base Package</Description>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -9,15 +7,17 @@
     <PackageTags>Management;Monitoring;Metrics;Distributed Trace</PackageTags>
     <RootNamespace>Steeltoe.Management.Exporter</RootNamespace>
   </PropertyGroup>
+
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedproject.props" />
   
-  <ItemGroup Condition="'$(CI_BUILD)' == ''">
+  <ItemGroup Condition="'$(TF_BUILD)' == ''">
     <ProjectReference Include="..\..\..\Common\src\Common.Http\Steeltoe.Common.Http.csproj" />
     <ProjectReference Include="..\..\..\Configuration\src\CloudFoundryBase\Steeltoe.Extensions.Configuration.CloudFoundryBase.csproj" />
     <ProjectReference Include="..\OpenCensusBase\Steeltoe.Management.OpenCensusBase.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(CI_BUILD)' == 'True'">
+  <ItemGroup Condition="'$(TF_BUILD)' == 'True'">
     <PackageReference Include="Steeltoe.Common.Http" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
     <PackageReference Include="Steeltoe.Extensions.Configuration.CloudFoundryBase" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
     <PackageReference Include="Steeltoe.Management.OpenCensusBase" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />

--- a/src/Management/src/ExporterBase/Steeltoe.Management.ExporterBase.csproj
+++ b/src/Management/src/ExporterBase/Steeltoe.Management.ExporterBase.csproj
@@ -11,15 +11,9 @@
   <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedproject.props" />
   
-  <ItemGroup Condition="'$(TF_BUILD)' == ''">
+  <ItemGroup>
     <ProjectReference Include="..\..\..\Common\src\Common.Http\Steeltoe.Common.Http.csproj" />
     <ProjectReference Include="..\..\..\Configuration\src\CloudFoundryBase\Steeltoe.Extensions.Configuration.CloudFoundryBase.csproj" />
     <ProjectReference Include="..\OpenCensusBase\Steeltoe.Management.OpenCensusBase.csproj" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TF_BUILD)' == 'True'">
-    <PackageReference Include="Steeltoe.Common.Http" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
-    <PackageReference Include="Steeltoe.Extensions.Configuration.CloudFoundryBase" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
-    <PackageReference Include="Steeltoe.Management.OpenCensusBase" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
   </ItemGroup>
 </Project>

--- a/src/Management/src/ExporterCore/Metrics/CloudFoundryForwarder/EndpointApplicationBuilderExtensions.cs
+++ b/src/Management/src/ExporterCore/Metrics/CloudFoundryForwarder/EndpointApplicationBuilderExtensions.cs
@@ -23,7 +23,7 @@ namespace Steeltoe.Management.Exporter.Metrics
             }
 
             var service = builder.ApplicationServices.GetRequiredService<IMetricsExporter>();
-#if NETCOREAPP3_0
+#if NETCOREAPP3_1
             var lifetime = builder.ApplicationServices.GetRequiredService<IHostApplicationLifetime>();
 #else
             var lifetime = builder.ApplicationServices.GetRequiredService<IApplicationLifetime>();

--- a/src/Management/src/ExporterCore/Steeltoe.Management.ExporterCore.csproj
+++ b/src/Management/src/ExporterCore/Steeltoe.Management.ExporterCore.csproj
@@ -1,28 +1,29 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
-  
   <PropertyGroup>
     <Description>Steeltoe Management Exporter</Description>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
     <AssemblyName>Steeltoe.Management.ExporterCore</AssemblyName>
     <PackageId>Steeltoe.Management.ExporterCore</PackageId>
     <PackageTags>Asp.NET Core, Management;Monitoring;Metrics;Distributed Trace</PackageTags>
   </PropertyGroup>
+
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedproject.props" />
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="$(AspNetCoreVersion)" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(CI_BUILD)' == ''">
+  <ItemGroup Condition="'$(TF_BUILD)' == ''">
     <ProjectReference Include="..\ExporterBase\Steeltoe.Management.ExporterBase.csproj" />
     <ProjectReference Include="..\OpenCensus.Exporter.Zipkin\Steeltoe.Management.OpenCensus.Exporter.Zipkin.csproj" />
     <ProjectReference Include="..\OpenCensus\Steeltoe.Management.OpenCensus.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(CI_BUILD)' == 'True'">
+  <ItemGroup Condition="'$(TF_BUILD)' == 'True'">
     <PackageReference Include="Steeltoe.Management.ExporterBase" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
     <PackageReference Include="Steeltoe.Management.OpenCensus.Exporter.Zipkin" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
     <PackageReference Include="Steeltoe.Management.OpenCensus" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />

--- a/src/Management/src/ExporterCore/Steeltoe.Management.ExporterCore.csproj
+++ b/src/Management/src/ExporterCore/Steeltoe.Management.ExporterCore.csproj
@@ -17,15 +17,9 @@
     <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="$(AspNetCoreVersion)" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TF_BUILD)' == ''">
+  <ItemGroup>
     <ProjectReference Include="..\ExporterBase\Steeltoe.Management.ExporterBase.csproj" />
     <ProjectReference Include="..\OpenCensus.Exporter.Zipkin\Steeltoe.Management.OpenCensus.Exporter.Zipkin.csproj" />
     <ProjectReference Include="..\OpenCensus\Steeltoe.Management.OpenCensus.csproj" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TF_BUILD)' == 'True'">
-    <PackageReference Include="Steeltoe.Management.ExporterBase" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
-    <PackageReference Include="Steeltoe.Management.OpenCensus.Exporter.Zipkin" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
-    <PackageReference Include="Steeltoe.Management.OpenCensus" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
   </ItemGroup>
 </Project>

--- a/src/Management/src/ExporterCore/Tracing/Zipkin/ZipkinExporterApplicationBuilderExtensions.cs
+++ b/src/Management/src/ExporterCore/Tracing/Zipkin/ZipkinExporterApplicationBuilderExtensions.cs
@@ -20,7 +20,7 @@ namespace Steeltoe.Management.Exporter.Tracing
             }
 
             var service = builder.ApplicationServices.GetRequiredService<ZipkinTraceExporter>();
-#if NETCOREAPP3_0
+#if NETCOREAPP3_1
             var lifetime = builder.ApplicationServices.GetRequiredService<IHostApplicationLifetime>();
 #else
             var lifetime = builder.ApplicationServices.GetRequiredService<IApplicationLifetime>();

--- a/src/Management/src/ExporterCore/Tracing/Zipkin/ZipkinExporterServiceCollectionExtensions.cs
+++ b/src/Management/src/ExporterCore/Tracing/Zipkin/ZipkinExporterServiceCollectionExtensions.cs
@@ -36,7 +36,7 @@ namespace Steeltoe.Management.Exporter.Tracing
 
         private static ZipkinTraceExporter CreateExporter(IServiceProvider p, IConfiguration config)
         {
-#if NETCOREAPP3_0
+#if NETCOREAPP3_1
             var h = p.GetRequiredService<IHostEnvironment>();
 #else
             var h = p.GetRequiredService<IHostingEnvironment>();

--- a/src/Management/src/OpenCensus.Abstractions/Steeltoe.Management.OpenCensus.Abstractions.csproj
+++ b/src/Management/src/OpenCensus.Abstractions/Steeltoe.Management.OpenCensus.Abstractions.csproj
@@ -1,5 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
     <TargetFrameworks Condition="$(OS) != 'Windows_NT'">netstandard2.0</TargetFrameworks>

--- a/src/Management/src/OpenCensus.Exporter.Zipkin/Steeltoe.Management.OpenCensus.Exporter.Zipkin.csproj
+++ b/src/Management/src/OpenCensus.Exporter.Zipkin/Steeltoe.Management.OpenCensus.Exporter.Zipkin.csproj
@@ -22,11 +22,11 @@
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
   </ItemGroup>
-  <ItemGroup Condition="'$(CI_BUILD)' == ''">
+  <ItemGroup Condition="'$(TF_BUILD)' == ''">
     <ProjectReference Include="..\OpenCensus.Abstractions\Steeltoe.Management.OpenCensus.Abstractions.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(CI_BUILD)' == 'True'">
+  <ItemGroup Condition="'$(TF_BUILD)' == 'True'">
     <PackageReference Include="Steeltoe.Management.OpenCensus.Abstractions" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
   </ItemGroup>
 

--- a/src/Management/src/OpenCensus.Exporter.Zipkin/Steeltoe.Management.OpenCensus.Exporter.Zipkin.csproj
+++ b/src/Management/src/OpenCensus.Exporter.Zipkin/Steeltoe.Management.OpenCensus.Exporter.Zipkin.csproj
@@ -22,12 +22,8 @@
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TF_BUILD)' == ''">
+  <ItemGroup>
     <ProjectReference Include="..\OpenCensus.Abstractions\Steeltoe.Management.OpenCensus.Abstractions.csproj" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TF_BUILD)' == 'True'">
-    <PackageReference Include="Steeltoe.Management.OpenCensus.Abstractions" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net46'">

--- a/src/Management/src/OpenCensus/Steeltoe.Management.OpenCensus.csproj
+++ b/src/Management/src/OpenCensus/Steeltoe.Management.OpenCensus.csproj
@@ -1,5 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFrameworks>net46;netstandard2.0</TargetFrameworks>
     <TargetFrameworks Condition="$(OS) != 'Windows_NT'">netstandard2.0</TargetFrameworks>
@@ -31,11 +30,11 @@
     <PackageReference Include="System.Collections.Immutable" Version="1.6.0" />
   </ItemGroup>
   
-  <ItemGroup Condition="'$(CI_BUILD)' == ''">
+  <ItemGroup Condition="'$(TF_BUILD)' == ''">
     <ProjectReference Include="..\OpenCensus.Abstractions\Steeltoe.Management.OpenCensus.Abstractions.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(CI_BUILD)' == 'True'">
+  <ItemGroup Condition="'$(TF_BUILD)' == 'True'">
     <PackageReference Include="Steeltoe.Management.OpenCensus.Abstractions" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
   </ItemGroup>
 </Project>

--- a/src/Management/src/OpenCensus/Steeltoe.Management.OpenCensus.csproj
+++ b/src/Management/src/OpenCensus/Steeltoe.Management.OpenCensus.csproj
@@ -30,11 +30,7 @@
     <PackageReference Include="System.Collections.Immutable" Version="1.6.0" />
   </ItemGroup>
   
-  <ItemGroup Condition="'$(TF_BUILD)' == ''">
+  <ItemGroup>
     <ProjectReference Include="..\OpenCensus.Abstractions\Steeltoe.Management.OpenCensus.Abstractions.csproj" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TF_BUILD)' == 'True'">
-    <PackageReference Include="Steeltoe.Management.OpenCensus.Abstractions" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
   </ItemGroup>
 </Project>

--- a/src/Management/src/OpenCensusBase/Steeltoe.Management.OpenCensusBase.csproj
+++ b/src/Management/src/OpenCensusBase/Steeltoe.Management.OpenCensusBase.csproj
@@ -11,12 +11,7 @@
   <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedproject.props" />
 
-  <ItemGroup Condition="'$(TF_BUILD)' == ''">
+  <ItemGroup>
     <ProjectReference Include="..\OpenCensus\Steeltoe.Management.OpenCensus.csproj" />
   </ItemGroup>
-
-  <ItemGroup Condition="'$(TF_BUILD)' == 'True'">
-    <PackageReference Include="Steeltoe.Management.OpenCensus" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
-  </ItemGroup>
-
 </Project>

--- a/src/Management/src/OpenCensusBase/Steeltoe.Management.OpenCensusBase.csproj
+++ b/src/Management/src/OpenCensusBase/Steeltoe.Management.OpenCensusBase.csproj
@@ -1,7 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
-  <Import Project="..\..\..\..\versions.props" />
-
   <PropertyGroup>
     <Description>Steeltoe Management OpenCensus</Description>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -10,13 +7,15 @@
     <PackageTags>Tracing;OpenCensus;Management;Monitoring</PackageTags>
     <RootNamespace>Steeltoe.Management.Census</RootNamespace>
   </PropertyGroup>
+
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedproject.props" />
 
-  <ItemGroup Condition="'$(CI_BUILD)' == ''">
+  <ItemGroup Condition="'$(TF_BUILD)' == ''">
     <ProjectReference Include="..\OpenCensus\Steeltoe.Management.OpenCensus.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(CI_BUILD)' == 'True'">
+  <ItemGroup Condition="'$(TF_BUILD)' == 'True'">
     <PackageReference Include="Steeltoe.Management.OpenCensus" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
   </ItemGroup>
 

--- a/src/Management/src/TaskCore/Steeltoe.Management.TaskCore.csproj
+++ b/src/Management/src/TaskCore/Steeltoe.Management.TaskCore.csproj
@@ -1,25 +1,26 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup>
     <Description>Extensions for running tasks embedded in your ASP.NET Core application. Ideal for cf run-task in Cloud Foundry.</Description>
     <AssemblyName>Steeltoe.Management.TaskCore</AssemblyName>
     <PackageId>Steeltoe.Management.TaskCore</PackageId>
     <PackageTags>Spring Cloud;Tasks;Management;Monitoring;Task;aspnetcore</PackageTags>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
+
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedproject.props" />
   
-  <ItemGroup Condition="'$(CI_BUILD)' == ''">
+  <ItemGroup Condition="'$(TF_BUILD)' == ''">
     <ProjectReference Include="..\..\..\Common\src\Common\Steeltoe.Common.csproj" />
   </ItemGroup>
-  <ItemGroup Condition="'$(CI_BUILD)' == 'True'">
+  <ItemGroup Condition="'$(TF_BUILD)' == 'True'">
     <PackageReference Include="Steeltoe.Common" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="$(AspNetCoreVersion)" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Management/src/TaskCore/Steeltoe.Management.TaskCore.csproj
+++ b/src/Management/src/TaskCore/Steeltoe.Management.TaskCore.csproj
@@ -10,11 +10,8 @@
   <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedproject.props" />
   
-  <ItemGroup Condition="'$(TF_BUILD)' == ''">
+  <ItemGroup>
     <ProjectReference Include="..\..\..\Common\src\Common\Steeltoe.Common.csproj" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TF_BUILD)' == 'True'">
-    <PackageReference Include="Steeltoe.Common" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">

--- a/src/Management/src/TracingBase/Steeltoe.Management.TracingBase.csproj
+++ b/src/Management/src/TracingBase/Steeltoe.Management.TracingBase.csproj
@@ -10,17 +10,10 @@
   <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedproject.props" />
   
-  <ItemGroup Condition="'$(TF_BUILD)' == ''">
+  <ItemGroup>
     <ProjectReference Include="..\..\..\Common\src\Common\Steeltoe.Common.csproj" />
     <ProjectReference Include="..\..\..\Configuration\src\CloudFoundryBase\Steeltoe.Extensions.Configuration.CloudFoundryBase.csproj" />
     <ProjectReference Include="..\..\..\Logging\src\DynamicLogger\Steeltoe.Extensions.Logging.DynamicLogger.csproj" />
     <ProjectReference Include="..\OpenCensusBase\Steeltoe.Management.OpenCensusBase.csproj" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TF_BUILD)' == 'True'">
-    <PackageReference Include="Steeltoe.Common" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
-    <PackageReference Include="Steeltoe.Extensions.Configuration.CloudFoundryBase" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
-    <PackageReference Include="Steeltoe.Extensions.Logging.DynamicLogger" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
-    <PackageReference Include="Steeltoe.Management.OpenCensusBase" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
   </ItemGroup>
 </Project>

--- a/src/Management/src/TracingBase/Steeltoe.Management.TracingBase.csproj
+++ b/src/Management/src/TracingBase/Steeltoe.Management.TracingBase.csproj
@@ -1,6 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
-  
   <PropertyGroup>
     <Description>Steeltoe Management TracingBase - Base Package</Description>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -8,16 +6,18 @@
     <PackageId>Steeltoe.Management.TracingBase</PackageId>
     <PackageTags>Management;Monitoring;Distributed Trace</PackageTags>
   </PropertyGroup>
+
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedproject.props" />
   
-  <ItemGroup Condition="'$(CI_BUILD)' == ''">
+  <ItemGroup Condition="'$(TF_BUILD)' == ''">
     <ProjectReference Include="..\..\..\Common\src\Common\Steeltoe.Common.csproj" />
     <ProjectReference Include="..\..\..\Configuration\src\CloudFoundryBase\Steeltoe.Extensions.Configuration.CloudFoundryBase.csproj" />
     <ProjectReference Include="..\..\..\Logging\src\DynamicLogger\Steeltoe.Extensions.Logging.DynamicLogger.csproj" />
     <ProjectReference Include="..\OpenCensusBase\Steeltoe.Management.OpenCensusBase.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(CI_BUILD)' == 'True'">
+  <ItemGroup Condition="'$(TF_BUILD)' == 'True'">
     <PackageReference Include="Steeltoe.Common" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
     <PackageReference Include="Steeltoe.Extensions.Configuration.CloudFoundryBase" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
     <PackageReference Include="Steeltoe.Extensions.Logging.DynamicLogger" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />

--- a/src/Management/src/TracingCore/Steeltoe.Management.TracingCore.csproj
+++ b/src/Management/src/TracingCore/Steeltoe.Management.TracingCore.csproj
@@ -22,13 +22,8 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Version="$(AspNetCoreVersion)" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TF_BUILD)' == ''">
+  <ItemGroup>
     <ProjectReference Include="..\..\..\Logging\src\DynamicLogger\Steeltoe.Extensions.Logging.DynamicLogger.csproj" />
     <ProjectReference Include="..\TracingBase\Steeltoe.Management.TracingBase.csproj" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TF_BUILD)' == 'True'">
-    <PackageReference Include="Steeltoe.Extensions.Logging.DynamicLogger" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
-    <PackageReference Include="Steeltoe.Management.TracingBase" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
   </ItemGroup>
 </Project>

--- a/src/Management/src/TracingCore/Steeltoe.Management.TracingCore.csproj
+++ b/src/Management/src/TracingCore/Steeltoe.Management.TracingCore.csproj
@@ -1,17 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
-  
   <PropertyGroup>
     <Description>Steeltoe Management Tracing Core</Description>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
     <AssemblyName>Steeltoe.Management.TracingCore</AssemblyName>
     <PackageId>Steeltoe.Management.TracingCore</PackageId>
     <PackageTags>Asp.NET Core, Management;Monitoring;Metrics;Distributed Trace</PackageTags>
     <RootNamespace>Steeltoe.Management.Tracing</RootNamespace>
   </PropertyGroup>
+
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedproject.props" />
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="$(ExtensionsVersion)" />
   </ItemGroup>
@@ -22,12 +22,12 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Version="$(AspNetCoreVersion)" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(CI_BUILD)' == ''">
+  <ItemGroup Condition="'$(TF_BUILD)' == ''">
     <ProjectReference Include="..\..\..\Logging\src\DynamicLogger\Steeltoe.Extensions.Logging.DynamicLogger.csproj" />
     <ProjectReference Include="..\TracingBase\Steeltoe.Management.TracingBase.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(CI_BUILD)' == 'True'">
+  <ItemGroup Condition="'$(TF_BUILD)' == 'True'">
     <PackageReference Include="Steeltoe.Extensions.Logging.DynamicLogger" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
     <PackageReference Include="Steeltoe.Management.TracingBase" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
   </ItemGroup>

--- a/src/Management/src/TracingCore/TracingServiceCollectionExtensions.cs
+++ b/src/Management/src/TracingCore/TracingServiceCollectionExtensions.cs
@@ -33,7 +33,7 @@ namespace Steeltoe.Management.Tracing
 
             services.TryAddSingleton<ITracingOptions>((p) =>
             {
-#if NETCOREAPP3_0
+#if NETCOREAPP3_1
                 var h = p.GetRequiredService<IHostEnvironment>();
 #else
                 if (!(p.GetService<Microsoft.AspNetCore.Hosting.IHostingEnvironment>() is IHostingEnvironment h))

--- a/src/Management/test/CloudFoundryCore.Test/CloudFoundryHostBuilderExtensionsTest.cs
+++ b/src/Management/test/CloudFoundryCore.Test/CloudFoundryHostBuilderExtensionsTest.cs
@@ -119,7 +119,7 @@ namespace Steeltoe.Management.CloudFoundry.Test
             Assert.IsType<CloudFoundryActuatorsStartupFilter>(filter);
         }
 
-#if NETCOREAPP3_0
+#if NETCOREAPP3_1
         [Fact]
         public async Task AddCloudFoundryActuators_IHostBuilder_IStartupFilterFires()
         {

--- a/src/Management/test/CloudFoundryCore.Test/CloudFoundryServiceCollectionExtensionsTest.cs
+++ b/src/Management/test/CloudFoundryCore.Test/CloudFoundryServiceCollectionExtensionsTest.cs
@@ -3,7 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.AspNetCore.Builder;
-#if !NETCOREAPP3_0
+#if !NETCOREAPP3_1
 using Microsoft.AspNetCore.Builder.Internal;
 #endif
 using Microsoft.AspNetCore.Cors.Infrastructure;

--- a/src/Management/test/CloudFoundryCore.Test/Steeltoe.Management.CloudFoundryCore.Test.csproj
+++ b/src/Management/test/CloudFoundryCore.Test/Steeltoe.Management.CloudFoundryCore.Test.csproj
@@ -1,11 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
+
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedtest.props" />
   <Import Project="..\..\..\..\targetframework.props" />
 
@@ -14,7 +15,7 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.0'">
+  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.1'">
     <PackageReference Include="Microsoft.AspNetCore" Version="$(AspNetCoreVersion)" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Management/test/CloudFoundryTasks.Test/Steeltoe.Management.CloudFoundryTasks.Test.csproj
+++ b/src/Management/test/CloudFoundryTasks.Test/Steeltoe.Management.CloudFoundryTasks.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
   <Import Project="..\..\..\..\sharedtest.props" />
 

--- a/src/Management/test/EndpointBase.Test/Env/EnvEndpointTest.cs
+++ b/src/Management/test/EndpointBase.Test/Env/EnvEndpointTest.cs
@@ -21,7 +21,7 @@ namespace Steeltoe.Management.Endpoint.Env.Test
         {
             IEnvOptions options = null;
             IConfiguration configuration = null;
-        #if NETCOREAPP3_0
+        #if NETCOREAPP3_1
             IHostEnvironment env = null;
         #else
             IHostingEnvironment env = null;

--- a/src/Management/test/EndpointBase.Test/Steeltoe.Management.EndpointBase.Test.csproj
+++ b/src/Management/test/EndpointBase.Test/Steeltoe.Management.EndpointBase.Test.csproj
@@ -1,11 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
+
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedtest.props" />
   <Import Project="..\..\..\..\targetframework.props" />
 

--- a/src/Management/test/EndpointCore.Test/Env/EndpointMiddlewareTest.cs
+++ b/src/Management/test/EndpointCore.Test/Env/EndpointMiddlewareTest.cs
@@ -33,7 +33,7 @@ namespace Steeltoe.Management.Endpoint.Env.Test
             ["management:endpoints:path"] = "/cloudfoundryapplication"
         };
 
-#if NETCOREAPP3_0
+#if NETCOREAPP3_1
         private IHostEnvironment host = HostingHelpers.GetHostingEnvironment();
 #else
         private Microsoft.Extensions.Hosting.IHostingEnvironment host = (Microsoft.Extensions.Hosting.IHostingEnvironment)HostingHelpers.GetHostingEnvironment();

--- a/src/Management/test/EndpointCore.Test/Env/EndpointServiceCollectionTest.cs
+++ b/src/Management/test/EndpointCore.Test/Env/EndpointServiceCollectionTest.cs
@@ -34,7 +34,7 @@ namespace Steeltoe.Management.Endpoint.Env.Test
         public void AddEnvActuator_AddsCorrectServices()
         {
             var services = new ServiceCollection();
-#if NETCOREAPP3_0
+#if NETCOREAPP3_1
             var host = HostingHelpers.GetHostingEnvironment();
             services.AddSingleton<IHostEnvironment>(host);
 #else

--- a/src/Management/test/EndpointCore.Test/ManagementHostBuilderExtensionsTest.cs
+++ b/src/Management/test/EndpointCore.Test/ManagementHostBuilderExtensionsTest.cs
@@ -53,7 +53,7 @@ namespace Steeltoe.Management.Endpoint.Test
             Assert.IsType<DbMigrationsStartupFilter>(filter);
         }
 
-#if NETCOREAPP3_0
+#if NETCOREAPP3_1
         [Fact]
         public async Task AddDbMigrationsActuator_IHostBuilder_IStartupFilterFires()
         {
@@ -88,7 +88,7 @@ namespace Steeltoe.Management.Endpoint.Test
             Assert.IsType<EnvStartupFilter>(filter);
         }
 
-#if NETCOREAPP3_0
+#if NETCOREAPP3_1
         [Fact]
         public async Task AddEnvActuator_IHostBuilder_IStartupFilterFires()
         {
@@ -157,7 +157,7 @@ namespace Steeltoe.Management.Endpoint.Test
             Assert.IsType<HealthStartupFilter>(filter);
         }
 
-#if NETCOREAPP3_0
+#if NETCOREAPP3_1
         [Fact]
         public async Task AddHealthActuator_IHostBuilder_IStartupFilterFires()
         {
@@ -195,7 +195,7 @@ namespace Steeltoe.Management.Endpoint.Test
             }
         }
 
-#if NETCOREAPP3_0
+#if NETCOREAPP3_1
         [Fact]
         public async Task AddHeapDumpActuator_IHostBuilder_IStartupFilterFires()
         {
@@ -233,7 +233,7 @@ namespace Steeltoe.Management.Endpoint.Test
             Assert.IsType<HypermediaStartupFilter>(filter);
         }
 
-#if NETCOREAPP3_0
+#if NETCOREAPP3_1
         [Fact]
         public async Task AddHypermediaActuator_IHostBuilder_IStartupFilterFires()
         {
@@ -285,7 +285,7 @@ namespace Steeltoe.Management.Endpoint.Test
             Assert.IsType<InfoStartupFilter>(filter);
         }
 
-#if NETCOREAPP3_0
+#if NETCOREAPP3_1
         [Fact]
         public async Task AddInfoActuator_IHostBuilder_IStartupFilterFires()
         {
@@ -320,7 +320,7 @@ namespace Steeltoe.Management.Endpoint.Test
             Assert.IsType<LoggersStartupFilter>(filter);
         }
 
-#if NETCOREAPP3_0
+#if NETCOREAPP3_1
         [Fact]
         public async Task AddLoggersActuator_IHostBuilder_IStartupFilterFires()
         {
@@ -355,7 +355,7 @@ namespace Steeltoe.Management.Endpoint.Test
             Assert.IsType<MappingsStartupFilter>(filter);
         }
 
-#if NETCOREAPP3_0
+#if NETCOREAPP3_1
         [Fact]
         public async Task AddMappingsActuator_IHostBuilder_IStartupFilterFires()
         {
@@ -390,7 +390,7 @@ namespace Steeltoe.Management.Endpoint.Test
             Assert.IsType<MetricsStartupFilter>(filter);
         }
 
-#if NETCOREAPP3_0
+#if NETCOREAPP3_1
         [Fact]
         public async Task AddMetricsActuator_IHostBuilder_IStartupFilterFires()
         {
@@ -425,7 +425,7 @@ namespace Steeltoe.Management.Endpoint.Test
             Assert.IsType<RefreshStartupFilter>(filter);
         }
 
-#if NETCOREAPP3_0
+#if NETCOREAPP3_1
         [Fact]
         public async Task AddRefreshActuator_IHostBuilder_IStartupFilterFires()
         {
@@ -463,7 +463,7 @@ namespace Steeltoe.Management.Endpoint.Test
             }
         }
 
-#if NETCOREAPP3_0
+#if NETCOREAPP3_1
         [Fact]
         public async Task AddThreadDumpActuator_IHostBuilder_IStartupFilterFires()
         {
@@ -501,7 +501,7 @@ namespace Steeltoe.Management.Endpoint.Test
             Assert.IsType<TraceStartupFilter>(filter);
         }
 
-#if NETCOREAPP3_0
+#if NETCOREAPP3_1
         [Fact]
         public async Task AddTraceActuator_IHostBuilder_IStartupFilterFires()
         {
@@ -536,7 +536,7 @@ namespace Steeltoe.Management.Endpoint.Test
             Assert.IsType<CloudFoundryActuatorStartupFilter>(filter);
         }
 
-#if NETCOREAPP3_0
+#if NETCOREAPP3_1
         [Fact]
         public async Task AddCloudFoundryActuator_IHostBuilder_IStartupFilterFires()
         {

--- a/src/Management/test/EndpointCore.Test/Mappings/Startup.cs
+++ b/src/Management/test/EndpointCore.Test/Mappings/Startup.cs
@@ -28,7 +28,7 @@ namespace Steeltoe.Management.Endpoint.Mappings.Test
         {
             app.UseMappingsActuator();
 
-#if NETCOREAPP3_0
+#if NETCOREAPP3_1
             app.UseRouting();
             app.UseEndpoints(endpoints =>
             {

--- a/src/Management/test/EndpointCore.Test/SpringBootAdminClient/SpringBootAdminClientExtensionTests.cs
+++ b/src/Management/test/EndpointCore.Test/SpringBootAdminClient/SpringBootAdminClientExtensionTests.cs
@@ -61,7 +61,7 @@ namespace Steeltoe.Management.EndpointCore.Test.SpringBootAdminClient
         private MyAppLifeTime AddApplicationLifetime(ServiceCollection services)
         {
             var appLifeTime = new MyAppLifeTime();
-#if NETCOREAPP3_0
+#if NETCOREAPP3_1
             services.TryAddSingleton<IHostApplicationLifetime>(appLifeTime);
 #else
             services.TryAddSingleton<IApplicationLifetime>(appLifeTime);
@@ -70,7 +70,7 @@ namespace Steeltoe.Management.EndpointCore.Test.SpringBootAdminClient
         }
 
         private class MyAppLifeTime :
-#if NETCOREAPP3_0
+#if NETCOREAPP3_1
             IHostApplicationLifetime
 #else
 #pragma warning disable CS0618 // Needed for 2.x

--- a/src/Management/test/EndpointCore.Test/Steeltoe.Management.EndpointCore.Test.csproj
+++ b/src/Management/test/EndpointCore.Test/Steeltoe.Management.EndpointCore.Test.csproj
@@ -1,11 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
+
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedtest.props" />
   <Import Project="..\..\..\..\targetframework.props" />
   
@@ -45,7 +46,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="$(ExtensionsVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="$(ExtensionsVersion)" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.0'">
+  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.1'">
     <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="$(AspNetCoreVersion)" />
   </ItemGroup>

--- a/src/Management/test/EndpointOwin.Net4Test/Steeltoe.Management.EndpointOwin.Test.csproj
+++ b/src/Management/test/EndpointOwin.Net4Test/Steeltoe.Management.EndpointOwin.Test.csproj
@@ -1,11 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup>
     <Description>Unit test project for Steeltoe.Management.EndpointOwin</Description>
     <TargetFrameworks>net461</TargetFrameworks>
-    <!-- <SignAssembly>true</SignAssembly>
-    <AssemblyOriginatorKeyFile>..\..\..\..\steeltoe.snk</AssemblyOriginatorKeyFile> -->
   </PropertyGroup>
+
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedtest.props" />
   <Import Project="..\..\..\..\targetframework.props" />
   

--- a/src/Management/test/EndpointOwinAutofac.Net4Test/Steeltoe.Management.EndpointOwinAutofac.Test.csproj
+++ b/src/Management/test/EndpointOwinAutofac.Net4Test/Steeltoe.Management.EndpointOwinAutofac.Test.csproj
@@ -1,10 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup>
     <Description>Unit test project for Steeltoe.Management.EndpointAutofac</Description>
     <TargetFrameworks>net461</TargetFrameworks>
     <AssemblyName>Steeltoe.Management.EndpointAutofac.Test</AssemblyName>
   </PropertyGroup>
+
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedtest.props" />
   <Import Project="..\..\..\..\targetframework.props" />
  

--- a/src/Management/test/EndpointWeb.Net4Test/Steeltoe.Management.EndpointWeb.Test.csproj
+++ b/src/Management/test/EndpointWeb.Net4Test/Steeltoe.Management.EndpointWeb.Test.csproj
@@ -1,5 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup>
     <TargetFramework>net461</TargetFramework>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
@@ -8,6 +7,8 @@
     <OutputType>Library</OutputType>
     <StartupObject />
   </PropertyGroup>
+
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedtest.props" />
   <Import Project="..\..\..\..\targetframework.props" />
 

--- a/src/Management/test/ExporterBase.Test/Steeltoe.Management.ExporterBase.Test.csproj
+++ b/src/Management/test/ExporterBase.Test/Steeltoe.Management.ExporterBase.Test.csproj
@@ -1,11 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
+
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedtest.props" />
   <Import Project="..\..\..\..\targetframework.props" />
 
@@ -17,7 +18,7 @@
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="$(ExtensionsVersion)" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.0'">
+  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.1'">
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="$(AspNetCoreVersion)" />
   </ItemGroup>
 </Project>

--- a/src/Management/test/ExporterCore.Test/Steeltoe.Management.ExporterCore.Test.csproj
+++ b/src/Management/test/ExporterCore.Test/Steeltoe.Management.ExporterCore.Test.csproj
@@ -1,11 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
+
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedtest.props" />
   <Import Project="..\..\..\..\targetframework.props" />
 
@@ -17,7 +18,7 @@
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="$(ExtensionsVersion)" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.0'">
+  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.1'">
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="$(AspNetCoreVersion)" />
   </ItemGroup>
 </Project>

--- a/src/Management/test/TaskCore.Test/Steeltoe.Management.TaskCore.Test.csproj
+++ b/src/Management/test/TaskCore.Test/Steeltoe.Management.TaskCore.Test.csproj
@@ -1,15 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
+
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedtest.props" />
   <Import Project="..\..\..\..\targetframework.props" />
 
-  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.0'">
+  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.1'">
     <PackageReference Include="Microsoft.AspNetCore" Version="$(AspNetCoreVersion)" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Management/test/TaskCore.Test/TaskRunTest.cs
+++ b/src/Management/test/TaskCore.Test/TaskRunTest.cs
@@ -36,7 +36,7 @@ namespace Steeltoe.Management.TaskCore.Test
             Assert.True(true, "If we reached this assertion, the app stopped without throwing anything");
         }
 
-#if NETCOREAPP3_0
+#if NETCOREAPP3_1
         [Fact]
         public void DelegatingTask_GenericHost_ExecutesRun()
         {

--- a/src/Management/test/TracingBase.Test/Steeltoe.Management.TracingBase.Test.csproj
+++ b/src/Management/test/TracingBase.Test/Steeltoe.Management.TracingBase.Test.csproj
@@ -1,11 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
+
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedtest.props" />
   <Import Project="..\..\..\..\targetframework.props" />
 
@@ -17,7 +18,7 @@
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="$(ExtensionsVersion)" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.0'">
+  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.1'">
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="$(AspNetCoreVersion)" />
   </ItemGroup>
 </Project>

--- a/src/Management/test/TracingCore.Test/Steeltoe.Management.TracingCore.Test.csproj
+++ b/src/Management/test/TracingCore.Test/Steeltoe.Management.TracingCore.Test.csproj
@@ -1,11 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
+
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedtest.props" />
   <Import Project="..\..\..\..\targetframework.props" />
 
@@ -17,7 +18,7 @@
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="$(ExtensionsVersion)" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.0'">
+  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.1'">
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="$(AspNetCoreVersion)" />
   </ItemGroup>
 </Project>

--- a/src/Security/src/Authentication.CloudFoundryBase/CloudFoundryHelper.cs
+++ b/src/Security/src/Authentication.CloudFoundryBase/CloudFoundryHelper.cs
@@ -9,7 +9,7 @@ using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
 using System.Net.Http;
-#if NETCOREAPP3_0
+#if NETCOREAPP3_1
 using System.Text.Json;
 #endif
 
@@ -19,7 +19,7 @@ namespace Steeltoe.Security.Authentication.CloudFoundry
     {
         private static readonly DateTime BaseTime = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
 
-#if NETCOREAPP3_0
+#if NETCOREAPP3_1
         public static List<string> GetScopes(JsonElement user)
         {
             var result = new List<string>();
@@ -106,7 +106,7 @@ namespace Steeltoe.Security.Authentication.CloudFoundry
             return parameters;
         }
 
-#if NETCOREAPP3_0
+#if NETCOREAPP3_1
         /// <summary>
         /// Retrieves the time at which a token was issued
         /// </summary>

--- a/src/Security/src/Authentication.CloudFoundryBase/Steeltoe.Security.Authentication.CloudFoundryBase.csproj
+++ b/src/Security/src/Authentication.CloudFoundryBase/Steeltoe.Security.Authentication.CloudFoundryBase.csproj
@@ -10,14 +10,9 @@
   <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedproject.props" />
   
-  <ItemGroup Condition="'$(TF_BUILD)' == ''">
+  <ItemGroup>
     <ProjectReference Include="..\..\..\Common\src\Common.Http\Steeltoe.Common.Http.csproj" />
     <ProjectReference Include="..\..\..\Connectors\src\ConnectorBase\Steeltoe.CloudFoundry.ConnectorBase.csproj" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TF_BUILD)' == 'True'">
-    <PackageReference Include="Steeltoe.Common.Http" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
-    <PackageReference Include="Steeltoe.CloudFoundry.ConnectorBase" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Security/src/Authentication.CloudFoundryBase/Steeltoe.Security.Authentication.CloudFoundryBase.csproj
+++ b/src/Security/src/Authentication.CloudFoundryBase/Steeltoe.Security.Authentication.CloudFoundryBase.csproj
@@ -1,20 +1,21 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup>
     <Description>Base Security Provider for CloudFoundry</Description>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
     <AssemblyName>Steeltoe.Security.Authentication.CloudFoundryBase</AssemblyName>
     <PackageId>Steeltoe.Security.Authentication.CloudFoundryBase</PackageId>
     <PackageTags>CloudFoundry;ASPNET;ASPNET Core;Security;OAuth2;SSO;OpenID</PackageTags>
   </PropertyGroup>
+
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedproject.props" />
   
-  <ItemGroup Condition="'$(CI_BUILD)' == ''">
+  <ItemGroup Condition="'$(TF_BUILD)' == ''">
     <ProjectReference Include="..\..\..\Common\src\Common.Http\Steeltoe.Common.Http.csproj" />
     <ProjectReference Include="..\..\..\Connectors\src\ConnectorBase\Steeltoe.CloudFoundry.ConnectorBase.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(CI_BUILD)' == 'True'">
+  <ItemGroup Condition="'$(TF_BUILD)' == 'True'">
     <PackageReference Include="Steeltoe.Common.Http" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
     <PackageReference Include="Steeltoe.CloudFoundry.ConnectorBase" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
   </ItemGroup>

--- a/src/Security/src/Authentication.CloudFoundryCore/CloudFoundryOAuthHandler.cs
+++ b/src/Security/src/Authentication.CloudFoundryCore/CloudFoundryOAuthHandler.cs
@@ -20,7 +20,7 @@ using System.Net.Security;
 using System.Security.Claims;
 using System.Text;
 using System.Text.Encodings.Web;
-#if NETCOREAPP3_0
+#if NETCOREAPP3_1
 using System.Text.Json;
 #endif
 using System.Threading.Tasks;
@@ -85,7 +85,7 @@ namespace Steeltoe.Security.Authentication.CloudFoundry
             return Backchannel;
         }
 
-#if NETCOREAPP3_0
+#if NETCOREAPP3_1
         protected override async Task<OAuthTokenResponse> ExchangeCodeAsync(OAuthCodeExchangeContext context)
         {
             _logger?.LogDebug("ExchangeCodeAsync({code}, {redirectUri})", context.Code, context.RedirectUri);
@@ -172,7 +172,7 @@ namespace Steeltoe.Security.Authentication.CloudFoundry
             var resp = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 
             _logger?.LogDebug("CreateTicketAsync() received json: {json}", resp);
-#if NETCOREAPP3_0
+#if NETCOREAPP3_1
             var payload = JsonDocument.Parse(resp).RootElement;
 #else
             var payload = JObject.Parse(resp);

--- a/src/Security/src/Authentication.CloudFoundryCore/CloudFoundryScopeClaimAction.cs
+++ b/src/Security/src/Authentication.CloudFoundryCore/CloudFoundryScopeClaimAction.cs
@@ -7,7 +7,7 @@ using Microsoft.AspNetCore.Authentication.OAuth.Claims;
 using Newtonsoft.Json.Linq;
 #endif
 using System.Security.Claims;
-#if NETCOREAPP3_0
+#if NETCOREAPP3_1
 using System.Text.Json;
 #endif
 
@@ -20,7 +20,7 @@ namespace Steeltoe.Security.Authentication.CloudFoundry
         {
         }
 
-#if NETCOREAPP3_0
+#if NETCOREAPP3_1
         public override void Run(JsonElement userData, ClaimsIdentity identity, string issuer)
 #else
         public override void Run(JObject userData, ClaimsIdentity identity, string issuer)

--- a/src/Security/src/Authentication.CloudFoundryCore/Steeltoe.Security.Authentication.CloudFoundryCore.csproj
+++ b/src/Security/src/Authentication.CloudFoundryCore/Steeltoe.Security.Authentication.CloudFoundryCore.csproj
@@ -1,13 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup>
     <Description>ASP.NET Core External Security Provider for CloudFoundry</Description>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
     <AssemblyName>Steeltoe.Security.Authentication.CloudFoundryCore</AssemblyName>
     <PackageId>Steeltoe.Security.Authentication.CloudFoundryCore</PackageId>
     <PackageTags>CloudFoundry;ASPNET Core;Security;OAuth2;SSO;OpenIDConnect</PackageTags>
     <RootNamespace>Steeltoe.Security.Authentication.CloudFoundry</RootNamespace>
   </PropertyGroup>
+
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedproject.props" />
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
@@ -18,10 +19,10 @@
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="$(AspNetCoreVersion)" />
   </ItemGroup>
-  <ItemGroup Condition="'$(CI_BUILD)' == ''">
+  <ItemGroup Condition="'$(TF_BUILD)' == ''">
     <ProjectReference Include="..\Authentication.CloudFoundryBase\Steeltoe.Security.Authentication.CloudFoundryBase.csproj" />
   </ItemGroup>
-  <ItemGroup Condition="'$(CI_BUILD)' == 'True'">
+  <ItemGroup Condition="'$(TF_BUILD)' == 'True'">
     <PackageReference Include="Steeltoe.Security.Authentication.CloudFoundryBase" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
   </ItemGroup>
 </Project>

--- a/src/Security/src/Authentication.CloudFoundryCore/Steeltoe.Security.Authentication.CloudFoundryCore.csproj
+++ b/src/Security/src/Authentication.CloudFoundryCore/Steeltoe.Security.Authentication.CloudFoundryCore.csproj
@@ -19,10 +19,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="$(AspNetCoreVersion)" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TF_BUILD)' == ''">
+  <ItemGroup>
     <ProjectReference Include="..\Authentication.CloudFoundryBase\Steeltoe.Security.Authentication.CloudFoundryBase.csproj" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TF_BUILD)' == 'True'">
-    <PackageReference Include="Steeltoe.Security.Authentication.CloudFoundryBase" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
   </ItemGroup>
 </Project>

--- a/src/Security/src/Authentication.CloudFoundryOwin/Steeltoe.Security.Authentication.CloudFoundryOwin.csproj
+++ b/src/Security/src/Authentication.CloudFoundryOwin/Steeltoe.Security.Authentication.CloudFoundryOwin.csproj
@@ -21,12 +21,8 @@
     </PackageReference>    
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TF_BUILD)' == ''">
+  <ItemGroup>
     <ProjectReference Include="..\..\..\Common\src\Common.Http\Steeltoe.Common.Http.csproj" />
     <ProjectReference Include="..\Authentication.CloudFoundryBase\Steeltoe.Security.Authentication.CloudFoundryBase.csproj" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TF_BUILD)' == 'True'">
-    <PackageReference Include="Steeltoe.Common.Http" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
-    <PackageReference Include="Steeltoe.Security.Authentication.CloudFoundryBase" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
   </ItemGroup>
 </Project>

--- a/src/Security/src/Authentication.CloudFoundryOwin/Steeltoe.Security.Authentication.CloudFoundryOwin.csproj
+++ b/src/Security/src/Authentication.CloudFoundryOwin/Steeltoe.Security.Authentication.CloudFoundryOwin.csproj
@@ -1,7 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
-  <Import Project="..\..\..\..\versions.props" />
-
   <PropertyGroup>
     <Description>ASP.NET 4.x External Security Provider for CloudFoundry - Owin</Description>
     <TargetFrameworks>net461</TargetFrameworks>
@@ -10,9 +7,11 @@
     <PackageTags>CloudFoundry;ASPNET;Security;OAuth2;SSO</PackageTags>
     <RootNamespace>Steeltoe.Security.Authentication.CloudFoundry.Owin</RootNamespace>
   </PropertyGroup>
-  <Import Project="..\..\..\..\sharedproject.props" />
 
+  <Import Project="..\..\..\..\versions.props" />
+  <Import Project="..\..\..\..\sharedproject.props" />
   <Import Project="..\..\..\..\targetframework.props" />
+
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="$(CSharpVersion)" />
     <PackageReference Include="Microsoft.Owin.Security.Jwt" Version="$(OwinOAuthVersion)" />
@@ -22,11 +21,11 @@
     </PackageReference>    
   </ItemGroup>
 
-  <ItemGroup Condition="'$(CI_BUILD)' == ''">
+  <ItemGroup Condition="'$(TF_BUILD)' == ''">
     <ProjectReference Include="..\..\..\Common\src\Common.Http\Steeltoe.Common.Http.csproj" />
     <ProjectReference Include="..\Authentication.CloudFoundryBase\Steeltoe.Security.Authentication.CloudFoundryBase.csproj" />
   </ItemGroup>
-  <ItemGroup Condition="'$(CI_BUILD)' == 'True'">
+  <ItemGroup Condition="'$(TF_BUILD)' == 'True'">
     <PackageReference Include="Steeltoe.Common.Http" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
     <PackageReference Include="Steeltoe.Security.Authentication.CloudFoundryBase" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
   </ItemGroup>

--- a/src/Security/src/Authentication.CloudFoundryWcf/Steeltoe.Security.Authentication.CloudFoundryWcf.csproj
+++ b/src/Security/src/Authentication.CloudFoundryWcf/Steeltoe.Security.Authentication.CloudFoundryWcf.csproj
@@ -1,7 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
-  <Import Project="..\..\..\..\versions.props" />
-
   <PropertyGroup>
     <Description>External Security Provider for CloudFoundry - WCF</Description>
     <TargetFrameworks>net461</TargetFrameworks>
@@ -10,9 +7,11 @@
     <PackageTags>CloudFoundry;ASPNET;Security;Jwt;OAuth2;Bearer;SSO</PackageTags>
     <RootNamespace>Steeltoe.Security.Authentication.CloudFoundry</RootNamespace>
   </PropertyGroup>
-  <Import Project="..\..\..\..\sharedproject.props" />
 
+  <Import Project="..\..\..\..\versions.props" />
+  <Import Project="..\..\..\..\sharedproject.props" />
   <Import Project="..\..\..\..\targetframework.props" />
+
   <ItemGroup>
     <PackageReference Include="System.Net.Http" Version="$(HttpClientVersion)" />
     <PackageReference Include="StyleCop.Analyzers" Version="$(StyleCopVersion)">
@@ -27,12 +26,12 @@
     <Reference Include="System.ServiceModel.Web" />
     <Reference Include="System.Web" />
   </ItemGroup>
-  <ItemGroup Condition="'$(CI_BUILD)' == ''">
+  <ItemGroup Condition="'$(TF_BUILD)' == ''">
     <ProjectReference Include="..\..\..\Common\src\Common.Http\Steeltoe.Common.Http.csproj" />
     <ProjectReference Include="..\..\..\Connectors\src\ConnectorBase\Steeltoe.CloudFoundry.ConnectorBase.csproj" />
     <ProjectReference Include="..\Authentication.CloudFoundryBase\Steeltoe.Security.Authentication.CloudFoundryBase.csproj" />
   </ItemGroup>
-  <ItemGroup Condition="'$(CI_BUILD)' == 'True'">
+  <ItemGroup Condition="'$(TF_BUILD)' == 'True'">
     <PackageReference Include="Steeltoe.Common.Http" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
     <PackageReference Include="Steeltoe.CloudFoundry.ConnectorBase" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
     <PackageReference Include="Steeltoe.Security.Authentication.CloudFoundryBase" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />

--- a/src/Security/src/Authentication.CloudFoundryWcf/Steeltoe.Security.Authentication.CloudFoundryWcf.csproj
+++ b/src/Security/src/Authentication.CloudFoundryWcf/Steeltoe.Security.Authentication.CloudFoundryWcf.csproj
@@ -26,14 +26,9 @@
     <Reference Include="System.ServiceModel.Web" />
     <Reference Include="System.Web" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TF_BUILD)' == ''">
+  <ItemGroup>
     <ProjectReference Include="..\..\..\Common\src\Common.Http\Steeltoe.Common.Http.csproj" />
     <ProjectReference Include="..\..\..\Connectors\src\ConnectorBase\Steeltoe.CloudFoundry.ConnectorBase.csproj" />
     <ProjectReference Include="..\Authentication.CloudFoundryBase\Steeltoe.Security.Authentication.CloudFoundryBase.csproj" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TF_BUILD)' == 'True'">
-    <PackageReference Include="Steeltoe.Common.Http" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
-    <PackageReference Include="Steeltoe.CloudFoundry.ConnectorBase" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
-    <PackageReference Include="Steeltoe.Security.Authentication.CloudFoundryBase" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
   </ItemGroup>
 </Project>

--- a/src/Security/src/DataProtection.CredHubBase/Steeltoe.Security.DataProtection.CredHubBase.csproj
+++ b/src/Security/src/DataProtection.CredHubBase/Steeltoe.Security.DataProtection.CredHubBase.csproj
@@ -14,10 +14,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="$(JsonNetVersion)" />
     <PackageReference Include="Portable.BouncyCastle" Version="$(BouncyCastleVersion)" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TF_BUILD)' == ''">
+  <ItemGroup>
     <ProjectReference Include="..\..\..\Common\src\Common.Http\Steeltoe.Common.Http.csproj" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TF_BUILD)' == 'True'">
-    <PackageReference Include="Steeltoe.Common.Http" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
   </ItemGroup>
 </Project>

--- a/src/Security/src/DataProtection.CredHubBase/Steeltoe.Security.DataProtection.CredHubBase.csproj
+++ b/src/Security/src/DataProtection.CredHubBase/Steeltoe.Security.DataProtection.CredHubBase.csproj
@@ -1,5 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup>
     <Description>.NET Client for CredHub - Base Package</Description>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
@@ -7,16 +6,18 @@
     <PackageId>Steeltoe.Security.DataProtection.CredHubBase</PackageId>
     <PackageTags>CloudFoundry;NET Core;Security;DataProtection;CredHub</PackageTags>
   </PropertyGroup>
+
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedproject.props" />
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="$(JsonNetVersion)" />
     <PackageReference Include="Portable.BouncyCastle" Version="$(BouncyCastleVersion)" />
   </ItemGroup>
-  <ItemGroup Condition="'$(CI_BUILD)' == ''">
+  <ItemGroup Condition="'$(TF_BUILD)' == ''">
     <ProjectReference Include="..\..\..\Common\src\Common.Http\Steeltoe.Common.Http.csproj" />
   </ItemGroup>
-  <ItemGroup Condition="'$(CI_BUILD)' == 'True'">
+  <ItemGroup Condition="'$(TF_BUILD)' == 'True'">
     <PackageReference Include="Steeltoe.Common.Http" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
   </ItemGroup>
 </Project>

--- a/src/Security/src/DataProtection.CredHubCore/Steeltoe.Security.DataProtection.CredHubCore.csproj
+++ b/src/Security/src/DataProtection.CredHubCore/Steeltoe.Security.DataProtection.CredHubCore.csproj
@@ -1,5 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup>
     <Description>ASP.NET Core Extensions for CredHub Client</Description>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
@@ -7,15 +6,17 @@
     <PackageId>Steeltoe.Security.DataProtection.CredHubCore</PackageId>
     <PackageTags>CloudFoundry;ASPNET Core;Security;DataProtection;CredHub</PackageTags>
   </PropertyGroup>
+
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedproject.props" />
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="$(AspNetCoreVersion)" />
   </ItemGroup>
-  <ItemGroup Condition="'$(CI_BUILD)' == ''">
+  <ItemGroup Condition="'$(TF_BUILD)' == ''">
     <ProjectReference Include="..\DataProtection.CredHubBase\Steeltoe.Security.DataProtection.CredHubBase.csproj" />
   </ItemGroup>
-  <ItemGroup Condition="'$(CI_BUILD)' == 'True'">
+  <ItemGroup Condition="'$(TF_BUILD)' == 'True'">
     <PackageReference Include="Steeltoe.Security.DataProtection.CredHubBase" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
   </ItemGroup>
 </Project>

--- a/src/Security/src/DataProtection.CredHubCore/Steeltoe.Security.DataProtection.CredHubCore.csproj
+++ b/src/Security/src/DataProtection.CredHubCore/Steeltoe.Security.DataProtection.CredHubCore.csproj
@@ -13,10 +13,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="$(AspNetCoreVersion)" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TF_BUILD)' == ''">
+  <ItemGroup>
     <ProjectReference Include="..\DataProtection.CredHubBase\Steeltoe.Security.DataProtection.CredHubBase.csproj" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TF_BUILD)' == 'True'">
-    <PackageReference Include="Steeltoe.Security.DataProtection.CredHubBase" Version="$(SteeltoeVersion)$(SteeltoeVersionSuffix)" />
   </ItemGroup>
 </Project>

--- a/src/Security/src/DataProtection.RedisCore/Steeltoe.Security.DataProtection.RedisCore.csproj
+++ b/src/Security/src/DataProtection.RedisCore/Steeltoe.Security.DataProtection.RedisCore.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup>
     <Description>ASP.NET Core DataProtection Redis Key Store</Description>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
@@ -7,6 +6,8 @@
     <PackageId>Steeltoe.Security.DataProtection.RedisCore</PackageId>
     <PackageTags>CloudFoundry;ASPNET Core;Security;DataProtection;Redis</PackageTags>
   </PropertyGroup>
+
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedproject.props" />
 
   <ItemGroup>

--- a/src/Security/test/Authentication.CloudFoundryBase.Test/CloudFoundryHelperTest.cs
+++ b/src/Security/test/Authentication.CloudFoundryBase.Test/CloudFoundryHelperTest.cs
@@ -2,11 +2,11 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-#if !NETCOREAPP3_0
+#if !NETCOREAPP3_1
 using Newtonsoft.Json.Linq;
 #endif
 using System;
-#if NETCOREAPP3_0
+#if NETCOREAPP3_1
 using System.Text.Json;
 #endif
 using Xunit;
@@ -40,7 +40,7 @@ namespace Steeltoe.Security.Authentication.CloudFoundry.Test
         public void GetExpTime_FindsTime()
         {
             var info = TestHelpers.GetValidTokenInfoRequestResponse();
-#if NETCOREAPP3_0
+#if NETCOREAPP3_1
             var payload = JsonDocument.Parse(info).RootElement;
 #else
             var payload = JObject.Parse(info);
@@ -53,7 +53,7 @@ namespace Steeltoe.Security.Authentication.CloudFoundry.Test
         public void GetIssueTime_FindsTime()
         {
             var info = TestHelpers.GetValidTokenInfoRequestResponse();
-#if NETCOREAPP3_0
+#if NETCOREAPP3_1
             var payload = JsonDocument.Parse(info).RootElement;
 #else
             var payload = JObject.Parse(info);
@@ -66,7 +66,7 @@ namespace Steeltoe.Security.Authentication.CloudFoundry.Test
         public void GetScopes_FindsScopes()
         {
             var info = TestHelpers.GetValidTokenInfoRequestResponse();
-#if NETCOREAPP3_0
+#if NETCOREAPP3_1
             var payload = JsonDocument.Parse(info).RootElement;
 #else
             var payload = JObject.Parse(info);

--- a/src/Security/test/Authentication.CloudFoundryBase.Test/Steeltoe.Security.Authentication.CloudFoundryBase.Test.csproj
+++ b/src/Security/test/Authentication.CloudFoundryBase.Test/Steeltoe.Security.Authentication.CloudFoundryBase.Test.csproj
@@ -1,11 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
+
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedtest.props" />
   <Import Project="..\..\..\..\targetframework.props" />
 

--- a/src/Security/test/Authentication.CloudFoundryCore.Test/CloudFoundryOAuthHandlerTest.cs
+++ b/src/Security/test/Authentication.CloudFoundryCore.Test/CloudFoundryOAuthHandlerTest.cs
@@ -7,7 +7,7 @@ using Microsoft.AspNetCore.Authentication.OAuth;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-#if !NETCOREAPP3_0
+#if !NETCOREAPP3_1
 using Newtonsoft.Json.Linq;
 #endif
 using System.Linq;
@@ -15,7 +15,7 @@ using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Security.Claims;
 using System.Text.Encodings.Web;
-#if NETCOREAPP3_0
+#if NETCOREAPP3_1
 using System.Text.Json;
 #endif
 using Xunit;
@@ -117,7 +117,7 @@ namespace Steeltoe.Security.Authentication.CloudFoundry.Test
 
             MyTestCloudFoundryHandler testHandler = GetTestHandler(opts);
 
-#if NETCOREAPP3_0
+#if NETCOREAPP3_1
             var payload = JsonDocument.Parse(TestHelpers.GetValidTokenInfoRequestResponse());
             var tokens = OAuthTokenResponse.Success(payload);
 #else
@@ -140,7 +140,7 @@ namespace Steeltoe.Security.Authentication.CloudFoundry.Test
             };
             MyTestCloudFoundryHandler testHandler = GetTestHandler(opts);
 
-#if NETCOREAPP3_0
+#if NETCOREAPP3_1
             var payload = JsonDocument.Parse(TestHelpers.GetValidTokenInfoRequestResponse());
             var tokens = OAuthTokenResponse.Success(payload);
 #else
@@ -176,7 +176,7 @@ namespace Steeltoe.Security.Authentication.CloudFoundry.Test
 
             ClaimsIdentity identity = new ClaimsIdentity();
 
-#if NETCOREAPP3_0
+#if NETCOREAPP3_1
             var payload = JsonDocument.Parse(TestHelpers.GetValidTokenInfoRequestResponse());
             var tokens = OAuthTokenResponse.Success(payload);
 #else

--- a/src/Security/test/Authentication.CloudFoundryCore.Test/CloudFoundryOpenIdConnectConfigurerTest.cs
+++ b/src/Security/test/Authentication.CloudFoundryCore.Test/CloudFoundryOpenIdConnectConfigurerTest.cs
@@ -27,7 +27,7 @@ namespace Steeltoe.Security.Authentication.CloudFoundry.Test
             Assert.Equal(CloudFoundryDefaults.ClientId, oidcOptions.ClientId);
             Assert.Equal(CloudFoundryDefaults.ClientSecret, oidcOptions.ClientSecret);
             Assert.Equal(new PathString(CloudFoundryDefaults.CallbackPath), oidcOptions.CallbackPath);
-#if NETCOREAPP3_0
+#if NETCOREAPP3_1
             Assert.Equal(19, oidcOptions.ClaimActions.Count());
 #else
             Assert.Equal(21, oidcOptions.ClaimActions.Count());
@@ -57,7 +57,7 @@ namespace Steeltoe.Security.Authentication.CloudFoundry.Test
             Assert.Equal("secret", oidcOptions.ClientSecret);
             Assert.Equal(new PathString(CloudFoundryDefaults.CallbackPath), oidcOptions.CallbackPath);
             Assert.Null(oidcOptions.BackchannelHttpHandler);
-#if NETCOREAPP3_0
+#if NETCOREAPP3_1
             Assert.Equal(19, oidcOptions.ClaimActions.Count());
 #else
             Assert.Equal(21, oidcOptions.ClaimActions.Count());

--- a/src/Security/test/Authentication.CloudFoundryCore.Test/CloudFoundryOpenIdConnectOptionsTest.cs
+++ b/src/Security/test/Authentication.CloudFoundryCore.Test/CloudFoundryOpenIdConnectOptionsTest.cs
@@ -22,7 +22,7 @@ namespace Steeltoe.Security.Authentication.CloudFoundry.Test
             Assert.Equal(CloudFoundryDefaults.ClientSecret, opts.ClientSecret);
             Assert.Equal(new PathString("/signin-cloudfoundry"), opts.CallbackPath);
             Assert.True(opts.ValidateCertificates);
-#if NETCOREAPP3_0
+#if NETCOREAPP3_1
             Assert.Equal(19, opts.ClaimActions.Count());
 #else
             Assert.Equal(21, opts.ClaimActions.Count());

--- a/src/Security/test/Authentication.CloudFoundryCore.Test/CloudFoundryScopeClaimActionTest.cs
+++ b/src/Security/test/Authentication.CloudFoundryCore.Test/CloudFoundryScopeClaimActionTest.cs
@@ -2,11 +2,11 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-#if !NETCOREAPP3_0
+#if !NETCOREAPP3_1
 using Newtonsoft.Json.Linq;
 #endif
 using System.Security.Claims;
-#if NETCOREAPP3_0
+#if NETCOREAPP3_1
 using System.Text.Json;
 #endif
 using Xunit;
@@ -19,7 +19,7 @@ namespace Steeltoe.Security.Authentication.CloudFoundry.Test
         public void Run_AddsClaims()
         {
             string resp = TestHelpers.GetValidTokenInfoRequestResponse();
-#if NETCOREAPP3_0
+#if NETCOREAPP3_1
             var payload = JsonDocument.Parse(resp).RootElement;
 #else
             var payload = JObject.Parse(resp);

--- a/src/Security/test/Authentication.CloudFoundryCore.Test/MyTestCloudFoundryHandler.cs
+++ b/src/Security/test/Authentication.CloudFoundryCore.Test/MyTestCloudFoundryHandler.cs
@@ -30,7 +30,7 @@ namespace Steeltoe.Security.Authentication.CloudFoundry.Test
 
         public async Task<OAuthTokenResponse> TestExchangeCodeAsync(string code, string redirectUri)
         {
-#if NETCOREAPP3_0
+#if NETCOREAPP3_1
             return await ExchangeCodeAsync(new OAuthCodeExchangeContext(new AuthenticationProperties(), code, redirectUri));
 #else
             return await ExchangeCodeAsync(code, redirectUri);

--- a/src/Security/test/Authentication.CloudFoundryCore.Test/Steeltoe.Security.Authentication.CloudFoundryCore.Test.csproj
+++ b/src/Security/test/Authentication.CloudFoundryCore.Test/Steeltoe.Security.Authentication.CloudFoundryCore.Test.csproj
@@ -1,11 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
+
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedtest.props" />
   <Import Project="..\..\..\..\targetframework.props" />
 

--- a/src/Security/test/Authentication.CloudFoundryOwin.Net4Test/Steeltoe.Security.Authentication.CloudFoundryOwin.Test.csproj
+++ b/src/Security/test/Authentication.CloudFoundryOwin.Net4Test/Steeltoe.Security.Authentication.CloudFoundryOwin.Test.csproj
@@ -1,13 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup>
     <RootNamespace>Steeltoe.Security.Authentication.CloudFoundry.Owin.Test</RootNamespace>
     <TargetFrameworks>net461</TargetFrameworks>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <IsPackable>false</IsPackable>
-    <!-- <SignAssembly>true</SignAssembly>
-    <AssemblyOriginatorKeyFile>..\..\..\..\steeltoe.snk</AssemblyOriginatorKeyFile> -->
   </PropertyGroup>
+
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedtest.props" />
   <Import Project="..\..\..\..\targetframework.props" />
 

--- a/src/Security/test/Authentication.CloudFoundryWcf.Net4Test/Steeltoe.Security.Authentication.CloudFoundryWcf.Test.csproj
+++ b/src/Security/test/Authentication.CloudFoundryWcf.Net4Test/Steeltoe.Security.Authentication.CloudFoundryWcf.Test.csproj
@@ -1,13 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup>
     <RootNamespace>Steeltoe.Security.Authentication.CloudFoundry.Wcf.Test</RootNamespace>
     <TargetFrameworks>net461</TargetFrameworks>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <IsPackable>false</IsPackable>
-    <!-- <SignAssembly>true</SignAssembly>
-    <AssemblyOriginatorKeyFile>..\..\..\..\steeltoe.snk</AssemblyOriginatorKeyFile> -->
   </PropertyGroup>
+
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedtest.props" />
   <Import Project="..\..\..\..\targetframework.props" />
 

--- a/src/Security/test/DataProtection.CredHubBase.Test/Steeltoe.Security.DataProtection.CredHubBase.Test.csproj
+++ b/src/Security/test/DataProtection.CredHubBase.Test/Steeltoe.Security.DataProtection.CredHubBase.Test.csproj
@@ -1,11 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
+
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedtest.props" />
   <Import Project="..\..\..\..\targetframework.props" />
 

--- a/src/Security/test/DataProtection.CredHubCore.Test/Steeltoe.Security.DataProtection.CredHubCore.Test.csproj
+++ b/src/Security/test/DataProtection.CredHubCore.Test/Steeltoe.Security.DataProtection.CredHubCore.Test.csproj
@@ -1,15 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
+
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedtest.props" />
   <Import Project="..\..\..\..\targetframework.props" />
 
-  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.0'">
+  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.1'">
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="$(AspNetCoreVersion)" />
   </ItemGroup>
 

--- a/src/Security/test/DataProtection.RedisCore.Test/Steeltoe.Security.DataProtection.RedisCore.Test.csproj
+++ b/src/Security/test/DataProtection.RedisCore.Test/Steeltoe.Security.DataProtection.RedisCore.Test.csproj
@@ -1,11 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\versions.props" />
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
+
+  <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedtest.props" />
   <Import Project="..\..\..\..\targetframework.props" />
 

--- a/versions.props
+++ b/versions.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup Condition="'$(TF_BUILD)' != 'true'">
-    <VersionPrefix>2.4.4</VersionPrefix>
+    <VersionPrefix>2.5.0</VersionPrefix>
   </PropertyGroup>
   <PropertyGroup>
     <CoreFxVersion>4.4.0</CoreFxVersion>
@@ -57,18 +57,11 @@
     <HealthChecksSqlServerVersion>2.2.0</HealthChecksSqlServerVersion>
 
     <SonarAnalyzerVersion>7.17.0.9346</SonarAnalyzerVersion>
-    <SourceLinkGitHubVersion>1.0.0-beta2-19367-01</SourceLinkGitHubVersion>
+    <SourceLinkGitHubVersion>1.0.0</SourceLinkGitHubVersion>
     <StyleCopVersion>1.1.118</StyleCopVersion>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.1' OR '$(TargetFramework)' == 'netcoreapp3.0'">
-    <AspNetCoreVersion>3.0.0</AspNetCoreVersion>
-    <EF6Version>6.3.0</EF6Version>
-    <ExtensionsVersion>3.0.0</ExtensionsVersion>
-    <HealthChecksVersion>3.0.0</HealthChecksVersion>
-    <LoggingVersion>3.0.0</LoggingVersion>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.1' OR '$(TargetFramework)' == 'netcoreapp3.1'">
     <AspNetCoreVersion>3.1.0</AspNetCoreVersion>
     <EF6Version>6.3.0</EF6Version>
     <ExtensionsVersion>3.1.0</ExtensionsVersion>


### PR DESCRIPTION
Several tests recently started failing on MacOS CI builds though no Steeltoe code changed, this PR skips those on Mac
Also:
- updates dependencies and tests to use netcoreapp3.1 instead of netcoreapp3.0
- .csproj and pipeline maintenance