### PR TITLE
Update Actuator Extensions to enable Security

### DIFF
--- a/src/Management/src/EndpointBase/Hypermedia/HypermediaService.cs
+++ b/src/Management/src/EndpointBase/Hypermedia/HypermediaService.cs
@@ -45,13 +45,16 @@ namespace Steeltoe.Management.Endpoint.Hypermedia
                 }
                 else
                 {
-                    if (!string.IsNullOrEmpty(opt.Id) && !links._links.ContainsKey(opt.Id))
+                    if (!string.IsNullOrEmpty(opt.Id))
                     {
-                        links._links.Add(opt.Id, new Link(baseUrl + "/" + opt.Path));
-                    }
-                    else if (links._links.ContainsKey(opt.Id))
-                    {
-                        _logger?.LogWarning("Duplicate endpoint id detected: {DuplicateEndpointId}", opt.Id);
+                        if (!links._links.ContainsKey(opt.Id))
+                        {
+                            links._links.Add(opt.Id, new Link(baseUrl + "/" + opt.Path));
+                        }
+                        else if (links._links.ContainsKey(opt.Id))
+                        {
+                            _logger?.LogWarning("Duplicate endpoint id detected: {DuplicateEndpointId}", opt.Id);
+                        }
                     }
                 }
             }

--- a/src/Management/src/EndpointCore/AllActuatorsStartupFilter.cs
+++ b/src/Management/src/EndpointCore/AllActuatorsStartupFilter.cs
@@ -10,14 +10,23 @@ namespace Steeltoe.Management.Endpoint
 {
     public class AllActuatorsStartupFilter : IStartupFilter
     {
+        public AllActuatorsStartupFilter(Action<IEndpointConventionBuilder> configureConventions = null)
+        {
+            _configureConventions = configureConventions;
+        }
+
+        private readonly Action<IEndpointConventionBuilder> _configureConventions;
+
         public Action<IApplicationBuilder> Configure(Action<IApplicationBuilder> next)
         {
             return app =>
             {
                 next(app);
+
                 app.UseEndpoints(endpoints =>
                 {
-                    endpoints.MapAllActuators();
+                    var builder = endpoints.MapAllActuators();
+                    _configureConventions?.Invoke(builder);
                 });
             };
         }

--- a/src/Management/src/EndpointCore/ManagementHostBuilderExtensions.cs
+++ b/src/Management/src/EndpointCore/ManagementHostBuilderExtensions.cs
@@ -2,7 +2,9 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Steeltoe.Common.HealthChecks;
@@ -257,14 +259,14 @@ namespace Steeltoe.Management.Endpoint
                 });
         }
 
-        public static IHostBuilder AddAllActuators(this IHostBuilder hostBuilder, MediaTypeVersion mediaTypeVersion = MediaTypeVersion.V2)
+        public static IHostBuilder AddAllActuators(this IHostBuilder hostBuilder, Action<IEndpointConventionBuilder> configureEndpoints = null, MediaTypeVersion mediaTypeVersion = MediaTypeVersion.V2)
         {
             return hostBuilder
                 .AddDynamicLogging()
                 .ConfigureServices((context, collection) =>
                 {
                     collection.AddAllActuators(context.Configuration, mediaTypeVersion);
-                    collection.AddTransient<IStartupFilter, AllActuatorsStartupFilter>();
+                    collection.AddTransient<IStartupFilter, AllActuatorsStartupFilter>(provider => new AllActuatorsStartupFilter(configureEndpoints));
                 });
         }
     }

--- a/src/Management/test/EndpointCore.Test/ActuatorRouteBuilderExtensionsTest.cs
+++ b/src/Management/test/EndpointCore.Test/ActuatorRouteBuilderExtensionsTest.cs
@@ -2,9 +2,24 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Steeltoe.Extensions.Logging.DynamicLogger;
+using Steeltoe.Management.Endpoint.CloudFoundry;
+using Steeltoe.Management.Endpoint.Health;
+using Steeltoe.Management.Endpoint.Hypermedia;
+using Steeltoe.Management.Endpoint.Test;
+using Steeltoe.Management.Endpoint.ThreadDump;
+using Steeltoe.Management.Endpoint.Trace;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using System.Reflection;
 using Xunit;
 
@@ -23,6 +38,20 @@ namespace Steeltoe.Management.Endpoint
             }
         }
 
+        public static IEnumerable<object[]> IEndpointImplementationsWithAuth
+        {
+            get
+            {
+                Func<Type, bool> query = t => t.GetInterfaces().Any(type => type.FullName == "Steeltoe.Management.IEndpoint");
+                var types = Assembly.Load("Steeltoe.Management.EndpointBase").GetTypes().Where(query).ToList();
+                types.AddRange(Assembly.Load("Steeltoe.Management.EndpointCore").GetTypes().Where(query));
+                var auths = new bool[] { true, false };
+                return from t in types
+                       from a in auths
+                       select new object[] { t, a };
+            }
+        }
+
         [Theory]
         [MemberData(nameof(IEndpointImplementations))]
         public void LookupMiddlewareTest(Type type)
