### PR TITLE
prefix field names with underscore to distinguish from local vars

### DIFF
--- a/Steeltoe.ruleset
+++ b/Steeltoe.ruleset
@@ -55,6 +55,7 @@
     <Rule Id="S127" Action="None" />
     <Rule Id="S1301" Action="None" />
     <Rule Id="S1309" Action="None" />
+    <Rule Id="SX1309" Action="Warning" />
     <Rule Id="S131" Action="None" />
     <Rule Id="S1313" Action="Warning" />
     <Rule Id="S134" Action="None" />

--- a/src/CircuitBreaker/src/Hystrix.MetricsEventsCore/Controllers/HystrixStreamBaseController.cs
+++ b/src/CircuitBreaker/src/Hystrix.MetricsEventsCore/Controllers/HystrixStreamBaseController.cs
@@ -12,13 +12,13 @@ namespace Steeltoe.CircuitBreaker.Hystrix.MetricsEvents.Controllers
 {
     public class HystrixStreamBaseController : Controller
     {
-        private IObservable<string> sampleStream;
+        private IObservable<string> _sampleStream;
 
-        private IDisposable sampleSubscription = null;
+        private IDisposable _sampleSubscription = null;
 
-        protected internal IObservable<string> SampleStream { get => sampleStream; set => sampleStream = value; }
+        protected internal IObservable<string> SampleStream { get => _sampleStream; set => _sampleStream = value; }
 
-        protected internal IDisposable SampleSubscription { get => sampleSubscription; set => sampleSubscription = value; }
+        protected internal IDisposable SampleSubscription { get => _sampleSubscription; set => _sampleSubscription = value; }
 
         public HystrixStreamBaseController(IObservable<string> observable)
         {

--- a/src/CircuitBreaker/src/Hystrix.MetricsEventsCore/Controllers/HystrixStreamBaseController.cs
+++ b/src/CircuitBreaker/src/Hystrix.MetricsEventsCore/Controllers/HystrixStreamBaseController.cs
@@ -12,13 +12,9 @@ namespace Steeltoe.CircuitBreaker.Hystrix.MetricsEvents.Controllers
 {
     public class HystrixStreamBaseController : Controller
     {
-        private IObservable<string> _sampleStream;
+        protected internal IObservable<string> SampleStream { get; set; }
 
-        private IDisposable _sampleSubscription = null;
-
-        protected internal IObservable<string> SampleStream { get => _sampleStream; set => _sampleStream = value; }
-
-        protected internal IDisposable SampleSubscription { get => _sampleSubscription; set => _sampleSubscription = value; }
+        protected internal IDisposable SampleSubscription { get; set; } = null;
 
         public HystrixStreamBaseController(IObservable<string> observable)
         {

--- a/src/CircuitBreaker/src/Hystrix.MetricsStreamAutofac/RabbitMetricsStreamPublisher.cs
+++ b/src/CircuitBreaker/src/Hystrix.MetricsStreamAutofac/RabbitMetricsStreamPublisher.cs
@@ -18,15 +18,15 @@ namespace Steeltoe.CircuitBreaker.Hystrix.MetricsStream
 {
     public class RabbitMetricsStreamPublisher : HystrixMetricsStreamPublisher
     {
-        private ConnectionFactory factory;
-        private IConnection connection;
-        private IModel channel;
+        private ConnectionFactory _factory;
+        private IConnection _connection;
+        private IModel _channel;
 
-        protected internal ConnectionFactory Factory { get => factory; set => factory = value; }
+        protected internal ConnectionFactory Factory { get => _factory; set => _factory = value; }
 
-        protected internal IConnection Connection { get => connection; set => connection = value; }
+        protected internal IConnection Connection { get => _connection; set => _connection = value; }
 
-        protected internal IModel Channel { get => channel; set => channel = value; }
+        protected internal IModel Channel { get => _channel; set => _channel = value; }
 
         public RabbitMetricsStreamPublisher(IOptions<HystrixMetricsStreamOptions> options, HystrixDashboardStream stream, HystrixConnectionFactory factory, ILogger<RabbitMetricsStreamPublisher> logger = null, IDiscoveryClient discoveryClient = null)
             : base(options, stream, logger, discoveryClient)

--- a/src/CircuitBreaker/src/Hystrix.MetricsStreamAutofac/RabbitMetricsStreamPublisher.cs
+++ b/src/CircuitBreaker/src/Hystrix.MetricsStreamAutofac/RabbitMetricsStreamPublisher.cs
@@ -18,15 +18,11 @@ namespace Steeltoe.CircuitBreaker.Hystrix.MetricsStream
 {
     public class RabbitMetricsStreamPublisher : HystrixMetricsStreamPublisher
     {
-        private ConnectionFactory _factory;
-        private IConnection _connection;
-        private IModel _channel;
+        protected internal ConnectionFactory Factory { get; set; }
 
-        protected internal ConnectionFactory Factory { get => _factory; set => _factory = value; }
+        protected internal IConnection Connection { get; set; }
 
-        protected internal IConnection Connection { get => _connection; set => _connection = value; }
-
-        protected internal IModel Channel { get => _channel; set => _channel = value; }
+        protected internal IModel Channel { get; set; }
 
         public RabbitMetricsStreamPublisher(IOptions<HystrixMetricsStreamOptions> options, HystrixDashboardStream stream, HystrixConnectionFactory factory, ILogger<RabbitMetricsStreamPublisher> logger = null, IDiscoveryClient discoveryClient = null)
             : base(options, stream, logger, discoveryClient)

--- a/src/CircuitBreaker/src/Hystrix.MetricsStreamCore/RabbitMetricsStreamPublisher.cs
+++ b/src/CircuitBreaker/src/Hystrix.MetricsStreamCore/RabbitMetricsStreamPublisher.cs
@@ -18,15 +18,15 @@ namespace Steeltoe.CircuitBreaker.Hystrix.MetricsStream
 {
     public class RabbitMetricsStreamPublisher : HystrixMetricsStreamPublisher
     {
-        private ConnectionFactory factory;
-        private IConnection connection;
-        private IModel channel;
+        private ConnectionFactory _factory;
+        private IConnection _connection;
+        private IModel _channel;
 
-        protected internal ConnectionFactory Factory { get => factory; set => factory = value; }
+        protected internal ConnectionFactory Factory { get => _factory; set => _factory = value; }
 
-        protected internal IConnection Connection { get => connection; set => connection = value; }
+        protected internal IConnection Connection { get => _connection; set => _connection = value; }
 
-        protected internal IModel Channel { get => channel; set => channel = value; }
+        protected internal IModel Channel { get => _channel; set => _channel = value; }
 
         public RabbitMetricsStreamPublisher(IOptions<HystrixMetricsStreamOptions> options, HystrixDashboardStream stream, HystrixConnectionFactory factory, ILogger<RabbitMetricsStreamPublisher> logger = null, IDiscoveryClient discoveryClient = null)
             : base(options, stream, logger, discoveryClient)

--- a/src/CircuitBreaker/src/Hystrix.MetricsStreamCore/RabbitMetricsStreamPublisher.cs
+++ b/src/CircuitBreaker/src/Hystrix.MetricsStreamCore/RabbitMetricsStreamPublisher.cs
@@ -18,15 +18,11 @@ namespace Steeltoe.CircuitBreaker.Hystrix.MetricsStream
 {
     public class RabbitMetricsStreamPublisher : HystrixMetricsStreamPublisher
     {
-        private ConnectionFactory _factory;
-        private IConnection _connection;
-        private IModel _channel;
+        protected internal ConnectionFactory Factory { get; set; }
 
-        protected internal ConnectionFactory Factory { get => _factory; set => _factory = value; }
+        protected internal IConnection Connection { get; set; }
 
-        protected internal IConnection Connection { get => _connection; set => _connection = value; }
-
-        protected internal IModel Channel { get => _channel; set => _channel = value; }
+        protected internal IModel Channel { get; set; }
 
         public RabbitMetricsStreamPublisher(IOptions<HystrixMetricsStreamOptions> options, HystrixDashboardStream stream, HystrixConnectionFactory factory, ILogger<RabbitMetricsStreamPublisher> logger = null, IDiscoveryClient discoveryClient = null)
             : base(options, stream, logger, discoveryClient)

--- a/src/CircuitBreaker/src/HystrixBase/CircuitBreaker/HystrixCircuitBreakerImpl.cs
+++ b/src/CircuitBreaker/src/HystrixBase/CircuitBreaker/HystrixCircuitBreakerImpl.cs
@@ -8,29 +8,29 @@ namespace Steeltoe.CircuitBreaker.Hystrix.CircuitBreaker
 {
     internal class HystrixCircuitBreakerImpl : IHystrixCircuitBreaker
     {
-        private readonly IHystrixCommandOptions options;
-        private readonly HystrixCommandMetrics metrics;
+        private readonly IHystrixCommandOptions _options;
+        private readonly HystrixCommandMetrics _metrics;
 
         /* track whether this circuit is open/closed at any given point in time (default to false==closed) */
-        private AtomicBoolean circuitOpen = new AtomicBoolean(false);
+        private AtomicBoolean _circuitOpen = new AtomicBoolean(false);
 
         /* when the circuit was marked open or was last allowed to try a 'singleTest' */
-        private AtomicLong circuitOpenedOrLastTestedTime = new AtomicLong();
+        private AtomicLong _circuitOpenedOrLastTestedTime = new AtomicLong();
 
         protected internal HystrixCircuitBreakerImpl(IHystrixCommandKey key, IHystrixCommandGroupKey commandGroup, IHystrixCommandOptions options, HystrixCommandMetrics metrics)
         {
-            this.options = options;
-            this.metrics = metrics;
+            this._options = options;
+            this._metrics = metrics;
         }
 
         public virtual void MarkSuccess()
         {
-            if (circuitOpen.Value && circuitOpen.CompareAndSet(true, false))
+            if (_circuitOpen.Value && _circuitOpen.CompareAndSet(true, false))
             {
                 // win the thread race to reset metrics
                 // Unsubscribe from the current stream to reset the health counts stream.  This only affects the health counts view,
                 // and all other metric consumers are unaffected by the reset
-                metrics.ResetStream();
+                _metrics.ResetStream();
             }
         }
 
@@ -38,13 +38,13 @@ namespace Steeltoe.CircuitBreaker.Hystrix.CircuitBreaker
         {
             get
             {
-                if (options.CircuitBreakerForceOpen)
+                if (_options.CircuitBreakerForceOpen)
                 {
                     // properties have asked us to force the circuit open so we will allow NO requests
                     return false;
                 }
 
-                if (options.CircuitBreakerForceClosed)
+                if (_options.CircuitBreakerForceClosed)
                 {
                     // we still want to allow isOpen() to perform it's calculations so we simulate normal behavior
                     var isOpen = IsOpen;
@@ -59,16 +59,16 @@ namespace Steeltoe.CircuitBreaker.Hystrix.CircuitBreaker
 
         public virtual bool AllowSingleTest()
         {
-            long timeCircuitOpenedOrWasLastTested = circuitOpenedOrLastTestedTime.Value;
+            long timeCircuitOpenedOrWasLastTested = _circuitOpenedOrLastTestedTime.Value;
 
             // 1) if the circuit is open
             // 2) and it's been longer than 'sleepWindow' since we opened the circuit
-            if (circuitOpen.Value && Time.CurrentTimeMillis > timeCircuitOpenedOrWasLastTested + options.CircuitBreakerSleepWindowInMilliseconds)
+            if (_circuitOpen.Value && Time.CurrentTimeMillis > timeCircuitOpenedOrWasLastTested + _options.CircuitBreakerSleepWindowInMilliseconds)
             {
                 // We push the 'circuitOpenedTime' ahead by 'sleepWindow' since we have allowed one request to try.
                 // If it succeeds the circuit will be closed, otherwise another singleTest will be allowed at the end of the 'sleepWindow'.
 #pragma warning disable S1066 // Collapsible "if" statements should be merged
-                if (circuitOpenedOrLastTestedTime.CompareAndSet(timeCircuitOpenedOrWasLastTested, Time.CurrentTimeMillis))
+                if (_circuitOpenedOrLastTestedTime.CompareAndSet(timeCircuitOpenedOrWasLastTested, Time.CurrentTimeMillis))
 #pragma warning restore S1066 // Collapsible "if" statements should be merged
                 {
                     // if this returns true that means we set the time so we'll return true to allow the singleTest
@@ -84,33 +84,33 @@ namespace Steeltoe.CircuitBreaker.Hystrix.CircuitBreaker
         {
             get
             {
-                if (circuitOpen.Value)
+                if (_circuitOpen.Value)
                 {
                     // if we're open we immediately return true and don't bother attempting to 'close' ourself as that is left to allowSingleTest and a subsequent successful test to close
                     return true;
                 }
 
                 // we're closed, so let's see if errors have made us so we should trip the circuit open
-                HealthCounts health = metrics.Healthcounts;
+                HealthCounts health = _metrics.Healthcounts;
 
                 // check if we are past the statisticalWindowVolumeThreshold
-                if (health.TotalRequests < options.CircuitBreakerRequestVolumeThreshold)
+                if (health.TotalRequests < _options.CircuitBreakerRequestVolumeThreshold)
                 {
                     // we are not past the minimum volume threshold for the statisticalWindow so we'll return false immediately and not calculate anything
                     return false;
                 }
 
-                if (health.ErrorPercentage < options.CircuitBreakerErrorThresholdPercentage)
+                if (health.ErrorPercentage < _options.CircuitBreakerErrorThresholdPercentage)
                 {
                     return false;
                 }
                 else
                 {
                     // our failure rate is too high, trip the circuit
-                    if (circuitOpen.CompareAndSet(false, true))
+                    if (_circuitOpen.CompareAndSet(false, true))
                     {
                         // if the previousValue was false then we want to set the currentTime
-                        circuitOpenedOrLastTestedTime.Value = Time.CurrentTimeMillis;
+                        _circuitOpenedOrLastTestedTime.Value = Time.CurrentTimeMillis;
                         return true;
                     }
                     else

--- a/src/CircuitBreaker/src/HystrixBase/Collapser/CollapsedRequest.cs
+++ b/src/CircuitBreaker/src/HystrixBase/Collapser/CollapsedRequest.cs
@@ -11,24 +11,24 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Collapser
 {
     public class CollapsedRequest<RequestResponseType, RequestArgumentType> : ICollapsedRequest<RequestResponseType, RequestArgumentType>
     {
-        private readonly ConcurrentQueue<CancellationToken> linkedTokens = new ConcurrentQueue<CancellationToken>();
-        private RequestResponseType response;
-        private Exception exception;
-        private bool complete;
+        private readonly ConcurrentQueue<CancellationToken> _linkedTokens = new ConcurrentQueue<CancellationToken>();
+        private RequestResponseType _response;
+        private Exception _exception;
+        private bool _complete;
 
         internal CollapsedRequest(RequestArgumentType arg, CancellationToken token)
         {
             Argument = arg;
             Token = token;
             CompletionSource = null;
-            response = default;
-            exception = null;
-            complete = false;
+            _response = default;
+            _exception = null;
+            _complete = false;
         }
 
         internal void AddLinkedToken(CancellationToken token)
         {
-            linkedTokens.Enqueue(token);
+            _linkedTokens.Enqueue(token);
         }
 
         internal CancellationToken Token { get; }
@@ -37,7 +37,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Collapser
 
         internal void SetExceptionIfResponseNotReceived(Exception e)
         {
-            if (!complete)
+            if (!_complete)
             {
                 Exception = e;
             }
@@ -47,7 +47,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Collapser
         {
             Exception newException = e;
 
-            if (!complete)
+            if (!_complete)
             {
                 if (e == null)
                 {
@@ -63,7 +63,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Collapser
 
         internal bool IsRequestCanceled()
         {
-            foreach (var linkedToken in linkedTokens)
+            foreach (var linkedToken in _linkedTokens)
             {
                 if (!linkedToken.IsCancellationRequested)
                 {
@@ -80,11 +80,11 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Collapser
 
         public bool Complete
         {
-            get => complete;
+            get => _complete;
 
             set
             {
-                complete = value;
+                _complete = value;
                 if (!CompletionSource.Task.IsCompleted)
                 {
                     Response = default;
@@ -94,12 +94,12 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Collapser
 
         public Exception Exception
         {
-            get => exception;
+            get => _exception;
 
             set
             {
-                exception = value;
-                complete = true;
+                _exception = value;
+                _complete = true;
                 if (!CompletionSource.TrySetException(value))
                 {
                     throw new InvalidOperationException("Task has already terminated so exectpion can not be set : " + value);
@@ -109,12 +109,12 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Collapser
 
         public RequestResponseType Response
         {
-            get => response;
+            get => _response;
 
             set
             {
-                response = value;
-                complete = true;
+                _response = value;
+                _complete = true;
                 if (!CompletionSource.TrySetResult(value))
                 {
                     throw new InvalidOperationException("Task has already terminated so response can not be set : " + value);

--- a/src/CircuitBreaker/src/HystrixBase/Collapser/CollapsedTask.cs
+++ b/src/CircuitBreaker/src/HystrixBase/Collapser/CollapsedTask.cs
@@ -9,11 +9,11 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Collapser
 {
     internal class CollapsedTask<BatchReturnType, ResponseType, RequestArgumentType> : ITimerListener
     {
-        private readonly RequestCollapser<BatchReturnType, ResponseType, RequestArgumentType> rq;
+        private readonly RequestCollapser<BatchReturnType, ResponseType, RequestArgumentType> _rq;
 
         public CollapsedTask(RequestCollapser<BatchReturnType, ResponseType, RequestArgumentType> rq)
         {
-            this.rq = rq;
+            this._rq = rq;
         }
 
         public void Tick()
@@ -22,14 +22,14 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Collapser
             {
                 // we fetch current so that when multiple threads race
                 // we can do compareAndSet with the expected/new to ensure only one happens
-                RequestBatch<BatchReturnType, ResponseType, RequestArgumentType> currentBatch = rq.Batch.Value;
+                RequestBatch<BatchReturnType, ResponseType, RequestArgumentType> currentBatch = _rq.Batch.Value;
 
                 // 1) it can be null if it got shutdown
                 // 2) we don't execute this batch if it has no requests and let it wait until next tick to be executed
                 if (currentBatch != null && currentBatch.Size > 0)
                 {
                     // do execution within context of wrapped Callable
-                    rq.CreateNewBatchAndExecutePreviousIfNeeded(currentBatch);
+                    _rq.CreateNewBatchAndExecutePreviousIfNeeded(currentBatch);
                 }
             }
             catch (Exception)
@@ -38,6 +38,6 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Collapser
             }
         }
 
-        public int IntervalTimeInMilliseconds => rq.Properties.TimerDelayInMilliseconds;
+        public int IntervalTimeInMilliseconds => _rq.Properties.TimerDelayInMilliseconds;
     }
 }

--- a/src/CircuitBreaker/src/HystrixBase/Collapser/RequestCollapser.cs
+++ b/src/CircuitBreaker/src/HystrixBase/Collapser/RequestCollapser.cs
@@ -11,28 +11,28 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Collapser
 {
     public class RequestCollapser<BatchReturnType, RequestResponseType, RequestArgumentType>
     {
-        private readonly HystrixCollapser<BatchReturnType, RequestResponseType, RequestArgumentType> commandCollapser;
+        private readonly HystrixCollapser<BatchReturnType, RequestResponseType, RequestArgumentType> _commandCollapser;
 
         // batch can be null once shutdown
-        private readonly AtomicReference<RequestBatch<BatchReturnType, RequestResponseType, RequestArgumentType>> batch = new AtomicReference<RequestBatch<BatchReturnType, RequestResponseType, RequestArgumentType>>();
-        private readonly AtomicReference<TimerReference> timerListenerReference = new AtomicReference<TimerReference>();
-        private readonly AtomicBoolean timerListenerRegistered = new AtomicBoolean();
-        private readonly ICollapserTimer timer;
-        private readonly IHystrixCollapserOptions properties;
-        private readonly HystrixConcurrencyStrategy concurrencyStrategy;
+        private readonly AtomicReference<RequestBatch<BatchReturnType, RequestResponseType, RequestArgumentType>> _batch = new AtomicReference<RequestBatch<BatchReturnType, RequestResponseType, RequestArgumentType>>();
+        private readonly AtomicReference<TimerReference> _timerListenerReference = new AtomicReference<TimerReference>();
+        private readonly AtomicBoolean _timerListenerRegistered = new AtomicBoolean();
+        private readonly ICollapserTimer _timer;
+        private readonly IHystrixCollapserOptions _properties;
+        private readonly HystrixConcurrencyStrategy _concurrencyStrategy;
 
-        public AtomicReference<RequestBatch<BatchReturnType, RequestResponseType, RequestArgumentType>> Batch => batch;
+        public AtomicReference<RequestBatch<BatchReturnType, RequestResponseType, RequestArgumentType>> Batch => _batch;
 
-        public IHystrixCollapserOptions Properties => properties;
+        public IHystrixCollapserOptions Properties => _properties;
 
         internal RequestCollapser(HystrixCollapser<BatchReturnType, RequestResponseType, RequestArgumentType> commandCollapser, IHystrixCollapserOptions properties, ICollapserTimer timer, HystrixConcurrencyStrategy concurrencyStrategy)
         {
             // the command with implementation of abstract methods we need
-            this.commandCollapser = commandCollapser;
-            this.concurrencyStrategy = concurrencyStrategy;
-            this.properties = properties;
-            this.timer = timer;
-            batch.Value = new RequestBatch<BatchReturnType, RequestResponseType, RequestArgumentType>(properties, commandCollapser, properties.MaxRequestsInBatch);
+            this._commandCollapser = commandCollapser;
+            this._concurrencyStrategy = concurrencyStrategy;
+            this._properties = properties;
+            this._timer = timer;
+            _batch.Value = new RequestBatch<BatchReturnType, RequestResponseType, RequestArgumentType>(properties, commandCollapser, properties.MaxRequestsInBatch);
         }
 
         public CollapsedRequest<RequestResponseType, RequestArgumentType> SubmitRequest(RequestArgumentType arg, CancellationToken token)
@@ -40,10 +40,10 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Collapser
             /*
              * We only want the timer ticking if there are actually things to do so we register it the first time something is added.
              */
-            if (!timerListenerRegistered.Value && timerListenerRegistered.CompareAndSet(false, true))
+            if (!_timerListenerRegistered.Value && _timerListenerRegistered.CompareAndSet(false, true))
             {
                 /* schedule the collapsing task to be executed every x milliseconds (x defined inside CollapsedTask) */
-                timerListenerReference.Value = timer.AddListener(new CollapsedTask<BatchReturnType, RequestResponseType, RequestArgumentType>(this));
+                _timerListenerReference.Value = _timer.AddListener(new CollapsedTask<BatchReturnType, RequestResponseType, RequestArgumentType>(this));
             }
 
             // loop until succeed (compare-and-set spin-loop)
@@ -78,10 +78,10 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Collapser
                 currentBatch.Shutdown();
             }
 
-            if (timerListenerReference.Value != null)
+            if (_timerListenerReference.Value != null)
             {
                 // if the timer was started we'll clear it so it stops ticking
-                timerListenerReference.Value.Dispose();
+                _timerListenerReference.Value.Dispose();
             }
         }
 
@@ -92,7 +92,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Collapser
                 throw new InvalidOperationException("Trying to start null batch which means it was shutdown already.");
             }
 
-            if (Batch.CompareAndSet(previousBatch, new RequestBatch<BatchReturnType, RequestResponseType, RequestArgumentType>(Properties, commandCollapser, Properties.MaxRequestsInBatch)))
+            if (Batch.CompareAndSet(previousBatch, new RequestBatch<BatchReturnType, RequestResponseType, RequestArgumentType>(Properties, _commandCollapser, Properties.MaxRequestsInBatch)))
             {
                 previousBatch.ExecuteBatchIfNotAlreadyStarted();
             }

--- a/src/CircuitBreaker/src/HystrixBase/Collapser/RequestCollapser.cs
+++ b/src/CircuitBreaker/src/HystrixBase/Collapser/RequestCollapser.cs
@@ -12,27 +12,23 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Collapser
     public class RequestCollapser<BatchReturnType, RequestResponseType, RequestArgumentType>
     {
         private readonly HystrixCollapser<BatchReturnType, RequestResponseType, RequestArgumentType> _commandCollapser;
-
-        // batch can be null once shutdown
-        private readonly AtomicReference<RequestBatch<BatchReturnType, RequestResponseType, RequestArgumentType>> _batch = new AtomicReference<RequestBatch<BatchReturnType, RequestResponseType, RequestArgumentType>>();
         private readonly AtomicReference<TimerReference> _timerListenerReference = new AtomicReference<TimerReference>();
         private readonly AtomicBoolean _timerListenerRegistered = new AtomicBoolean();
         private readonly ICollapserTimer _timer;
-        private readonly IHystrixCollapserOptions _properties;
         private readonly HystrixConcurrencyStrategy _concurrencyStrategy;
 
-        public AtomicReference<RequestBatch<BatchReturnType, RequestResponseType, RequestArgumentType>> Batch => _batch;
+        public AtomicReference<RequestBatch<BatchReturnType, RequestResponseType, RequestArgumentType>> Batch { get; } = new AtomicReference<RequestBatch<BatchReturnType, RequestResponseType, RequestArgumentType>>();
 
-        public IHystrixCollapserOptions Properties => _properties;
+        public IHystrixCollapserOptions Properties { get; }
 
         internal RequestCollapser(HystrixCollapser<BatchReturnType, RequestResponseType, RequestArgumentType> commandCollapser, IHystrixCollapserOptions properties, ICollapserTimer timer, HystrixConcurrencyStrategy concurrencyStrategy)
         {
             // the command with implementation of abstract methods we need
             this._commandCollapser = commandCollapser;
             this._concurrencyStrategy = concurrencyStrategy;
-            this._properties = properties;
+            this.Properties = properties;
             this._timer = timer;
-            _batch.Value = new RequestBatch<BatchReturnType, RequestResponseType, RequestArgumentType>(properties, commandCollapser, properties.MaxRequestsInBatch);
+            Batch.Value = new RequestBatch<BatchReturnType, RequestResponseType, RequestArgumentType>(properties, commandCollapser, properties.MaxRequestsInBatch);
         }
 
         public CollapsedRequest<RequestResponseType, RequestArgumentType> SubmitRequest(RequestArgumentType arg, CancellationToken token)

--- a/src/CircuitBreaker/src/HystrixBase/Collapser/RequestCollapserFactory.cs
+++ b/src/CircuitBreaker/src/HystrixBase/Collapser/RequestCollapserFactory.cs
@@ -12,14 +12,14 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Collapser
 {
     public class RequestCollapserFactory
     {
-        private readonly ICollapserTimer timer;
-        private readonly HystrixConcurrencyStrategy concurrencyStrategy;
+        private readonly ICollapserTimer _timer;
+        private readonly HystrixConcurrencyStrategy _concurrencyStrategy;
 
         public RequestCollapserFactory(IHystrixCollapserKey collapserKey, RequestCollapserScope scope, ICollapserTimer timer, IHystrixCollapserOptions properties)
         {
             /* strategy: ConcurrencyStrategy */
-            concurrencyStrategy = HystrixPlugins.ConcurrencyStrategy;
-            this.timer = timer;
+            _concurrencyStrategy = HystrixPlugins.ConcurrencyStrategy;
+            this._timer = timer;
             Scope = scope;
             CollapserKey = collapserKey;
             Properties = properties;
@@ -75,7 +75,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Collapser
 
         private RequestCollapser<BatchReturnType, ResponseType, RequestArgumentType> GetCollapserForGlobalScope<BatchReturnType, ResponseType, RequestArgumentType>(HystrixCollapser<BatchReturnType, ResponseType, RequestArgumentType> commandCollapser)
         {
-            var result = globalScopedCollapsers.GetOrAddEx(CollapserKey.Name, (k) => new RequestCollapser<BatchReturnType, ResponseType, RequestArgumentType>(commandCollapser, Properties, timer, concurrencyStrategy));
+            var result = globalScopedCollapsers.GetOrAddEx(CollapserKey.Name, (k) => new RequestCollapser<BatchReturnType, ResponseType, RequestArgumentType>(commandCollapser, Properties, _timer, _concurrencyStrategy));
             return (RequestCollapser<BatchReturnType, ResponseType, RequestArgumentType>)result;
         }
 
@@ -89,7 +89,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Collapser
 
         private RequestCollapserRequestVariable<BatchReturnType, ResponseType, RequestArgumentType> GetRequestVariableForCommand<BatchReturnType, ResponseType, RequestArgumentType>(HystrixCollapser<BatchReturnType, ResponseType, RequestArgumentType> commandCollapser)
         {
-            var result = requestScopedCollapsers.GetOrAddEx(commandCollapser.CollapserKey.Name, (k) => new RequestCollapserRequestVariable<BatchReturnType, ResponseType, RequestArgumentType>(commandCollapser, Properties, timer, concurrencyStrategy));
+            var result = requestScopedCollapsers.GetOrAddEx(commandCollapser.CollapserKey.Name, (k) => new RequestCollapserRequestVariable<BatchReturnType, ResponseType, RequestArgumentType>(commandCollapser, Properties, _timer, _concurrencyStrategy));
             return (RequestCollapserRequestVariable<BatchReturnType, ResponseType, RequestArgumentType>)result;
         }
 

--- a/src/CircuitBreaker/src/HystrixBase/Config/HystrixCommandConfiguration.cs
+++ b/src/CircuitBreaker/src/HystrixBase/Config/HystrixCommandConfiguration.cs
@@ -8,7 +8,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Config
 {
     public class HystrixCommandConfiguration
     {
-        private readonly IHystrixCommandKey commandKey;
+        private readonly IHystrixCommandKey _commandKey;
 
         public HystrixCommandConfiguration(
             IHystrixCommandKey commandKey,
@@ -18,7 +18,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Config
             HystrixCommandCircuitBreakerConfig circuitBreakerConfig,
             HystrixCommandMetricsConfig metricsConfig)
         {
-            this.commandKey = commandKey;
+            this._commandKey = commandKey;
             ThreadPoolKey = threadPoolKey;
             GroupKey = groupKey;
             ExecutionConfig = executionConfig;

--- a/src/CircuitBreaker/src/HystrixBase/Config/HystrixConfigurationStream.cs
+++ b/src/CircuitBreaker/src/HystrixBase/Config/HystrixConfigurationStream.cs
@@ -13,9 +13,9 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Config
     public class HystrixConfigurationStream
     {
         private static int dataEmissionIntervalInMs = 5000;
-        private readonly int intervalInMilliseconds;
-        private readonly IObservable<HystrixConfiguration> allConfigurationStream;
-        private readonly AtomicBoolean isSourceCurrentlySubscribed = new AtomicBoolean(false);
+        private readonly int _intervalInMilliseconds;
+        private readonly IObservable<HystrixConfiguration> _allConfigurationStream;
+        private readonly AtomicBoolean _isSourceCurrentlySubscribed = new AtomicBoolean(false);
 
         private static Func<long, HystrixConfiguration> AllConfig { get; } =
             (long timestamp) =>
@@ -28,16 +28,16 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Config
 
         public HystrixConfigurationStream(int intervalInMilliseconds)
         {
-            this.intervalInMilliseconds = intervalInMilliseconds;
-            this.allConfigurationStream = Observable.Interval(TimeSpan.FromMilliseconds(intervalInMilliseconds))
+            this._intervalInMilliseconds = intervalInMilliseconds;
+            this._allConfigurationStream = Observable.Interval(TimeSpan.FromMilliseconds(intervalInMilliseconds))
                     .Map(AllConfig)
                     .OnSubscribe(() =>
                 {
-                    isSourceCurrentlySubscribed.Value = true;
+                    _isSourceCurrentlySubscribed.Value = true;
                 })
                     .OnDispose(() =>
                 {
-                    isSourceCurrentlySubscribed.Value = false;
+                    _isSourceCurrentlySubscribed.Value = false;
                 })
                     .Publish().RefCount();
         }
@@ -54,32 +54,32 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Config
          // Return a ref-counted stream that will only do work when at least one subscriber is present
         public IObservable<HystrixConfiguration> Observe()
         {
-            return allConfigurationStream;
+            return _allConfigurationStream;
         }
 
         public IObservable<Dictionary<IHystrixCommandKey, HystrixCommandConfiguration>> ObserveCommandConfiguration()
         {
-            return allConfigurationStream.Map(OnlyCommandConfig);
+            return _allConfigurationStream.Map(OnlyCommandConfig);
         }
 
         public IObservable<Dictionary<IHystrixThreadPoolKey, HystrixThreadPoolConfiguration>> ObserveThreadPoolConfiguration()
         {
-            return allConfigurationStream.Map(OnlyThreadPoolConfig);
+            return _allConfigurationStream.Map(OnlyThreadPoolConfig);
         }
 
         public IObservable<Dictionary<IHystrixCollapserKey, HystrixCollapserConfiguration>> ObserveCollapserConfiguration()
         {
-            return allConfigurationStream.Map(OnlyCollapserConfig);
+            return _allConfigurationStream.Map(OnlyCollapserConfig);
         }
 
         public int IntervalInMilliseconds
         {
-            get { return this.intervalInMilliseconds; }
+            get { return this._intervalInMilliseconds; }
         }
 
         public bool IsSourceCurrentlySubscribed
         {
-            get { return isSourceCurrentlySubscribed.Value; }
+            get { return _isSourceCurrentlySubscribed.Value; }
         }
 
         internal static HystrixConfigurationStream GetNonSingletonInstanceOnlyUsedInUnitTests(int delayInMs)

--- a/src/CircuitBreaker/src/HystrixBase/Config/HystrixConfigurationStream.cs
+++ b/src/CircuitBreaker/src/HystrixBase/Config/HystrixConfigurationStream.cs
@@ -13,7 +13,6 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Config
     public class HystrixConfigurationStream
     {
         private static int dataEmissionIntervalInMs = 5000;
-        private readonly int _intervalInMilliseconds;
         private readonly IObservable<HystrixConfiguration> _allConfigurationStream;
         private readonly AtomicBoolean _isSourceCurrentlySubscribed = new AtomicBoolean(false);
 
@@ -28,7 +27,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Config
 
         public HystrixConfigurationStream(int intervalInMilliseconds)
         {
-            this._intervalInMilliseconds = intervalInMilliseconds;
+            this.IntervalInMilliseconds = intervalInMilliseconds;
             this._allConfigurationStream = Observable.Interval(TimeSpan.FromMilliseconds(intervalInMilliseconds))
                     .Map(AllConfig)
                     .OnSubscribe(() =>
@@ -72,10 +71,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Config
             return _allConfigurationStream.Map(OnlyCollapserConfig);
         }
 
-        public int IntervalInMilliseconds
-        {
-            get { return this._intervalInMilliseconds; }
-        }
+        public int IntervalInMilliseconds { get; }
 
         public bool IsSourceCurrentlySubscribed
         {

--- a/src/CircuitBreaker/src/HystrixBase/Config/HystrixThreadPoolConfiguration.cs
+++ b/src/CircuitBreaker/src/HystrixBase/Config/HystrixThreadPoolConfiguration.cs
@@ -6,7 +6,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Config
 {
     public class HystrixThreadPoolConfiguration
     {
-        private readonly int maximumSize;
+        private readonly int _maximumSize;
 
         public HystrixThreadPoolConfiguration(
             IHystrixThreadPoolKey threadPoolKey,
@@ -21,7 +21,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Config
         {
             ThreadPoolKey = threadPoolKey;
             CoreSize = coreSize;
-            this.maximumSize = maximumSize;
+            this._maximumSize = maximumSize;
             MaxQueueSize = maxQueueSize;
             QueueRejectionThreshold = queueRejectionThreshold;
             KeepAliveTimeInMinutes = keepAliveTimeInMinutes;
@@ -54,7 +54,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Config
             {
                 if (AllowMaximumSizeToDivergeFromCoreSize)
                 {
-                    return maximumSize;
+                    return _maximumSize;
                 }
                 else
                 {

--- a/src/CircuitBreaker/src/HystrixBase/ExecutionResult.cs
+++ b/src/CircuitBreaker/src/HystrixBase/ExecutionResult.cs
@@ -55,25 +55,25 @@ namespace Steeltoe.CircuitBreaker.Hystrix
 
         public sealed class EventCounts
         {
-            private readonly BitArray events;
-            private readonly int numEmissions;
-            private readonly int numFallbackEmissions;
-            private readonly int numCollapsed;
+            private readonly BitArray _events;
+            private readonly int _numEmissions;
+            private readonly int _numFallbackEmissions;
+            private readonly int _numCollapsed;
 
             internal EventCounts()
             {
-                events = new BitArray(NUM_EVENT_TYPES);
-                numEmissions = 0;
-                numFallbackEmissions = 0;
-                numCollapsed = 0;
+                _events = new BitArray(NUM_EVENT_TYPES);
+                _numEmissions = 0;
+                _numFallbackEmissions = 0;
+                _numCollapsed = 0;
             }
 
             internal EventCounts(BitArray events, int numEmissions, int numFallbackEmissions, int numCollapsed)
             {
-                this.events = events;
-                this.numEmissions = numEmissions;
-                this.numFallbackEmissions = numFallbackEmissions;
-                this.numCollapsed = numCollapsed;
+                this._events = events;
+                this._numEmissions = numEmissions;
+                this._numFallbackEmissions = numFallbackEmissions;
+                this._numCollapsed = numCollapsed;
             }
 
             internal EventCounts(HystrixEventType[] eventTypes)
@@ -104,15 +104,15 @@ namespace Steeltoe.CircuitBreaker.Hystrix
                     }
                 }
 
-                events = newBitSet;
-                numEmissions = localNumEmits;
-                numFallbackEmissions = localNumFallbackEmits;
-                numCollapsed = localNumCollapsed;
+                _events = newBitSet;
+                _numEmissions = localNumEmits;
+                _numFallbackEmissions = localNumFallbackEmits;
+                _numCollapsed = localNumCollapsed;
             }
 
             public bool Contains(HystrixEventType eventType)
             {
-                return events.Get((int)eventType);
+                return _events.Get((int)eventType);
             }
 
             public bool ContainsAnyOf(BitArray other)
@@ -124,12 +124,12 @@ namespace Steeltoe.CircuitBreaker.Hystrix
 
                 for (int i = 0; i < other.Length; i++)
                 {
-                    if (i >= events.Length)
+                    if (i >= _events.Length)
                     {
                         return false;
                     }
 
-                    if (other[i] && events[i])
+                    if (other[i] && _events[i])
                     {
                         return true;
                     }
@@ -142,10 +142,10 @@ namespace Steeltoe.CircuitBreaker.Hystrix
             {
                 switch (eventType)
                 {
-                    case HystrixEventType.EMIT: return numEmissions;
-                    case HystrixEventType.FALLBACK_EMIT: return numFallbackEmissions;
+                    case HystrixEventType.EMIT: return _numEmissions;
+                    case HystrixEventType.FALLBACK_EMIT: return _numFallbackEmissions;
                     case HystrixEventType.EXCEPTION_THROWN: return ContainsAnyOf(EXCEPTION_PRODUCING_EVENTS) ? 1 : 0;
-                    case HystrixEventType.COLLAPSED: return numCollapsed;
+                    case HystrixEventType.COLLAPSED: return _numCollapsed;
                     default: return Contains(eventType) ? 1 : 0;
                 }
             }
@@ -164,40 +164,40 @@ namespace Steeltoe.CircuitBreaker.Hystrix
 
                 EventCounts that = (EventCounts)o;
 
-                if (numEmissions != that.numEmissions)
+                if (_numEmissions != that._numEmissions)
                 {
                     return false;
                 }
 
-                if (numFallbackEmissions != that.numFallbackEmissions)
+                if (_numFallbackEmissions != that._numFallbackEmissions)
                 {
                     return false;
                 }
 
-                if (numCollapsed != that.numCollapsed)
+                if (_numCollapsed != that._numCollapsed)
                 {
                     return false;
                 }
 
-                return Equals(that.events);
+                return Equals(that._events);
             }
 
             public override int GetHashCode()
             {
-                int result = GetHashCode(events);
-                result = (31 * result) + numEmissions;
-                result = (31 * result) + numFallbackEmissions;
-                result = (31 * result) + numCollapsed;
+                int result = GetHashCode(_events);
+                result = (31 * result) + _numEmissions;
+                result = (31 * result) + _numFallbackEmissions;
+                result = (31 * result) + _numCollapsed;
                 return result;
             }
 
             public override string ToString()
             {
                 return "EventCounts{" +
-                        "events=" + events +
-                        ", numEmissions=" + numEmissions +
-                        ", numFallbackEmissions=" + numFallbackEmissions +
-                        ", numCollapsed=" + numCollapsed +
+                        "events=" + _events +
+                        ", numEmissions=" + _numEmissions +
+                        ", numFallbackEmissions=" + _numFallbackEmissions +
+                        ", numCollapsed=" + _numCollapsed +
                         '}';
             }
 
@@ -208,10 +208,10 @@ namespace Steeltoe.CircuitBreaker.Hystrix
 
             internal EventCounts Plus(HystrixEventType eventType, int count)
             {
-                BitArray newBitSet = new BitArray(events);
-                int localNumEmits = numEmissions;
-                int localNumFallbackEmits = numFallbackEmissions;
-                int localNumCollapsed = numCollapsed;
+                BitArray newBitSet = new BitArray(_events);
+                int localNumEmits = _numEmissions;
+                int localNumFallbackEmits = _numFallbackEmissions;
+                int localNumCollapsed = _numCollapsed;
                 switch (eventType)
                 {
                     case HystrixEventType.EMIT:
@@ -236,14 +236,14 @@ namespace Steeltoe.CircuitBreaker.Hystrix
 
             private bool Equals(BitArray other)
             {
-                if (other.Length != events.Length)
+                if (other.Length != _events.Length)
                 {
                     return false;
                 }
 
-                for (int i = 0; i < events.Length; i++)
+                for (int i = 0; i < _events.Length; i++)
                 {
-                    if (events[i] != other[i])
+                    if (_events[i] != other[i])
                     {
                         return false;
                     }

--- a/src/CircuitBreaker/src/HystrixBase/HystrixCollapser.cs
+++ b/src/CircuitBreaker/src/HystrixBase/HystrixCollapser.cs
@@ -25,9 +25,9 @@ namespace Steeltoe.CircuitBreaker.Hystrix
     {
         protected internal CancellationToken _token;
 
-        private readonly RequestCollapserFactory collapserFactory;
-        private readonly HystrixRequestCache requestCache;
-        private readonly HystrixCollapserMetrics metrics;
+        private readonly RequestCollapserFactory _collapserFactory;
+        private readonly HystrixRequestCache _requestCache;
+        private readonly HystrixCollapserMetrics _metrics;
 
         protected HystrixCollapser()
             : this(null, RequestCollapserScope.REQUEST)
@@ -63,30 +63,30 @@ namespace Steeltoe.CircuitBreaker.Hystrix
             }
 
             IHystrixCollapserOptions options = HystrixOptionsFactory.GetCollapserOptions(collapserKey, optionsDefault);
-            collapserFactory = new RequestCollapserFactory(collapserKey, scope, timer, options);
-            requestCache = HystrixRequestCache.GetInstance(collapserKey);
+            _collapserFactory = new RequestCollapserFactory(collapserKey, scope, timer, options);
+            _requestCache = HystrixRequestCache.GetInstance(collapserKey);
 
             if (metrics == null)
             {
-                this.metrics = HystrixCollapserMetrics.GetInstance(collapserKey, options);
+                this._metrics = HystrixCollapserMetrics.GetInstance(collapserKey, options);
             }
             else
             {
-                this.metrics = metrics;
+                this._metrics = metrics;
             }
 
-            HystrixMetricsPublisherFactory.CreateOrRetrievePublisherForCollapser(collapserKey, this.metrics, options);
+            HystrixMetricsPublisherFactory.CreateOrRetrievePublisherForCollapser(collapserKey, this._metrics, options);
         }
 
-        public virtual IHystrixCollapserKey CollapserKey => collapserFactory.CollapserKey;
+        public virtual IHystrixCollapserKey CollapserKey => _collapserFactory.CollapserKey;
 
-        public virtual RequestCollapserScope Scope => collapserFactory.Scope;
+        public virtual RequestCollapserScope Scope => _collapserFactory.Scope;
 
-        public virtual HystrixCollapserMetrics Metrics => metrics;
+        public virtual HystrixCollapserMetrics Metrics => _metrics;
 
         public abstract RequestArgumentType RequestArgument { get; }
 
-        private IHystrixCollapserOptions Properties => collapserFactory.Properties;
+        private IHystrixCollapserOptions Properties => _collapserFactory.Properties;
 
         public RequestResponseType Execute()
         {
@@ -114,12 +114,12 @@ namespace Steeltoe.CircuitBreaker.Hystrix
 
         public Task<RequestResponseType> ToTask()
         {
-            RequestCollapser<BatchReturnType, RequestResponseType, RequestArgumentType> requestCollapser = collapserFactory.GetRequestCollapser(this);
+            RequestCollapser<BatchReturnType, RequestResponseType, RequestArgumentType> requestCollapser = _collapserFactory.GetRequestCollapser(this);
             CollapsedRequest<RequestResponseType, RequestArgumentType> request = null;
 
             if (AddCacheEntryIfAbsent(CacheKey, out HystrixCachedTask<RequestResponseType> entry))
             {
-                metrics.MarkResponseFromCache();
+                _metrics.MarkResponseFromCache();
                 var origTask = entry.CachedTask;
                 request = entry.CachedTask.AsyncState as CollapsedRequest<RequestResponseType, RequestArgumentType>;
                 request.AddLinkedToken(_token);
@@ -199,7 +199,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix
             var newEntry = new HystrixCachedTask<RequestResponseType>();
             if (Properties.RequestCacheEnabled && cacheKey != null)
             {
-                entry = requestCache.PutIfAbsent(cacheKey, newEntry);
+                entry = _requestCache.PutIfAbsent(cacheKey, newEntry);
                 if (entry != null)
                 {
                     return true;
@@ -221,7 +221,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix
         {
             ICollection<ICollapsedRequest<RequestResponseType, RequestArgumentType>> theRequests = new List<ICollapsedRequest<RequestResponseType, RequestArgumentType>>(requests);
             ICollection<ICollection<ICollapsedRequest<RequestResponseType, RequestArgumentType>>> shards = ShardRequests(theRequests);
-            metrics.MarkShards(shards.Count);
+            _metrics.MarkShards(shards.Count);
             return shards;
         }
 
@@ -230,7 +230,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix
             HystrixCommand<BatchReturnType> command = CreateCommand(requests);
 
             command.MarkAsCollapsedCommand(CollapserKey, requests.Count);
-            metrics.MarkBatch(requests.Count);
+            _metrics.MarkBatch(requests.Count);
 
             return command;
         }

--- a/src/CircuitBreaker/src/HystrixBase/HystrixCollapserMetrics.cs
+++ b/src/CircuitBreaker/src/HystrixBase/HystrixCollapserMetrics.cs
@@ -65,9 +65,9 @@ namespace Steeltoe.CircuitBreaker.Hystrix
             Metrics.Clear();
         }
 
-        private readonly RollingCollapserEventCounterStream rollingCollapserEventCounterStream;
-        private readonly CumulativeCollapserEventCounterStream cumulativeCollapserEventCounterStream;
-        private readonly RollingCollapserBatchSizeDistributionStream rollingCollapserBatchSizeDistributionStream;
+        private readonly RollingCollapserEventCounterStream _rollingCollapserEventCounterStream;
+        private readonly CumulativeCollapserEventCounterStream _cumulativeCollapserEventCounterStream;
+        private readonly RollingCollapserBatchSizeDistributionStream _rollingCollapserBatchSizeDistributionStream;
 
         internal HystrixCollapserMetrics(IHystrixCollapserKey key, IHystrixCollapserOptions properties)
             : base(null)
@@ -75,9 +75,9 @@ namespace Steeltoe.CircuitBreaker.Hystrix
             CollapserKey = key;
             Properties = properties;
 
-            rollingCollapserEventCounterStream = RollingCollapserEventCounterStream.GetInstance(key, properties);
-            cumulativeCollapserEventCounterStream = CumulativeCollapserEventCounterStream.GetInstance(key, properties);
-            rollingCollapserBatchSizeDistributionStream = RollingCollapserBatchSizeDistributionStream.GetInstance(key, properties);
+            _rollingCollapserEventCounterStream = RollingCollapserEventCounterStream.GetInstance(key, properties);
+            _cumulativeCollapserEventCounterStream = CumulativeCollapserEventCounterStream.GetInstance(key, properties);
+            _rollingCollapserBatchSizeDistributionStream = RollingCollapserBatchSizeDistributionStream.GetInstance(key, properties);
         }
 
         public IHystrixCollapserKey CollapserKey { get; }
@@ -86,7 +86,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix
 
         public long GetRollingCount(CollapserEventType collapserEventType)
         {
-            return rollingCollapserEventCounterStream.GetLatest(collapserEventType);
+            return _rollingCollapserEventCounterStream.GetLatest(collapserEventType);
         }
 
         public override long GetRollingCount(HystrixRollingNumberEvent @event)
@@ -96,7 +96,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix
 
         public long GetCumulativeCount(CollapserEventType collapserEventType)
         {
-            return cumulativeCollapserEventCounterStream.GetLatest(collapserEventType);
+            return _cumulativeCollapserEventCounterStream.GetLatest(collapserEventType);
         }
 
         public override long GetCumulativeCount(HystrixRollingNumberEvent @event)
@@ -106,12 +106,12 @@ namespace Steeltoe.CircuitBreaker.Hystrix
 
         public int GetBatchSizePercentile(double percentile)
         {
-            return rollingCollapserBatchSizeDistributionStream.GetLatestPercentile(percentile);
+            return _rollingCollapserBatchSizeDistributionStream.GetLatestPercentile(percentile);
         }
 
         public int BatchSizeMean
         {
-            get { return rollingCollapserBatchSizeDistributionStream.LatestMean; }
+            get { return _rollingCollapserBatchSizeDistributionStream.LatestMean; }
         }
 
         public int GetShardSizePercentile(double percentile)

--- a/src/CircuitBreaker/src/HystrixBase/HystrixCollapserOptions.cs
+++ b/src/CircuitBreaker/src/HystrixBase/HystrixCollapserOptions.cs
@@ -19,7 +19,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix
         internal const int DEFAULT_METRICS_ROLLING_PERCENTILE_BUCKET_SIZE = 100; // default to 100 values max per bucket
 
         protected const string HYSTRIX_COLLAPSER_PREFIX = "hystrix:collapser";
-        private IHystrixCollapserOptions defaults;
+        private IHystrixCollapserOptions _defaults;
 
         public HystrixCollapserOptions(IHystrixCollapserKey collapserKey, IHystrixCollapserOptions defaults = null, IHystrixDynamicOptions dynamic = null)
             : this(collapserKey, RequestCollapserScope.REQUEST, defaults, dynamic)
@@ -31,7 +31,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix
         {
             this.CollapserKey = key;
             this.Scope = scope;
-            this.defaults = defaults;
+            this._defaults = defaults;
 
             MaxRequestsInBatch = GetInteger(HYSTRIX_COLLAPSER_PREFIX, key.Name, "maxRequestsInBatch", DEFAULT_MAX_REQUESTS_IN_BATCH, defaults?.MaxRequestsInBatch);
             TimerDelayInMilliseconds = GetInteger(HYSTRIX_COLLAPSER_PREFIX, key.Name, "timerDelayInMilliseconds", DEFAULT_TIMER_DELAY_IN_MILLISECONDS, defaults?.TimerDelayInMilliseconds);

--- a/src/CircuitBreaker/src/HystrixBase/HystrixCommandMetrics.cs
+++ b/src/CircuitBreaker/src/HystrixBase/HystrixCommandMetrics.cs
@@ -118,17 +118,17 @@ namespace Steeltoe.CircuitBreaker.Hystrix
             Metrics.Clear();
         }
 
-        private readonly AtomicInteger concurrentExecutionCount = new AtomicInteger();
+        private readonly AtomicInteger _concurrentExecutionCount = new AtomicInteger();
 
-        private readonly RollingCommandEventCounterStream rollingCommandEventCounterStream;
-        private readonly CumulativeCommandEventCounterStream cumulativeCommandEventCounterStream;
-        private readonly RollingCommandLatencyDistributionStream rollingCommandLatencyDistributionStream;
-        private readonly RollingCommandUserLatencyDistributionStream rollingCommandUserLatencyDistributionStream;
-        private readonly RollingCommandMaxConcurrencyStream rollingCommandMaxConcurrencyStream;
+        private readonly RollingCommandEventCounterStream _rollingCommandEventCounterStream;
+        private readonly CumulativeCommandEventCounterStream _cumulativeCommandEventCounterStream;
+        private readonly RollingCommandLatencyDistributionStream _rollingCommandLatencyDistributionStream;
+        private readonly RollingCommandUserLatencyDistributionStream _rollingCommandUserLatencyDistributionStream;
+        private readonly RollingCommandMaxConcurrencyStream _rollingCommandMaxConcurrencyStream;
 
         private readonly object _syncLock = new object();
 
-        private HealthCountsStream healthCountsStream;
+        private HealthCountsStream _healthCountsStream;
 
         internal HystrixCommandMetrics(IHystrixCommandKey key, IHystrixCommandGroupKey commandGroup, IHystrixThreadPoolKey threadPoolKey, IHystrixCommandOptions properties, HystrixEventNotifier eventNotifier)
             : base(null)
@@ -138,13 +138,13 @@ namespace Steeltoe.CircuitBreaker.Hystrix
             ThreadPoolKey = threadPoolKey;
             Properties = properties;
 
-            healthCountsStream = HealthCountsStream.GetInstance(key, properties);
-            rollingCommandEventCounterStream = RollingCommandEventCounterStream.GetInstance(key, properties);
-            cumulativeCommandEventCounterStream = CumulativeCommandEventCounterStream.GetInstance(key, properties);
+            _healthCountsStream = HealthCountsStream.GetInstance(key, properties);
+            _rollingCommandEventCounterStream = RollingCommandEventCounterStream.GetInstance(key, properties);
+            _cumulativeCommandEventCounterStream = CumulativeCommandEventCounterStream.GetInstance(key, properties);
 
-            rollingCommandLatencyDistributionStream = RollingCommandLatencyDistributionStream.GetInstance(key, properties);
-            rollingCommandUserLatencyDistributionStream = RollingCommandUserLatencyDistributionStream.GetInstance(key, properties);
-            rollingCommandMaxConcurrencyStream = RollingCommandMaxConcurrencyStream.GetInstance(key, properties);
+            _rollingCommandLatencyDistributionStream = RollingCommandLatencyDistributionStream.GetInstance(key, properties);
+            _rollingCommandUserLatencyDistributionStream = RollingCommandUserLatencyDistributionStream.GetInstance(key, properties);
+            _rollingCommandMaxConcurrencyStream = RollingCommandMaxConcurrencyStream.GetInstance(key, properties);
         }
 
         /* package */
@@ -152,9 +152,9 @@ namespace Steeltoe.CircuitBreaker.Hystrix
         {
             lock (_syncLock)
             {
-                healthCountsStream.Unsubscribe();
+                _healthCountsStream.Unsubscribe();
                 HealthCountsStream.RemoveByKey(CommandKey);
-                healthCountsStream = HealthCountsStream.GetInstance(CommandKey, Properties);
+                _healthCountsStream = HealthCountsStream.GetInstance(CommandKey, Properties);
             }
         }
 
@@ -168,7 +168,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix
 
         public long GetRollingCount(HystrixEventType eventType)
         {
-            return rollingCommandEventCounterStream.GetLatest(eventType);
+            return _rollingCommandEventCounterStream.GetLatest(eventType);
         }
 
         public override long GetRollingCount(HystrixRollingNumberEvent @event)
@@ -178,7 +178,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix
 
         public long GetCumulativeCount(HystrixEventType eventType)
         {
-            return cumulativeCommandEventCounterStream.GetLatest(eventType);
+            return _cumulativeCommandEventCounterStream.GetLatest(eventType);
         }
 
         public override long GetCumulativeCount(HystrixRollingNumberEvent @event)
@@ -188,28 +188,28 @@ namespace Steeltoe.CircuitBreaker.Hystrix
 
         public int GetExecutionTimePercentile(double percentile)
         {
-            return rollingCommandLatencyDistributionStream.GetLatestPercentile(percentile);
+            return _rollingCommandLatencyDistributionStream.GetLatestPercentile(percentile);
         }
 
         public int ExecutionTimeMean
         {
-            get { return rollingCommandLatencyDistributionStream.LatestMean; }
+            get { return _rollingCommandLatencyDistributionStream.LatestMean; }
         }
 
         public int GetTotalTimePercentile(double percentile)
         {
-            return rollingCommandUserLatencyDistributionStream.GetLatestPercentile(percentile);
+            return _rollingCommandUserLatencyDistributionStream.GetLatestPercentile(percentile);
         }
 
-        public int TotalTimeMean => rollingCommandUserLatencyDistributionStream.LatestMean;
+        public int TotalTimeMean => _rollingCommandUserLatencyDistributionStream.LatestMean;
 
-        public long RollingMaxConcurrentExecutions => rollingCommandMaxConcurrencyStream.LatestRollingMax;
+        public long RollingMaxConcurrentExecutions => _rollingCommandMaxConcurrencyStream.LatestRollingMax;
 
-        public int CurrentConcurrentExecutionCount => concurrentExecutionCount.Value;
+        public int CurrentConcurrentExecutionCount => _concurrentExecutionCount.Value;
 
         internal void MarkCommandStart(IHystrixCommandKey commandKey, IHystrixThreadPoolKey threadPoolKey, ExecutionIsolationStrategy isolationStrategy)
         {
-            int currentCount = concurrentExecutionCount.IncrementAndGet();
+            int currentCount = _concurrentExecutionCount.IncrementAndGet();
             HystrixThreadEventStream.GetInstance().CommandExecutionStarted(commandKey, threadPoolKey, isolationStrategy, currentCount);
         }
 
@@ -218,20 +218,20 @@ namespace Steeltoe.CircuitBreaker.Hystrix
             HystrixThreadEventStream.GetInstance().ExecutionDone(executionResult, commandKey, threadPoolKey);
             if (executionStarted)
             {
-                concurrentExecutionCount.DecrementAndGet();
+                _concurrentExecutionCount.DecrementAndGet();
             }
         }
 
-        public HealthCounts Healthcounts => healthCountsStream.Latest;
+        public HealthCounts Healthcounts => _healthCountsStream.Latest;
 
         private void UnsubscribeAll()
         {
-            healthCountsStream.Unsubscribe();
-            rollingCommandEventCounterStream.Unsubscribe();
-            cumulativeCommandEventCounterStream.Unsubscribe();
-            rollingCommandLatencyDistributionStream.Unsubscribe();
-            rollingCommandUserLatencyDistributionStream.Unsubscribe();
-            rollingCommandMaxConcurrencyStream.Unsubscribe();
+            _healthCountsStream.Unsubscribe();
+            _rollingCommandEventCounterStream.Unsubscribe();
+            _cumulativeCommandEventCounterStream.Unsubscribe();
+            _rollingCommandLatencyDistributionStream.Unsubscribe();
+            _rollingCommandUserLatencyDistributionStream.Unsubscribe();
+            _rollingCommandMaxConcurrencyStream.Unsubscribe();
         }
     }
 }

--- a/src/CircuitBreaker/src/HystrixBase/HystrixRequestCache.cs
+++ b/src/CircuitBreaker/src/HystrixBase/HystrixRequestCache.cs
@@ -42,11 +42,11 @@ namespace Steeltoe.CircuitBreaker.Hystrix
             return Caches.GetOrAddEx(rcKey, (k) => new HystrixRequestCache(rcKey));
         }
 
-        private readonly RequestCacheKey rcKey;
+        private readonly RequestCacheKey _rcKey;
 
         private HystrixRequestCache(RequestCacheKey rcKey)
         {
-            this.rcKey = rcKey;
+            this._rcKey = rcKey;
         }
 
         public T Get<T>(string cacheKey)
@@ -103,7 +103,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix
             if (cacheKey != null)
             {
                 /* create the cache key we will use to retrieve/store that include the type key prefix */
-                return new ValueCacheKey(rcKey, cacheKey);
+                return new ValueCacheKey(_rcKey, cacheKey);
             }
 
             return null;
@@ -111,21 +111,21 @@ namespace Steeltoe.CircuitBreaker.Hystrix
 
         private class ValueCacheKey
         {
-            private readonly RequestCacheKey rvKey;
-            private readonly string valueCacheKey;
+            private readonly RequestCacheKey _rvKey;
+            private readonly string _valueCacheKey;
 
             public ValueCacheKey(RequestCacheKey rvKey, string valueCacheKey)
             {
-                this.rvKey = rvKey;
-                this.valueCacheKey = valueCacheKey;
+                this._rvKey = rvKey;
+                this._valueCacheKey = valueCacheKey;
             }
 
             public override int GetHashCode()
             {
                 int prime = 31;
                 int result = 1;
-                result = (prime * result) + ((rvKey == null) ? 0 : rvKey.GetHashCode());
-                result = (prime * result) + ((valueCacheKey == null) ? 0 : valueCacheKey.GetHashCode());
+                result = (prime * result) + ((_rvKey == null) ? 0 : _rvKey.GetHashCode());
+                result = (prime * result) + ((_valueCacheKey == null) ? 0 : _valueCacheKey.GetHashCode());
                 return result;
             }
 
@@ -147,26 +147,26 @@ namespace Steeltoe.CircuitBreaker.Hystrix
                 }
 
                 ValueCacheKey other = (ValueCacheKey)obj;
-                if (rvKey == null)
+                if (_rvKey == null)
                 {
-                    if (other.rvKey != null)
+                    if (other._rvKey != null)
                     {
                         return false;
                     }
                 }
-                else if (!rvKey.Equals(other.rvKey))
+                else if (!_rvKey.Equals(other._rvKey))
                 {
                     return false;
                 }
 
-                if (valueCacheKey == null)
+                if (_valueCacheKey == null)
                 {
-                    if (other.valueCacheKey != null)
+                    if (other._valueCacheKey != null)
                     {
                         return false;
                     }
                 }
-                else if (!valueCacheKey.Equals(other.valueCacheKey))
+                else if (!_valueCacheKey.Equals(other._valueCacheKey))
                 {
                     return false;
                 }
@@ -177,32 +177,32 @@ namespace Steeltoe.CircuitBreaker.Hystrix
 
         private class RequestCacheKey
         {
-            private readonly short type; // used to differentiate between Collapser/Command if key is same between them
-            private readonly string key;
+            private readonly short _type; // used to differentiate between Collapser/Command if key is same between them
+            private readonly string _key;
 
             public RequestCacheKey(IHystrixCommandKey commandKey)
             {
-                type = 1;
+                _type = 1;
                 if (commandKey == null)
                 {
-                    this.key = null;
+                    this._key = null;
                 }
                 else
                 {
-                    this.key = commandKey.Name;
+                    this._key = commandKey.Name;
                 }
             }
 
             public RequestCacheKey(IHystrixCollapserKey collapserKey)
             {
-                type = 2;
+                _type = 2;
                 if (collapserKey == null)
                 {
-                    this.key = null;
+                    this._key = null;
                 }
                 else
                 {
-                    this.key = collapserKey.Name;
+                    this._key = collapserKey.Name;
                 }
             }
 
@@ -210,8 +210,8 @@ namespace Steeltoe.CircuitBreaker.Hystrix
             {
                 int prime = 31;
                 int result = 1;
-                result = (prime * result) + ((key == null) ? 0 : key.GetHashCode());
-                result = (prime * result) + type;
+                result = (prime * result) + ((_key == null) ? 0 : _key.GetHashCode());
+                result = (prime * result) + _type;
                 return result;
             }
 
@@ -233,19 +233,19 @@ namespace Steeltoe.CircuitBreaker.Hystrix
                 }
 
                 RequestCacheKey other = (RequestCacheKey)obj;
-                if (type != other.type)
+                if (_type != other._type)
                 {
                     return false;
                 }
 
-                if (key == null)
+                if (_key == null)
                 {
-                    if (other.key != null)
+                    if (other._key != null)
                     {
                         return false;
                     }
                 }
-                else if (!key.Equals(other.key))
+                else if (!_key.Equals(other._key))
                 {
                     return false;
                 }

--- a/src/CircuitBreaker/src/HystrixBase/HystrixRequestLog.cs
+++ b/src/CircuitBreaker/src/HystrixBase/HystrixRequestLog.cs
@@ -43,7 +43,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix
         }
 
         protected internal const int MAX_STORAGE = 1000;
-        private BlockingCollection<IHystrixInvokableInfo> allExecutedCommands = new BlockingCollection<IHystrixInvokableInfo>(MAX_STORAGE);
+        private BlockingCollection<IHystrixInvokableInfo> _allExecutedCommands = new BlockingCollection<IHystrixInvokableInfo>(MAX_STORAGE);
 
         internal HystrixRequestLog()
         {
@@ -51,7 +51,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix
 
         internal void AddExecutedCommand(IHystrixInvokableInfo command)
         {
-            if (!allExecutedCommands.TryAdd(command))
+            if (!_allExecutedCommands.TryAdd(command))
             {
                 // see RequestLog: Reduce Chance of Memory Leak https://github.com/Netflix/Hystrix/issues/53
                 // logger.warn("RequestLog ignoring command after reaching limit of " + MAX_STORAGE + ". See https://github.com/Netflix/Hystrix/issues/53 for more information.");
@@ -62,7 +62,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix
         {
             get
             {
-                return allExecutedCommands.ToList().AsReadOnly();
+                return _allExecutedCommands.ToList().AsReadOnly();
             }
         }
 
@@ -75,7 +75,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix
 
                 StringBuilder builder = new StringBuilder();
                 int estimatedLength = 0;
-                foreach (IHystrixInvokableInfo command in allExecutedCommands)
+                foreach (IHystrixInvokableInfo command in _allExecutedCommands)
                 {
                     builder.Length = 0;
                     builder.Append(command.CommandKey.Name);

--- a/src/CircuitBreaker/src/HystrixBase/HystrixThreadPoolMetrics.cs
+++ b/src/CircuitBreaker/src/HystrixBase/HystrixThreadPoolMetrics.cs
@@ -87,11 +87,11 @@ namespace Steeltoe.CircuitBreaker.Hystrix
             Metrics.Clear();
         }
 
-        private readonly AtomicInteger concurrentExecutionCount = new AtomicInteger();
+        private readonly AtomicInteger _concurrentExecutionCount = new AtomicInteger();
 
-        private readonly RollingThreadPoolEventCounterStream rollingCounterStream;
-        private readonly CumulativeThreadPoolEventCounterStream cumulativeCounterStream;
-        private readonly RollingThreadPoolMaxConcurrencyStream rollingThreadPoolMaxConcurrencyStream;
+        private readonly RollingThreadPoolEventCounterStream _rollingCounterStream;
+        private readonly CumulativeThreadPoolEventCounterStream _cumulativeCounterStream;
+        private readonly RollingThreadPoolMaxConcurrencyStream _rollingThreadPoolMaxConcurrencyStream;
 
         private HystrixThreadPoolMetrics(IHystrixThreadPoolKey threadPoolKey, IHystrixTaskScheduler threadPool, IHystrixThreadPoolOptions properties)
             : base(null)
@@ -100,16 +100,16 @@ namespace Steeltoe.CircuitBreaker.Hystrix
             TaskScheduler = threadPool;
             Properties = properties;
 
-            rollingCounterStream = RollingThreadPoolEventCounterStream.GetInstance(threadPoolKey, properties);
-            cumulativeCounterStream = CumulativeThreadPoolEventCounterStream.GetInstance(threadPoolKey, properties);
-            rollingThreadPoolMaxConcurrencyStream = RollingThreadPoolMaxConcurrencyStream.GetInstance(threadPoolKey, properties);
+            _rollingCounterStream = RollingThreadPoolEventCounterStream.GetInstance(threadPoolKey, properties);
+            _cumulativeCounterStream = CumulativeThreadPoolEventCounterStream.GetInstance(threadPoolKey, properties);
+            _rollingThreadPoolMaxConcurrencyStream = RollingThreadPoolMaxConcurrencyStream.GetInstance(threadPoolKey, properties);
         }
 
         public static Func<int> GetCurrentConcurrencyThunk(IHystrixThreadPoolKey threadPoolKey)
         {
             return () =>
             {
-                return GetInstance(threadPoolKey).concurrentExecutionCount.Value;
+                return GetInstance(threadPoolKey)._concurrentExecutionCount.Value;
             };
         }
 
@@ -137,50 +137,50 @@ namespace Steeltoe.CircuitBreaker.Hystrix
 
         public void MarkThreadExecution()
         {
-            concurrentExecutionCount.IncrementAndGet();
+            _concurrentExecutionCount.IncrementAndGet();
         }
 
-        public long RollingCountThreadsExecuted => rollingCounterStream.GetLatestCount(ThreadPoolEventType.EXECUTED);
+        public long RollingCountThreadsExecuted => _rollingCounterStream.GetLatestCount(ThreadPoolEventType.EXECUTED);
 
-        public long CumulativeCountThreadsExecuted => cumulativeCounterStream.GetLatestCount(ThreadPoolEventType.EXECUTED);
+        public long CumulativeCountThreadsExecuted => _cumulativeCounterStream.GetLatestCount(ThreadPoolEventType.EXECUTED);
 
-        public long RollingCountThreadsRejected => rollingCounterStream.GetLatestCount(ThreadPoolEventType.REJECTED);
+        public long RollingCountThreadsRejected => _rollingCounterStream.GetLatestCount(ThreadPoolEventType.REJECTED);
 
-        public long CumulativeCountThreadsRejected => cumulativeCounterStream.GetLatestCount(ThreadPoolEventType.REJECTED);
+        public long CumulativeCountThreadsRejected => _cumulativeCounterStream.GetLatestCount(ThreadPoolEventType.REJECTED);
 
         public long GetRollingCount(ThreadPoolEventType @event)
         {
-            return rollingCounterStream.GetLatestCount(@event);
+            return _rollingCounterStream.GetLatestCount(@event);
         }
 
         public override long GetRollingCount(HystrixRollingNumberEvent @event)
         {
-            return rollingCounterStream.GetLatestCount(ThreadPoolEventTypeHelper.From(@event));
+            return _rollingCounterStream.GetLatestCount(ThreadPoolEventTypeHelper.From(@event));
         }
 
         public long GetCumulativeCount(ThreadPoolEventType @event)
         {
-            return cumulativeCounterStream.GetLatestCount(@event);
+            return _cumulativeCounterStream.GetLatestCount(@event);
         }
 
         public override long GetCumulativeCount(HystrixRollingNumberEvent @event)
         {
-            return cumulativeCounterStream.GetLatestCount(ThreadPoolEventTypeHelper.From(@event));
+            return _cumulativeCounterStream.GetLatestCount(ThreadPoolEventTypeHelper.From(@event));
         }
 
         public void MarkThreadCompletion()
         {
-            concurrentExecutionCount.DecrementAndGet();
+            _concurrentExecutionCount.DecrementAndGet();
         }
 
         public long RollingMaxActiveThreads
         {
-            get { return rollingThreadPoolMaxConcurrencyStream.LatestRollingMax; }
+            get { return _rollingThreadPoolMaxConcurrencyStream.LatestRollingMax; }
         }
 
         public void MarkThreadRejection()
         {
-            concurrentExecutionCount.DecrementAndGet();
+            _concurrentExecutionCount.DecrementAndGet();
         }
     }
 }

--- a/src/CircuitBreaker/src/HystrixBase/IHystrixKey.cs
+++ b/src/CircuitBreaker/src/HystrixBase/IHystrixKey.cs
@@ -13,21 +13,16 @@ namespace Steeltoe.CircuitBreaker.Hystrix
 
     public abstract class HystrixKeyDefault : IHystrixKey
     {
-        private readonly string _name;
-
         public HystrixKeyDefault(string name)
         {
-            this._name = name;
+            this.Name = name;
         }
 
-        public string Name
-        {
-            get { return _name; }
-        }
+        public string Name { get; }
 
         public override string ToString()
         {
-            return _name;
+            return Name;
         }
     }
 }

--- a/src/CircuitBreaker/src/HystrixBase/IHystrixKey.cs
+++ b/src/CircuitBreaker/src/HystrixBase/IHystrixKey.cs
@@ -13,21 +13,21 @@ namespace Steeltoe.CircuitBreaker.Hystrix
 
     public abstract class HystrixKeyDefault : IHystrixKey
     {
-        private readonly string name;
+        private readonly string _name;
 
         public HystrixKeyDefault(string name)
         {
-            this.name = name;
+            this._name = name;
         }
 
         public string Name
         {
-            get { return name; }
+            get { return _name; }
         }
 
         public override string ToString()
         {
-            return name;
+            return _name;
         }
     }
 }

--- a/src/CircuitBreaker/src/HystrixBase/Metric/CachedValuesHistogram.cs
+++ b/src/CircuitBreaker/src/HystrixBase/Metric/CachedValuesHistogram.cs
@@ -11,35 +11,35 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric
     {
         private const int NUMBER_SIGNIFICANT_DIGITS = 3;
 
-        private readonly int mean;
-        private readonly int p0;
-        private readonly int p5;
-        private readonly int p10;
-        private readonly int p15;
-        private readonly int p20;
-        private readonly int p25;
-        private readonly int p30;
-        private readonly int p35;
-        private readonly int p40;
-        private readonly int p45;
-        private readonly int p50;
-        private readonly int p55;
-        private readonly int p60;
-        private readonly int p65;
-        private readonly int p70;
-        private readonly int p75;
-        private readonly int p80;
-        private readonly int p85;
-        private readonly int p90;
-        private readonly int p95;
-        private readonly int p99;
-        private readonly int p99_5;
-        private readonly int p99_9;
-        private readonly int p99_95;
-        private readonly int p99_99;
-        private readonly int p100;
+        private readonly int _mean;
+        private readonly int _p0;
+        private readonly int _p5;
+        private readonly int _p10;
+        private readonly int _p15;
+        private readonly int _p20;
+        private readonly int _p25;
+        private readonly int _p30;
+        private readonly int _p35;
+        private readonly int _p40;
+        private readonly int _p45;
+        private readonly int _p50;
+        private readonly int _p55;
+        private readonly int _p60;
+        private readonly int _p65;
+        private readonly int _p70;
+        private readonly int _p75;
+        private readonly int _p80;
+        private readonly int _p85;
+        private readonly int _p90;
+        private readonly int _p95;
+        private readonly int _p99;
+        private readonly int _p99_5;
+        private readonly int _p99_9;
+        private readonly int _p99_95;
+        private readonly int _p99_99;
+        private readonly int _p100;
 
-        private readonly long totalCount;
+        private readonly long _totalCount;
 
         public static LongHistogram GetNewHistogram()
         {
@@ -62,42 +62,42 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric
              */
             if (underlying.TotalCount > 0)
             {
-                mean = (int)underlying.GetMean();
-                p0 = (int)underlying.GetValueAtPercentile(0);
-                p5 = (int)underlying.GetValueAtPercentile(5);
-                p10 = (int)underlying.GetValueAtPercentile(10);
-                p15 = (int)underlying.GetValueAtPercentile(15);
-                p20 = (int)underlying.GetValueAtPercentile(20);
-                p25 = (int)underlying.GetValueAtPercentile(25);
-                p30 = (int)underlying.GetValueAtPercentile(30);
-                p35 = (int)underlying.GetValueAtPercentile(35);
-                p40 = (int)underlying.GetValueAtPercentile(40);
-                p45 = (int)underlying.GetValueAtPercentile(45);
-                p50 = (int)underlying.GetValueAtPercentile(50);
-                p55 = (int)underlying.GetValueAtPercentile(55);
-                p60 = (int)underlying.GetValueAtPercentile(60);
-                p65 = (int)underlying.GetValueAtPercentile(65);
-                p70 = (int)underlying.GetValueAtPercentile(70);
-                p75 = (int)underlying.GetValueAtPercentile(75);
-                p80 = (int)underlying.GetValueAtPercentile(80);
-                p85 = (int)underlying.GetValueAtPercentile(85);
-                p90 = (int)underlying.GetValueAtPercentile(90);
-                p95 = (int)underlying.GetValueAtPercentile(95);
-                p99 = (int)underlying.GetValueAtPercentile(99);
-                p99_5 = (int)underlying.GetValueAtPercentile(99.5);
-                p99_9 = (int)underlying.GetValueAtPercentile(99.9);
-                p99_95 = (int)underlying.GetValueAtPercentile(99.95);
-                p99_99 = (int)underlying.GetValueAtPercentile(99.99);
-                p100 = (int)underlying.GetValueAtPercentile(100);
+                _mean = (int)underlying.GetMean();
+                _p0 = (int)underlying.GetValueAtPercentile(0);
+                _p5 = (int)underlying.GetValueAtPercentile(5);
+                _p10 = (int)underlying.GetValueAtPercentile(10);
+                _p15 = (int)underlying.GetValueAtPercentile(15);
+                _p20 = (int)underlying.GetValueAtPercentile(20);
+                _p25 = (int)underlying.GetValueAtPercentile(25);
+                _p30 = (int)underlying.GetValueAtPercentile(30);
+                _p35 = (int)underlying.GetValueAtPercentile(35);
+                _p40 = (int)underlying.GetValueAtPercentile(40);
+                _p45 = (int)underlying.GetValueAtPercentile(45);
+                _p50 = (int)underlying.GetValueAtPercentile(50);
+                _p55 = (int)underlying.GetValueAtPercentile(55);
+                _p60 = (int)underlying.GetValueAtPercentile(60);
+                _p65 = (int)underlying.GetValueAtPercentile(65);
+                _p70 = (int)underlying.GetValueAtPercentile(70);
+                _p75 = (int)underlying.GetValueAtPercentile(75);
+                _p80 = (int)underlying.GetValueAtPercentile(80);
+                _p85 = (int)underlying.GetValueAtPercentile(85);
+                _p90 = (int)underlying.GetValueAtPercentile(90);
+                _p95 = (int)underlying.GetValueAtPercentile(95);
+                _p99 = (int)underlying.GetValueAtPercentile(99);
+                _p99_5 = (int)underlying.GetValueAtPercentile(99.5);
+                _p99_9 = (int)underlying.GetValueAtPercentile(99.9);
+                _p99_95 = (int)underlying.GetValueAtPercentile(99.95);
+                _p99_99 = (int)underlying.GetValueAtPercentile(99.99);
+                _p100 = (int)underlying.GetValueAtPercentile(100);
 
-                totalCount = underlying.TotalCount;
+                _totalCount = underlying.TotalCount;
             }
         }
 
          // Return the cached value only
         public int GetMean()
         {
-            return mean;
+            return _mean;
         }
 
          // Return the cached value if available. Otherwise, we need to synchronize access to the underlying {@link Histogram}
@@ -106,39 +106,39 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric
             int permyriad = (int)percentile * 100;
             switch (permyriad)
             {
-                case 0: return p0;
-                case 500: return p5;
-                case 1000: return p10;
-                case 1500: return p15;
-                case 2000: return p20;
-                case 2500: return p25;
-                case 3000: return p30;
-                case 3500: return p35;
-                case 4000: return p40;
-                case 4500: return p45;
-                case 5000: return p50;
-                case 5500: return p55;
-                case 6000: return p60;
-                case 6500: return p65;
-                case 7000: return p70;
-                case 7500: return p75;
-                case 8000: return p80;
-                case 8500: return p85;
-                case 9000: return p90;
-                case 9500: return p95;
-                case 9900: return p99;
-                case 9950: return p99_5;
-                case 9990: return p99_9;
-                case 9995: return p99_95;
-                case 9999: return p99_99;
-                case 10000: return p100;
+                case 0: return _p0;
+                case 500: return _p5;
+                case 1000: return _p10;
+                case 1500: return _p15;
+                case 2000: return _p20;
+                case 2500: return _p25;
+                case 3000: return _p30;
+                case 3500: return _p35;
+                case 4000: return _p40;
+                case 4500: return _p45;
+                case 5000: return _p50;
+                case 5500: return _p55;
+                case 6000: return _p60;
+                case 6500: return _p65;
+                case 7000: return _p70;
+                case 7500: return _p75;
+                case 8000: return _p80;
+                case 8500: return _p85;
+                case 9000: return _p90;
+                case 9500: return _p95;
+                case 9900: return _p99;
+                case 9950: return _p99_5;
+                case 9990: return _p99_9;
+                case 9995: return _p99_95;
+                case 9999: return _p99_99;
+                case 10000: return _p100;
                 default: throw new ArgumentException("Percentile (" + percentile + ") is not currently cached");
             }
         }
 
         public long GetTotalCount()
         {
-            return totalCount;
+            return _totalCount;
         }
 
         public override string ToString()

--- a/src/CircuitBreaker/src/HystrixBase/Metric/CommandAndCacheKey.cs
+++ b/src/CircuitBreaker/src/HystrixBase/Metric/CommandAndCacheKey.cs
@@ -8,13 +8,13 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric
 {
     public class CommandAndCacheKey
     {
-        private readonly string commandName;
-        private readonly string cacheKey;
+        private readonly string _commandName;
+        private readonly string _cacheKey;
 
         public CommandAndCacheKey(string commandName, string cacheKey)
         {
-            this.commandName = commandName;
-            this.cacheKey = cacheKey;
+            this._commandName = commandName;
+            this._cacheKey = cacheKey;
         }
 
         public override bool Equals(object o)
@@ -31,26 +31,26 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric
 
             CommandAndCacheKey that = (CommandAndCacheKey)o;
 
-            if (!commandName.Equals(that.commandName))
+            if (!_commandName.Equals(that._commandName))
             {
                 return false;
             }
 
-            return cacheKey.Equals(that.cacheKey);
+            return _cacheKey.Equals(that._cacheKey);
         }
 
         public override int GetHashCode()
         {
-            int result = commandName.GetHashCode();
-            result = (31 * result) + cacheKey.GetHashCode();
+            int result = _commandName.GetHashCode();
+            result = (31 * result) + _cacheKey.GetHashCode();
             return result;
         }
 
         public override string ToString()
         {
             return "CommandAndCacheKey{" +
-                    "commandName='" + commandName + '\'' +
-                    ", cacheKey='" + cacheKey + '\'' +
+                    "commandName='" + _commandName + '\'' +
+                    ", cacheKey='" + _cacheKey + '\'' +
                     '}';
         }
     }

--- a/src/CircuitBreaker/src/HystrixBase/Metric/Consumer/BucketedRollingCounterStream.cs
+++ b/src/CircuitBreaker/src/HystrixBase/Metric/Consumer/BucketedRollingCounterStream.cs
@@ -15,8 +15,8 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric.Consumer
         where Event : IHystrixEvent
     {
         protected BehaviorSubject<Output> counterSubject;
-        private readonly AtomicBoolean isSourceCurrentlySubscribed = new AtomicBoolean(false);
-        private IObservable<Output> sourceStream;
+        private readonly AtomicBoolean _isSourceCurrentlySubscribed = new AtomicBoolean(false);
+        private IObservable<Output> _sourceStream;
 
         protected BucketedRollingCounterStream(IHystrixEventStream<Event> stream, int numBuckets, int bucketSizeInMs, Func<Bucket, Event, Bucket> appendRawEventToBucket, Func<Output, Bucket, Output> reduceBucket)
             : base(stream, numBuckets, bucketSizeInMs, appendRawEventToBucket)
@@ -27,7 +27,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric.Consumer
                 return result;
             };
             counterSubject = new BehaviorSubject<Output>(EmptyOutputValue);
-            sourceStream = bucketedStream // stream broken up into buckets
+            _sourceStream = bucketedStream // stream broken up into buckets
 
                 .Window(numBuckets, 1) // emit overlapping windows of buckets
 
@@ -36,25 +36,25 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric.Consumer
 
                 .OnSubscribe(() =>
                 {
-                    isSourceCurrentlySubscribed.Value = true;
+                    _isSourceCurrentlySubscribed.Value = true;
                 })
                 .OnDispose(() =>
                  {
-                     isSourceCurrentlySubscribed.Value = false;
+                     _isSourceCurrentlySubscribed.Value = false;
                  })
                 .Publish().RefCount();                // multiple subscribers should get same data
         }
 
         public override IObservable<Output> Observe()
         {
-            return sourceStream;
+            return _sourceStream;
         }
 
         internal bool IsSourceCurrentlySubscribed
         {
             get
             {
-                return isSourceCurrentlySubscribed.Value;
+                return _isSourceCurrentlySubscribed.Value;
             }
         }
 

--- a/src/CircuitBreaker/src/HystrixBase/Metric/Consumer/HystrixDashboardStream.cs
+++ b/src/CircuitBreaker/src/HystrixBase/Metric/Consumer/HystrixDashboardStream.cs
@@ -57,40 +57,18 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric.Consumer
 
         public class DashboardData
         {
-            private readonly ICollection<HystrixCommandMetrics> _commandMetrics;
-            private readonly ICollection<HystrixThreadPoolMetrics> _threadPoolMetrics;
-            private readonly ICollection<HystrixCollapserMetrics> _collapserMetrics;
-
             public DashboardData(ICollection<HystrixCommandMetrics> commandMetrics, ICollection<HystrixThreadPoolMetrics> threadPoolMetrics, ICollection<HystrixCollapserMetrics> collapserMetrics)
             {
-                this._commandMetrics = commandMetrics;
-                this._threadPoolMetrics = threadPoolMetrics;
-                this._collapserMetrics = collapserMetrics;
+                this.CommandMetrics = commandMetrics;
+                this.ThreadPoolMetrics = threadPoolMetrics;
+                this.CollapserMetrics = collapserMetrics;
             }
 
-            public ICollection<HystrixCommandMetrics> CommandMetrics
-            {
-                get
-                {
-                    return _commandMetrics;
-                }
-            }
+            public ICollection<HystrixCommandMetrics> CommandMetrics { get; }
 
-            public ICollection<HystrixThreadPoolMetrics> ThreadPoolMetrics
-            {
-                get
-                {
-                    return _threadPoolMetrics;
-                }
-            }
+            public ICollection<HystrixThreadPoolMetrics> ThreadPoolMetrics { get; }
 
-            public ICollection<HystrixCollapserMetrics> CollapserMetrics
-            {
-                get
-                {
-                    return _collapserMetrics;
-                }
-            }
+            public ICollection<HystrixCollapserMetrics> CollapserMetrics { get; }
         }
     }
 }

--- a/src/CircuitBreaker/src/HystrixBase/Metric/Consumer/HystrixDashboardStream.cs
+++ b/src/CircuitBreaker/src/HystrixBase/Metric/Consumer/HystrixDashboardStream.cs
@@ -13,17 +13,17 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric.Consumer
     public class HystrixDashboardStream
     {
         private const int Default_Dashboard_IntervalInMilliseconds = 500;
-        private readonly int delayInMs;
-        private readonly IObservable<DashboardData> singleSource;
-        private readonly AtomicBoolean isSourceCurrentlySubscribed = new AtomicBoolean(false);
+        private readonly int _delayInMs;
+        private readonly IObservable<DashboardData> _singleSource;
+        private readonly AtomicBoolean _isSourceCurrentlySubscribed = new AtomicBoolean(false);
 
         private HystrixDashboardStream(int delayInMs)
         {
-            this.delayInMs = delayInMs;
-            this.singleSource = Observable.Interval(TimeSpan.FromMilliseconds(delayInMs))
+            this._delayInMs = delayInMs;
+            this._singleSource = Observable.Interval(TimeSpan.FromMilliseconds(delayInMs))
                                 .Map((timestamp) => { return new DashboardData(HystrixCommandMetrics.GetInstances(), HystrixThreadPoolMetrics.GetInstances(), HystrixCollapserMetrics.GetInstances()); })
-                                .OnSubscribe(() => { isSourceCurrentlySubscribed.Value = true; })
-                                .OnDispose(() => { isSourceCurrentlySubscribed.Value = false; })
+                                .OnSubscribe(() => { _isSourceCurrentlySubscribed.Value = true; })
+                                .OnDispose(() => { _isSourceCurrentlySubscribed.Value = false; })
                                 .Publish().RefCount();
         }
 
@@ -39,14 +39,14 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric.Consumer
          // Return a ref-counted stream that will only do work when at least one subscriber is present
         public IObservable<DashboardData> Observe()
         {
-            return singleSource;
+            return _singleSource;
         }
 
         public bool IsSourceCurrentlySubscribed
         {
             get
             {
-                return isSourceCurrentlySubscribed.Value;
+                return _isSourceCurrentlySubscribed.Value;
             }
         }
 
@@ -57,22 +57,22 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric.Consumer
 
         public class DashboardData
         {
-            private readonly ICollection<HystrixCommandMetrics> commandMetrics;
-            private readonly ICollection<HystrixThreadPoolMetrics> threadPoolMetrics;
-            private readonly ICollection<HystrixCollapserMetrics> collapserMetrics;
+            private readonly ICollection<HystrixCommandMetrics> _commandMetrics;
+            private readonly ICollection<HystrixThreadPoolMetrics> _threadPoolMetrics;
+            private readonly ICollection<HystrixCollapserMetrics> _collapserMetrics;
 
             public DashboardData(ICollection<HystrixCommandMetrics> commandMetrics, ICollection<HystrixThreadPoolMetrics> threadPoolMetrics, ICollection<HystrixCollapserMetrics> collapserMetrics)
             {
-                this.commandMetrics = commandMetrics;
-                this.threadPoolMetrics = threadPoolMetrics;
-                this.collapserMetrics = collapserMetrics;
+                this._commandMetrics = commandMetrics;
+                this._threadPoolMetrics = threadPoolMetrics;
+                this._collapserMetrics = collapserMetrics;
             }
 
             public ICollection<HystrixCommandMetrics> CommandMetrics
             {
                 get
                 {
-                    return commandMetrics;
+                    return _commandMetrics;
                 }
             }
 
@@ -80,7 +80,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric.Consumer
             {
                 get
                 {
-                    return threadPoolMetrics;
+                    return _threadPoolMetrics;
                 }
             }
 
@@ -88,7 +88,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric.Consumer
             {
                 get
                 {
-                    return collapserMetrics;
+                    return _collapserMetrics;
                 }
             }
         }

--- a/src/CircuitBreaker/src/HystrixBase/Metric/ExecutionSignature.cs
+++ b/src/CircuitBreaker/src/HystrixBase/Metric/ExecutionSignature.cs
@@ -8,21 +8,16 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric
 {
     public class ExecutionSignature
     {
-        private readonly string _commandName;
-        private readonly ExecutionResult.EventCounts _eventCounts;
         private readonly string _cacheKey;
-        private readonly int _cachedCount;
-        private readonly IHystrixCollapserKey _collapserKey;
-        private readonly int _collapserBatchSize;
 
         private ExecutionSignature(IHystrixCommandKey commandKey, ExecutionResult.EventCounts eventCounts, string cacheKey, int cachedCount, IHystrixCollapserKey collapserKey, int collapserBatchSize)
         {
-            this._commandName = commandKey.Name;
-            this._eventCounts = eventCounts;
+            this.CommandName = commandKey.Name;
+            this.Eventcounts = eventCounts;
             this._cacheKey = cacheKey;
-            this._cachedCount = cachedCount;
-            this._collapserKey = collapserKey;
-            this._collapserBatchSize = collapserBatchSize;
+            this.CachedCount = cachedCount;
+            this.CollapserKey = collapserKey;
+            this.CollapserBatchSize = collapserBatchSize;
         }
 
         public static ExecutionSignature From(IHystrixInvokableInfo execution)
@@ -49,12 +44,12 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric
 
             ExecutionSignature that = (ExecutionSignature)o;
 
-            if (!_commandName.Equals(that._commandName))
+            if (!CommandName.Equals(that.CommandName))
             {
                 return false;
             }
 
-            if (!_eventCounts.Equals(that._eventCounts))
+            if (!Eventcounts.Equals(that.Eventcounts))
             {
                 return false;
             }
@@ -64,35 +59,20 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric
 
         public override int GetHashCode()
         {
-            int result = _commandName.GetHashCode();
-            result = (31 * result) + _eventCounts.GetHashCode();
+            int result = CommandName.GetHashCode();
+            result = (31 * result) + Eventcounts.GetHashCode();
             result = (31 * result) + (_cacheKey != null ? _cacheKey.GetHashCode() : 0);
             return result;
         }
 
-        public string CommandName
-        {
-            get { return _commandName; }
-        }
+        public string CommandName { get; }
 
-        public ExecutionResult.EventCounts Eventcounts
-        {
-            get { return _eventCounts; }
-        }
+        public ExecutionResult.EventCounts Eventcounts { get; }
 
-        public int CachedCount
-        {
-            get { return _cachedCount; }
-        }
+        public int CachedCount { get; }
 
-        public IHystrixCollapserKey CollapserKey
-        {
-            get { return _collapserKey; }
-        }
+        public IHystrixCollapserKey CollapserKey { get; }
 
-        public int CollapserBatchSize
-        {
-            get { return _collapserBatchSize; }
-        }
+        public int CollapserBatchSize { get; }
     }
 }

--- a/src/CircuitBreaker/src/HystrixBase/Metric/ExecutionSignature.cs
+++ b/src/CircuitBreaker/src/HystrixBase/Metric/ExecutionSignature.cs
@@ -8,21 +8,21 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric
 {
     public class ExecutionSignature
     {
-        private readonly string commandName;
-        private readonly ExecutionResult.EventCounts eventCounts;
-        private readonly string cacheKey;
-        private readonly int cachedCount;
-        private readonly IHystrixCollapserKey collapserKey;
-        private readonly int collapserBatchSize;
+        private readonly string _commandName;
+        private readonly ExecutionResult.EventCounts _eventCounts;
+        private readonly string _cacheKey;
+        private readonly int _cachedCount;
+        private readonly IHystrixCollapserKey _collapserKey;
+        private readonly int _collapserBatchSize;
 
         private ExecutionSignature(IHystrixCommandKey commandKey, ExecutionResult.EventCounts eventCounts, string cacheKey, int cachedCount, IHystrixCollapserKey collapserKey, int collapserBatchSize)
         {
-            this.commandName = commandKey.Name;
-            this.eventCounts = eventCounts;
-            this.cacheKey = cacheKey;
-            this.cachedCount = cachedCount;
-            this.collapserKey = collapserKey;
-            this.collapserBatchSize = collapserBatchSize;
+            this._commandName = commandKey.Name;
+            this._eventCounts = eventCounts;
+            this._cacheKey = cacheKey;
+            this._cachedCount = cachedCount;
+            this._collapserKey = collapserKey;
+            this._collapserBatchSize = collapserBatchSize;
         }
 
         public static ExecutionSignature From(IHystrixInvokableInfo execution)
@@ -49,50 +49,50 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric
 
             ExecutionSignature that = (ExecutionSignature)o;
 
-            if (!commandName.Equals(that.commandName))
+            if (!_commandName.Equals(that._commandName))
             {
                 return false;
             }
 
-            if (!eventCounts.Equals(that.eventCounts))
+            if (!_eventCounts.Equals(that._eventCounts))
             {
                 return false;
             }
 
-            return !(cacheKey != null ? !cacheKey.Equals(that.cacheKey) : that.cacheKey != null);
+            return !(_cacheKey != null ? !_cacheKey.Equals(that._cacheKey) : that._cacheKey != null);
         }
 
         public override int GetHashCode()
         {
-            int result = commandName.GetHashCode();
-            result = (31 * result) + eventCounts.GetHashCode();
-            result = (31 * result) + (cacheKey != null ? cacheKey.GetHashCode() : 0);
+            int result = _commandName.GetHashCode();
+            result = (31 * result) + _eventCounts.GetHashCode();
+            result = (31 * result) + (_cacheKey != null ? _cacheKey.GetHashCode() : 0);
             return result;
         }
 
         public string CommandName
         {
-            get { return commandName; }
+            get { return _commandName; }
         }
 
         public ExecutionResult.EventCounts Eventcounts
         {
-            get { return eventCounts; }
+            get { return _eventCounts; }
         }
 
         public int CachedCount
         {
-            get { return cachedCount; }
+            get { return _cachedCount; }
         }
 
         public IHystrixCollapserKey CollapserKey
         {
-            get { return collapserKey; }
+            get { return _collapserKey; }
         }
 
         public int CollapserBatchSize
         {
-            get { return collapserBatchSize; }
+            get { return _collapserBatchSize; }
         }
     }
 }

--- a/src/CircuitBreaker/src/HystrixBase/Metric/HystrixCollapserEvent.cs
+++ b/src/CircuitBreaker/src/HystrixBase/Metric/HystrixCollapserEvent.cs
@@ -6,15 +6,15 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric
 {
     public class HystrixCollapserEvent : IHystrixEvent
     {
-        private readonly IHystrixCollapserKey collapserKey;
-        private readonly CollapserEventType eventType;
-        private readonly int count;
+        private readonly IHystrixCollapserKey _collapserKey;
+        private readonly CollapserEventType _eventType;
+        private readonly int _count;
 
         protected HystrixCollapserEvent(IHystrixCollapserKey collapserKey, CollapserEventType eventType, int count)
         {
-            this.collapserKey = collapserKey;
-            this.eventType = eventType;
-            this.count = count;
+            this._collapserKey = collapserKey;
+            this._eventType = eventType;
+            this._count = count;
         }
 
         public static HystrixCollapserEvent From(IHystrixCollapserKey collapserKey, CollapserEventType eventType, int count)
@@ -24,22 +24,22 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric
 
         public IHystrixCollapserKey CollapserKey
         {
-            get { return collapserKey; }
+            get { return _collapserKey; }
         }
 
         public CollapserEventType EventType
         {
-            get { return eventType; }
+            get { return _eventType; }
         }
 
         public int Count
         {
-            get { return count; }
+            get { return _count; }
         }
 
         public override string ToString()
         {
-            return "HystrixCollapserEvent[" + collapserKey.Name + "] : " + eventType + " : " + count;
+            return "HystrixCollapserEvent[" + _collapserKey.Name + "] : " + _eventType + " : " + _count;
         }
     }
 }

--- a/src/CircuitBreaker/src/HystrixBase/Metric/HystrixCollapserEvent.cs
+++ b/src/CircuitBreaker/src/HystrixBase/Metric/HystrixCollapserEvent.cs
@@ -6,15 +6,11 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric
 {
     public class HystrixCollapserEvent : IHystrixEvent
     {
-        private readonly IHystrixCollapserKey _collapserKey;
-        private readonly CollapserEventType _eventType;
-        private readonly int _count;
-
         protected HystrixCollapserEvent(IHystrixCollapserKey collapserKey, CollapserEventType eventType, int count)
         {
-            this._collapserKey = collapserKey;
-            this._eventType = eventType;
-            this._count = count;
+            this.CollapserKey = collapserKey;
+            this.EventType = eventType;
+            this.Count = count;
         }
 
         public static HystrixCollapserEvent From(IHystrixCollapserKey collapserKey, CollapserEventType eventType, int count)
@@ -22,24 +18,15 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric
             return new HystrixCollapserEvent(collapserKey, eventType, count);
         }
 
-        public IHystrixCollapserKey CollapserKey
-        {
-            get { return _collapserKey; }
-        }
+        public IHystrixCollapserKey CollapserKey { get; }
 
-        public CollapserEventType EventType
-        {
-            get { return _eventType; }
-        }
+        public CollapserEventType EventType { get; }
 
-        public int Count
-        {
-            get { return _count; }
-        }
+        public int Count { get; }
 
         public override string ToString()
         {
-            return "HystrixCollapserEvent[" + _collapserKey.Name + "] : " + _eventType + " : " + _count;
+            return "HystrixCollapserEvent[" + CollapserKey.Name + "] : " + EventType + " : " + Count;
         }
     }
 }

--- a/src/CircuitBreaker/src/HystrixBase/Metric/HystrixCollapserEventStream.cs
+++ b/src/CircuitBreaker/src/HystrixBase/Metric/HystrixCollapserEventStream.cs
@@ -14,10 +14,10 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric
     {
         private static readonly ConcurrentDictionary<string, HystrixCollapserEventStream> Streams = new ConcurrentDictionary<string, HystrixCollapserEventStream>();
 
-        private readonly IHystrixCollapserKey collapserKey;
+        private readonly IHystrixCollapserKey _collapserKey;
 
-        private readonly ISubject<HystrixCollapserEvent, HystrixCollapserEvent> writeOnlyStream;
-        private readonly IObservable<HystrixCollapserEvent> readOnlyStream;
+        private readonly ISubject<HystrixCollapserEvent, HystrixCollapserEvent> _writeOnlyStream;
+        private readonly IObservable<HystrixCollapserEvent> _readOnlyStream;
 
         public static HystrixCollapserEventStream GetInstance(IHystrixCollapserKey collapserKey)
         {
@@ -26,9 +26,9 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric
 
         internal HystrixCollapserEventStream(IHystrixCollapserKey collapserKey)
         {
-            this.collapserKey = collapserKey;
-            this.writeOnlyStream = Subject.Synchronize<HystrixCollapserEvent, HystrixCollapserEvent>(new Subject<HystrixCollapserEvent>());
-            this.readOnlyStream = writeOnlyStream.AsObservable();
+            this._collapserKey = collapserKey;
+            this._writeOnlyStream = Subject.Synchronize<HystrixCollapserEvent, HystrixCollapserEvent>(new Subject<HystrixCollapserEvent>());
+            this._readOnlyStream = _writeOnlyStream.AsObservable();
         }
 
         public static void Reset()
@@ -38,17 +38,17 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric
 
         public void Write(HystrixCollapserEvent @event)
         {
-            writeOnlyStream.OnNext(@event);
+            _writeOnlyStream.OnNext(@event);
         }
 
         public IObservable<HystrixCollapserEvent> Observe()
         {
-            return readOnlyStream;
+            return _readOnlyStream;
         }
 
         public override string ToString()
         {
-            return "HystrixCollapserEventStream(" + collapserKey.Name + ")";
+            return "HystrixCollapserEventStream(" + _collapserKey.Name + ")";
         }
     }
 }

--- a/src/CircuitBreaker/src/HystrixBase/Metric/HystrixCommandCompletionStream.cs
+++ b/src/CircuitBreaker/src/HystrixBase/Metric/HystrixCommandCompletionStream.cs
@@ -14,9 +14,9 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric
     {
         private static readonly ConcurrentDictionary<string, HystrixCommandCompletionStream> Streams = new ConcurrentDictionary<string, HystrixCommandCompletionStream>();
 
-        private readonly IHystrixCommandKey commandKey;
-        private readonly ISubject<HystrixCommandCompletion, HystrixCommandCompletion> writeOnlySubject;
-        private readonly IObservable<HystrixCommandCompletion> readOnlyStream;
+        private readonly IHystrixCommandKey _commandKey;
+        private readonly ISubject<HystrixCommandCompletion, HystrixCommandCompletion> _writeOnlySubject;
+        private readonly IObservable<HystrixCommandCompletion> _readOnlyStream;
 
         public static HystrixCommandCompletionStream GetInstance(IHystrixCommandKey commandKey)
         {
@@ -25,9 +25,9 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric
 
         internal HystrixCommandCompletionStream(IHystrixCommandKey commandKey)
         {
-            this.commandKey = commandKey;
-            this.writeOnlySubject = Subject.Synchronize<HystrixCommandCompletion, HystrixCommandCompletion>(new Subject<HystrixCommandCompletion>());
-            this.readOnlyStream = writeOnlySubject.AsObservable();
+            this._commandKey = commandKey;
+            this._writeOnlySubject = Subject.Synchronize<HystrixCommandCompletion, HystrixCommandCompletion>(new Subject<HystrixCommandCompletion>());
+            this._readOnlyStream = _writeOnlySubject.AsObservable();
         }
 
         public static void Reset()
@@ -37,17 +37,17 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric
 
         public void Write(HystrixCommandCompletion @event)
         {
-            writeOnlySubject.OnNext(@event);
+            _writeOnlySubject.OnNext(@event);
         }
 
         public IObservable<HystrixCommandCompletion> Observe()
         {
-            return readOnlyStream;
+            return _readOnlyStream;
         }
 
         public override string ToString()
         {
-            return "HystrixCommandCompletionStream(" + commandKey.Name + ")";
+            return "HystrixCommandCompletionStream(" + _commandKey.Name + ")";
         }
     }
 }

--- a/src/CircuitBreaker/src/HystrixBase/Metric/HystrixCommandEvent.cs
+++ b/src/CircuitBreaker/src/HystrixBase/Metric/HystrixCommandEvent.cs
@@ -8,13 +8,13 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric
 {
     public abstract class HystrixCommandEvent : IHystrixEvent
     {
-        private readonly IHystrixCommandKey commandKey;
-        private readonly IHystrixThreadPoolKey threadPoolKey;
+        private readonly IHystrixCommandKey _commandKey;
+        private readonly IHystrixThreadPoolKey _threadPoolKey;
 
         protected HystrixCommandEvent(IHystrixCommandKey commandKey, IHystrixThreadPoolKey threadPoolKey)
         {
-            this.commandKey = commandKey;
-            this.threadPoolKey = threadPoolKey;
+            this._commandKey = commandKey;
+            this._threadPoolKey = threadPoolKey;
         }
 
         public static Func<HystrixCommandEvent, bool> FilterCompletionsOnly { get; } = (commandEvent) =>
@@ -29,12 +29,12 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric
 
         public virtual IHystrixCommandKey CommandKey
         {
-            get { return commandKey; }
+            get { return _commandKey; }
         }
 
         public virtual IHystrixThreadPoolKey ThreadPoolKey
         {
-            get { return threadPoolKey; }
+            get { return _threadPoolKey; }
         }
 
         public abstract bool IsExecutionStart { get; }

--- a/src/CircuitBreaker/src/HystrixBase/Metric/HystrixCommandExecutionStarted.cs
+++ b/src/CircuitBreaker/src/HystrixBase/Metric/HystrixCommandExecutionStarted.cs
@@ -7,13 +7,12 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric
     public class HystrixCommandExecutionStarted : HystrixCommandEvent
     {
         private readonly ExecutionIsolationStrategy _isolationStrategy;
-        private readonly int _currentConcurrency;
 
         public HystrixCommandExecutionStarted(IHystrixCommandKey commandKey, IHystrixThreadPoolKey threadPoolKey, ExecutionIsolationStrategy isolationStrategy, int currentConcurrency)
             : base(commandKey, threadPoolKey)
         {
             this._isolationStrategy = isolationStrategy;
-            this._currentConcurrency = currentConcurrency;
+            this.CurrentConcurrency = currentConcurrency;
         }
 
         public override bool IsExecutionStart
@@ -41,9 +40,6 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric
             get { return false; }
         }
 
-        public int CurrentConcurrency
-        {
-            get { return _currentConcurrency; }
-        }
+        public int CurrentConcurrency { get; }
     }
 }

--- a/src/CircuitBreaker/src/HystrixBase/Metric/HystrixCommandExecutionStarted.cs
+++ b/src/CircuitBreaker/src/HystrixBase/Metric/HystrixCommandExecutionStarted.cs
@@ -6,14 +6,14 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric
 {
     public class HystrixCommandExecutionStarted : HystrixCommandEvent
     {
-        private readonly ExecutionIsolationStrategy isolationStrategy;
-        private readonly int currentConcurrency;
+        private readonly ExecutionIsolationStrategy _isolationStrategy;
+        private readonly int _currentConcurrency;
 
         public HystrixCommandExecutionStarted(IHystrixCommandKey commandKey, IHystrixThreadPoolKey threadPoolKey, ExecutionIsolationStrategy isolationStrategy, int currentConcurrency)
             : base(commandKey, threadPoolKey)
         {
-            this.isolationStrategy = isolationStrategy;
-            this.currentConcurrency = currentConcurrency;
+            this._isolationStrategy = isolationStrategy;
+            this._currentConcurrency = currentConcurrency;
         }
 
         public override bool IsExecutionStart
@@ -23,7 +23,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric
 
         public override bool IsExecutedInThread
         {
-            get { return isolationStrategy == ExecutionIsolationStrategy.THREAD; }
+            get { return _isolationStrategy == ExecutionIsolationStrategy.THREAD; }
         }
 
         public override bool IsResponseThreadPoolRejected
@@ -43,7 +43,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric
 
         public int CurrentConcurrency
         {
-            get { return currentConcurrency; }
+            get { return _currentConcurrency; }
         }
     }
 }

--- a/src/CircuitBreaker/src/HystrixBase/Metric/HystrixCommandStartStream.cs
+++ b/src/CircuitBreaker/src/HystrixBase/Metric/HystrixCommandStartStream.cs
@@ -14,9 +14,9 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric
     {
         private static readonly ConcurrentDictionary<string, HystrixCommandStartStream> Streams = new ConcurrentDictionary<string, HystrixCommandStartStream>();
 
-        private readonly IHystrixCommandKey commandKey;
-        private readonly ISubject<HystrixCommandExecutionStarted, HystrixCommandExecutionStarted> writeOnlySubject;
-        private readonly IObservable<HystrixCommandExecutionStarted> readOnlyStream;
+        private readonly IHystrixCommandKey _commandKey;
+        private readonly ISubject<HystrixCommandExecutionStarted, HystrixCommandExecutionStarted> _writeOnlySubject;
+        private readonly IObservable<HystrixCommandExecutionStarted> _readOnlyStream;
 
         public static HystrixCommandStartStream GetInstance(IHystrixCommandKey commandKey)
         {
@@ -25,9 +25,9 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric
 
         internal HystrixCommandStartStream(IHystrixCommandKey commandKey)
         {
-            this.commandKey = commandKey;
-            this.writeOnlySubject = Subject.Synchronize<HystrixCommandExecutionStarted, HystrixCommandExecutionStarted>(new Subject<HystrixCommandExecutionStarted>());
-            this.readOnlyStream = writeOnlySubject.AsObservable();
+            this._commandKey = commandKey;
+            this._writeOnlySubject = Subject.Synchronize<HystrixCommandExecutionStarted, HystrixCommandExecutionStarted>(new Subject<HystrixCommandExecutionStarted>());
+            this._readOnlyStream = _writeOnlySubject.AsObservable();
         }
 
         public static void Reset()
@@ -37,17 +37,17 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric
 
         public void Write(HystrixCommandExecutionStarted @event)
         {
-            writeOnlySubject.OnNext(@event);
+            _writeOnlySubject.OnNext(@event);
         }
 
         public IObservable<HystrixCommandExecutionStarted> Observe()
         {
-            return readOnlyStream;
+            return _readOnlyStream;
         }
 
         public override string ToString()
         {
-            return "HystrixCommandStartStream(" + commandKey.Name + ")";
+            return "HystrixCommandStartStream(" + _commandKey.Name + ")";
         }
     }
 }

--- a/src/CircuitBreaker/src/HystrixBase/Metric/HystrixRequestEvents.cs
+++ b/src/CircuitBreaker/src/HystrixBase/Metric/HystrixRequestEvents.cs
@@ -9,25 +9,20 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric
 {
     public class HystrixRequestEvents
     {
-        private readonly ICollection<IHystrixInvokableInfo> _executions;
-
         public HystrixRequestEvents(ICollection<IHystrixInvokableInfo> executions)
         {
-            this._executions = executions;
+            this.Executions = executions;
         }
 
-        public ICollection<IHystrixInvokableInfo> Executions
-        {
-            get { return _executions; }
-        }
+        public ICollection<IHystrixInvokableInfo> Executions { get; }
 
         public IDictionary<ExecutionSignature, List<int>> ExecutionsMappedToLatencies
         {
             get
             {
                 Dictionary<CommandAndCacheKey, int> cachingDetector = new Dictionary<CommandAndCacheKey, int>();
-                List<IHystrixInvokableInfo> nonCachedExecutions = new List<IHystrixInvokableInfo>(_executions.Count);
-                foreach (IHystrixInvokableInfo execution in _executions)
+                List<IHystrixInvokableInfo> nonCachedExecutions = new List<IHystrixInvokableInfo>(Executions.Count);
+                foreach (IHystrixInvokableInfo execution in Executions)
                 {
                     if (execution.PublicCacheKey != null)
                     {

--- a/src/CircuitBreaker/src/HystrixBase/Metric/HystrixRequestEvents.cs
+++ b/src/CircuitBreaker/src/HystrixBase/Metric/HystrixRequestEvents.cs
@@ -9,16 +9,16 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric
 {
     public class HystrixRequestEvents
     {
-        private readonly ICollection<IHystrixInvokableInfo> executions;
+        private readonly ICollection<IHystrixInvokableInfo> _executions;
 
         public HystrixRequestEvents(ICollection<IHystrixInvokableInfo> executions)
         {
-            this.executions = executions;
+            this._executions = executions;
         }
 
         public ICollection<IHystrixInvokableInfo> Executions
         {
-            get { return executions; }
+            get { return _executions; }
         }
 
         public IDictionary<ExecutionSignature, List<int>> ExecutionsMappedToLatencies
@@ -26,8 +26,8 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric
             get
             {
                 Dictionary<CommandAndCacheKey, int> cachingDetector = new Dictionary<CommandAndCacheKey, int>();
-                List<IHystrixInvokableInfo> nonCachedExecutions = new List<IHystrixInvokableInfo>(executions.Count);
-                foreach (IHystrixInvokableInfo execution in executions)
+                List<IHystrixInvokableInfo> nonCachedExecutions = new List<IHystrixInvokableInfo>(_executions.Count);
+                foreach (IHystrixInvokableInfo execution in _executions)
                 {
                     if (execution.PublicCacheKey != null)
                     {

--- a/src/CircuitBreaker/src/HystrixBase/Metric/HystrixRequestEventsStream.cs
+++ b/src/CircuitBreaker/src/HystrixBase/Metric/HystrixRequestEventsStream.cs
@@ -11,13 +11,13 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric
 {
     public class HystrixRequestEventsStream
     {
-        private readonly ISubject<HystrixRequestEvents, HystrixRequestEvents> writeOnlyRequestEventsSubject;
-        private readonly IObservable<HystrixRequestEvents> readOnlyRequestEvents;
+        private readonly ISubject<HystrixRequestEvents, HystrixRequestEvents> _writeOnlyRequestEventsSubject;
+        private readonly IObservable<HystrixRequestEvents> _readOnlyRequestEvents;
 
         internal HystrixRequestEventsStream()
         {
-            this.writeOnlyRequestEventsSubject = Subject.Synchronize<HystrixRequestEvents, HystrixRequestEvents>(new Subject<HystrixRequestEvents>());
-            this.readOnlyRequestEvents = writeOnlyRequestEventsSubject.AsObservable();
+            this._writeOnlyRequestEventsSubject = Subject.Synchronize<HystrixRequestEvents, HystrixRequestEvents>(new Subject<HystrixRequestEvents>());
+            this._readOnlyRequestEvents = _writeOnlyRequestEventsSubject.AsObservable();
         }
 
         private static readonly HystrixRequestEventsStream INSTANCE = new HystrixRequestEventsStream();
@@ -29,18 +29,18 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric
 
         public void Shutdown()
         {
-            writeOnlyRequestEventsSubject.OnCompleted();
+            _writeOnlyRequestEventsSubject.OnCompleted();
         }
 
         public void Write(ICollection<IHystrixInvokableInfo> executions)
         {
             HystrixRequestEvents requestEvents = new HystrixRequestEvents(executions);
-            writeOnlyRequestEventsSubject.OnNext(requestEvents);
+            _writeOnlyRequestEventsSubject.OnNext(requestEvents);
         }
 
         public IObservable<HystrixRequestEvents> Observe()
         {
-            return readOnlyRequestEvents;
+            return _readOnlyRequestEvents;
         }
     }
 }

--- a/src/CircuitBreaker/src/HystrixBase/Metric/HystrixThreadPoolCompletionStream.cs
+++ b/src/CircuitBreaker/src/HystrixBase/Metric/HystrixThreadPoolCompletionStream.cs
@@ -14,9 +14,9 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric
     {
         private static readonly ConcurrentDictionary<string, HystrixThreadPoolCompletionStream> Streams = new ConcurrentDictionary<string, HystrixThreadPoolCompletionStream>();
 
-        private readonly IHystrixThreadPoolKey threadPoolKey;
-        private readonly ISubject<HystrixCommandCompletion, HystrixCommandCompletion> writeOnlySubject;
-        private readonly IObservable<HystrixCommandCompletion> readOnlyStream;
+        private readonly IHystrixThreadPoolKey _threadPoolKey;
+        private readonly ISubject<HystrixCommandCompletion, HystrixCommandCompletion> _writeOnlySubject;
+        private readonly IObservable<HystrixCommandCompletion> _readOnlyStream;
 
         public static HystrixThreadPoolCompletionStream GetInstance(IHystrixThreadPoolKey threadPoolKey)
         {
@@ -25,9 +25,9 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric
 
         internal HystrixThreadPoolCompletionStream(IHystrixThreadPoolKey threadPoolKey)
         {
-            this.threadPoolKey = threadPoolKey;
-            this.writeOnlySubject = Subject.Synchronize<HystrixCommandCompletion, HystrixCommandCompletion>(new Subject<HystrixCommandCompletion>());
-            this.readOnlyStream = writeOnlySubject.AsObservable();
+            this._threadPoolKey = threadPoolKey;
+            this._writeOnlySubject = Subject.Synchronize<HystrixCommandCompletion, HystrixCommandCompletion>(new Subject<HystrixCommandCompletion>());
+            this._readOnlyStream = _writeOnlySubject.AsObservable();
         }
 
         public static void Reset()
@@ -37,17 +37,17 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric
 
         public void Write(HystrixCommandCompletion @event)
         {
-            writeOnlySubject.OnNext(@event);
+            _writeOnlySubject.OnNext(@event);
         }
 
         public IObservable<HystrixCommandCompletion> Observe()
         {
-            return readOnlyStream;
+            return _readOnlyStream;
         }
 
         public override string ToString()
         {
-            return "HystrixThreadPoolCompletionStream(" + threadPoolKey.Name + ")";
+            return "HystrixThreadPoolCompletionStream(" + _threadPoolKey.Name + ")";
         }
     }
 }

--- a/src/CircuitBreaker/src/HystrixBase/Metric/HystrixThreadPoolStartStream.cs
+++ b/src/CircuitBreaker/src/HystrixBase/Metric/HystrixThreadPoolStartStream.cs
@@ -14,9 +14,9 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric
     {
         private static readonly ConcurrentDictionary<string, HystrixThreadPoolStartStream> Streams = new ConcurrentDictionary<string, HystrixThreadPoolStartStream>();
 
-        private readonly IHystrixThreadPoolKey threadPoolKey;
-        private readonly ISubject<HystrixCommandExecutionStarted, HystrixCommandExecutionStarted> writeOnlySubject;
-        private readonly IObservable<HystrixCommandExecutionStarted> readOnlyStream;
+        private readonly IHystrixThreadPoolKey _threadPoolKey;
+        private readonly ISubject<HystrixCommandExecutionStarted, HystrixCommandExecutionStarted> _writeOnlySubject;
+        private readonly IObservable<HystrixCommandExecutionStarted> _readOnlyStream;
 
         public static HystrixThreadPoolStartStream GetInstance(IHystrixThreadPoolKey threadPoolKey)
         {
@@ -25,9 +25,9 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric
 
         internal HystrixThreadPoolStartStream(IHystrixThreadPoolKey threadPoolKey)
         {
-            this.threadPoolKey = threadPoolKey;
-            this.writeOnlySubject = Subject.Synchronize<HystrixCommandExecutionStarted, HystrixCommandExecutionStarted>(new Subject<HystrixCommandExecutionStarted>());
-            this.readOnlyStream = writeOnlySubject.AsObservable();
+            this._threadPoolKey = threadPoolKey;
+            this._writeOnlySubject = Subject.Synchronize<HystrixCommandExecutionStarted, HystrixCommandExecutionStarted>(new Subject<HystrixCommandExecutionStarted>());
+            this._readOnlyStream = _writeOnlySubject.AsObservable();
         }
 
         public static void Reset()
@@ -37,17 +37,17 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric
 
         public void Write(HystrixCommandExecutionStarted @event)
         {
-            writeOnlySubject.OnNext(@event);
+            _writeOnlySubject.OnNext(@event);
         }
 
         public IObservable<HystrixCommandExecutionStarted> Observe()
         {
-            return readOnlyStream;
+            return _readOnlyStream;
         }
 
         public override string ToString()
         {
-            return "HystrixThreadPoolStartStream(" + threadPoolKey.Name + ")";
+            return "HystrixThreadPoolStartStream(" + _threadPoolKey.Name + ")";
         }
     }
 }

--- a/src/CircuitBreaker/src/HystrixBase/Metric/Sample/HystrixCommandUtilization.cs
+++ b/src/CircuitBreaker/src/HystrixBase/Metric/Sample/HystrixCommandUtilization.cs
@@ -6,11 +6,9 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric.Sample
 {
     public class HystrixCommandUtilization
     {
-        private readonly int _concurrentCommandCount;
-
         public HystrixCommandUtilization(int concurrentCommandCount)
         {
-            this._concurrentCommandCount = concurrentCommandCount;
+            this.ConcurrentCommandCount = concurrentCommandCount;
         }
 
         public static HystrixCommandUtilization Sample(HystrixCommandMetrics commandMetrics)
@@ -18,9 +16,6 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric.Sample
             return new HystrixCommandUtilization(commandMetrics.CurrentConcurrentExecutionCount);
         }
 
-        public int ConcurrentCommandCount
-        {
-            get { return _concurrentCommandCount; }
-        }
+        public int ConcurrentCommandCount { get; }
     }
 }

--- a/src/CircuitBreaker/src/HystrixBase/Metric/Sample/HystrixCommandUtilization.cs
+++ b/src/CircuitBreaker/src/HystrixBase/Metric/Sample/HystrixCommandUtilization.cs
@@ -6,11 +6,11 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric.Sample
 {
     public class HystrixCommandUtilization
     {
-        private readonly int concurrentCommandCount;
+        private readonly int _concurrentCommandCount;
 
         public HystrixCommandUtilization(int concurrentCommandCount)
         {
-            this.concurrentCommandCount = concurrentCommandCount;
+            this._concurrentCommandCount = concurrentCommandCount;
         }
 
         public static HystrixCommandUtilization Sample(HystrixCommandMetrics commandMetrics)
@@ -20,7 +20,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric.Sample
 
         public int ConcurrentCommandCount
         {
-            get { return concurrentCommandCount; }
+            get { return _concurrentCommandCount; }
         }
     }
 }

--- a/src/CircuitBreaker/src/HystrixBase/Metric/Sample/HystrixThreadPoolUtilization.cs
+++ b/src/CircuitBreaker/src/HystrixBase/Metric/Sample/HystrixThreadPoolUtilization.cs
@@ -6,17 +6,17 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric.Sample
 {
     public class HystrixThreadPoolUtilization
     {
-        private readonly int currentActiveCount;
-        private readonly int currentCorePoolSize;
-        private readonly int currentPoolSize;
-        private readonly int currentQueueSize;
+        private readonly int _currentActiveCount;
+        private readonly int _currentCorePoolSize;
+        private readonly int _currentPoolSize;
+        private readonly int _currentQueueSize;
 
         public HystrixThreadPoolUtilization(int currentActiveCount, int currentCorePoolSize, int currentPoolSize, int currentQueueSize)
         {
-            this.currentActiveCount = currentActiveCount;
-            this.currentCorePoolSize = currentCorePoolSize;
-            this.currentPoolSize = currentPoolSize;
-            this.currentQueueSize = currentQueueSize;
+            this._currentActiveCount = currentActiveCount;
+            this._currentCorePoolSize = currentCorePoolSize;
+            this._currentPoolSize = currentPoolSize;
+            this._currentQueueSize = currentQueueSize;
         }
 
         public static HystrixThreadPoolUtilization Sample(HystrixThreadPoolMetrics threadPoolMetrics)
@@ -30,22 +30,22 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric.Sample
 
         public int CurrentActiveCount
         {
-            get { return currentActiveCount; }
+            get { return _currentActiveCount; }
         }
 
         public int CurrentCorePoolSize
         {
-            get { return currentCorePoolSize; }
+            get { return _currentCorePoolSize; }
         }
 
         public int CurrentPoolSize
         {
-            get { return currentPoolSize; }
+            get { return _currentPoolSize; }
         }
 
         public int CurrentQueueSize
         {
-            get { return currentQueueSize; }
+            get { return _currentQueueSize; }
         }
     }
 }

--- a/src/CircuitBreaker/src/HystrixBase/Metric/Sample/HystrixThreadPoolUtilization.cs
+++ b/src/CircuitBreaker/src/HystrixBase/Metric/Sample/HystrixThreadPoolUtilization.cs
@@ -6,17 +6,12 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric.Sample
 {
     public class HystrixThreadPoolUtilization
     {
-        private readonly int _currentActiveCount;
-        private readonly int _currentCorePoolSize;
-        private readonly int _currentPoolSize;
-        private readonly int _currentQueueSize;
-
         public HystrixThreadPoolUtilization(int currentActiveCount, int currentCorePoolSize, int currentPoolSize, int currentQueueSize)
         {
-            this._currentActiveCount = currentActiveCount;
-            this._currentCorePoolSize = currentCorePoolSize;
-            this._currentPoolSize = currentPoolSize;
-            this._currentQueueSize = currentQueueSize;
+            this.CurrentActiveCount = currentActiveCount;
+            this.CurrentCorePoolSize = currentCorePoolSize;
+            this.CurrentPoolSize = currentPoolSize;
+            this.CurrentQueueSize = currentQueueSize;
         }
 
         public static HystrixThreadPoolUtilization Sample(HystrixThreadPoolMetrics threadPoolMetrics)
@@ -28,24 +23,12 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric.Sample
                     threadPoolMetrics.CurrentQueueSize);
         }
 
-        public int CurrentActiveCount
-        {
-            get { return _currentActiveCount; }
-        }
+        public int CurrentActiveCount { get; }
 
-        public int CurrentCorePoolSize
-        {
-            get { return _currentCorePoolSize; }
-        }
+        public int CurrentCorePoolSize { get; }
 
-        public int CurrentPoolSize
-        {
-            get { return _currentPoolSize; }
-        }
+        public int CurrentPoolSize { get; }
 
-        public int CurrentQueueSize
-        {
-            get { return _currentQueueSize; }
-        }
+        public int CurrentQueueSize { get; }
     }
 }

--- a/src/CircuitBreaker/src/HystrixBase/Metric/Sample/HystrixUtilization.cs
+++ b/src/CircuitBreaker/src/HystrixBase/Metric/Sample/HystrixUtilization.cs
@@ -8,15 +8,12 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric.Sample
 {
     public class HystrixUtilization
     {
-        private readonly Dictionary<IHystrixCommandKey, HystrixCommandUtilization> _commandUtilizationMap;
-        private readonly Dictionary<IHystrixThreadPoolKey, HystrixThreadPoolUtilization> _threadPoolUtilizationMap;
-
         public HystrixUtilization(
             Dictionary<IHystrixCommandKey, HystrixCommandUtilization> commandUtilizationMap,
             Dictionary<IHystrixThreadPoolKey, HystrixThreadPoolUtilization> threadPoolUtilizationMap)
         {
-            this._commandUtilizationMap = commandUtilizationMap;
-            this._threadPoolUtilizationMap = threadPoolUtilizationMap;
+            this.CommandUtilizationMap = commandUtilizationMap;
+            this.ThreadPoolUtilizationMap = threadPoolUtilizationMap;
         }
 
         public static HystrixUtilization From(
@@ -26,14 +23,8 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric.Sample
             return new HystrixUtilization(commandUtilizationMap, threadPoolUtilizationMap);
         }
 
-        public Dictionary<IHystrixCommandKey, HystrixCommandUtilization> CommandUtilizationMap
-        {
-            get { return _commandUtilizationMap; }
-        }
+        public Dictionary<IHystrixCommandKey, HystrixCommandUtilization> CommandUtilizationMap { get; }
 
-        public Dictionary<IHystrixThreadPoolKey, HystrixThreadPoolUtilization> ThreadPoolUtilizationMap
-        {
-            get { return _threadPoolUtilizationMap; }
-        }
+        public Dictionary<IHystrixThreadPoolKey, HystrixThreadPoolUtilization> ThreadPoolUtilizationMap { get; }
     }
 }

--- a/src/CircuitBreaker/src/HystrixBase/Metric/Sample/HystrixUtilization.cs
+++ b/src/CircuitBreaker/src/HystrixBase/Metric/Sample/HystrixUtilization.cs
@@ -8,15 +8,15 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric.Sample
 {
     public class HystrixUtilization
     {
-        private readonly Dictionary<IHystrixCommandKey, HystrixCommandUtilization> commandUtilizationMap;
-        private readonly Dictionary<IHystrixThreadPoolKey, HystrixThreadPoolUtilization> threadPoolUtilizationMap;
+        private readonly Dictionary<IHystrixCommandKey, HystrixCommandUtilization> _commandUtilizationMap;
+        private readonly Dictionary<IHystrixThreadPoolKey, HystrixThreadPoolUtilization> _threadPoolUtilizationMap;
 
         public HystrixUtilization(
             Dictionary<IHystrixCommandKey, HystrixCommandUtilization> commandUtilizationMap,
             Dictionary<IHystrixThreadPoolKey, HystrixThreadPoolUtilization> threadPoolUtilizationMap)
         {
-            this.commandUtilizationMap = commandUtilizationMap;
-            this.threadPoolUtilizationMap = threadPoolUtilizationMap;
+            this._commandUtilizationMap = commandUtilizationMap;
+            this._threadPoolUtilizationMap = threadPoolUtilizationMap;
         }
 
         public static HystrixUtilization From(
@@ -28,12 +28,12 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric.Sample
 
         public Dictionary<IHystrixCommandKey, HystrixCommandUtilization> CommandUtilizationMap
         {
-            get { return commandUtilizationMap; }
+            get { return _commandUtilizationMap; }
         }
 
         public Dictionary<IHystrixThreadPoolKey, HystrixThreadPoolUtilization> ThreadPoolUtilizationMap
         {
-            get { return threadPoolUtilizationMap; }
+            get { return _threadPoolUtilizationMap; }
         }
     }
 }

--- a/src/CircuitBreaker/src/HystrixBase/Metric/Sample/HystrixUtilizationStream.cs
+++ b/src/CircuitBreaker/src/HystrixBase/Metric/Sample/HystrixUtilizationStream.cs
@@ -13,7 +13,6 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric.Sample
     public class HystrixUtilizationStream
     {
         private const int DataEmissionIntervalInMs = 500;
-        private readonly int _intervalInMilliseconds;
         private readonly IObservable<HystrixUtilization> _allUtilizationStream;
         private readonly AtomicBoolean _isSourceCurrentlySubscribed = new AtomicBoolean(false);
 
@@ -27,7 +26,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric.Sample
 
         public HystrixUtilizationStream(int intervalInMilliseconds)
         {
-            this._intervalInMilliseconds = intervalInMilliseconds;
+            this.IntervalInMilliseconds = intervalInMilliseconds;
             this._allUtilizationStream = Observable.Interval(TimeSpan.FromMilliseconds(intervalInMilliseconds))
                     .Map((t) => AllUtilization(t))
                     .OnSubscribe(() =>
@@ -66,10 +65,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric.Sample
             return _allUtilizationStream.Map((a) => OnlyThreadPoolUtilization(a));
         }
 
-        public int IntervalInMilliseconds
-        {
-            get { return this._intervalInMilliseconds; }
-        }
+        public int IntervalInMilliseconds { get; }
 
         public bool IsSourceCurrentlySubscribed
         {

--- a/src/CircuitBreaker/src/HystrixBase/Metric/Sample/HystrixUtilizationStream.cs
+++ b/src/CircuitBreaker/src/HystrixBase/Metric/Sample/HystrixUtilizationStream.cs
@@ -13,9 +13,9 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric.Sample
     public class HystrixUtilizationStream
     {
         private const int DataEmissionIntervalInMs = 500;
-        private readonly int intervalInMilliseconds;
-        private readonly IObservable<HystrixUtilization> allUtilizationStream;
-        private readonly AtomicBoolean isSourceCurrentlySubscribed = new AtomicBoolean(false);
+        private readonly int _intervalInMilliseconds;
+        private readonly IObservable<HystrixUtilization> _allUtilizationStream;
+        private readonly AtomicBoolean _isSourceCurrentlySubscribed = new AtomicBoolean(false);
 
         private static Func<long, HystrixUtilization> AllUtilization { get; } =
           (long timestamp) =>
@@ -27,16 +27,16 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric.Sample
 
         public HystrixUtilizationStream(int intervalInMilliseconds)
         {
-            this.intervalInMilliseconds = intervalInMilliseconds;
-            this.allUtilizationStream = Observable.Interval(TimeSpan.FromMilliseconds(intervalInMilliseconds))
+            this._intervalInMilliseconds = intervalInMilliseconds;
+            this._allUtilizationStream = Observable.Interval(TimeSpan.FromMilliseconds(intervalInMilliseconds))
                     .Map((t) => AllUtilization(t))
                     .OnSubscribe(() =>
                     {
-                        isSourceCurrentlySubscribed.Value = true;
+                        _isSourceCurrentlySubscribed.Value = true;
                     })
                     .OnDispose(() =>
                     {
-                        isSourceCurrentlySubscribed.Value = false;
+                        _isSourceCurrentlySubscribed.Value = false;
                     })
                     .Publish().RefCount();
         }
@@ -53,27 +53,27 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric.Sample
          // Return a ref-counted stream that will only do work when at least one subscriber is present
         public IObservable<HystrixUtilization> Observe()
         {
-            return allUtilizationStream;
+            return _allUtilizationStream;
         }
 
         public IObservable<Dictionary<IHystrixCommandKey, HystrixCommandUtilization>> ObserveCommandUtilization()
         {
-            return allUtilizationStream.Map((a) => OnlyCommandUtilization(a));
+            return _allUtilizationStream.Map((a) => OnlyCommandUtilization(a));
         }
 
         public IObservable<Dictionary<IHystrixThreadPoolKey, HystrixThreadPoolUtilization>> ObserveThreadPoolUtilization()
         {
-            return allUtilizationStream.Map((a) => OnlyThreadPoolUtilization(a));
+            return _allUtilizationStream.Map((a) => OnlyThreadPoolUtilization(a));
         }
 
         public int IntervalInMilliseconds
         {
-            get { return this.intervalInMilliseconds; }
+            get { return this._intervalInMilliseconds; }
         }
 
         public bool IsSourceCurrentlySubscribed
         {
-            get { return isSourceCurrentlySubscribed.Value; }
+            get { return _isSourceCurrentlySubscribed.Value; }
         }
 
         internal static HystrixUtilizationStream GetNonSingletonInstanceOnlyUsedInUnitTests(int delayInMs)

--- a/src/CircuitBreaker/src/HystrixBase/Strategy/Concurrency/HystrixSyncTaskScheduler.cs
+++ b/src/CircuitBreaker/src/HystrixBase/Strategy/Concurrency/HystrixSyncTaskScheduler.cs
@@ -19,7 +19,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Strategy.Concurrency
         [ThreadStatic]
         private static ThreadTaskQueue workQueue;
 
-        private ThreadTaskQueue[] workQueues;
+        private ThreadTaskQueue[] _workQueues;
 
         public HystrixSyncTaskScheduler(IHystrixThreadPoolOptions options)
             : base(options)
@@ -51,14 +51,14 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Strategy.Concurrency
         {
             for (int i = 0; i < corePoolSize; i++)
             {
-                if (!workQueues[i].ThreadAssigned)
+                if (!_workQueues[i].ThreadAssigned)
                 {
-                    lock (workQueues[i])
+                    lock (_workQueues[i])
                     {
-                        if (!workQueues[i].ThreadAssigned)
+                        if (!_workQueues[i].ThreadAssigned)
                         {
-                            workQueues[i].ThreadAssigned = true;
-                            StartThreadPoolWorker(workQueues[i]);
+                            _workQueues[i].ThreadAssigned = true;
+                            StartThreadPoolWorker(_workQueues[i]);
                             Interlocked.Increment(ref runningThreads);
                             break;
                         }
@@ -158,7 +158,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Strategy.Concurrency
 
         protected virtual bool TryAddToAny(Task task)
         {
-            foreach (ThreadTaskQueue queue in workQueues)
+            foreach (ThreadTaskQueue queue in _workQueues)
             {
                 if (queue.ThreadAssigned && queue.Task == null)
                 {
@@ -179,10 +179,10 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Strategy.Concurrency
 
         protected void SetupWorkQueues(int size)
         {
-            workQueues = new ThreadTaskQueue[size];
+            _workQueues = new ThreadTaskQueue[size];
             for (int i = 0; i < size; i++)
             {
-                workQueues[i] = new ThreadTaskQueue();
+                _workQueues[i] = new ThreadTaskQueue();
             }
         }
 
@@ -192,9 +192,9 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Strategy.Concurrency
             get
             {
                 int size = 0;
-                for (int i = 0; i < workQueues.Length; i++)
+                for (int i = 0; i < _workQueues.Length; i++)
                 {
-                    ThreadTaskQueue queue = workQueues[i];
+                    ThreadTaskQueue queue = _workQueues[i];
                     if (queue.ThreadAssigned && queue.Task != null)
                     {
                         size++;
@@ -207,7 +207,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Strategy.Concurrency
 
         public override bool IsQueueSpaceAvailable
         {
-            get { return CurrentQueueSize < workQueues.Length;  }
+            get { return CurrentQueueSize < _workQueues.Length;  }
         }
 
         #endregion IHystrixTaskScheduler

--- a/src/CircuitBreaker/src/HystrixBase/Strategy/Metrics/HystrixMetricsPublisherFactory.cs
+++ b/src/CircuitBreaker/src/HystrixBase/Strategy/Metrics/HystrixMetricsPublisherFactory.cs
@@ -38,7 +38,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Strategy.Metrics
         {
         }
 
-        private readonly ConcurrentDictionary<string, IHystrixMetricsPublisherCommand> commandPublishers = new ConcurrentDictionary<string, IHystrixMetricsPublisherCommand>();
+        private readonly ConcurrentDictionary<string, IHystrixMetricsPublisherCommand> _commandPublishers = new ConcurrentDictionary<string, IHystrixMetricsPublisherCommand>();
 
         internal IHystrixMetricsPublisherCommand GetPublisherForCommand(IHystrixCommandKey commandKey, IHystrixCommandGroupKey commandOwner, HystrixCommandMetrics metrics, IHystrixCircuitBreaker circuitBreaker, IHystrixCommandOptions properties)
         {
@@ -50,7 +50,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Strategy.Metrics
             });
         }
 
-        private readonly ConcurrentDictionary<string, IHystrixMetricsPublisherThreadPool> threadPoolPublishers = new ConcurrentDictionary<string, IHystrixMetricsPublisherThreadPool>();
+        private readonly ConcurrentDictionary<string, IHystrixMetricsPublisherThreadPool> _threadPoolPublishers = new ConcurrentDictionary<string, IHystrixMetricsPublisherThreadPool>();
 
         internal IHystrixMetricsPublisherThreadPool GetPublisherForThreadPool(IHystrixThreadPoolKey threadPoolKey, HystrixThreadPoolMetrics metrics, IHystrixThreadPoolOptions properties)
         {
@@ -62,13 +62,13 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Strategy.Metrics
             });
         }
 
-        private readonly ConcurrentDictionary<string, IHystrixMetricsPublisherCollapser> collapserPublishers = new ConcurrentDictionary<string, IHystrixMetricsPublisherCollapser>();
+        private readonly ConcurrentDictionary<string, IHystrixMetricsPublisherCollapser> _collapserPublishers = new ConcurrentDictionary<string, IHystrixMetricsPublisherCollapser>();
 
-        internal ConcurrentDictionary<string, IHystrixMetricsPublisherCommand> CommandPublishers => commandPublishers;
+        internal ConcurrentDictionary<string, IHystrixMetricsPublisherCommand> CommandPublishers => _commandPublishers;
 
-        internal ConcurrentDictionary<string, IHystrixMetricsPublisherThreadPool> ThreadPoolPublishers => threadPoolPublishers;
+        internal ConcurrentDictionary<string, IHystrixMetricsPublisherThreadPool> ThreadPoolPublishers => _threadPoolPublishers;
 
-        internal ConcurrentDictionary<string, IHystrixMetricsPublisherCollapser> CollapserPublishers => collapserPublishers;
+        internal ConcurrentDictionary<string, IHystrixMetricsPublisherCollapser> CollapserPublishers => _collapserPublishers;
 
         internal IHystrixMetricsPublisherCollapser GetPublisherForCollapser(IHystrixCollapserKey collapserKey, HystrixCollapserMetrics metrics, IHystrixCollapserOptions properties)
         {

--- a/src/CircuitBreaker/src/HystrixBase/Strategy/Metrics/HystrixMetricsPublisherFactory.cs
+++ b/src/CircuitBreaker/src/HystrixBase/Strategy/Metrics/HystrixMetricsPublisherFactory.cs
@@ -38,8 +38,6 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Strategy.Metrics
         {
         }
 
-        private readonly ConcurrentDictionary<string, IHystrixMetricsPublisherCommand> _commandPublishers = new ConcurrentDictionary<string, IHystrixMetricsPublisherCommand>();
-
         internal IHystrixMetricsPublisherCommand GetPublisherForCommand(IHystrixCommandKey commandKey, IHystrixCommandGroupKey commandOwner, HystrixCommandMetrics metrics, IHystrixCircuitBreaker circuitBreaker, IHystrixCommandOptions properties)
         {
             return CommandPublishers.GetOrAddEx(commandKey.Name, (k) =>
@@ -49,8 +47,6 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Strategy.Metrics
                 return newPublisher;
             });
         }
-
-        private readonly ConcurrentDictionary<string, IHystrixMetricsPublisherThreadPool> _threadPoolPublishers = new ConcurrentDictionary<string, IHystrixMetricsPublisherThreadPool>();
 
         internal IHystrixMetricsPublisherThreadPool GetPublisherForThreadPool(IHystrixThreadPoolKey threadPoolKey, HystrixThreadPoolMetrics metrics, IHystrixThreadPoolOptions properties)
         {
@@ -62,13 +58,11 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Strategy.Metrics
             });
         }
 
-        private readonly ConcurrentDictionary<string, IHystrixMetricsPublisherCollapser> _collapserPublishers = new ConcurrentDictionary<string, IHystrixMetricsPublisherCollapser>();
+        internal ConcurrentDictionary<string, IHystrixMetricsPublisherCommand> CommandPublishers { get; } = new ConcurrentDictionary<string, IHystrixMetricsPublisherCommand>();
 
-        internal ConcurrentDictionary<string, IHystrixMetricsPublisherCommand> CommandPublishers => _commandPublishers;
+        internal ConcurrentDictionary<string, IHystrixMetricsPublisherThreadPool> ThreadPoolPublishers { get; } = new ConcurrentDictionary<string, IHystrixMetricsPublisherThreadPool>();
 
-        internal ConcurrentDictionary<string, IHystrixMetricsPublisherThreadPool> ThreadPoolPublishers => _threadPoolPublishers;
-
-        internal ConcurrentDictionary<string, IHystrixMetricsPublisherCollapser> CollapserPublishers => _collapserPublishers;
+        internal ConcurrentDictionary<string, IHystrixMetricsPublisherCollapser> CollapserPublishers { get; } = new ConcurrentDictionary<string, IHystrixMetricsPublisherCollapser>();
 
         internal IHystrixMetricsPublisherCollapser GetPublisherForCollapser(IHystrixCollapserKey collapserKey, HystrixCollapserMetrics metrics, IHystrixCollapserOptions properties)
         {

--- a/src/CircuitBreaker/src/HystrixBase/Strategy/Options/HystrixDynamicOptionsDefault.cs
+++ b/src/CircuitBreaker/src/HystrixBase/Strategy/Options/HystrixDynamicOptionsDefault.cs
@@ -9,16 +9,16 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Strategy.Options
 {
     public class HystrixDynamicOptionsDefault : IHystrixDynamicOptions
     {
-        private IConfiguration configSource;
+        private IConfiguration _configSource;
 
         public HystrixDynamicOptionsDefault(IConfiguration configSource)
         {
-            this.configSource = configSource;
+            this._configSource = configSource;
         }
 
         public bool GetBoolean(string name, bool fallback)
         {
-            var val = configSource[name];
+            var val = _configSource[name];
             if (val == null)
             {
                 return fallback;
@@ -34,7 +34,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Strategy.Options
 
         public int GetInteger(string name, int fallback)
         {
-            var val = configSource[name];
+            var val = _configSource[name];
             if (val == null)
             {
                 return fallback;
@@ -51,7 +51,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Strategy.Options
 
         public long GetLong(string name, long fallback)
         {
-            var val = configSource[name];
+            var val = _configSource[name];
             if (val == null)
             {
                 return fallback;
@@ -68,7 +68,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Strategy.Options
 
         public string GetString(string name, string fallback)
         {
-            var val = configSource[name];
+            var val = _configSource[name];
             if (val == null)
             {
                 return fallback;

--- a/src/CircuitBreaker/src/HystrixBase/ThreadPool/HystrixThreadPoolDefault.cs
+++ b/src/CircuitBreaker/src/HystrixBase/ThreadPool/HystrixThreadPoolDefault.cs
@@ -13,47 +13,47 @@ namespace Steeltoe.CircuitBreaker.Hystrix.ThreadPool
 {
     public class HystrixThreadPoolDefault : IHystrixThreadPool
     {
-        private readonly IHystrixThreadPoolOptions properties;
-        private readonly IHystrixTaskScheduler taskScheduler;
-        private readonly HystrixThreadPoolMetrics metrics;
-        private readonly int queueSize;
+        private readonly IHystrixThreadPoolOptions _properties;
+        private readonly IHystrixTaskScheduler _taskScheduler;
+        private readonly HystrixThreadPoolMetrics _metrics;
+        private readonly int _queueSize;
 
         public HystrixThreadPoolDefault(IHystrixThreadPoolKey threadPoolKey, IHystrixThreadPoolOptions propertiesDefaults)
         {
-            this.properties = HystrixOptionsFactory.GetThreadPoolOptions(threadPoolKey, propertiesDefaults);
-            this.properties = propertiesDefaults ?? new HystrixThreadPoolOptions(threadPoolKey);
+            this._properties = HystrixOptionsFactory.GetThreadPoolOptions(threadPoolKey, propertiesDefaults);
+            this._properties = propertiesDefaults ?? new HystrixThreadPoolOptions(threadPoolKey);
             HystrixConcurrencyStrategy concurrencyStrategy = HystrixPlugins.ConcurrencyStrategy;
-            this.queueSize = properties.MaxQueueSize;
-            this.metrics = HystrixThreadPoolMetrics.GetInstance(threadPoolKey, concurrencyStrategy.GetTaskScheduler(properties), properties);
-            this.taskScheduler = this.metrics.TaskScheduler;
+            this._queueSize = _properties.MaxQueueSize;
+            this._metrics = HystrixThreadPoolMetrics.GetInstance(threadPoolKey, concurrencyStrategy.GetTaskScheduler(_properties), _properties);
+            this._taskScheduler = this._metrics.TaskScheduler;
 
             /* strategy: HystrixMetricsPublisherThreadPool */
-            HystrixMetricsPublisherFactory.CreateOrRetrievePublisherForThreadPool(threadPoolKey, this.metrics, this.properties);
+            HystrixMetricsPublisherFactory.CreateOrRetrievePublisherForThreadPool(threadPoolKey, this._metrics, this._properties);
         }
 
         public IHystrixTaskScheduler GetScheduler()
         {
-            return this.taskScheduler;
+            return this._taskScheduler;
         }
 
         public TaskScheduler GetTaskScheduler()
         {
-            return this.taskScheduler as TaskScheduler;
+            return this._taskScheduler as TaskScheduler;
         }
 
         public void MarkThreadExecution()
         {
-            metrics.MarkThreadExecution();
+            _metrics.MarkThreadExecution();
         }
 
         public void MarkThreadCompletion()
         {
-            metrics.MarkThreadCompletion();
+            _metrics.MarkThreadCompletion();
         }
 
         public void MarkThreadRejection()
         {
-            metrics.MarkThreadRejection();
+            _metrics.MarkThreadRejection();
         }
 
         public void Dispose()
@@ -64,14 +64,14 @@ namespace Steeltoe.CircuitBreaker.Hystrix.ThreadPool
 
         protected virtual void Dispose(bool disposing)
         {
-            this.taskScheduler.Dispose();
+            this._taskScheduler.Dispose();
         }
 
         public bool IsQueueSpaceAvailable
         {
             get
             {
-                if (queueSize <= 0)
+                if (_queueSize <= 0)
                 {
                     // we don't have a queue so we won't look for space but instead
                     // let the thread-pool reject or not
@@ -79,14 +79,14 @@ namespace Steeltoe.CircuitBreaker.Hystrix.ThreadPool
                 }
                 else
                 {
-                    return taskScheduler.IsQueueSpaceAvailable;
+                    return _taskScheduler.IsQueueSpaceAvailable;
                 }
             }
         }
 
         public bool IsShutdown
         {
-            get { return this.taskScheduler.IsShutdown; }
+            get { return this._taskScheduler.IsShutdown; }
         }
     }
 }

--- a/src/CircuitBreaker/src/HystrixBase/ThreadPool/HystrixThreadPoolFactory.cs
+++ b/src/CircuitBreaker/src/HystrixBase/ThreadPool/HystrixThreadPoolFactory.cs
@@ -9,8 +9,6 @@ namespace Steeltoe.CircuitBreaker.Hystrix.ThreadPool
 {
     internal static class HystrixThreadPoolFactory
     {
-        private static readonly ConcurrentDictionary<string, IHystrixThreadPool> _threadPools = new ConcurrentDictionary<string, IHystrixThreadPool>();
-
         internal static IHystrixThreadPool GetInstance(IHystrixThreadPoolKey threadPoolKey, IHystrixThreadPoolOptions propertiesBuilder)
         {
             // get the key to use instead of using the object itself so that if people forget to implement equals/hashcode things will still work
@@ -22,7 +20,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix.ThreadPool
 
         private static object shutdownLock = new object();
 
-        internal static ConcurrentDictionary<string, IHystrixThreadPool> ThreadPools => _threadPools;
+        internal static ConcurrentDictionary<string, IHystrixThreadPool> ThreadPools { get; } = new ConcurrentDictionary<string, IHystrixThreadPool>();
 
         internal static void Shutdown()
         {

--- a/src/CircuitBreaker/src/HystrixBase/ThreadPoolEventTypeHelper.cs
+++ b/src/CircuitBreaker/src/HystrixBase/ThreadPoolEventTypeHelper.cs
@@ -10,17 +10,12 @@ namespace Steeltoe.CircuitBreaker.Hystrix
 {
     public static class ThreadPoolEventTypeHelper
     {
-        private static readonly IList<ThreadPoolEventType> ValueList = new List<ThreadPoolEventType>();
-
-        public static IList<ThreadPoolEventType> Values
-        {
-            get { return ValueList; }
-        }
+        public static IList<ThreadPoolEventType> Values { get; } = new List<ThreadPoolEventType>();
 
         static ThreadPoolEventTypeHelper()
         {
-            ValueList.Add(ThreadPoolEventType.EXECUTED);
-            ValueList.Add(ThreadPoolEventType.REJECTED);
+            Values.Add(ThreadPoolEventType.EXECUTED);
+            Values.Add(ThreadPoolEventType.REJECTED);
         }
 
         public static ThreadPoolEventType From(this HystrixRollingNumberEvent @event)

--- a/src/CircuitBreaker/src/HystrixBase/Util/HystrixRollingNumber.cs
+++ b/src/CircuitBreaker/src/HystrixBase/Util/HystrixRollingNumber.cs
@@ -19,7 +19,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Util
         internal readonly CumulativeSum _cumulativeSum = new CumulativeSum();
 
         private static ITime actual_time = new ActualTime();
-        private readonly ITime time;
+        private readonly ITime _time;
 
         public HystrixRollingNumber(int timeInMilliseconds, int numberOfBuckets)
             : this(actual_time, timeInMilliseconds, numberOfBuckets)
@@ -29,7 +29,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Util
         /* package for testing */
         internal HystrixRollingNumber(ITime time, int timeInMilliseconds, int numberOfBuckets)
         {
-            this.time = time;
+            this._time = time;
             this._timeInMilliseconds = timeInMilliseconds;
             this._numberOfBuckets = numberOfBuckets;
 
@@ -151,12 +151,12 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Util
             }
         }
 
-        private object newBucketLock = new object();
+        private object _newBucketLock = new object();
 
         /* package for testing */
         internal Bucket GetCurrentBucket()
         {
-            long currentTime = time.CurrentTimeInMillis;
+            long currentTime = _time.CurrentTimeInMillis;
 
             /* a shortcut to try and get the most common result of immediately finding the current bucket */
 
@@ -194,10 +194,10 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Util
              * versus a synchronized block needs to be accommodated.
              */
             bool lockTaken = false;
-            Monitor.TryEnter(newBucketLock, ref lockTaken);
+            Monitor.TryEnter(_newBucketLock, ref lockTaken);
             if (lockTaken)
             {
-                currentTime = time.CurrentTimeInMillis;
+                currentTime = _time.CurrentTimeInMillis;
                 try
                 {
                     if (_buckets.PeekLast == null)
@@ -248,7 +248,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Util
                 }
                 finally
                 {
-                    Monitor.Exit(newBucketLock);
+                    Monitor.Exit(_newBucketLock);
                 }
             }
             else
@@ -442,9 +442,9 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Util
 
         internal class BucketCircularArray : IEnumerable<Bucket>
         {
-            private readonly AtomicReference<ListState> state;
-            private readonly int dataLength; // we don't resize, we always stay the same, so remember this
-            private readonly int numBuckets;
+            private readonly AtomicReference<ListState> _state;
+            private readonly int _dataLength; // we don't resize, we always stay the same, so remember this
+            private readonly int _numBuckets;
 
             internal class ListState
             {
@@ -470,7 +470,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Util
                     }
                     else
                     {
-                        this._size = (tail + ca.dataLength - head) % ca.dataLength;
+                        this._size = (tail + ca._dataLength - head) % ca._dataLength;
                     }
 
                     this._data = data;
@@ -513,7 +513,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Util
 
                 public ListState Clear()
                 {
-                    return new ListState(_ca, new AtomicReferenceArray<Bucket>(_ca.dataLength), 0, 0);
+                    return new ListState(_ca, new AtomicReferenceArray<Bucket>(_ca._dataLength), 0, 0);
                 }
 
                 public ListState AddBucket(Bucket b)
@@ -533,21 +533,21 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Util
                 // always 0) and calculates the index within elementData
                 private int Convert(int index)
                 {
-                    return (index + _head) % _ca.dataLength;
+                    return (index + _head) % _ca._dataLength;
                 }
 
                 private ListState IncrementTail()
                 {
                     /* if incrementing results in growing larger than 'length' which is the max we should be at, then also increment head (equivalent of removeFirst but done atomically) */
-                    if (_size == _ca.numBuckets)
+                    if (_size == _ca._numBuckets)
                     {
                         // increment tail and head
-                        return new ListState(_ca, _data, (_head + 1) % _ca.dataLength, (_listtail + 1) % _ca.dataLength);
+                        return new ListState(_ca, _data, (_head + 1) % _ca._dataLength, (_listtail + 1) % _ca._dataLength);
                     }
                     else
                     {
                         // increment only tail
-                        return new ListState(_ca, _data, _head, (_listtail + 1) % _ca.dataLength);
+                        return new ListState(_ca, _data, _head, (_listtail + 1) % _ca._dataLength);
                     }
                 }
             }
@@ -555,9 +555,9 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Util
             public BucketCircularArray(int size)
             {
                 AtomicReferenceArray<Bucket> buckets = new AtomicReferenceArray<Bucket>(size + 1); // + 1 as extra room for the add/remove;
-                state = new AtomicReference<ListState>(new ListState(this, buckets, 0, 0));
-                dataLength = buckets.Length;
-                numBuckets = size;
+                _state = new AtomicReference<ListState>(new ListState(this, buckets, 0, 0));
+                _dataLength = buckets.Length;
+                _numBuckets = size;
             }
 
             public void Clear()
@@ -575,9 +575,9 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Util
                      * The rare scenario in which that would occur, we'll accept the possible data loss while clearing it
                      * since the code has stated its desire to clear() anyways.
                      */
-                    ListState current = state.Value;
+                    ListState current = _state.Value;
                     ListState newState = current.Clear();
-                    if (state.CompareAndSet(current, newState))
+                    if (_state.CompareAndSet(current, newState))
                     {
                         return;
                     }
@@ -586,7 +586,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Util
 
             public void AddLast(Bucket o)
             {
-                ListState currentState = state.Value;
+                ListState currentState = _state.Value;
 
                 // create new version of state (what we want it to become)
                 ListState newState = currentState.AddBucket(o);
@@ -596,7 +596,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Util
                  * provided in <code>getCurrentBucket</code>)
                  */
 #pragma warning disable S3923 // All branches in a conditional structure should not have exactly the same implementation
-                if (state.CompareAndSet(currentState, newState))
+                if (_state.CompareAndSet(currentState, newState))
                 {
                     // we succeeded
                 }
@@ -618,7 +618,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Util
             {
                 // the size can also be worked out each time as:
                 // return (tail + data.length() - head) % data.length();
-                get { return state.Value._size; }
+                get { return _state.Value._size; }
             }
 
             IEnumerator IEnumerable.GetEnumerator()
@@ -634,12 +634,12 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Util
 
             public Bucket PeekLast
             {
-                get { return state.Value.Tail; }
+                get { return _state.Value.Tail; }
             }
 
             public Bucket[] Array
             {
-                get { return state.Value.Array; }
+                get { return _state.Value.Array; }
             }
         }
     }

--- a/src/CircuitBreaker/src/HystrixBase/Util/HystrixRollingNumberEventHelper.cs
+++ b/src/CircuitBreaker/src/HystrixBase/Util/HystrixRollingNumberEventHelper.cs
@@ -9,37 +9,32 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Util
 {
     internal static class HystrixRollingNumberEventHelper
     {
-        private static readonly IList<HystrixRollingNumberEvent> _valueList = new List<HystrixRollingNumberEvent>();
-
         static HystrixRollingNumberEventHelper()
         {
-            _valueList.Add(HystrixRollingNumberEvent.SUCCESS);
-            _valueList.Add(HystrixRollingNumberEvent.FAILURE);
-            _valueList.Add(HystrixRollingNumberEvent.TIMEOUT);
-            _valueList.Add(HystrixRollingNumberEvent.SHORT_CIRCUITED);
-            _valueList.Add(HystrixRollingNumberEvent.THREAD_POOL_REJECTED);
-            _valueList.Add(HystrixRollingNumberEvent.SEMAPHORE_REJECTED);
-            _valueList.Add(HystrixRollingNumberEvent.BAD_REQUEST);
-            _valueList.Add(HystrixRollingNumberEvent.FALLBACK_SUCCESS);
-            _valueList.Add(HystrixRollingNumberEvent.FALLBACK_FAILURE);
-            _valueList.Add(HystrixRollingNumberEvent.FALLBACK_REJECTION);
-            _valueList.Add(HystrixRollingNumberEvent.FALLBACK_MISSING);
-            _valueList.Add(HystrixRollingNumberEvent.EXCEPTION_THROWN);
-            _valueList.Add(HystrixRollingNumberEvent.COMMAND_MAX_ACTIVE);
-            _valueList.Add(HystrixRollingNumberEvent.EMIT);
-            _valueList.Add(HystrixRollingNumberEvent.FALLBACK_EMIT);
-            _valueList.Add(HystrixRollingNumberEvent.THREAD_EXECUTION);
-            _valueList.Add(HystrixRollingNumberEvent.THREAD_MAX_ACTIVE);
-            _valueList.Add(HystrixRollingNumberEvent.COLLAPSED);
-            _valueList.Add(HystrixRollingNumberEvent.RESPONSE_FROM_CACHE);
-            _valueList.Add(HystrixRollingNumberEvent.COLLAPSER_REQUEST_BATCHED);
-            _valueList.Add(HystrixRollingNumberEvent.COLLAPSER_BATCH);
+            Values.Add(HystrixRollingNumberEvent.SUCCESS);
+            Values.Add(HystrixRollingNumberEvent.FAILURE);
+            Values.Add(HystrixRollingNumberEvent.TIMEOUT);
+            Values.Add(HystrixRollingNumberEvent.SHORT_CIRCUITED);
+            Values.Add(HystrixRollingNumberEvent.THREAD_POOL_REJECTED);
+            Values.Add(HystrixRollingNumberEvent.SEMAPHORE_REJECTED);
+            Values.Add(HystrixRollingNumberEvent.BAD_REQUEST);
+            Values.Add(HystrixRollingNumberEvent.FALLBACK_SUCCESS);
+            Values.Add(HystrixRollingNumberEvent.FALLBACK_FAILURE);
+            Values.Add(HystrixRollingNumberEvent.FALLBACK_REJECTION);
+            Values.Add(HystrixRollingNumberEvent.FALLBACK_MISSING);
+            Values.Add(HystrixRollingNumberEvent.EXCEPTION_THROWN);
+            Values.Add(HystrixRollingNumberEvent.COMMAND_MAX_ACTIVE);
+            Values.Add(HystrixRollingNumberEvent.EMIT);
+            Values.Add(HystrixRollingNumberEvent.FALLBACK_EMIT);
+            Values.Add(HystrixRollingNumberEvent.THREAD_EXECUTION);
+            Values.Add(HystrixRollingNumberEvent.THREAD_MAX_ACTIVE);
+            Values.Add(HystrixRollingNumberEvent.COLLAPSED);
+            Values.Add(HystrixRollingNumberEvent.RESPONSE_FROM_CACHE);
+            Values.Add(HystrixRollingNumberEvent.COLLAPSER_REQUEST_BATCHED);
+            Values.Add(HystrixRollingNumberEvent.COLLAPSER_BATCH);
         }
 
-        public static IList<HystrixRollingNumberEvent> Values
-        {
-            get { return _valueList; }
-        }
+        public static IList<HystrixRollingNumberEvent> Values { get; } = new List<HystrixRollingNumberEvent>();
 
         public static HystrixRollingNumberEvent From(HystrixEventType eventType)
         {

--- a/src/CircuitBreaker/src/HystrixBase/Util/HystrixRollingPercentile.cs
+++ b/src/CircuitBreaker/src/HystrixBase/Util/HystrixRollingPercentile.cs
@@ -301,7 +301,6 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Util
         {
             private readonly int[] _data;
             private readonly int _length;
-            private int _mean;
 
             /* package for testing */
             public PercentileSnapshot(Bucket[] buckets)
@@ -333,11 +332,11 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Util
                 _length = index;
                 if (_length == 0)
                 {
-                    _mean = 0;
+                    Mean = 0;
                 }
                 else
                 {
-                    _mean = sum / _length;
+                    Mean = sum / _length;
                 }
 
                 Array.Sort(_data, 0, _length);
@@ -355,16 +354,13 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Util
                     sum += v;
                 }
 
-                _mean = sum / _length;
+                Mean = sum / _length;
 
                 Array.Sort(this._data, 0, _length);
             }
 
             /* package for testing */
-            public int Mean
-            {
-                get { return _mean; }
-            }
+            public int Mean { get; }
 
             public int GetPercentile(double percentile)
             {

--- a/src/CircuitBreaker/src/HystrixBase/Util/HystrixTimer.cs
+++ b/src/CircuitBreaker/src/HystrixBase/Util/HystrixTimer.cs
@@ -11,7 +11,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Util
     {
         private static readonly HystrixTimer Instance = new HystrixTimer();
 
-        private readonly List<TimerReference> timerList = new List<TimerReference>();
+        private readonly List<TimerReference> _timerList = new List<TimerReference>();
         private readonly object _lock = new object();
 
         private HystrixTimer()
@@ -28,7 +28,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Util
             HystrixTimer timer = GetInstance();
             lock (timer._lock)
             {
-                foreach (TimerReference refr in timer.timerList)
+                foreach (TimerReference refr in timer._timerList)
                 {
                     refr.Dispose();
                 }
@@ -42,7 +42,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Util
 
             lock (_lock)
             {
-                timerList.Add(refr);
+                _timerList.Add(refr);
             }
 
             return refr;

--- a/src/CircuitBreaker/test/HystrixBase.Test/HystrixThreadPoolTest.cs
+++ b/src/CircuitBreaker/test/HystrixBase.Test/HystrixThreadPoolTest.cs
@@ -44,21 +44,16 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Test
 
         private class HystrixMetricsPublisherThreadPoolContainer : IHystrixMetricsPublisherThreadPool
         {
-            private readonly HystrixThreadPoolMetrics hystrixThreadPoolMetrics;
-
             public HystrixMetricsPublisherThreadPoolContainer(HystrixThreadPoolMetrics hystrixThreadPoolMetrics)
             {
-                this.hystrixThreadPoolMetrics = hystrixThreadPoolMetrics;
+                this.HystrixThreadPoolMetrics = hystrixThreadPoolMetrics;
             }
 
             public void Initialize()
             {
             }
 
-            public HystrixThreadPoolMetrics HystrixThreadPoolMetrics
-            {
-                get { return hystrixThreadPoolMetrics; }
-            }
+            public HystrixThreadPoolMetrics HystrixThreadPoolMetrics { get; private set; }
         }
 
         private class MyHystrixMetricsPublisher : HystrixMetricsPublisher

--- a/src/CircuitBreaker/test/HystrixBase.Test/Serial/SerialHystrixRequestEventsTest.cs
+++ b/src/CircuitBreaker/test/HystrixBase.Test/Serial/SerialHystrixRequestEventsTest.cs
@@ -298,38 +298,35 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Serial.Test
 
         private class SimpleExecution : IHystrixInvokableInfo
         {
-            private readonly IHystrixCommandKey commandKey;
             private readonly ExecutionResult executionResult;
-            private readonly string cacheKey;
-            private readonly IHystrixCollapserKey collapserKey;
 
             public SimpleExecution(IHystrixCommandKey commandKey, int latency, params HystrixEventType[] events)
             {
-                this.commandKey = commandKey;
+                this.CommandKey = commandKey;
                 this.executionResult = ExecutionResult.From(events).SetExecutionLatency(latency);
-                this.cacheKey = null;
-                this.collapserKey = null;
+                this.PublicCacheKey = null;
+                this.OriginatingCollapserKey = null;
             }
 
             public SimpleExecution(IHystrixCommandKey commandKey, int latency, string cacheKey, params HystrixEventType[] events)
             {
-                this.commandKey = commandKey;
+                this.CommandKey = commandKey;
                 this.executionResult = ExecutionResult.From(events).SetExecutionLatency(latency);
-                this.cacheKey = cacheKey;
-                this.collapserKey = null;
+                this.PublicCacheKey = cacheKey;
+                this.OriginatingCollapserKey = null;
             }
 
             public SimpleExecution(IHystrixCommandKey commandKey, string cacheKey)
             {
-                this.commandKey = commandKey;
+                this.CommandKey = commandKey;
                 this.executionResult = ExecutionResult.From(HystrixEventType.RESPONSE_FROM_CACHE);
-                this.cacheKey = cacheKey;
-                this.collapserKey = null;
+                this.PublicCacheKey = cacheKey;
+                this.OriginatingCollapserKey = null;
             }
 
             public SimpleExecution(IHystrixCommandKey commandKey, int latency, IHystrixCollapserKey collapserKey, int batchSize, params HystrixEventType[] events)
             {
-                this.commandKey = commandKey;
+                this.CommandKey = commandKey;
                 ExecutionResult interimResult = ExecutionResult.From(events).SetExecutionLatency(latency);
                 for (int i = 0; i < batchSize; i++)
                 {
@@ -337,8 +334,8 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Serial.Test
                 }
 
                 this.executionResult = interimResult;
-                this.cacheKey = null;
-                this.collapserKey = collapserKey;
+                this.PublicCacheKey = null;
+                this.OriginatingCollapserKey = collapserKey;
             }
 
             public IHystrixCommandGroupKey CommandGroup
@@ -346,25 +343,16 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Serial.Test
                 get { return GroupKey; }
             }
 
-            public IHystrixCommandKey CommandKey
-            {
-                get { return commandKey; }
-            }
+            public IHystrixCommandKey CommandKey { get; private set; }
 
             public IHystrixThreadPoolKey ThreadPoolKey
             {
                 get { return SerialHystrixRequestEventsTest.ThreadPoolKey; }
             }
 
-            public string PublicCacheKey
-            {
-                get { return cacheKey; }
-            }
+            public string PublicCacheKey { get; private set; }
 
-            public IHystrixCollapserKey OriginatingCollapserKey
-            {
-                get { return collapserKey; }
-            }
+            public IHystrixCollapserKey OriginatingCollapserKey { get; private set; }
 
             public HystrixCommandMetrics Metrics
             {
@@ -479,10 +467,10 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Serial.Test
             public override string ToString()
             {
                 return "SimpleExecution{" +
-                        "commandKey=" + commandKey.Name +
+                        "commandKey=" + CommandKey.Name +
                         ", executionResult=" + executionResult +
-                        ", cacheKey='" + cacheKey + '\'' +
-                        ", collapserKey=" + collapserKey +
+                        ", cacheKey='" + PublicCacheKey + '\'' +
+                        ", collapserKey=" + OriginatingCollapserKey +
                         '}';
             }
         }

--- a/src/Common/src/Common.Autofac/Logging/LoggerFilterConfigureOptions.cs
+++ b/src/Common/src/Common.Autofac/Logging/LoggerFilterConfigureOptions.cs
@@ -11,11 +11,11 @@ namespace Steeltoe.Common.Logging.Autofac
 {
     public class LoggerFilterConfigureOptions : IConfigureOptions<LoggerFilterOptions>
     {
-        private readonly IConfiguration configuration;
+        private readonly IConfiguration _configuration;
 
         public LoggerFilterConfigureOptions(IConfiguration configuration)
         {
-            this.configuration = configuration;
+            this._configuration = configuration;
         }
 
         public void Configure(LoggerFilterOptions options)
@@ -42,12 +42,12 @@ namespace Steeltoe.Common.Logging.Autofac
 
         private void LoadDefaultConfigValues(LoggerFilterOptions options)
         {
-            if (configuration == null)
+            if (_configuration == null)
             {
                 return;
             }
 
-            foreach (var configurationSection in configuration.GetChildren())
+            foreach (var configurationSection in _configuration.GetChildren())
             {
                 if (configurationSection.Key == "LogLevel")
                 {

--- a/src/Common/src/Common/Diagnostics/DiagnosticsManager.cs
+++ b/src/Common/src/Common/Diagnostics/DiagnosticsManager.cs
@@ -101,7 +101,7 @@ namespace Steeltoe.Common.Diagnostics
             }
         }
 
-        private bool disposed = false;
+        private bool _disposed = false;
 
         public void Dispose()
         {
@@ -112,7 +112,7 @@ namespace Steeltoe.Common.Diagnostics
         protected virtual void Dispose(bool disposing)
         {
             // Cleanup
-            if (!this.disposed)
+            if (!this._disposed)
             {
                 if (disposing)
                 {
@@ -131,7 +131,7 @@ namespace Steeltoe.Common.Diagnostics
                     _logger = null;
                 }
 
-                disposed = true;
+                _disposed = true;
             }
         }
 

--- a/src/Common/test/Common.Http.Test/TestServiceInstance.cs
+++ b/src/Common/test/Common.Http.Test/TestServiceInstance.cs
@@ -10,11 +10,9 @@ namespace Steeltoe.Common.Http.Test
 {
     internal class TestServiceInstance : IServiceInstance
     {
-        private Uri _uri;
-
         public TestServiceInstance(Uri uri)
         {
-            _uri = uri;
+            Uri = uri;
         }
 
         public string Host
@@ -57,12 +55,6 @@ namespace Steeltoe.Common.Http.Test
             }
         }
 
-        public Uri Uri
-        {
-            get
-            {
-                return _uri;
-            }
-        }
+        public Uri Uri { get; private set; }
     }
 }

--- a/src/Configuration/src/ConfigServerBase/ConfigServerClientSettings.cs
+++ b/src/Configuration/src/ConfigServerBase/ConfigServerClientSettings.cs
@@ -120,8 +120,8 @@ namespace Steeltoe.Extensions.Configuration.ConfigServer
         private static readonly char[] COLON_DELIMIT = new char[] { ':' };
         private static readonly char[] COMMA_DELIMIT = new char[] { ',' };
 
-        private string username;
-        private string password;
+        private string _username;
+        private string _password;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ConfigServerClientSettings"/> class.
@@ -179,7 +179,7 @@ namespace Steeltoe.Extensions.Configuration.ConfigServer
         public virtual string Username
         {
             get { return GetUserName(); }
-            set { this.username = value; }
+            set { this._username = value; }
         }
 
         /// <summary>
@@ -188,7 +188,7 @@ namespace Steeltoe.Extensions.Configuration.ConfigServer
         public virtual string Password
         {
             get { return GetPassword(); }
-            set { this.password = value; }
+            set { this._password = value; }
         }
 #pragma warning restore S4275 // Getters and setters should access the expected fields
 
@@ -377,9 +377,9 @@ namespace Steeltoe.Extensions.Configuration.ConfigServer
 
         internal string GetPassword(string uri)
         {
-            if (!string.IsNullOrEmpty(password))
+            if (!string.IsNullOrEmpty(_password))
             {
-                return password;
+                return _password;
             }
 
             return GetUserPassElement(uri, 1);
@@ -392,9 +392,9 @@ namespace Steeltoe.Extensions.Configuration.ConfigServer
 
         internal string GetUserName(string uri)
         {
-            if (!string.IsNullOrEmpty(username))
+            if (!string.IsNullOrEmpty(_username))
             {
-                return username;
+                return _username;
             }
 
             return GetUserPassElement(uri, 0);

--- a/src/Configuration/src/ConfigServerBase/ConfigServerConfigurationProvider.cs
+++ b/src/Configuration/src/ConfigServerBase/ConfigServerConfigurationProvider.cs
@@ -53,7 +53,7 @@ namespace Steeltoe.Extensions.Configuration.ConfigServer
         private static readonly char[] COMMA_DELIMIT = new char[] { ',' };
         private static readonly string[] EMPTY_LABELS = new string[] { string.Empty };
 
-        private Timer tokenRenewTimer;
+        private Timer _tokenRenewTimer;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ConfigServerConfigurationProvider"/> class with default
@@ -771,9 +771,9 @@ namespace Steeltoe.Extensions.Configuration.ConfigServer
 
         protected internal virtual void RenewToken(string token)
         {
-            if (tokenRenewTimer == null)
+            if (_tokenRenewTimer == null)
             {
-                tokenRenewTimer = new Timer(
+                _tokenRenewTimer = new Timer(
                     this.RefreshVaultTokenAsync,
                     null,
                     TimeSpan.FromMilliseconds(_settings.TokenRenewRate),

--- a/src/Configuration/src/PlaceholderBase/PlaceholderResolverProvider.cs
+++ b/src/Configuration/src/PlaceholderBase/PlaceholderResolverProvider.cs
@@ -20,7 +20,6 @@ namespace Steeltoe.Extensions.Configuration
     {
         internal IList<IConfigurationProvider> _providers = new List<IConfigurationProvider>();
         internal ILogger<PlaceholderResolverProvider> _logger;
-        private IList<string> _resolvedKeys = new List<string>();
 
         /// <summary>
         /// Gets the configuration this placeholder resolver wraps
@@ -67,10 +66,7 @@ namespace Steeltoe.Extensions.Configuration
             get { return _providers; }
         }
 
-        public IList<string> ResolvedKeys
-        {
-            get { return _resolvedKeys; }
-        }
+        public IList<string> ResolvedKeys { get; } = new List<string>();
 
         /// <summary>
         /// Tries to get a configuration value for the specified key. If the value is a placeholder
@@ -85,9 +81,9 @@ namespace Steeltoe.Extensions.Configuration
             var originalValue = Configuration[key];
             value = PropertyPlaceholderHelper.ResolvePlaceholders(originalValue, Configuration);
 
-            if (value != originalValue && !_resolvedKeys.Contains(key))
+            if (value != originalValue && !ResolvedKeys.Contains(key))
             {
-                _resolvedKeys.Add(key);
+                ResolvedKeys.Add(key);
             }
 
             return !string.IsNullOrEmpty(value);

--- a/src/Connectors/src/ConnectorBase/Cache/RedisCacheConnectorOptions.cs
+++ b/src/Connectors/src/ConnectorBase/Cache/RedisCacheConnectorOptions.cs
@@ -15,7 +15,7 @@ namespace Steeltoe.CloudFoundry.Connector.Redis
         private const string Default_Host = "localhost";
         private const int Default_Port = 6379;
         private const string RedisClientSectionPrefix = "redis:client";
-        private bool cloudFoundryConfigFound = false;
+        private bool _cloudFoundryConfigFound = false;
 
         public RedisCacheConnectorOptions()
             : base(',', Default_Separator)
@@ -33,7 +33,7 @@ namespace Steeltoe.CloudFoundry.Connector.Redis
             var section = config.GetSection(RedisClientSectionPrefix);
             section.Bind(this);
 
-            cloudFoundryConfigFound = config.HasCloudFoundryServiceConfigurations();
+            _cloudFoundryConfigFound = config.HasCloudFoundryServiceConfigurations();
         }
 
         // Configure either a single Host/Port or optionaly provide
@@ -86,7 +86,7 @@ namespace Steeltoe.CloudFoundry.Connector.Redis
         // public int? DefaultDatabase { get; set; }
         public override string ToString()
         {
-            if (!string.IsNullOrEmpty(ConnectionString) && !cloudFoundryConfigFound)
+            if (!string.IsNullOrEmpty(ConnectionString) && !_cloudFoundryConfigFound)
             {
                 return ConnectionString;
             }

--- a/src/Connectors/src/ConnectorBase/DocumentDB/MongoDb/MongoDbConnectorOptions.cs
+++ b/src/Connectors/src/ConnectorBase/DocumentDB/MongoDb/MongoDbConnectorOptions.cs
@@ -15,7 +15,7 @@ namespace Steeltoe.CloudFoundry.Connector.MongoDb
         public const string Default_Server = "localhost";
         public const int Default_Port = 27017;
         private const string MONGODB_CLIENT_SECTION_PREFIX = "mongodb:client";
-        private readonly bool cloudFoundryConfigFound = false;
+        private readonly bool _cloudFoundryConfigFound = false;
 
         public MongoDbConnectorOptions()
         {
@@ -32,7 +32,7 @@ namespace Steeltoe.CloudFoundry.Connector.MongoDb
             var section = config.GetSection(MONGODB_CLIENT_SECTION_PREFIX);
             section.Bind(this);
 
-            cloudFoundryConfigFound = config.HasCloudFoundryServiceConfigurations();
+            _cloudFoundryConfigFound = config.HasCloudFoundryServiceConfigurations();
         }
 
         public string ConnectionString { get; set; }
@@ -53,7 +53,7 @@ namespace Steeltoe.CloudFoundry.Connector.MongoDb
 
         public override string ToString()
         {
-            if (!string.IsNullOrEmpty(ConnectionString) && !cloudFoundryConfigFound)
+            if (!string.IsNullOrEmpty(ConnectionString) && !_cloudFoundryConfigFound)
             {
                 // Connection string was provided and VCAP_SERVICES wasn't found, just use the connectionstring
                 return ConnectionString;

--- a/src/Connectors/src/ConnectorBase/Queue/RabbitMQHealthContributor.cs
+++ b/src/Connectors/src/ConnectorBase/Queue/RabbitMQHealthContributor.cs
@@ -33,7 +33,7 @@ namespace Steeltoe.CloudFoundry.Connector.RabbitMQ
         private readonly RabbitMQProviderConnectorFactory _factory;
         private readonly ILogger<RabbitMQHealthContributor> _logger;
         private readonly object _connFactory;
-        private object connection;
+        private object _connection;
 
         public RabbitMQHealthContributor(RabbitMQProviderConnectorFactory factory, ILogger<RabbitMQHealthContributor> logger = null)
         {
@@ -50,21 +50,21 @@ namespace Steeltoe.CloudFoundry.Connector.RabbitMQ
             var result = new HealthCheckResult();
             try
             {
-                connection ??= ConnectorHelpers.Invoke(RabbitMQTypeLocator.CreateConnectionMethod, _connFactory, null);
+                _connection ??= ConnectorHelpers.Invoke(RabbitMQTypeLocator.CreateConnectionMethod, _connFactory, null);
 
-                if (connection == null)
+                if (_connection == null)
                 {
                     throw new ConnectorException("Failed to open RabbitMQ connection!");
                 }
 
-                if (RabbitMQTypeLocator.IConnection.GetProperty("IsOpen").GetValue(connection).Equals(false))
+                if (RabbitMQTypeLocator.IConnection.GetProperty("IsOpen").GetValue(_connection).Equals(false))
                 {
                     throw new ConnectorException("RabbitMQ connection is closed!");
                 }
 
                 try
                 {
-                    var serverproperties = RabbitMQTypeLocator.IConnection.GetProperty("ServerProperties").GetValue(connection) as Dictionary<string, object>;
+                    var serverproperties = RabbitMQTypeLocator.IConnection.GetProperty("ServerProperties").GetValue(_connection) as Dictionary<string, object>;
                     result.Details.Add("version", Encoding.UTF8.GetString(serverproperties["version"] as byte[]));
                 }
                 catch (Exception e)

--- a/src/Connectors/src/ConnectorBase/Relational/MySql/MySqlProviderConnectorOptions.cs
+++ b/src/Connectors/src/ConnectorBase/Relational/MySql/MySqlProviderConnectorOptions.cs
@@ -18,7 +18,7 @@ namespace Steeltoe.CloudFoundry.Connector.MySql
         public const string Default_Server = "localhost";
         public const int Default_Port = 3306;
         private const string MYSQL_CLIENT_SECTION_PREFIX = "mysql:client";
-        private bool cloudFoundryConfigFound = false;
+        private bool _cloudFoundryConfigFound = false;
 
         public MySqlProviderConnectorOptions()
         {
@@ -35,7 +35,7 @@ namespace Steeltoe.CloudFoundry.Connector.MySql
             var section = config.GetSection(MYSQL_CLIENT_SECTION_PREFIX);
             section.Bind(this);
 
-            cloudFoundryConfigFound = config.HasCloudFoundryServiceConfigurations();
+            _cloudFoundryConfigFound = config.HasCloudFoundryServiceConfigurations();
         }
 
         public string ConnectionString { get; set; }
@@ -86,7 +86,7 @@ namespace Steeltoe.CloudFoundry.Connector.MySql
 
         public override string ToString()
         {
-            if (!string.IsNullOrEmpty(ConnectionString) && !cloudFoundryConfigFound)
+            if (!string.IsNullOrEmpty(ConnectionString) && !_cloudFoundryConfigFound)
             {
                 return ConnectionString;
             }

--- a/src/Connectors/src/ConnectorBase/Relational/Oracle/OracleProviderConnectorOptions.cs
+++ b/src/Connectors/src/ConnectorBase/Relational/Oracle/OracleProviderConnectorOptions.cs
@@ -13,7 +13,7 @@ namespace Steeltoe.CloudFoundry.Connector.Oracle
         public const string Default_Server = "localhost";
         public const int Default_Port = 1521;
         private const string ORACLE_CLIENT_SECTION_PREFIX = "oracle:client";
-        private bool cloudFoundryConfigFound = false;
+        private bool _cloudFoundryConfigFound = false;
 
         public OracleProviderConnectorOptions()
         {
@@ -31,7 +31,7 @@ namespace Steeltoe.CloudFoundry.Connector.Oracle
 
             section.Bind(this);
 
-            cloudFoundryConfigFound = config.HasCloudFoundryServiceConfigurations();
+            _cloudFoundryConfigFound = config.HasCloudFoundryServiceConfigurations();
         }
 
         public string ConnectionString { get; set; }
@@ -50,7 +50,7 @@ namespace Steeltoe.CloudFoundry.Connector.Oracle
 
         public override string ToString()
         {
-            if (!string.IsNullOrEmpty(ConnectionString) && !cloudFoundryConfigFound)
+            if (!string.IsNullOrEmpty(ConnectionString) && !_cloudFoundryConfigFound)
             {
                 return ConnectionString;
             }

--- a/src/Connectors/src/ConnectorBase/Relational/PostgreSQL/PostgresProviderConnectorOptions.cs
+++ b/src/Connectors/src/ConnectorBase/Relational/PostgreSQL/PostgresProviderConnectorOptions.cs
@@ -15,7 +15,7 @@ namespace Steeltoe.CloudFoundry.Connector.PostgreSql
         public const string Default_Host = "localhost";
         public const int Default_Port = 5432;
         private const string POSTGRES_CLIENT_SECTION_PREFIX = "postgres:client";
-        private bool cloudFoundryConfigFound = false;
+        private bool _cloudFoundryConfigFound = false;
 
         public PostgresProviderConnectorOptions()
         {
@@ -32,7 +32,7 @@ namespace Steeltoe.CloudFoundry.Connector.PostgreSql
             var section = config.GetSection(POSTGRES_CLIENT_SECTION_PREFIX);
             section.Bind(this);
 
-            cloudFoundryConfigFound = config.HasCloudFoundryServiceConfigurations();
+            _cloudFoundryConfigFound = config.HasCloudFoundryServiceConfigurations();
         }
 
         public string ConnectionString { get; set; }
@@ -65,7 +65,7 @@ namespace Steeltoe.CloudFoundry.Connector.PostgreSql
         {
             StringBuilder sb;
 
-            if (!string.IsNullOrEmpty(ConnectionString) && !cloudFoundryConfigFound)
+            if (!string.IsNullOrEmpty(ConnectionString) && !_cloudFoundryConfigFound)
             {
                 sb = new StringBuilder(ConnectionString);
             }

--- a/src/Connectors/src/ConnectorBase/Relational/SqlServer/SqlServerProviderConnectorOptions.cs
+++ b/src/Connectors/src/ConnectorBase/Relational/SqlServer/SqlServerProviderConnectorOptions.cs
@@ -15,7 +15,7 @@ namespace Steeltoe.CloudFoundry.Connector.SqlServer
         public const string Default_Server = "localhost";
         public const int Default_Port = 1433;
         private const string SQL_CLIENT_SECTION_PREFIX = "sqlserver:credentials";
-        private bool cloudFoundryConfigFound = false;
+        private bool _cloudFoundryConfigFound = false;
 
         public SqlServerProviderConnectorOptions()
         {
@@ -44,7 +44,7 @@ namespace Steeltoe.CloudFoundry.Connector.SqlServer
 
             section.Bind(this);
 
-            cloudFoundryConfigFound = config.HasCloudFoundryServiceConfigurations();
+            _cloudFoundryConfigFound = config.HasCloudFoundryServiceConfigurations();
         }
 
         public string ConnectionString { get; set; }
@@ -84,7 +84,7 @@ namespace Steeltoe.CloudFoundry.Connector.SqlServer
 
         public override string ToString()
         {
-            if (!string.IsNullOrEmpty(ConnectionString) && !cloudFoundryConfigFound)
+            if (!string.IsNullOrEmpty(ConnectionString) && !_cloudFoundryConfigFound)
             {
                 return ConnectionString;
             }

--- a/src/Connectors/src/ConnectorBase/Services/HystrixRabbitMQServiceInfo.cs
+++ b/src/Connectors/src/ConnectorBase/Services/HystrixRabbitMQServiceInfo.cs
@@ -8,28 +8,28 @@ namespace Steeltoe.CloudFoundry.Connector.Services
 {
     public class HystrixRabbitMQServiceInfo : ServiceInfo
     {
-        private RabbitMQServiceInfo rabbitInfo;
-        private bool sslEnabled = false;
+        private RabbitMQServiceInfo _rabbitInfo;
+        private bool _sslEnabled = false;
 
         public HystrixRabbitMQServiceInfo(string id, string uri, bool sslEnabled)
             : base(id)
         {
-            this.sslEnabled = sslEnabled;
-            rabbitInfo = new RabbitMQServiceInfo(id, uri);
+            this._sslEnabled = sslEnabled;
+            _rabbitInfo = new RabbitMQServiceInfo(id, uri);
         }
 
         public HystrixRabbitMQServiceInfo(string id, string uri, List<string> uris, bool sslEnabled)
             : base(id)
         {
-            rabbitInfo = new RabbitMQServiceInfo(id, uri, null, uris, null);
-            this.sslEnabled = sslEnabled;
+            _rabbitInfo = new RabbitMQServiceInfo(id, uri, null, uris, null);
+            this._sslEnabled = sslEnabled;
         }
 
         public RabbitMQServiceInfo RabbitInfo
         {
             get
             {
-                return rabbitInfo;
+                return _rabbitInfo;
             }
         }
 
@@ -37,7 +37,7 @@ namespace Steeltoe.CloudFoundry.Connector.Services
         {
             get
             {
-                return rabbitInfo.Scheme;
+                return _rabbitInfo.Scheme;
             }
         }
 
@@ -45,7 +45,7 @@ namespace Steeltoe.CloudFoundry.Connector.Services
         {
             get
             {
-                return rabbitInfo.Query;
+                return _rabbitInfo.Query;
             }
         }
 
@@ -53,7 +53,7 @@ namespace Steeltoe.CloudFoundry.Connector.Services
         {
             get
             {
-                return rabbitInfo.Path;
+                return _rabbitInfo.Path;
             }
         }
 
@@ -61,7 +61,7 @@ namespace Steeltoe.CloudFoundry.Connector.Services
         {
             get
             {
-                return rabbitInfo.Uri;
+                return _rabbitInfo.Uri;
             }
         }
 
@@ -69,7 +69,7 @@ namespace Steeltoe.CloudFoundry.Connector.Services
         {
             get
             {
-                return rabbitInfo.Uris;
+                return _rabbitInfo.Uris;
             }
         }
 
@@ -77,7 +77,7 @@ namespace Steeltoe.CloudFoundry.Connector.Services
         {
             get
             {
-                return rabbitInfo.Host;
+                return _rabbitInfo.Host;
             }
         }
 
@@ -85,7 +85,7 @@ namespace Steeltoe.CloudFoundry.Connector.Services
         {
             get
             {
-                return rabbitInfo.Port;
+                return _rabbitInfo.Port;
             }
         }
 
@@ -93,7 +93,7 @@ namespace Steeltoe.CloudFoundry.Connector.Services
         {
             get
             {
-                return rabbitInfo.UserName;
+                return _rabbitInfo.UserName;
             }
         }
 
@@ -101,7 +101,7 @@ namespace Steeltoe.CloudFoundry.Connector.Services
         {
             get
             {
-                return rabbitInfo.Password;
+                return _rabbitInfo.Password;
             }
         }
 
@@ -109,7 +109,7 @@ namespace Steeltoe.CloudFoundry.Connector.Services
         {
             get
             {
-                return this.sslEnabled;
+                return this._sslEnabled;
             }
         }
     }

--- a/src/Connectors/src/ConnectorBase/Services/HystrixRabbitMQServiceInfo.cs
+++ b/src/Connectors/src/ConnectorBase/Services/HystrixRabbitMQServiceInfo.cs
@@ -8,36 +8,27 @@ namespace Steeltoe.CloudFoundry.Connector.Services
 {
     public class HystrixRabbitMQServiceInfo : ServiceInfo
     {
-        private RabbitMQServiceInfo _rabbitInfo;
-        private bool _sslEnabled = false;
-
         public HystrixRabbitMQServiceInfo(string id, string uri, bool sslEnabled)
             : base(id)
         {
-            this._sslEnabled = sslEnabled;
-            _rabbitInfo = new RabbitMQServiceInfo(id, uri);
+            this.IsSslEnabled = sslEnabled;
+            RabbitInfo = new RabbitMQServiceInfo(id, uri);
         }
 
         public HystrixRabbitMQServiceInfo(string id, string uri, List<string> uris, bool sslEnabled)
             : base(id)
         {
-            _rabbitInfo = new RabbitMQServiceInfo(id, uri, null, uris, null);
-            this._sslEnabled = sslEnabled;
+            RabbitInfo = new RabbitMQServiceInfo(id, uri, null, uris, null);
+            this.IsSslEnabled = sslEnabled;
         }
 
-        public RabbitMQServiceInfo RabbitInfo
-        {
-            get
-            {
-                return _rabbitInfo;
-            }
-        }
+        public RabbitMQServiceInfo RabbitInfo { get; }
 
         public string Scheme
         {
             get
             {
-                return _rabbitInfo.Scheme;
+                return RabbitInfo.Scheme;
             }
         }
 
@@ -45,7 +36,7 @@ namespace Steeltoe.CloudFoundry.Connector.Services
         {
             get
             {
-                return _rabbitInfo.Query;
+                return RabbitInfo.Query;
             }
         }
 
@@ -53,7 +44,7 @@ namespace Steeltoe.CloudFoundry.Connector.Services
         {
             get
             {
-                return _rabbitInfo.Path;
+                return RabbitInfo.Path;
             }
         }
 
@@ -61,7 +52,7 @@ namespace Steeltoe.CloudFoundry.Connector.Services
         {
             get
             {
-                return _rabbitInfo.Uri;
+                return RabbitInfo.Uri;
             }
         }
 
@@ -69,7 +60,7 @@ namespace Steeltoe.CloudFoundry.Connector.Services
         {
             get
             {
-                return _rabbitInfo.Uris;
+                return RabbitInfo.Uris;
             }
         }
 
@@ -77,7 +68,7 @@ namespace Steeltoe.CloudFoundry.Connector.Services
         {
             get
             {
-                return _rabbitInfo.Host;
+                return RabbitInfo.Host;
             }
         }
 
@@ -85,7 +76,7 @@ namespace Steeltoe.CloudFoundry.Connector.Services
         {
             get
             {
-                return _rabbitInfo.Port;
+                return RabbitInfo.Port;
             }
         }
 
@@ -93,7 +84,7 @@ namespace Steeltoe.CloudFoundry.Connector.Services
         {
             get
             {
-                return _rabbitInfo.UserName;
+                return RabbitInfo.UserName;
             }
         }
 
@@ -101,16 +92,10 @@ namespace Steeltoe.CloudFoundry.Connector.Services
         {
             get
             {
-                return _rabbitInfo.Password;
+                return RabbitInfo.Password;
             }
         }
 
-        public bool IsSslEnabled
-        {
-            get
-            {
-                return this._sslEnabled;
-            }
-        }
+        public bool IsSslEnabled { get; } = false;
     }
 }

--- a/src/Connectors/src/ConnectorBase/Services/UriInfo.cs
+++ b/src/Connectors/src/ConnectorBase/Services/UriInfo.cs
@@ -11,9 +11,9 @@ namespace Steeltoe.CloudFoundry.Connector.Services
 {
     public class UriInfo
     {
-        private char[] questionMark = new char[] { '?' };
+        private char[] _questionMark = new char[] { '?' };
 
-        private char[] colon = new char[] { ':' };
+        private char[] _colon = new char[] { ':' };
 
         public UriInfo(string scheme, string host, int port, string username, string password, string path = null, string query = null)
         {
@@ -205,7 +205,7 @@ namespace Steeltoe.CloudFoundry.Connector.Services
 
                 if (firstAmp > 0)
                 {
-                    uriString = uriString.Substring(0, firstAmp) + questionMark[0] + uriString.Substring(firstAmp + 1, uriString.Length - firstAmp - 1);
+                    uriString = uriString.Substring(0, firstAmp) + _questionMark[0] + uriString.Substring(firstAmp + 1, uriString.Length - firstAmp - 1);
                 }
             }
         }
@@ -217,7 +217,7 @@ namespace Steeltoe.CloudFoundry.Connector.Services
                 return null;
             }
 
-            string[] split = pathAndQuery.Split(questionMark);
+            string[] split = pathAndQuery.Split(_questionMark);
             if (split.Length == 0)
             {
                 return null;
@@ -233,7 +233,7 @@ namespace Steeltoe.CloudFoundry.Connector.Services
                 return null;
             }
 
-            string[] split = pathAndQuery.Split(questionMark);
+            string[] split = pathAndQuery.Split(_questionMark);
             if (split.Length <= 1)
             {
                 return null;
@@ -249,7 +249,7 @@ namespace Steeltoe.CloudFoundry.Connector.Services
                 return new string[2] { null, null };
             }
 
-            string[] split = userPass.Split(colon);
+            string[] split = userPass.Split(_colon);
             if (split.Length != 2)
             {
                 throw new ArgumentException(

--- a/src/Discovery/src/ClientAutofac/DiscoveryContainerBuilderExtensions.cs
+++ b/src/Discovery/src/ClientAutofac/DiscoveryContainerBuilderExtensions.cs
@@ -290,7 +290,7 @@ namespace Steeltoe.Discovery.Client
 
         public class ApplicationLifecycle : IDiscoveryLifecycle
         {
-            private CancellationTokenSource source = new CancellationTokenSource();
+            private CancellationTokenSource _source = new CancellationTokenSource();
 
             public ApplicationLifecycle()
             {
@@ -298,14 +298,14 @@ namespace Steeltoe.Discovery.Client
 
             public void Shutdown()
             {
-                source.Cancel();
+                _source.Cancel();
             }
 
             public CancellationToken ApplicationStopping
             {
                 get
                 {
-                    return source.Token;
+                    return _source.Token;
                 }
             }
         }

--- a/src/Discovery/src/ClientAutofac/DiscoveryContainerBuilderExtensions.cs
+++ b/src/Discovery/src/ClientAutofac/DiscoveryContainerBuilderExtensions.cs
@@ -312,18 +312,16 @@ namespace Steeltoe.Discovery.Client
 
         public class OptionsMonitorWrapper<T> : IOptionsMonitor<T>
         {
-            private T _option;
-
             public OptionsMonitorWrapper(T option)
             {
-                _option = option;
+                CurrentValue = option;
             }
 
-            public T CurrentValue => _option;
+            public T CurrentValue { get; }
 
             public T Get(string name)
             {
-                return _option;
+                return CurrentValue;
             }
 
             public IDisposable OnChange(Action<T, string> listener)

--- a/src/Discovery/src/ClientCore/DiscoveryServiceCollectionExtensions.cs
+++ b/src/Discovery/src/ClientCore/DiscoveryServiceCollectionExtensions.cs
@@ -313,18 +313,16 @@ namespace Steeltoe.Discovery.Client
 
         public class OptionsMonitorWrapper<T> : IOptionsMonitor<T>
         {
-            private T _option;
-
             public OptionsMonitorWrapper(T option)
             {
-                _option = option;
+                CurrentValue = option;
             }
 
-            public T CurrentValue => _option;
+            public T CurrentValue { get; }
 
             public T Get(string name)
             {
-                return _option;
+                return CurrentValue;
             }
 
             public IDisposable OnChange(Action<T, string> listener)

--- a/src/Discovery/src/ConsulBase/Discovery/ConsulDiscoveryClient.cs
+++ b/src/Discovery/src/ConsulBase/Discovery/ConsulDiscoveryClient.cs
@@ -188,7 +188,7 @@ namespace Steeltoe.Discovery.Consul.Discovery
             }
         }
 
-        private bool disposed = false;
+        private bool _disposed = false;
 
         /// <summary>
         /// Dispose of the client and also the Consul service registrar if provided
@@ -201,14 +201,14 @@ namespace Steeltoe.Discovery.Consul.Discovery
 
         protected virtual void Dispose(bool disposing)
         {
-            if (!disposed)
+            if (!_disposed)
             {
                 if (disposing && _registrar != null)
                 {
                     _registrar.Dispose();
                 }
 
-                disposed = true;
+                _disposed = true;
             }
         }
 

--- a/src/Discovery/src/ConsulBase/Discovery/TtlScheduler.cs
+++ b/src/Discovery/src/ConsulBase/Discovery/TtlScheduler.cs
@@ -117,7 +117,7 @@ namespace Steeltoe.Discovery.Consul.Discovery
             }
         }
 
-        private bool disposed = false;
+        private bool _disposed = false;
 
         /// <summary>
         /// Remove all heart beats from scheduler
@@ -130,7 +130,7 @@ namespace Steeltoe.Discovery.Consul.Discovery
 
         protected virtual void Dispose(bool disposing)
         {
-            if (!disposed)
+            if (!_disposed)
             {
                 if (disposing)
                 {
@@ -141,7 +141,7 @@ namespace Steeltoe.Discovery.Consul.Discovery
                     }
                 }
 
-                disposed = true;
+                _disposed = true;
             }
         }
 

--- a/src/Discovery/src/ConsulBase/Registry/ConsulServiceRegistrar.cs
+++ b/src/Discovery/src/ConsulBase/Registry/ConsulServiceRegistrar.cs
@@ -156,7 +156,7 @@ namespace Steeltoe.Discovery.Consul.Registry
             while (true);
         }
 
-        private bool disposed = false;
+        private bool _disposed = false;
 
         /// <inheritdoc/>
         public void Dispose()
@@ -167,7 +167,7 @@ namespace Steeltoe.Discovery.Consul.Registry
 
         protected virtual void Dispose(bool disposing)
         {
-            if (!disposed)
+            if (!_disposed)
             {
                 if (disposing)
                 {
@@ -180,7 +180,7 @@ namespace Steeltoe.Discovery.Consul.Registry
                     _registry.Dispose();
                 }
 
-                disposed = true;
+                _disposed = true;
             }
         }
 

--- a/src/Discovery/src/ConsulBase/Registry/ConsulServiceRegistry.cs
+++ b/src/Discovery/src/ConsulBase/Registry/ConsulServiceRegistry.cs
@@ -215,7 +215,7 @@ namespace Steeltoe.Discovery.Consul.Registry
             return (S)result;
         }
 
-        private bool disposed = false;
+        private bool _disposed = false;
 
         /// <inheritdoc/>
         public void Dispose()
@@ -226,7 +226,7 @@ namespace Steeltoe.Discovery.Consul.Registry
 
         protected virtual void Dispose(bool disposing)
         {
-            if (!disposed)
+            if (!_disposed)
             {
                 if (disposing)
                 {
@@ -234,7 +234,7 @@ namespace Steeltoe.Discovery.Consul.Registry
                     _scheduler?.Dispose();
                 }
 
-                disposed = true;
+                _disposed = true;
             }
         }
 

--- a/src/Discovery/src/EurekaBase/AppInfo/Application.cs
+++ b/src/Discovery/src/EurekaBase/AppInfo/Application.cs
@@ -11,15 +11,13 @@ namespace Steeltoe.Discovery.Eureka.AppInfo
 {
     public class Application
     {
-        private ConcurrentDictionary<string, InstanceInfo> _instanceMap = new ConcurrentDictionary<string, InstanceInfo>();
-
         public string Name { get; internal set; }
 
         public int Count
         {
             get
             {
-                return _instanceMap.Count;
+                return InstanceMap.Count;
             }
         }
 
@@ -27,13 +25,13 @@ namespace Steeltoe.Discovery.Eureka.AppInfo
         {
             get
             {
-                return new List<InstanceInfo>(_instanceMap.Values);
+                return new List<InstanceInfo>(InstanceMap.Values);
             }
         }
 
         public InstanceInfo GetInstance(string instanceId)
         {
-            _instanceMap.TryGetValue(instanceId, out InstanceInfo result);
+            InstanceMap.TryGetValue(instanceId, out InstanceInfo result);
             return result;
         }
 
@@ -70,29 +68,23 @@ namespace Steeltoe.Discovery.Eureka.AppInfo
         {
             if (!string.IsNullOrEmpty(info.InstanceId))
             {
-                _instanceMap[info.InstanceId] = info;
+                InstanceMap[info.InstanceId] = info;
             }
             else if (!string.IsNullOrEmpty(info.HostName))
             {
-                _instanceMap[info.HostName] = info;
+                InstanceMap[info.HostName] = info;
             }
         }
 
         internal void Remove(InstanceInfo info)
         {
-            if (!_instanceMap.TryRemove(info.InstanceId, out InstanceInfo removed))
+            if (!InstanceMap.TryRemove(info.InstanceId, out InstanceInfo removed))
             {
-                _instanceMap.TryRemove(info.HostName, out removed);
+                InstanceMap.TryRemove(info.HostName, out removed);
             }
         }
 
-        internal ConcurrentDictionary<string, InstanceInfo> InstanceMap
-        {
-            get
-            {
-                return _instanceMap;
-            }
-        }
+        internal ConcurrentDictionary<string, InstanceInfo> InstanceMap { get; } = new ConcurrentDictionary<string, InstanceInfo>();
 
         internal static Application FromJsonApplication(JsonApplication japp)
         {

--- a/src/Discovery/src/EurekaBase/AppInfo/Applications.cs
+++ b/src/Discovery/src/EurekaBase/AppInfo/Applications.cs
@@ -13,10 +13,6 @@ namespace Steeltoe.Discovery.Eureka.AppInfo
 {
     public class Applications
     {
-        private ConcurrentDictionary<string, Application> _applicationMap = new ConcurrentDictionary<string, Application>();
-        private ConcurrentDictionary<string, ConcurrentDictionary<string, InstanceInfo>> _virtHostInstanceMap = new ConcurrentDictionary<string, ConcurrentDictionary<string, InstanceInfo>>();
-        private ConcurrentDictionary<string, ConcurrentDictionary<string, InstanceInfo>> _secureVirtHostInstanceMap = new ConcurrentDictionary<string, ConcurrentDictionary<string, InstanceInfo>>();
-
         private object _addRemoveInstanceLock = new object();
 
         public string AppsHashCode { get; internal set; }
@@ -27,7 +23,7 @@ namespace Steeltoe.Discovery.Eureka.AppInfo
 
         public IList<Application> GetRegisteredApplications()
         {
-            return new List<Application>(_applicationMap.Values);
+            return new List<Application>(ApplicationMap.Values);
         }
 
         public Application GetRegisteredApplication(string appName)
@@ -37,7 +33,7 @@ namespace Steeltoe.Discovery.Eureka.AppInfo
                 throw new ArgumentException(nameof(appName));
             }
 
-            _applicationMap.TryGetValue(appName.ToUpperInvariant(), out Application result);
+            ApplicationMap.TryGetValue(appName.ToUpperInvariant(), out Application result);
             return result;
         }
 
@@ -48,7 +44,7 @@ namespace Steeltoe.Discovery.Eureka.AppInfo
                 throw new ArgumentException(nameof(secureVirtualHostName));
             }
 
-            return DoGetByVirtualHostName(secureVirtualHostName, _secureVirtHostInstanceMap);
+            return DoGetByVirtualHostName(secureVirtualHostName, SecureVirtualHostInstanceMap);
         }
 
         public IList<InstanceInfo> GetInstancesByVirtualHostName(string virtualHostName)
@@ -58,7 +54,7 @@ namespace Steeltoe.Discovery.Eureka.AppInfo
                 throw new ArgumentException(nameof(virtualHostName));
             }
 
-            return DoGetByVirtualHostName(virtualHostName, _virtHostInstanceMap);
+            return DoGetByVirtualHostName(virtualHostName, VirtualHostInstanceMap);
         }
 
         public override string ToString()
@@ -98,7 +94,7 @@ namespace Steeltoe.Discovery.Eureka.AppInfo
                 throw new ArgumentNullException(nameof(app));
             }
 
-            _applicationMap.AddOrUpdate(app.Name.ToUpperInvariant(), app, (key, existing) => { return app; });
+            ApplicationMap.AddOrUpdate(app.Name.ToUpperInvariant(), app, (key, existing) => { return app; });
             AddInstances(app);
         }
 
@@ -114,12 +110,12 @@ namespace Steeltoe.Discovery.Eureka.AppInfo
         {
             if (!string.IsNullOrEmpty(inst.VipAddress))
             {
-                AddInstanceToVip(inst.VipAddress, inst, _virtHostInstanceMap);
+                AddInstanceToVip(inst.VipAddress, inst, VirtualHostInstanceMap);
             }
 
             if (!string.IsNullOrEmpty(inst.SecureVipAddress))
             {
-                AddInstanceToVip(inst.SecureVipAddress, inst, _secureVirtHostInstanceMap);
+                AddInstanceToVip(inst.SecureVipAddress, inst, SecureVirtualHostInstanceMap);
             }
         }
 
@@ -147,12 +143,12 @@ namespace Steeltoe.Discovery.Eureka.AppInfo
         {
             if (!string.IsNullOrEmpty(inst.VipAddress))
             {
-                RemoveInstanceFromVip(inst.VipAddress, inst, _virtHostInstanceMap);
+                RemoveInstanceFromVip(inst.VipAddress, inst, VirtualHostInstanceMap);
             }
 
             if (!string.IsNullOrEmpty(inst.SecureVipAddress))
             {
-                RemoveInstanceFromVip(inst.SecureVipAddress, inst, _secureVirtHostInstanceMap);
+                RemoveInstanceFromVip(inst.SecureVipAddress, inst, SecureVirtualHostInstanceMap);
             }
         }
 
@@ -239,29 +235,11 @@ namespace Steeltoe.Discovery.Eureka.AppInfo
             return hashcodeBuilder.ToString();
         }
 
-        internal ConcurrentDictionary<string, Application> ApplicationMap
-        {
-            get
-            {
-                return _applicationMap;
-            }
-        }
+        internal ConcurrentDictionary<string, Application> ApplicationMap { get; } = new ConcurrentDictionary<string, Application>();
 
-        internal ConcurrentDictionary<string, ConcurrentDictionary<string, InstanceInfo>> VirtualHostInstanceMap
-        {
-            get
-            {
-                return _virtHostInstanceMap;
-            }
-        }
+        internal ConcurrentDictionary<string, ConcurrentDictionary<string, InstanceInfo>> VirtualHostInstanceMap { get; } = new ConcurrentDictionary<string, ConcurrentDictionary<string, InstanceInfo>>();
 
-        internal ConcurrentDictionary<string, ConcurrentDictionary<string, InstanceInfo>> SecureVirtualHostInstanceMap
-        {
-            get
-            {
-                return _secureVirtHostInstanceMap;
-            }
-        }
+        internal ConcurrentDictionary<string, ConcurrentDictionary<string, InstanceInfo>> SecureVirtualHostInstanceMap { get; } = new ConcurrentDictionary<string, ConcurrentDictionary<string, InstanceInfo>>();
 
         internal static Applications FromJsonApplications(JsonApplications japps)
         {

--- a/src/Discovery/test/EurekaBase.Test/TestOptionMonitorWrapper.cs
+++ b/src/Discovery/test/EurekaBase.Test/TestOptionMonitorWrapper.cs
@@ -9,18 +9,16 @@ namespace Steeltoe.Discovery.Eureka.Test
 {
     public class TestOptionMonitorWrapper<T> : IOptionsMonitor<T>
     {
-        private T _opt;
-
         public TestOptionMonitorWrapper(T opt)
         {
-            _opt = opt;
+            CurrentValue = opt;
         }
 
-        public T CurrentValue => _opt;
+        public T CurrentValue { get; private set; }
 
         public T Get(string name)
         {
-            return _opt;
+            return CurrentValue;
         }
 
         public IDisposable OnChange(Action<T, string> listener)

--- a/src/Logging/src/DynamicLogger/DynamicConsoleLoggerProvider.cs
+++ b/src/Logging/src/DynamicLogger/DynamicConsoleLoggerProvider.cs
@@ -26,7 +26,7 @@ namespace Steeltoe.Extensions.Logging
         private ConcurrentDictionary<string, DynamicConsoleLogger> _loggers = new ConcurrentDictionary<string, DynamicConsoleLogger>();
         private ConsoleLoggerProvider _delegate;
 
-        private bool disposed = false;
+        private bool _disposed = false;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DynamicConsoleLoggerProvider"/> class.
@@ -154,7 +154,7 @@ namespace Steeltoe.Extensions.Logging
 
         protected virtual void Dispose(bool disposing)
         {
-            if (!disposed)
+            if (!_disposed)
             {
                 if (disposing)
                 {
@@ -164,7 +164,7 @@ namespace Steeltoe.Extensions.Logging
                     _loggers = null;
                 }
 
-                disposed = true;
+                _disposed = true;
             }
         }
 

--- a/src/Logging/src/SerilogDynamicLoggerCore/SerilogDynamicProvider.cs
+++ b/src/Logging/src/SerilogDynamicLoggerCore/SerilogDynamicProvider.cs
@@ -27,7 +27,7 @@ namespace Steeltoe.Extensions.Logging.SerilogDynamicLogger
         private ConcurrentDictionary<string, LoggingLevelSwitch> _loggerSwitches = new ConcurrentDictionary<string, LoggingLevelSwitch>();
         private ConcurrentDictionary<string, LogEventLevel> _runningLevels = new ConcurrentDictionary<string, LogEventLevel>();
         private LogEventLevel? _defaultLevel = null;
-        private bool disposed = false;
+        private bool _disposed = false;
         private IConfiguration _subLoggerConfiguration;
 
         [Obsolete("Will be removed in a future release; Use SerilogDynamicProvider(IConfiguration, ISerilogOptions, Logger, LoggingLevelSwitch) instead")]
@@ -187,7 +187,7 @@ namespace Steeltoe.Extensions.Logging.SerilogDynamicLogger
 
         protected virtual void Dispose(bool disposing)
         {
-            if (!disposed)
+            if (!_disposed)
             {
                 if (disposing)
                 {
@@ -197,7 +197,7 @@ namespace Steeltoe.Extensions.Logging.SerilogDynamicLogger
                     _loggers = null;
                 }
 
-                disposed = true;
+                _disposed = true;
             }
         }
 

--- a/src/Management/src/EndpointBase/Diagnostics/DiagnosticServices.cs
+++ b/src/Management/src/EndpointBase/Diagnostics/DiagnosticServices.cs
@@ -12,24 +12,24 @@ namespace Steeltoe.Management.Endpoint.Diagnostics
 {
     public class DiagnosticServices : IHostedService
     {
-        private readonly IDiagnosticsManager observerManager;
-        private readonly ILogger<DiagnosticServices> logger;
+        private readonly IDiagnosticsManager _observerManager;
+        private readonly ILogger<DiagnosticServices> _logger;
 
         public DiagnosticServices(IDiagnosticsManager observerManager, ILogger<DiagnosticServices> logger = null)
         {
-            this.observerManager = observerManager;
-            this.logger = logger;
+            this._observerManager = observerManager;
+            this._logger = logger;
         }
 
         public Task StartAsync(CancellationToken cancellationToken)
         {
-            observerManager.Start();
+            _observerManager.Start();
             return Task.CompletedTask;
         }
 
         public Task StopAsync(CancellationToken cancellationToken)
         {
-            observerManager.Stop();
+            _observerManager.Stop();
             return Task.CompletedTask;
         }
     }

--- a/src/Management/src/EndpointBase/Env/Sanitizer.cs
+++ b/src/Management/src/EndpointBase/Env/Sanitizer.cs
@@ -10,7 +10,7 @@ namespace Steeltoe.Management.Endpoint.Env
 {
     public class Sanitizer
     {
-        private readonly string[] regex_parts = new string[] { "*", "$", "^", "+" };
+        private readonly string[] _regex_parts = new string[] { "*", "$", "^", "+" };
         private readonly string[] _keysToSanitize;
         private readonly List<Regex> _matchers = new List<Regex>();
 
@@ -38,7 +38,7 @@ namespace Steeltoe.Management.Endpoint.Env
 
         private bool IsRegex(string value)
         {
-            foreach (var part in regex_parts)
+            foreach (var part in _regex_parts)
             {
                 if (value.Contains(part))
                 {

--- a/src/Management/src/EndpointBase/Info/InfoBuilder.cs
+++ b/src/Management/src/EndpointBase/Info/InfoBuilder.cs
@@ -8,18 +8,18 @@ namespace Steeltoe.Management.Endpoint.Info
 {
     public class InfoBuilder : IInfoBuilder
     {
-        private readonly Dictionary<string, object> info = new Dictionary<string, object>();
+        private readonly Dictionary<string, object> _info = new Dictionary<string, object>();
 
         public Dictionary<string, object> Build()
         {
-            return info;
+            return _info;
         }
 
         public IInfoBuilder WithInfo(string key, object value)
         {
             if (!string.IsNullOrEmpty(key))
             {
-                info[key] = value;
+                _info[key] = value;
             }
 
             return this;
@@ -31,7 +31,7 @@ namespace Steeltoe.Management.Endpoint.Info
             {
                 foreach (var pair in items)
                 {
-                    info[pair.Key] = pair.Value;
+                    _info[pair.Key] = pair.Value;
                 }
             }
 

--- a/src/Management/src/EndpointBase/Metrics/Observer/CLRRuntimeObserver.cs
+++ b/src/Management/src/EndpointBase/Metrics/Observer/CLRRuntimeObserver.cs
@@ -24,36 +24,36 @@ namespace Steeltoe.Management.Endpoint.Metrics.Observer
 
         private const string GENERATION_TAGVALUE_NAME = "gen";
 
-        private readonly ITagKey threadKindKey = TagKey.Create("kind");
-        private readonly ITagValue threadPoolWorkerKind = TagValue.Create("worker");
-        private readonly ITagValue threadPoolComppKind = TagValue.Create("completionPort");
+        private readonly ITagKey _threadKindKey = TagKey.Create("kind");
+        private readonly ITagValue _threadPoolWorkerKind = TagValue.Create("worker");
+        private readonly ITagValue _threadPoolComppKind = TagValue.Create("completionPort");
 
-        private readonly IMeasureLong activeThreadsMeasure;
-        private readonly IMeasureLong availThreadsMeasure;
-        private readonly ITagContext threadPoolWorkerTagValues;
-        private readonly ITagContext threadPoolCompPortTagValues;
+        private readonly IMeasureLong _activeThreadsMeasure;
+        private readonly IMeasureLong _availThreadsMeasure;
+        private readonly ITagContext _threadPoolWorkerTagValues;
+        private readonly ITagContext _threadPoolCompPortTagValues;
 
-        private readonly ITagKey generationKey = TagKey.Create("generation");
-        private readonly IMeasureLong collectionCountMeasure;
+        private readonly ITagKey _generationKey = TagKey.Create("generation");
+        private readonly IMeasureLong _collectionCountMeasure;
 
-        private readonly ITagKey memoryAreaKey = TagKey.Create("area");
-        private readonly ITagValue heapArea = TagValue.Create("heap");
-        private readonly IMeasureLong memoryUsedMeasure;
-        private readonly ITagContext memoryTagValues;
+        private readonly ITagKey _memoryAreaKey = TagKey.Create("area");
+        private readonly ITagValue _heapArea = TagValue.Create("heap");
+        private readonly IMeasureLong _memoryUsedMeasure;
+        private readonly ITagContext _memoryTagValues;
 
-        private CLRRuntimeSource.HeapMetrics previous = default(CLRRuntimeSource.HeapMetrics);
+        private CLRRuntimeSource.HeapMetrics _previous = default(CLRRuntimeSource.HeapMetrics);
 
         public CLRRuntimeObserver(IMetricsOptions options, IStats censusStats, ITags censusTags, ILogger<CLRRuntimeObserver> logger)
             : base(OBSERVER_NAME, DIAGNOSTIC_NAME, options, censusStats, censusTags, logger)
         {
-            memoryUsedMeasure = MeasureLong.Create("memory.used.value", "Current CLR memory usage", MeasureUnit.Bytes);
-            collectionCountMeasure = MeasureLong.Create("collection.count", "Garbage collection count", "count");
-            activeThreadsMeasure = MeasureLong.Create("active.thread.value", "Active thread count", "count");
-            availThreadsMeasure = MeasureLong.Create("avail.thread.value", "Available thread count", "count");
+            _memoryUsedMeasure = MeasureLong.Create("memory.used.value", "Current CLR memory usage", MeasureUnit.Bytes);
+            _collectionCountMeasure = MeasureLong.Create("collection.count", "Garbage collection count", "count");
+            _activeThreadsMeasure = MeasureLong.Create("active.thread.value", "Active thread count", "count");
+            _availThreadsMeasure = MeasureLong.Create("avail.thread.value", "Available thread count", "count");
 
-            memoryTagValues = Tagger.CurrentBuilder.Put(memoryAreaKey, heapArea).Build();
-            threadPoolWorkerTagValues = Tagger.CurrentBuilder.Put(threadKindKey, threadPoolWorkerKind).Build();
-            threadPoolCompPortTagValues = Tagger.CurrentBuilder.Put(threadKindKey, threadPoolComppKind).Build();
+            _memoryTagValues = Tagger.CurrentBuilder.Put(_memoryAreaKey, _heapArea).Build();
+            _threadPoolWorkerTagValues = Tagger.CurrentBuilder.Put(_threadKindKey, _threadPoolWorkerKind).Build();
+            _threadPoolCompPortTagValues = Tagger.CurrentBuilder.Put(_threadKindKey, _threadPoolComppKind).Build();
 
             RegisterViews();
         }
@@ -85,29 +85,29 @@ namespace Steeltoe.Management.Endpoint.Metrics.Observer
         {
             StatsRecorder
                 .NewMeasureMap()
-                .Put(memoryUsedMeasure, metrics.TotalMemory)
-                .Record(memoryTagValues);
+                .Put(_memoryUsedMeasure, metrics.TotalMemory)
+                .Record(_memoryTagValues);
 
             for (int i = 0; i < metrics.CollectionCounts.Count; i++)
             {
                 var count = metrics.CollectionCounts[i];
-                if (previous.CollectionCounts != null && i < previous.CollectionCounts.Count && previous.CollectionCounts[i] <= count)
+                if (_previous.CollectionCounts != null && i < _previous.CollectionCounts.Count && _previous.CollectionCounts[i] <= count)
                 {
-                    count -= previous.CollectionCounts[i];
+                    count -= _previous.CollectionCounts[i];
                 }
 
                 var tagContext = Tagger
                     .EmptyBuilder
-                    .Put(generationKey, TagValue.Create(GENERATION_TAGVALUE_NAME + i.ToString()))
+                    .Put(_generationKey, TagValue.Create(GENERATION_TAGVALUE_NAME + i.ToString()))
                     .Build();
 
                 StatsRecorder
                     .NewMeasureMap()
-                    .Put(collectionCountMeasure, count)
+                    .Put(_collectionCountMeasure, count)
                     .Record(tagContext);
             }
 
-            previous = metrics;
+            _previous = metrics;
         }
 
         protected internal void HandleThreadsEvent(CLRRuntimeSource.ThreadMetrics metrics)
@@ -117,15 +117,15 @@ namespace Steeltoe.Management.Endpoint.Metrics.Observer
 
             StatsRecorder
                 .NewMeasureMap()
-                .Put(activeThreadsMeasure, activeWorkers)
-                .Put(availThreadsMeasure, metrics.AvailableThreadPoolWorkers)
-                .Record(threadPoolWorkerTagValues);
+                .Put(_activeThreadsMeasure, activeWorkers)
+                .Put(_availThreadsMeasure, metrics.AvailableThreadPoolWorkers)
+                .Record(_threadPoolWorkerTagValues);
 
             StatsRecorder
                 .NewMeasureMap()
-                .Put(activeThreadsMeasure, activeCompPort)
-                .Put(availThreadsMeasure, metrics.AvailableThreadCompletionPort)
-                .Record(threadPoolCompPortTagValues);
+                .Put(_activeThreadsMeasure, activeCompPort)
+                .Put(_availThreadsMeasure, metrics.AvailableThreadCompletionPort)
+                .Record(_threadPoolCompPortTagValues);
         }
 
         protected internal void RegisterViews()
@@ -133,33 +133,33 @@ namespace Steeltoe.Management.Endpoint.Metrics.Observer
             IView view = View.Create(
                     ViewName.Create("clr.memory.used"),
                     "Current CLR memory usage",
-                    memoryUsedMeasure,
+                    _memoryUsedMeasure,
                     Mean.Create(),
-                    new List<ITagKey>() { memoryAreaKey });
+                    new List<ITagKey>() { _memoryAreaKey });
             ViewManager.RegisterView(view);
 
             view = View.Create(
                     ViewName.Create("clr.gc.collections"),
                     "Garbage collection count",
-                    collectionCountMeasure,
+                    _collectionCountMeasure,
                     Sum.Create(),
-                    new List<ITagKey>() { generationKey });
+                    new List<ITagKey>() { _generationKey });
             ViewManager.RegisterView(view);
 
             view = View.Create(
                     ViewName.Create("clr.threadpool.active"),
                     "Active thread count",
-                    activeThreadsMeasure,
+                    _activeThreadsMeasure,
                     Mean.Create(),
-                    new List<ITagKey>() { threadKindKey });
+                    new List<ITagKey>() { _threadKindKey });
             ViewManager.RegisterView(view);
 
             view = View.Create(
                     ViewName.Create("clr.threadpool.avail"),
                     "Available thread count",
-                    availThreadsMeasure,
+                    _availThreadsMeasure,
                     Mean.Create(),
-                    new List<ITagKey>() { threadKindKey });
+                    new List<ITagKey>() { _threadKindKey });
             ViewManager.RegisterView(view);
         }
     }

--- a/src/Management/src/EndpointBase/Metrics/Observer/HttpClientCoreObserver.cs
+++ b/src/Management/src/EndpointBase/Metrics/Observer/HttpClientCoreObserver.cs
@@ -28,36 +28,36 @@ namespace Steeltoe.Management.Endpoint.Metrics.Observer
         internal const string STOP_EVENT = "System.Net.Http.HttpRequestOut.Stop";
         internal const string EXCEPTION_EVENT = "System.Net.Http.Exception";
 
-        private readonly ITagKey statusTagKey = TagKey.Create("status");
-        private readonly ITagKey uriTagKey = TagKey.Create("uri");
-        private readonly ITagKey methodTagKey = TagKey.Create("method");
-        private readonly ITagKey clientTagKey = TagKey.Create("clientName");
+        private readonly ITagKey _statusTagKey = TagKey.Create("status");
+        private readonly ITagKey _uriTagKey = TagKey.Create("uri");
+        private readonly ITagKey _methodTagKey = TagKey.Create("method");
+        private readonly ITagKey _clientTagKey = TagKey.Create("clientName");
 
-        private readonly IMeasureDouble clientTimeMeasure;
-        private readonly IMeasureLong clientCountMeasure;
+        private readonly IMeasureDouble _clientTimeMeasure;
+        private readonly IMeasureLong _clientCountMeasure;
 
         public HttpClientCoreObserver(IMetricsOptions options, IStats censusStats, ITags censusTags, ILogger<HttpClientCoreObserver> logger)
             : base(OBSERVER_NAME, DIAGNOSTIC_NAME, options, censusStats, censusTags, logger)
         {
             PathMatcher = new Regex(options.EgressIgnorePattern);
 
-            clientTimeMeasure = MeasureDouble.Create("client.core.totalTime", "Total request time", MeasureUnit.MilliSeconds);
-            clientCountMeasure = MeasureLong.Create("client.core.totalRequests", "Total request count", "count");
+            _clientTimeMeasure = MeasureDouble.Create("client.core.totalTime", "Total request time", MeasureUnit.MilliSeconds);
+            _clientCountMeasure = MeasureLong.Create("client.core.totalRequests", "Total request count", "count");
 
             var view = View.Create(
                     ViewName.Create("http.client.request.time"),
                     "Total request time",
-                    clientTimeMeasure,
+                    _clientTimeMeasure,
                     Distribution.Create(BucketBoundaries.Create(new List<double>() { 0.0, 1.0, 5.0, 10.0, 100.0 })),
-                    new List<ITagKey>() { statusTagKey, uriTagKey, methodTagKey, clientTagKey });
+                    new List<ITagKey>() { _statusTagKey, _uriTagKey, _methodTagKey, _clientTagKey });
             ViewManager.RegisterView(view);
 
             view = View.Create(
                 ViewName.Create("http.client.request.count"),
                 "Total request counts",
-                clientCountMeasure,
+                _clientCountMeasure,
                 Sum.Create(),
-                new List<ITagKey>() { statusTagKey, uriTagKey, methodTagKey, clientTagKey });
+                new List<ITagKey>() { _statusTagKey, _uriTagKey, _methodTagKey, _clientTagKey });
 
             ViewManager.RegisterView(view);
         }
@@ -119,8 +119,8 @@ namespace Steeltoe.Management.Endpoint.Metrics.Observer
                 ITagContext tagContext = GetTagContext(request, response, taskStatus);
                 StatsRecorder
                     .NewMeasureMap()
-                    .Put(clientTimeMeasure, current.Duration.TotalMilliseconds)
-                    .Put(clientCountMeasure, 1)
+                    .Put(_clientTimeMeasure, current.Duration.TotalMilliseconds)
+                    .Put(_clientCountMeasure, 1)
                     .Record(tagContext);
             }
         }
@@ -132,10 +132,10 @@ namespace Steeltoe.Management.Endpoint.Metrics.Observer
 
             return Tagger
                 .EmptyBuilder
-                .Put(uriTagKey, TagValue.Create(uri))
-                .Put(statusTagKey, TagValue.Create(statusCode))
-                .Put(clientTagKey, TagValue.Create(request.RequestUri.Host))
-                .Put(methodTagKey, TagValue.Create(request.Method.ToString()))
+                .Put(_uriTagKey, TagValue.Create(uri))
+                .Put(_statusTagKey, TagValue.Create(statusCode))
+                .Put(_clientTagKey, TagValue.Create(request.RequestUri.Host))
+                .Put(_methodTagKey, TagValue.Create(request.Method.ToString()))
                 .Build();
         }
 

--- a/src/Management/src/EndpointBase/Metrics/Observer/HttpClientDesktopObserver.cs
+++ b/src/Management/src/EndpointBase/Metrics/Observer/HttpClientDesktopObserver.cs
@@ -27,37 +27,37 @@ namespace Steeltoe.Management.Endpoint.Metrics.Observer
         internal const string STOP_EVENT = "System.Net.Http.Desktop.HttpRequestOut.Stop";
         internal const string STOPEX_EVENT = "System.Net.Http.Desktop.HttpRequestOut.Ex.Stop";
 
-        private readonly ITagKey statusTagKey = TagKey.Create("status");
-        private readonly ITagKey uriTagKey = TagKey.Create("uri");
-        private readonly ITagKey methodTagKey = TagKey.Create("method");
-        private readonly ITagKey clientTagKey = TagKey.Create("clientName");
+        private readonly ITagKey _statusTagKey = TagKey.Create("status");
+        private readonly ITagKey _uriTagKey = TagKey.Create("uri");
+        private readonly ITagKey _methodTagKey = TagKey.Create("method");
+        private readonly ITagKey _clientTagKey = TagKey.Create("clientName");
 
-        private readonly IMeasureDouble clientTimeMeasure;
-        private readonly IMeasureLong clientCountMeasure;
+        private readonly IMeasureDouble _clientTimeMeasure;
+        private readonly IMeasureLong _clientCountMeasure;
 
         public HttpClientDesktopObserver(IMetricsOptions options, IStats censusStats, ITags censusTags, ILogger<HttpClientDesktopObserver> logger)
             : base(OBSERVER_NAME, DIAGNOSTIC_NAME, options, censusStats, censusTags, logger)
         {
             PathMatcher = new Regex(options.EgressIgnorePattern);
 
-            clientTimeMeasure = MeasureDouble.Create("client.desk.totalTime", "Total request time", MeasureUnit.MilliSeconds);
-            clientCountMeasure = MeasureLong.Create("client.core.totalRequests", "Total request count", "count");
+            _clientTimeMeasure = MeasureDouble.Create("client.desk.totalTime", "Total request time", MeasureUnit.MilliSeconds);
+            _clientCountMeasure = MeasureLong.Create("client.core.totalRequests", "Total request count", "count");
 
             var view = View.Create(
                     ViewName.Create("http.desktop.client.request.time"),
                     "Total request time",
-                    clientTimeMeasure,
+                    _clientTimeMeasure,
                     Distribution.Create(BucketBoundaries.Create(new List<double>() { 0.0, 1.0, 5.0, 10.0, 100.0 })),
-                    new List<ITagKey>() { statusTagKey, uriTagKey, methodTagKey, clientTagKey });
+                    new List<ITagKey>() { _statusTagKey, _uriTagKey, _methodTagKey, _clientTagKey });
 
             ViewManager.RegisterView(view);
 
             view = View.Create(
                     ViewName.Create("http.desktop.client.request.count"),
                     "Total request counts",
-                    clientCountMeasure,
+                    _clientCountMeasure,
                     Sum.Create(),
-                    new List<ITagKey>() { statusTagKey, uriTagKey, methodTagKey, clientTagKey });
+                    new List<ITagKey>() { _statusTagKey, _uriTagKey, _methodTagKey, _clientTagKey });
             ViewManager.RegisterView(view);
         }
 
@@ -117,8 +117,8 @@ namespace Steeltoe.Management.Endpoint.Metrics.Observer
                 ITagContext tagContext = GetTagContext(request, statusCode);
                 StatsRecorder
                     .NewMeasureMap()
-                    .Put(clientTimeMeasure, current.Duration.TotalMilliseconds)
-                    .Put(clientCountMeasure, 1)
+                    .Put(_clientTimeMeasure, current.Duration.TotalMilliseconds)
+                    .Put(_clientCountMeasure, 1)
                     .Record(tagContext);
             }
         }
@@ -130,10 +130,10 @@ namespace Steeltoe.Management.Endpoint.Metrics.Observer
 
             return Tagger
                 .EmptyBuilder
-                .Put(uriTagKey, TagValue.Create(uri))
-                .Put(statusTagKey, TagValue.Create(statusCode))
-                .Put(clientTagKey, TagValue.Create(request.RequestUri.Host))
-                .Put(methodTagKey, TagValue.Create(request.Method.ToString()))
+                .Put(_uriTagKey, TagValue.Create(uri))
+                .Put(_statusTagKey, TagValue.Create(statusCode))
+                .Put(_clientTagKey, TagValue.Create(request.RequestUri.Host))
+                .Put(_methodTagKey, TagValue.Create(request.Method.ToString()))
                 .Build();
         }
     }

--- a/src/Management/src/EndpointBase/Trace/HttpTraceResult.cs
+++ b/src/Management/src/EndpointBase/Trace/HttpTraceResult.cs
@@ -9,7 +9,7 @@ namespace Steeltoe.Management.Endpoint.Trace
 {
     public class HttpTraceResult
     {
-        private readonly List<TraceResult> list;
+        private readonly List<TraceResult> _list;
 
         [JsonProperty("traces")]
         public List<HttpTrace> Traces { get; }
@@ -21,7 +21,7 @@ namespace Steeltoe.Management.Endpoint.Trace
 
         public HttpTraceResult(List<TraceResult> list)
         {
-            this.list = list;
+            this._list = list;
         }
     }
 

--- a/src/Management/src/EndpointCore/Metrics/Observer/AspNetCoreHostingObserver.cs
+++ b/src/Management/src/EndpointCore/Metrics/Observer/AspNetCoreHostingObserver.cs
@@ -26,37 +26,37 @@ namespace Steeltoe.Management.Endpoint.Metrics.Observer
         private const string OBSERVER_NAME = "AspNetCoreHostingObserver";
         private const string DIAGNOSTIC_NAME = "Microsoft.AspNetCore";
 
-        private readonly ITagKey statusTagKey = TagKey.Create("status");
-        private readonly ITagKey exceptionTagKey = TagKey.Create("exception");
-        private readonly ITagKey methodTagKey = TagKey.Create("method");
-        private readonly ITagKey uriTagKey = TagKey.Create("uri");
+        private readonly ITagKey _statusTagKey = TagKey.Create("status");
+        private readonly ITagKey _exceptionTagKey = TagKey.Create("exception");
+        private readonly ITagKey _methodTagKey = TagKey.Create("method");
+        private readonly ITagKey _uriTagKey = TagKey.Create("uri");
 
-        private readonly IMeasureDouble responseTimeMeasure;
-        private readonly IMeasureLong serverCountMeasure;
+        private readonly IMeasureDouble _responseTimeMeasure;
+        private readonly IMeasureLong _serverCountMeasure;
 
         public AspNetCoreHostingObserver(IMetricsOptions options, IStats censusStats, ITags censusTags, ILogger<AspNetCoreHostingObserver> logger)
             : base(OBSERVER_NAME, DIAGNOSTIC_NAME, options, censusStats, censusTags, logger)
         {
             PathMatcher = new Regex(options.IngressIgnorePattern);
 
-            responseTimeMeasure = MeasureDouble.Create("server.core.totalTime", "Total request time", MeasureUnit.MilliSeconds);
-            serverCountMeasure = MeasureLong.Create("server.core.totalRequests", "Total request count", "count");
+            _responseTimeMeasure = MeasureDouble.Create("server.core.totalTime", "Total request time", MeasureUnit.MilliSeconds);
+            _serverCountMeasure = MeasureLong.Create("server.core.totalRequests", "Total request count", "count");
 
             var view = View.Create(
                     ViewName.Create("http.server.request.time"),
                     "Total request time",
-                    responseTimeMeasure,
+                    _responseTimeMeasure,
                     Distribution.Create(BucketBoundaries.Create(new List<double>() { 0.0, 1.0, 5.0, 10.0, 100.0 })),
-                    new List<ITagKey>() { statusTagKey, exceptionTagKey, methodTagKey, uriTagKey });
+                    new List<ITagKey>() { _statusTagKey, _exceptionTagKey, _methodTagKey, _uriTagKey });
 
             ViewManager.RegisterView(view);
 
             view = View.Create(
                     ViewName.Create("http.server.request.count"),
                     "Total request counts",
-                    serverCountMeasure,
+                    _serverCountMeasure,
                     Sum.Create(),
-                    new List<ITagKey>() { statusTagKey, exceptionTagKey, methodTagKey, uriTagKey });
+                    new List<ITagKey>() { _statusTagKey, _exceptionTagKey, _methodTagKey, _uriTagKey });
 
             ViewManager.RegisterView(view);
         }
@@ -102,8 +102,8 @@ namespace Steeltoe.Management.Endpoint.Metrics.Observer
                 ITagContext tagContext = GetTagContext(arg);
                 StatsRecorder
                     .NewMeasureMap()
-                    .Put(responseTimeMeasure, current.Duration.TotalMilliseconds)
-                    .Put(serverCountMeasure, 1)
+                    .Put(_responseTimeMeasure, current.Duration.TotalMilliseconds)
+                    .Put(_serverCountMeasure, 1)
                     .Record(tagContext);
             }
         }
@@ -116,10 +116,10 @@ namespace Steeltoe.Management.Endpoint.Metrics.Observer
 
             return Tagger
                 .EmptyBuilder
-                .Put(uriTagKey, TagValue.Create(uri))
-                .Put(statusTagKey, TagValue.Create(statusCode))
-                .Put(exceptionTagKey, TagValue.Create(exception))
-                .Put(methodTagKey, TagValue.Create(arg.Request.Method))
+                .Put(_uriTagKey, TagValue.Create(uri))
+                .Put(_statusTagKey, TagValue.Create(statusCode))
+                .Put(_exceptionTagKey, TagValue.Create(exception))
+                .Put(_methodTagKey, TagValue.Create(arg.Request.Method))
                 .Build();
         }
 

--- a/src/Management/src/EndpointCore/SpringBootAdminClient/BootAdminAppBuilderExtensions.cs
+++ b/src/Management/src/EndpointCore/SpringBootAdminClient/BootAdminAppBuilderExtensions.cs
@@ -22,9 +22,8 @@ namespace Steeltoe.Management.Endpoint.SpringBootAdminClient
     public static class BootAdminAppBuilderExtensions
     {
         private const int ConnectionTimeoutMs = 100000;
-        private static RegistrationResult registrationResult;
 
-        internal static RegistrationResult RegistrationResult { get => registrationResult; }
+        internal static RegistrationResult RegistrationResult { get; private set; }
 
         public static void RegisterSpringBootAdmin(this IApplicationBuilder builder, IConfiguration configuration, HttpClient testClient = null)
         {
@@ -63,7 +62,7 @@ namespace Steeltoe.Management.Endpoint.SpringBootAdminClient
                 if (result.IsSuccessStatusCode)
                 {
                     var task = result.Content.ReadAsStringAsync();
-                    registrationResult = JsonConvert.DeserializeObject<RegistrationResult>(task.Result);
+                    RegistrationResult = JsonConvert.DeserializeObject<RegistrationResult>(task.Result);
                 }
             };
             Action onStopped = () =>

--- a/src/Management/src/EndpointOwin/Metrics/Observer/OwinHostingObserver.cs
+++ b/src/Management/src/EndpointOwin/Metrics/Observer/OwinHostingObserver.cs
@@ -26,37 +26,37 @@ namespace Steeltoe.Management.Endpoint.Metrics.Observer
         private const string OBSERVER_NAME = "OwinHostingObserver";
         private const string DIAGNOSTIC_NAME = "Steeltoe.Owin";
 
-        private readonly ITagKey statusTagKey = TagKey.Create("status");
-        private readonly ITagKey exceptionTagKey = TagKey.Create("exception");
-        private readonly ITagKey methodTagKey = TagKey.Create("method");
-        private readonly ITagKey uriTagKey = TagKey.Create("uri");
+        private readonly ITagKey _statusTagKey = TagKey.Create("status");
+        private readonly ITagKey _exceptionTagKey = TagKey.Create("exception");
+        private readonly ITagKey _methodTagKey = TagKey.Create("method");
+        private readonly ITagKey _uriTagKey = TagKey.Create("uri");
 
-        private readonly IMeasureDouble responseTimeMeasure;
-        private readonly IMeasureLong serverCountMeasure;
+        private readonly IMeasureDouble _responseTimeMeasure;
+        private readonly IMeasureLong _serverCountMeasure;
 
         public OwinHostingObserver(IMetricsOptions options, IStats censusStats, ITags censusTags, ILogger<OwinHostingObserver> logger)
             : base(OBSERVER_NAME, DIAGNOSTIC_NAME, options, censusStats, censusTags, logger)
         {
             PathMatcher = new Regex(options.IngressIgnorePattern);
 
-            responseTimeMeasure = MeasureDouble.Create("server.owin.totalTime", "Total request time", MeasureUnit.MilliSeconds);
-            serverCountMeasure = MeasureLong.Create("server.owin.totalRequests", "Total request count", "count");
+            _responseTimeMeasure = MeasureDouble.Create("server.owin.totalTime", "Total request time", MeasureUnit.MilliSeconds);
+            _serverCountMeasure = MeasureLong.Create("server.owin.totalRequests", "Total request count", "count");
 
             var view = View.Create(
                     ViewName.Create("http.server.request.time"),
                     "Total request time",
-                    responseTimeMeasure,
+                    _responseTimeMeasure,
                     Distribution.Create(BucketBoundaries.Create(new List<double>() { 0.0, 1.0, 5.0, 10.0, 100.0 })),
-                    new List<ITagKey>() { statusTagKey, exceptionTagKey, methodTagKey, uriTagKey });
+                    new List<ITagKey>() { _statusTagKey, _exceptionTagKey, _methodTagKey, _uriTagKey });
 
             ViewManager.RegisterView(view);
 
             view = View.Create(
                     ViewName.Create("http.server.request.count"),
                     "Total request counts",
-                    serverCountMeasure,
+                    _serverCountMeasure,
                     Sum.Create(),
-                    new List<ITagKey>() { statusTagKey, exceptionTagKey, methodTagKey, uriTagKey });
+                    new List<ITagKey>() { _statusTagKey, _exceptionTagKey, _methodTagKey, _uriTagKey });
 
             ViewManager.RegisterView(view);
         }
@@ -102,8 +102,8 @@ namespace Steeltoe.Management.Endpoint.Metrics.Observer
                 ITagContext tagContext = GetTagContext(arg);
                 StatsRecorder
                     .NewMeasureMap()
-                    .Put(responseTimeMeasure, current.Duration.TotalMilliseconds)
-                    .Put(serverCountMeasure, 1)
+                    .Put(_responseTimeMeasure, current.Duration.TotalMilliseconds)
+                    .Put(_serverCountMeasure, 1)
                     .Record(tagContext);
             }
         }
@@ -116,10 +116,10 @@ namespace Steeltoe.Management.Endpoint.Metrics.Observer
 
             return Tagger
                 .EmptyBuilder
-                .Put(uriTagKey, TagValue.Create(uri))
-                .Put(statusTagKey, TagValue.Create(statusCode))
-                .Put(exceptionTagKey, TagValue.Create(exception))
-                .Put(methodTagKey, TagValue.Create(arg.Request.Method))
+                .Put(_uriTagKey, TagValue.Create(uri))
+                .Put(_statusTagKey, TagValue.Create(statusCode))
+                .Put(_exceptionTagKey, TagValue.Create(exception))
+                .Put(_methodTagKey, TagValue.Create(arg.Request.Method))
                 .Build();
         }
 

--- a/src/Management/src/EndpointWeb/ActuatorConfigurator.cs
+++ b/src/Management/src/EndpointWeb/ActuatorConfigurator.cs
@@ -358,14 +358,14 @@ namespace Steeltoe.Management.Endpoint
 
         public class DefaultHostingEnvironment : IHostingEnvironment
         {
-            private readonly string profile;
+            private readonly string _profile;
 
             public DefaultHostingEnvironment(string profile)
             {
-                this.profile = profile;
+                this._profile = profile;
             }
 
-            public string EnvironmentName { get => profile; set => throw new NotImplementedException(); }
+            public string EnvironmentName { get => _profile; set => throw new NotImplementedException(); }
 
             public string ApplicationName { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
 

--- a/src/Management/src/EndpointWeb/Observer/AspNetHostingObserver.cs
+++ b/src/Management/src/EndpointWeb/Observer/AspNetHostingObserver.cs
@@ -28,37 +28,37 @@ namespace Steeltoe.Management.Endpoint.Metrics.Observer
         internal const string STOP_EVENT_ACTIVITY_LOST = "Microsoft.AspNet.HttpReqIn.ActivityLost.Stop";
         internal const string STOP_EVENT_ACTIVITY_RESTORED = "Microsoft.AspNet.HttpReqIn.ActivityRestored.Stop";
 
-        private readonly ITagKey statusTagKey = TagKey.Create("status");
-        private readonly ITagKey exceptionTagKey = TagKey.Create("exception");
-        private readonly ITagKey methodTagKey = TagKey.Create("method");
-        private readonly ITagKey uriTagKey = TagKey.Create("uri");
+        private readonly ITagKey _statusTagKey = TagKey.Create("status");
+        private readonly ITagKey _exceptionTagKey = TagKey.Create("exception");
+        private readonly ITagKey _methodTagKey = TagKey.Create("method");
+        private readonly ITagKey _uriTagKey = TagKey.Create("uri");
 
-        private readonly IMeasureDouble responseTimeMeasure;
-        private readonly IMeasureLong serverCountMeasure;
+        private readonly IMeasureDouble _responseTimeMeasure;
+        private readonly IMeasureLong _serverCountMeasure;
 
         public AspNetHostingObserver(IMetricsOptions options, IStats censusStats, ITags censusTags, ILogger<AspNetHostingObserver> logger)
             : base(OBSERVER_NAME, DIAGNOSTIC_NAME, options, censusStats, censusTags, logger)
         {
             PathMatcher = new Regex(options.IngressIgnorePattern);
 
-            responseTimeMeasure = MeasureDouble.Create("server.core.totalTime", "Total request time", MeasureUnit.MilliSeconds);
-            serverCountMeasure = MeasureLong.Create("server.core.totalRequests", "Total request count", "count");
+            _responseTimeMeasure = MeasureDouble.Create("server.core.totalTime", "Total request time", MeasureUnit.MilliSeconds);
+            _serverCountMeasure = MeasureLong.Create("server.core.totalRequests", "Total request count", "count");
 
             var view = View.Create(
                     ViewName.Create("http.server.request.time"),
                     "Total request time",
-                    responseTimeMeasure,
+                    _responseTimeMeasure,
                     Distribution.Create(BucketBoundaries.Create(new List<double>() { 0.0, 1.0, 5.0, 10.0, 100.0 })),
-                    new List<ITagKey>() { statusTagKey, exceptionTagKey, methodTagKey, uriTagKey });
+                    new List<ITagKey>() { _statusTagKey, _exceptionTagKey, _methodTagKey, _uriTagKey });
 
             ViewManager.RegisterView(view);
 
             view = View.Create(
                     ViewName.Create("http.server.request.count"),
                     "Total request counts",
-                    serverCountMeasure,
+                    _serverCountMeasure,
                     Sum.Create(),
-                    new List<ITagKey>() { statusTagKey, exceptionTagKey, methodTagKey, uriTagKey });
+                    new List<ITagKey>() { _statusTagKey, _exceptionTagKey, _methodTagKey, _uriTagKey });
 
             ViewManager.RegisterView(view);
         }
@@ -141,8 +141,8 @@ namespace Steeltoe.Management.Endpoint.Metrics.Observer
                 ITagContext tagContext = GetTagContext(arg);
                 StatsRecorder
                     .NewMeasureMap()
-                    .Put(responseTimeMeasure, duration.TotalMilliseconds)
-                    .Put(serverCountMeasure, 1)
+                    .Put(_responseTimeMeasure, duration.TotalMilliseconds)
+                    .Put(_serverCountMeasure, 1)
                     .Record(tagContext);
             }
         }
@@ -155,10 +155,10 @@ namespace Steeltoe.Management.Endpoint.Metrics.Observer
 
             return Tagger
                 .EmptyBuilder
-                .Put(uriTagKey, TagValue.Create(uri))
-                .Put(statusTagKey, TagValue.Create(statusCode))
-                .Put(exceptionTagKey, TagValue.Create(exception))
-                .Put(methodTagKey, TagValue.Create(arg.Request.HttpMethod))
+                .Put(_uriTagKey, TagValue.Create(uri))
+                .Put(_statusTagKey, TagValue.Create(statusCode))
+                .Put(_exceptionTagKey, TagValue.Create(exception))
+                .Put(_methodTagKey, TagValue.Create(arg.Request.HttpMethod))
                 .Build();
         }
 

--- a/src/Management/src/ExporterBase/Tracing/Zipkin/ZipkinSpan.cs
+++ b/src/Management/src/ExporterBase/Tracing/Zipkin/ZipkinSpan.cs
@@ -122,91 +122,91 @@ namespace Steeltoe.Management.Exporter.Tracing.Zipkin
 
         public class Builder
         {
-            private string traceId;
-            private string parentId;
-            private string id;
-            private ZipkinSpanKind kind;
-            private string name;
-            private long timestamp;
-            private long duration; // zero means null
-            private ZipkinEndpoint localEndpoint;
-            private ZipkinEndpoint remoteEndpoint;
-            private List<ZipkinAnnotation> annotations;
-            private Dictionary<string, string> tags;
-            private bool debug;
-            private bool shared;
+            private string _traceId;
+            private string _parentId;
+            private string _id;
+            private ZipkinSpanKind _kind;
+            private string _name;
+            private long _timestamp;
+            private long _duration; // zero means null
+            private ZipkinEndpoint _localEndpoint;
+            private ZipkinEndpoint _remoteEndpoint;
+            private List<ZipkinAnnotation> _annotations;
+            private Dictionary<string, string> _tags;
+            private bool _debug;
+            private bool _shared;
 
             internal Builder TraceId(string v)
             {
-                traceId = v;
+                _traceId = v;
                 return this;
             }
 
             internal Builder Id(string v)
             {
-                id = v;
+                _id = v;
                 return this;
             }
 
             internal Builder ParentId(string v)
             {
-                parentId = v;
+                _parentId = v;
                 return this;
             }
 
             internal Builder Kind(ZipkinSpanKind v)
             {
-                kind = v;
+                _kind = v;
                 return this;
             }
 
             internal Builder Name(string v)
             {
-                name = v;
+                _name = v;
                 return this;
             }
 
             internal Builder Timestamp(long v)
             {
-                timestamp = v;
+                _timestamp = v;
                 return this;
             }
 
             internal Builder Duration(long v)
             {
-                duration = v;
+                _duration = v;
                 return this;
             }
 
             internal Builder LocalEndpoint(ZipkinEndpoint v)
             {
-                localEndpoint = v;
+                _localEndpoint = v;
                 return this;
             }
 
             internal Builder RemoteEndpoint(ZipkinEndpoint v)
             {
-                remoteEndpoint = v;
+                _remoteEndpoint = v;
                 return this;
             }
 
             internal Builder Debug(bool v)
             {
-                debug = v;
+                _debug = v;
                 return this;
             }
 
             internal Builder Shared(bool v)
             {
-                shared = v;
+                _shared = v;
                 return this;
             }
 
             internal Builder PutTag(string key, string value)
             {
-                if (tags == null)
+                if (_tags == null)
                 {
-                    tags = new Dictionary<string, string>();
+                    _tags = new Dictionary<string, string>();
                 }
 
                 if (key == null)
@@ -219,30 +219,30 @@ namespace Steeltoe.Management.Exporter.Tracing.Zipkin
                     throw new ArgumentNullException(nameof(value));
                 }
 
-                this.tags[key] = value;
+                this._tags[key] = value;
                 return this;
             }
 
             internal Builder AddAnnotation(long timestamp, string value)
             {
-                if (annotations == null)
+                if (_annotations == null)
                 {
-                    annotations = new List<ZipkinAnnotation>(2);
+                    _annotations = new List<ZipkinAnnotation>(2);
                 }
 
-                annotations.Add(new ZipkinAnnotation() { Timestamp = timestamp, Value = value });
+                _annotations.Add(new ZipkinAnnotation() { Timestamp = timestamp, Value = value });
                 return this;
             }
 
             internal ZipkinSpan Build()
             {
                 string missing = string.Empty;
-                if (traceId == null)
+                if (_traceId == null)
                 {
                     missing += " traceId";
                 }
 
-                if (id == null)
+                if (_id == null)
                 {
                     missing += " id";
                 }
@@ -254,19 +254,19 @@ namespace Steeltoe.Management.Exporter.Tracing.Zipkin
 
                 return new ZipkinSpan()
                 {
-                    TraceId = traceId,
-                    ParentId = parentId,
-                    Id = id,
-                    Kind = kind,
-                    Name = name,
-                    Timestamp = timestamp,
-                    Duration = duration,
-                    LocalEndpoint = localEndpoint,
-                    RemoteEndpoint = remoteEndpoint,
-                    Annotations = annotations,
-                    Tags = tags,
-                    Shared = shared,
-                    Debug = debug
+                    TraceId = _traceId,
+                    ParentId = _parentId,
+                    Id = _id,
+                    Kind = _kind,
+                    Name = _name,
+                    Timestamp = _timestamp,
+                    Duration = _duration,
+                    LocalEndpoint = _localEndpoint,
+                    RemoteEndpoint = _remoteEndpoint,
+                    Annotations = _annotations,
+                    Tags = _tags,
+                    Shared = _shared,
+                    Debug = _debug
                 };
             }
         }

--- a/src/Management/src/OpenCensus.Abstractions/Trace/Sampler/Samplers.cs
+++ b/src/Management/src/OpenCensus.Abstractions/Trace/Sampler/Samplers.cs
@@ -21,30 +21,16 @@ namespace OpenCensus.Trace.Sampler
     /// </summary>
     public sealed class Samplers
     {
-        private static readonly ISampler AlwaysSampleInstance = new AlwaysSampleSampler();
-        private static readonly ISampler NeverSampleInstance = new NeverSampleSampler();
 
         /// <summary>
         /// Gets the sampler that always sample.
         /// </summary>
-        public static ISampler AlwaysSample
-        {
-            get
-            {
-                return AlwaysSampleInstance;
-            }
-        }
+        public static ISampler AlwaysSample { get; } = new AlwaysSampleSampler();
 
         /// <summary>
         /// Gets the sampler than never samples.
         /// </summary>
-        public static ISampler NeverSample
-        {
-            get
-            {
-                return NeverSampleInstance;
-            }
-        }
+        public static ISampler NeverSample { get; } = new NeverSampleSampler();
 
         /// <summary>
         /// Gets the probability sampler.

--- a/src/Management/src/OpenCensus.Abstractions/Trace/TraceState.cs
+++ b/src/Management/src/OpenCensus.Abstractions/Trace/TraceState.cs
@@ -34,11 +34,9 @@ namespace OpenCensus.Trace
         private const int ValueMaxSize = 256;
         private const int MaxKeyValuePairsCount = 32;
 
-        private readonly IEnumerable<Entry> entries;
-
         private Tracestate(IEnumerable<Entry> entries)
         {
-            this.entries = entries;
+            this.Entries = entries;
         }
 
         /// <summary>
@@ -55,7 +53,7 @@ namespace OpenCensus.Trace
         /// <summary>
         /// Gets the list of entris in tracestate.
         /// </summary>
-        public IEnumerable<Entry> Entries { get => this.entries; }
+        public IEnumerable<Entry> Entries { get; private set; }
 
         /// <summary>
         /// Returns the value to which the specified key is mapped, or null if this map contains no mapping
@@ -202,24 +200,21 @@ namespace OpenCensus.Trace
         /// </summary>
         public sealed class Entry
         {
-            private readonly string key;
-            private readonly string value;
-
             private Entry(string key, string value)
             {
-                this.key = key;
-                this.value = value;
+                this.Key = key;
+                this.Value = value;
             }
 
             /// <summary>
             /// Gets the key of tracestate entry.
             /// </summary>
-            public string Key { get => this.key; }
+            public string Key { get; private set; }
 
             /// <summary>
             /// Gets the value of tracestate entry.
             /// </summary>
-            public string Value { get => this.value; }
+            public string Value { get; private set; }
 
             /// <summary>
             /// Creates a new Entry with the given name and value.

--- a/src/Management/src/OpenCensus/Stats/CurrentStatsState.cs
+++ b/src/Management/src/OpenCensus/Stats/CurrentStatsState.cs
@@ -21,7 +21,6 @@ namespace OpenCensus.Stats
     public sealed class CurrentStatsState
     {
         private readonly object lck = new object();
-        private StatsCollectionState currentState = StatsCollectionState.ENABLED;
         private bool isRead;
 
         public StatsCollectionState Value
@@ -40,13 +39,7 @@ namespace OpenCensus.Stats
             }
         }
 
-        internal StatsCollectionState Internal
-        {
-            get
-            {
-                return this.currentState;
-            }
-        }
+        internal StatsCollectionState Internal { get; private set; } = StatsCollectionState.ENABLED;
 
         // Sets current state to the given state. Returns true if the current state is changed, false
         // otherwise.
@@ -59,13 +52,13 @@ namespace OpenCensus.Stats
                     throw new ArgumentException("State was already read, cannot set state.");
                 }
 
-                if (state == this.currentState)
+                if (state == this.Internal)
                 {
                     return false;
                 }
                 else
                 {
-                    this.currentState = state;
+                    this.Internal = state;
                     return true;
                 }
             }

--- a/src/Management/src/OpenCensus/Trace/Export/NoopExportComponent.cs
+++ b/src/Management/src/OpenCensus/Trace/Export/NoopExportComponent.cs
@@ -18,8 +18,6 @@ namespace OpenCensus.Trace.Export
 {
     internal sealed class NoopExportComponent : IExportComponent
     {
-        private readonly ISampledSpanStore noopSampledSpanStore = Export.SampledSpanStoreBase.NewNoopSampledSpanStore;
-
         public ISpanExporter SpanExporter
         {
             get
@@ -36,12 +34,6 @@ namespace OpenCensus.Trace.Export
             }
         }
 
-        public ISampledSpanStore SampledSpanStore
-        {
-            get
-            {
-                return this.noopSampledSpanStore;
-            }
-        }
+        public ISampledSpanStore SampledSpanStore { get; } = Export.SampledSpanStoreBase.NewNoopSampledSpanStore;
     }
 }

--- a/src/Management/src/OpenCensus/Trace/Export/RunningSpanStoreBase.cs
+++ b/src/Management/src/OpenCensus/Trace/Export/RunningSpanStoreBase.cs
@@ -20,21 +20,13 @@ namespace OpenCensus.Trace.Export
 
     public abstract class RunningSpanStoreBase : IRunningSpanStore
     {
-        private static readonly IRunningSpanStore NoopRunningSpanStoreInstance = new NoopRunningSpanStore();
-
         protected RunningSpanStoreBase()
         {
         }
 
         public abstract IRunningSpanStoreSummary Summary { get; }
 
-        internal static IRunningSpanStore NoopRunningSpanStore
-        {
-            get
-            {
-                return NoopRunningSpanStoreInstance;
-            }
-        }
+        internal static IRunningSpanStore NoopRunningSpanStore { get; } = new NoopRunningSpanStore();
 
         public abstract IEnumerable<ISpanData> GetRunningSpans(IRunningSpanStoreFilter filter);
 

--- a/src/Management/src/OpenCensus/Trace/Export/SampledSpanStoreBase.cs
+++ b/src/Management/src/OpenCensus/Trace/Export/SampledSpanStoreBase.cs
@@ -20,8 +20,6 @@ namespace OpenCensus.Trace.Export
 
     public abstract class SampledSpanStoreBase : ISampledSpanStore
     {
-        private static readonly ISampledSpanStore NoopSampledSpanStoreInstance = new NoopSampledSpanStore();
-
         protected SampledSpanStoreBase()
         {
         }
@@ -30,13 +28,7 @@ namespace OpenCensus.Trace.Export
 
         public abstract ISet<string> RegisteredSpanNamesForCollection { get; }
 
-        internal static ISampledSpanStore NoopSampledSpanStore
-        {
-            get
-            {
-                return NoopSampledSpanStoreInstance;
-            }
-        }
+        internal static ISampledSpanStore NoopSampledSpanStore { get; } = new NoopSampledSpanStore();
 
         internal static ISampledSpanStore NewNoopSampledSpanStore
         {

--- a/src/Management/src/OpenCensus/Trace/Export/SpanExporter.cs
+++ b/src/Management/src/OpenCensus/Trace/Export/SpanExporter.cs
@@ -23,28 +23,20 @@ namespace OpenCensus.Trace.Export
 
     public sealed class SpanExporter : SpanExporterBase
     {
-        private readonly Thread workerThread;
-
         private readonly SpanExporterWorker worker;
 
         internal SpanExporter(SpanExporterWorker worker)
         {
             this.worker = worker;
-            this.workerThread = new Thread(worker.Run)
+            this.ServiceExporterThread = new Thread(worker.Run)
             {
                 IsBackground = true,
                 Name = "SpanExporter",
             };
-            this.workerThread.Start();
+            this.ServiceExporterThread.Start();
         }
 
-        internal Thread ServiceExporterThread
-        {
-            get
-            {
-                return this.workerThread;
-            }
-        }
+        internal Thread ServiceExporterThread { get; private set; }
 
         public override void AddSpan(ISpan span)
         {

--- a/src/Management/src/OpenCensus/Trace/Export/SpanExporterBase.cs
+++ b/src/Management/src/OpenCensus/Trace/Export/SpanExporterBase.cs
@@ -22,15 +22,7 @@ namespace OpenCensus.Trace.Export
 
     public abstract class SpanExporterBase : ISpanExporter
     {
-        private static readonly ISpanExporter NoopSpanExporterInstance = new NoopSpanExporter();
-
-        public static ISpanExporter NoopSpanExporter
-        {
-            get
-            {
-                return NoopSpanExporterInstance;
-            }
-        }
+        public static ISpanExporter NoopSpanExporter { get; } = new NoopSpanExporter();
 
         public abstract void AddSpan(ISpan span);
 

--- a/src/Management/src/OpenCensus/Trace/NoopTraceComponent.cs
+++ b/src/Management/src/OpenCensus/Trace/NoopTraceComponent.cs
@@ -23,8 +23,6 @@ namespace OpenCensus.Trace
 
     internal sealed class NoopTraceComponent : ITraceComponent
     {
-        private readonly IExportComponent noopExportComponent = Export.ExportComponentBase.NewNoopExportComponent;
-
         public ITracer Tracer
         {
             get
@@ -49,13 +47,7 @@ namespace OpenCensus.Trace
             }
         }
 
-        public IExportComponent ExportComponent
-        {
-            get
-            {
-                return this.noopExportComponent;
-            }
-        }
+        public IExportComponent ExportComponent { get; } = Export.ExportComponentBase.NewNoopExportComponent;
 
         public ITraceConfig TraceConfig
         {

--- a/src/Management/src/OpenCensus/Trace/Propagation/PropagationComponentBase.cs
+++ b/src/Management/src/OpenCensus/Trace/Propagation/PropagationComponentBase.cs
@@ -20,15 +20,7 @@ namespace OpenCensus.Trace.Propagation
 
     public abstract class PropagationComponentBase : IPropagationComponent
     {
-        private static readonly IPropagationComponent NoopPropagationComponentInstance = new NoopPropagationComponent();
-
-        public static IPropagationComponent NoopPropagationComponent
-        {
-            get
-            {
-                return NoopPropagationComponentInstance;
-            }
-        }
+        public static IPropagationComponent NoopPropagationComponent { get; } = new NoopPropagationComponent();
 
         public abstract IBinaryFormat BinaryFormat { get; }
 

--- a/src/Management/src/OpenCensus/Trace/TraceEvents.cs
+++ b/src/Management/src/OpenCensus/Trace/TraceEvents.cs
@@ -20,31 +20,24 @@ namespace OpenCensus.Trace
 
     internal class TraceEvents<T>
     {
-        private readonly EvictingQueue<T> events;
         private int totalRecordedEvents = 0;
 
         public TraceEvents(int maxNumEvents)
         {
-            this.events = new EvictingQueue<T>(maxNumEvents);
+            this.Events = new EvictingQueue<T>(maxNumEvents);
         }
 
-        public EvictingQueue<T> Events
-        {
-            get
-            {
-                return this.events;
-            }
-        }
+        public EvictingQueue<T> Events { get; private set; }
 
         public int NumberOfDroppedEvents
         {
-            get { return this.totalRecordedEvents - this.events.Count; }
+            get { return this.totalRecordedEvents - this.Events.Count; }
         }
 
         internal void AddEvent(T @event)
         {
             this.totalRecordedEvents++;
-            this.events.Add(@event);
+            this.Events.Add(@event);
         }
     }
 }

--- a/src/Management/src/OpenCensus/Trace/TracerBase.cs
+++ b/src/Management/src/OpenCensus/Trace/TracerBase.cs
@@ -22,8 +22,6 @@ namespace OpenCensus.Trace
 
     public abstract class TracerBase : ITracer
     {
-        private static readonly NoopTracer NoopTracerInstance = new NoopTracer();
-
         public ISpan CurrentSpan
         {
             get
@@ -33,13 +31,7 @@ namespace OpenCensus.Trace
             }
         }
 
-        internal static NoopTracer NoopTracer
-        {
-            get
-            {
-                return NoopTracerInstance;
-            }
-        }
+        internal static NoopTracer NoopTracer { get; } = new NoopTracer();
 
         public IScope WithSpan(ISpan span)
         {

--- a/src/Management/src/OpenCensus/Utils/ConcurrentIntrusiveList.cs
+++ b/src/Management/src/OpenCensus/Utils/ConcurrentIntrusiveList.cs
@@ -22,20 +22,13 @@ namespace OpenCensus.Utils
     internal sealed class ConcurrentIntrusiveList<T> where T : IElement<T>
     {
         private readonly object lck = new object();
-        private int size = 0;
         private T head = default(T);
 
         public ConcurrentIntrusiveList()
         {
         }
 
-        public int Count
-        {
-            get
-            {
-                return this.size;
-            }
-        }
+        public int Count { get; private set; } = 0;
 
         public void AddElement(T element)
         {
@@ -46,7 +39,7 @@ namespace OpenCensus.Utils
                     throw new ArgumentOutOfRangeException("Element already in a list");
                 }
 
-                this.size++;
+                this.Count++;
                 if (this.head == null)
                 {
                     this.head = element;
@@ -69,7 +62,7 @@ namespace OpenCensus.Utils
                     throw new ArgumentOutOfRangeException("Element not in the list");
                 }
 
-                this.size--;
+                this.Count--;
                 if (element.Previous == null)
                 {
                     // This is the first element
@@ -102,7 +95,7 @@ namespace OpenCensus.Utils
         {
             lock (this.lck)
             {
-                List<T> all = new List<T>(this.size);
+                List<T> all = new List<T>(this.Count);
                 for (T e = this.head; e != null; e = e.Next)
                 {
                     all.Add(e);

--- a/src/Management/src/OpenCensusBase/Stats/OpenCensusStats.cs
+++ b/src/Management/src/OpenCensusBase/Stats/OpenCensusStats.cs
@@ -13,7 +13,7 @@ namespace Steeltoe.Management.Census.Stats
 
         public static OpenCensusStats Instance => AsSingleton.Value;
 
-        private readonly IStatsComponent statsComponent = new StatsComponent();
+        private readonly IStatsComponent _statsComponent = new StatsComponent();
 
         public OpenCensusStats()
         {
@@ -23,7 +23,7 @@ namespace Steeltoe.Management.Census.Stats
         {
             get
             {
-                return statsComponent.StatsRecorder;
+                return _statsComponent.StatsRecorder;
             }
         }
 
@@ -31,7 +31,7 @@ namespace Steeltoe.Management.Census.Stats
         {
             get
             {
-                return statsComponent.ViewManager;
+                return _statsComponent.ViewManager;
             }
         }
 
@@ -39,12 +39,12 @@ namespace Steeltoe.Management.Census.Stats
         {
             get
             {
-                return statsComponent.State;
+                return _statsComponent.State;
             }
 
             set
             {
-                ((StatsComponent)statsComponent).State = value;
+                ((StatsComponent)_statsComponent).State = value;
             }
         }
     }

--- a/src/Management/src/OpenCensusBase/Tags/OpenCensusTags.cs
+++ b/src/Management/src/OpenCensusBase/Tags/OpenCensusTags.cs
@@ -14,13 +14,13 @@ namespace Steeltoe.Management.Census.Tags
 
         public static OpenCensusTags Instance => AsSingleton.Value;
 
-        private readonly ITagsComponent tagsComponent = new TagsComponent();
+        private readonly ITagsComponent _tagsComponent = new TagsComponent();
 
         public ITagger Tagger
         {
             get
             {
-                return tagsComponent.Tagger;
+                return _tagsComponent.Tagger;
             }
         }
 
@@ -28,7 +28,7 @@ namespace Steeltoe.Management.Census.Tags
         {
             get
             {
-                return tagsComponent.TagPropagationComponent;
+                return _tagsComponent.TagPropagationComponent;
             }
         }
 
@@ -36,7 +36,7 @@ namespace Steeltoe.Management.Census.Tags
         {
             get
             {
-                return tagsComponent.State;
+                return _tagsComponent.State;
             }
         }
     }

--- a/src/Management/src/OpenCensusBase/Trace/OpenCensusTracing.cs
+++ b/src/Management/src/OpenCensusBase/Trace/OpenCensusTracing.cs
@@ -13,11 +13,11 @@ namespace Steeltoe.Management.Census.Trace
 {
     public class OpenCensusTracing : ITracing
     {
-        private readonly ITracingOptions options;
+        private readonly ITracingOptions _options;
 
         public OpenCensusTracing(ITracingOptions options, ISampler sampler = null)
         {
-            this.options = options;
+            this._options = options;
             var builder = TraceParams.Default.ToBuilder();
 
             if (sampler != null)
@@ -56,23 +56,23 @@ namespace Steeltoe.Management.Census.Trace
             TraceConfig.UpdateActiveTraceParams(builder.Build());
         }
 
-        private readonly ITraceComponent traceComponent = new TraceComponent();
+        private readonly ITraceComponent _traceComponent = new TraceComponent();
 
         public ITracer Tracer
         {
             get
             {
-                return traceComponent.Tracer;
+                return _traceComponent.Tracer;
             }
         }
 
-        private readonly IPropagationComponent propagation = new B3PropagationComponent();
+        private readonly IPropagationComponent _propagation = new B3PropagationComponent();
 
         public IPropagationComponent PropagationComponent
         {
             get
             {
-                return propagation;
+                return _propagation;
             }
         }
 
@@ -80,7 +80,7 @@ namespace Steeltoe.Management.Census.Trace
         {
             get
             {
-                return traceComponent.ExportComponent;
+                return _traceComponent.ExportComponent;
             }
         }
 
@@ -88,7 +88,7 @@ namespace Steeltoe.Management.Census.Trace
         {
             get
             {
-                return traceComponent.TraceConfig;
+                return _traceComponent.TraceConfig;
             }
         }
     }

--- a/src/Management/src/OpenCensusBase/Trace/OpenCensusTracing.cs
+++ b/src/Management/src/OpenCensusBase/Trace/OpenCensusTracing.cs
@@ -66,15 +66,7 @@ namespace Steeltoe.Management.Census.Trace
             }
         }
 
-        private readonly IPropagationComponent _propagation = new B3PropagationComponent();
-
-        public IPropagationComponent PropagationComponent
-        {
-            get
-            {
-                return _propagation;
-            }
-        }
+        public IPropagationComponent PropagationComponent { get; } = new B3PropagationComponent();
 
         public IExportComponent ExportComponent
         {

--- a/src/Management/src/OpenCensusBase/Trace/Propagation/B3PropagationComponent.cs
+++ b/src/Management/src/OpenCensusBase/Trace/Propagation/B3PropagationComponent.cs
@@ -8,15 +8,15 @@ namespace Steeltoe.Management.Census.Trace.Propagation
 {
     public sealed class B3PropagationComponent : PropagationComponentBase
     {
-        private readonly ThrowsBinaryFormat binaryFormat = new ThrowsBinaryFormat();
-        private readonly B3Format textFormat = new B3Format();
+        private readonly ThrowsBinaryFormat _binaryFormat = new ThrowsBinaryFormat();
+        private readonly B3Format _textFormat = new B3Format();
 
         /// <inheritdoc/>
         public override IBinaryFormat BinaryFormat
         {
             get
             {
-                return this.binaryFormat;
+                return this._binaryFormat;
             }
         }
 
@@ -25,7 +25,7 @@ namespace Steeltoe.Management.Census.Trace.Propagation
         {
             get
             {
-                return this.textFormat;
+                return this._textFormat;
             }
         }
     }

--- a/src/Management/src/TracingBase/TracingLogProcessor.cs
+++ b/src/Management/src/TracingBase/TracingLogProcessor.cs
@@ -11,13 +11,13 @@ namespace Steeltoe.Management.Tracing
 {
     public class TracingLogProcessor : IDynamicMessageProcessor
     {
-        private readonly ITracing tracing;
-        private readonly ITracingOptions options;
+        private readonly ITracing _tracing;
+        private readonly ITracingOptions _options;
 
         public TracingLogProcessor(ITracingOptions options, ITracing tracing)
         {
-            this.options = options;
-            this.tracing = tracing;
+            this._options = options;
+            this._tracing = tracing;
         }
 
         public string Process(string inputLogMessage)
@@ -29,11 +29,11 @@ namespace Steeltoe.Management.Tracing
                 if (context != null)
                 {
                     StringBuilder sb = new StringBuilder(" [");
-                    sb.Append(options.Name);
+                    sb.Append(_options.Name);
                     sb.Append(",");
 
                     var traceId = context.TraceId.ToLowerBase16();
-                    if (traceId.Length > 16 && options.UseShortTraceIds)
+                    if (traceId.Length > 16 && _options.UseShortTraceIds)
                     {
                         traceId = traceId.Substring(traceId.Length - 16, 16);
                     }
@@ -70,7 +70,7 @@ namespace Steeltoe.Management.Tracing
 
         protected internal Span GetCurrentSpan()
         {
-            var span = tracing.Tracer?.CurrentSpan;
+            var span = _tracing.Tracer?.CurrentSpan;
             if (span == null || span.Context == SpanContext.Invalid)
             {
                 return null;

--- a/src/Management/src/TracingCore/TracingService.cs
+++ b/src/Management/src/TracingCore/TracingService.cs
@@ -12,24 +12,24 @@ namespace Steeltoe.Management.Tracing
 {
     internal class TracingService : IHostedService
     {
-        private readonly IDiagnosticsManager observerManager;
-        private readonly ILogger<TracingService> logger;
+        private readonly IDiagnosticsManager _observerManager;
+        private readonly ILogger<TracingService> _logger;
 
         public TracingService(IDiagnosticsManager observerManager, ILogger<TracingService> logger = null)
         {
-            this.observerManager = observerManager;
-            this.logger = logger;
+            this._observerManager = observerManager;
+            this._logger = logger;
         }
 
         public Task StartAsync(CancellationToken cancellationToken)
         {
-            observerManager.Start();
+            _observerManager.Start();
             return Task.CompletedTask;
         }
 
         public Task StopAsync(CancellationToken cancellationToken)
         {
-            observerManager.Stop();
+            _observerManager.Stop();
             return Task.CompletedTask;
         }
     }

--- a/src/Security/src/DataProtection.CredHubBase/Credentials/SSH/SshGenerationRequest.cs
+++ b/src/Security/src/DataProtection.CredHubBase/Credentials/SSH/SshGenerationRequest.cs
@@ -8,7 +8,7 @@ namespace Steeltoe.Security.DataProtection.CredHub
 {
     public class SshGenerationRequest : CredHubGenerateRequest
     {
-        private SshGenerationParameters defaultParams = new SshGenerationParameters { KeyLength = CertificateKeyLength.Length_2048, SshComment = null };
+        private SshGenerationParameters _defaultParams = new SshGenerationParameters { KeyLength = CertificateKeyLength.Length_2048, SshComment = null };
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SshGenerationRequest"/> class.
@@ -21,7 +21,7 @@ namespace Steeltoe.Security.DataProtection.CredHub
         {
             Name = credentialName;
             Type = CredentialType.SSH;
-            Parameters = parameters ?? defaultParams;
+            Parameters = parameters ?? _defaultParams;
             Mode = overwriteMode;
         }
     }

--- a/src/Security/test/Authentication.CloudFoundryCore.Test/MonitorWrapper.cs
+++ b/src/Security/test/Authentication.CloudFoundryCore.Test/MonitorWrapper.cs
@@ -9,24 +9,16 @@ namespace Steeltoe.Security.Authentication.CloudFoundry.Test
 {
     public class MonitorWrapper<T> : IOptionsMonitor<T>
     {
-        private T _options;
-
         public MonitorWrapper(T options)
         {
-            _options = options;
+            CurrentValue = options;
         }
 
-        public T CurrentValue
-        {
-            get
-            {
-                return _options;
-            }
-        }
+        public T CurrentValue { get; private set; }
 
         public T Get(string name)
         {
-            return _options;
+            return CurrentValue;
         }
 
         public IDisposable OnChange(Action<T, string> listener)


### PR DESCRIPTION
- Force field names to start with `_` so they can be more quickly distinguished from local variables
- Drop some fields in favor of auto-implemented properties