### PR TITLE
FindAssembliesWithAttribute<T> should load assemblies with <T> that haven't been loaded yet

### DIFF
--- a/src/Common/src/Common/Steeltoe.Common.csproj
+++ b/src/Common/src/Common/Steeltoe.Common.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(ExtensionsVersion)" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="$(ExtensionsVersion)" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="$(DiagnosticSourceVersion)" />
+    <PackageReference Include="System.Reflection.MetadataLoadContext" Version="$(SystemReflectionVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/versions.props
+++ b/versions.props
@@ -17,6 +17,7 @@
     <SymReaderPortableVersion>1.4.0</SymReaderPortableVersion>
     <SystemDiagnosticsVersion>4.6.0</SystemDiagnosticsVersion>
     <SystemJsonVersion>4.6.0</SystemJsonVersion>
+    <SystemReflectionVersion>4.6.0</SystemReflectionVersion>
     <TelemetryCorrelationVersion>1.0.0</TelemetryCorrelationVersion>
     <WebInfrastructureVersion>1.0.0</WebInfrastructureVersion>
     <KubernetesClientVersion>2.0.16</KubernetesClientVersion>


### PR DESCRIPTION
Finds dlls in AppDomain.CurrentDomain.BaseDirectory that have the attribute we're searching for but haven't yet been loaded, tries to load them - fixes #401 