@@ -30,6 +59,53 @@ namespace Steeltoe.Management.Endpoint
             var (middleware, options) = ActuatorRouteBuilderExtensions.LookupMiddleware(type);
             Assert.NotNull(middleware);
             Assert.NotNull(options);
+        }
+
+        [Theory]
+        [MemberData(nameof(IEndpointImplementationsWithAuth))]
+        public async void MapTestAuthSuccess(Type type, bool authSuccess)
+        {
+            // Arrange
+            ServiceProvider provider = null;
+            Action<AuthorizationPolicyBuilder> policyAction = policy => policy.RequireClaim("scope", "invalidscope");
+
+            if (authSuccess)
+            {
+                policyAction = policy => policy.RequireClaim("scope", "actuators.read"); // Set up for success
+            }
+
+            var hostBuilder = new HostBuilder().ConfigureWebHost(builder =>
+                    builder.UseTestServer()
+                    .ConfigureServices((context, s) =>
+                    {
+                        s.AddRouting();
+                        s.AddTraceActuator(context.Configuration, MediaTypeVersion.V1);
+                        s.AddThreadDumpActuator(context.Configuration, MediaTypeVersion.V1);
+                        s.AddCloudFoundryActuator(context.Configuration);
+                        s.AddAllActuators(context.Configuration); // Add all of them, but map one at a time
+                        s.AddAuthentication(TestAuthHandler.AuthenticationScheme)
+                        .AddScheme<AuthenticationSchemeOptions, TestAuthHandler>(TestAuthHandler.AuthenticationScheme, options => { });
+                        s.AddAuthorization(options => options.AddPolicy("TestAuth", policyAction)); // setup Auth based on test Case
+                        provider = s.BuildServiceProvider();
+                    })
+                    .Configure(a => a.UseRouting().UseAuthentication().UseAuthorization().UseEndpoints(endpoints => endpoints.MapActuatorEndpoint(type).RequireAuthorization("TestAuth"))));
+
+            // Act
+            var host = await hostBuilder.AddDynamicLogging().StartAsync();
+
+            // Assert
+            var (middleware, optionsType) = ActuatorRouteBuilderExtensions.LookupMiddleware(type);
+            var options = provider.GetService(optionsType) as IEndpointOptions;
+            var mgmtContext = type.IsAssignableFrom(typeof(CloudFoundryEndpoint))
+                ? (IManagementOptions)provider.GetRequiredService<CloudFoundryManagementOptions>()
+                : (IManagementOptions)provider.GetRequiredService<ActuatorManagementOptions>();
+            var path = options.GetContextPath(mgmtContext);
+            Assert.NotNull(path);
+
+            var response = host.GetTestServer().CreateClient().GetAsync(path);
+            var expected = authSuccess ? HttpStatusCode.OK : HttpStatusCode.Unauthorized;
+
+            Assert.True(expected == response.Result.StatusCode, $"Expected {expected}, but got {response.Result.StatusCode} for {path} and type {type}");
         }
     }
 }

--- a/src/Management/test/EndpointCore.Test/TestHelpers.cs
+++ b/src/Management/test/EndpointCore.Test/TestHelpers.cs
@@ -1,14 +1,20 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
-
+using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Steeltoe.Management.Endpoint.CloudFoundry;
+using System;
 using System.Collections.Generic;
+using System.Security.Claims;
+using System.Text.Encodings.Web;
+using System.Threading.Tasks;
 
 namespace Steeltoe.Management.Endpoint.Test
 {
@@ -20,10 +26,21 @@ namespace Steeltoe.Management.Endpoint.Test
             mgmtOptions.EndpointOptions.AddRange(options);
             return new List<IManagementOptions>() { mgmtOptions };
         }
+    }
 
-        public static IHostBuilder GetTestHost()
+    public class TestAuthHandler : AuthenticationHandler<AuthenticationSchemeOptions>
+    {
+        public static string AuthenticationScheme = "TestScheme";
+
+        public TestAuthHandler(IOptionsMonitor<AuthenticationSchemeOptions> options, ILoggerFactory logger, UrlEncoder encoder, ISystemClock clock)
+            : base(options, logger, encoder, clock)
         {
-            return new HostBuilder().ConfigureWebHost(builder => builder.UseTestServer().ConfigureServices(s => s.AddRouting()).Configure(a => a.UseRouting()));
+        }
+
+        protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+        {
+            var ticket = new AuthenticationTicket(new ClaimsPrincipal(new ClaimsIdentity(new[] { new Claim("scope", "actuators.read") })), TestAuthHandler.AuthenticationScheme);
+            return Task.FromResult<AuthenticateResult>(AuthenticateResult.Success(ticket));
         }
     }
 }


### PR DESCRIPTION
* The MapXXXActuator and MapAllActuators now return IEndpointConventionBuilder allowing MapXXXActuator().RequireAuthorization()
* The MapAllActuators takes an optional EndpointConventionBuilderCollection to apply the added convention to all
of the endpoints.

