### PR TITLE
Fix discovery client assemblies not found with reflection approach

### DIFF
--- a/src/Discovery/src/ClientBase/DiscoveryClientAssemblyAttribute.cs
+++ b/src/Discovery/src/ClientBase/DiscoveryClientAssemblyAttribute.cs
@@ -16,7 +16,7 @@ namespace Steeltoe.Discovery
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="DiscoveryClientAssemblyAttribute"/> class.
-        /// Used to override the default ServiceInfoCreator
+        /// Used to identify assemblies that contain a discovery client
         /// </summary>
         /// <param name="discoveryClientExtensionType">The <see cref="IDiscoveryClientExtension"/></param>
         public DiscoveryClientAssemblyAttribute(Type discoveryClientExtensionType)

--- a/src/Discovery/src/ClientBase/DiscoveryClientAssemblyAttribute.cs
+++ b/src/Discovery/src/ClientBase/DiscoveryClientAssemblyAttribute.cs
@@ -1,0 +1,27 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+using Steeltoe.Common.Attributes;
+using Steeltoe.Discovery.Client;
+using System;
+
+namespace Steeltoe.Discovery
+{
+    /// <summary>
+    /// Identify assemblies containing ServiceInfoCreators
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Assembly)]
+    public sealed class DiscoveryClientAssemblyAttribute : AssemblyContainsTypeAttribute
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DiscoveryClientAssemblyAttribute"/> class.
+        /// Used to override the default ServiceInfoCreator
+        /// </summary>
+        /// <param name="discoveryClientExtensionType">The <see cref="IDiscoveryClientExtension"/></param>
+        public DiscoveryClientAssemblyAttribute(Type discoveryClientExtensionType)
+            : base(discoveryClientExtensionType)
+        {
+        }
+    }
+}

--- a/src/Discovery/src/ClientBase/DiscoveryHostBuilderExtensions.cs
+++ b/src/Discovery/src/ClientBase/DiscoveryHostBuilderExtensions.cs
@@ -14,6 +14,23 @@ namespace Steeltoe.Discovery.Client
     {
         /// <summary>
         /// Adds service discovery to your application. This method can be used in place of configuration via your Startup class.<para />
+        /// Uses reflection to find discovery client packages. If no package is found, a <see cref="NoOpDiscoveryClient"/> will be configured
+        /// </summary>
+        /// <param name="hostBuilder">Your HostBuilder</param>
+        /// <remarks>Also configures named HttpClients "DiscoveryRandom" and "DiscoveryRoundRobin" for automatic injection</remarks>
+        /// <exception cref="AmbiguousMatchException">Thrown if multiple IDiscoveryClient implementations are configured</exception>
+        /// <exception cref="ConnectorException">Thrown if no service info with expected name or type are found or when multiple service infos are found and a single was expected</exception>
+        public static IHostBuilder AddDiscoveryClient(this IHostBuilder hostBuilder)
+        {
+            return hostBuilder
+                .ConfigureServices((context, collection) =>
+                    collection
+                        .AddDiscoveryClient()
+                        .AddHostedService(services => new DiscoveryClientService(services.GetRequiredService<IDiscoveryLifecycle>())));
+        }
+
+        /// <summary>
+        /// Adds service discovery to your application. This method can be used in place of configuration via your Startup class.<para />
         /// If <paramref name="optionsAction"/> is not provided, a <see cref="NoOpDiscoveryClient"/> will be configured
         /// </summary>
         /// <param name="hostBuilder">Your HostBuilder</param>
@@ -23,13 +40,11 @@ namespace Steeltoe.Discovery.Client
         /// <exception cref="ConnectorException">Thrown if no service info with expected name or type are found or when multiple service infos are found and a single was expected</exception>
         public static IHostBuilder AddServiceDiscovery(this IHostBuilder hostBuilder, Action<DiscoveryClientBuilder> optionsAction)
         {
-            return hostBuilder.ConfigureServices((context, collection) => AddServices(collection, optionsAction));
-        }
-
-        private static void AddServices(IServiceCollection collection, Action<DiscoveryClientBuilder> optionsAction)
-        {
-            collection.AddServiceDiscovery(optionsAction);
-            collection.AddHostedService(services => new DiscoveryClientService(services.GetRequiredService<IDiscoveryLifecycle>()));
+            return hostBuilder
+                .ConfigureServices((context, collection) =>
+                    collection
+                        .AddServiceDiscovery(optionsAction)
+                        .AddHostedService(services => new DiscoveryClientService(services.GetRequiredService<IDiscoveryLifecycle>())));
         }
     }
 }

--- a/src/Discovery/src/ClientCore/DiscoveryWebHostBuilderExtensions.cs
+++ b/src/Discovery/src/ClientCore/DiscoveryWebHostBuilderExtensions.cs
@@ -4,7 +4,6 @@
 
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
 using Steeltoe.Connector;
 using System;
 using System.Reflection;
@@ -15,7 +14,7 @@ namespace Steeltoe.Discovery.Client
     {
         /// <summary>
         /// Adds service discovery to your application. This method can be used in place of configuration via your Startup class.<para />
-        /// If is no discovery client package reference is used, a <see cref="NoOpDiscoveryClient"/> will be configured
+        /// Uses reflection to find discovery client packages. If no package is found, a <see cref="NoOpDiscoveryClient"/> will be configured
         /// </summary>
         /// <param name="hostBuilder">Your HostBuilder</param>
         /// <remarks>Also configures named HttpClients "DiscoveryRandom" and "DiscoveryRoundRobin" for automatic injection</remarks>

--- a/src/Discovery/src/Consul/Properties/AssemblyInfo.cs
+++ b/src/Discovery/src/Consul/Properties/AssemblyInfo.cs
@@ -2,7 +2,10 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
+using Steeltoe.Discovery;
+using Steeltoe.Discovery.Consul;
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("Steeltoe.Discovery.Consul.Test")]
 [assembly: InternalsVisibleTo("Steeltoe.Discovery.ClientCore.Test")]
+[assembly: DiscoveryClientAssembly(typeof(ConsulDiscoveryClientExtension))]

--- a/src/Discovery/src/Eureka/Properties/AssemblyInfo.cs
+++ b/src/Discovery/src/Eureka/Properties/AssemblyInfo.cs
@@ -2,7 +2,10 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
+using Steeltoe.Discovery;
+using Steeltoe.Discovery.Eureka;
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("Steeltoe.Discovery.Eureka.Test")]
 [assembly: InternalsVisibleTo("Steeltoe.Discovery.ClientCore.Test")]
+[assembly: DiscoveryClientAssembly(typeof(EurekaDiscoveryClientExtension))]

--- a/src/Discovery/src/Kubernetes/Properties/AssemblyInfo.cs
+++ b/src/Discovery/src/Kubernetes/Properties/AssemblyInfo.cs
@@ -1,0 +1,8 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+using Steeltoe.Discovery;
+using Steeltoe.Discovery.Kubernetes;
+
+[assembly: DiscoveryClientAssembly(typeof(KubernetesDiscoveryClientExtension))]


### PR DESCRIPTION
addresses #407 and ensures parity between (Web)HostBuilder discovery extensions
