### PR TITLE
fix Availability, less BuildInfo

### DIFF
--- a/src/Management/src/CloudFoundryCore/CloudFoundryActuatorsStartupFilter.cs
+++ b/src/Management/src/CloudFoundryCore/CloudFoundryActuatorsStartupFilter.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Steeltoe.Management.Endpoint;
 using Steeltoe.Management.Endpoint.CloudFoundry;
+using Steeltoe.Management.Endpoint.Health;
 using System;
 
 namespace Steeltoe.Management.CloudFoundry
@@ -31,6 +32,8 @@ namespace Steeltoe.Management.CloudFoundry
                     endpoints.Map<CloudFoundryEndpoint>();
                     endpoints.MapAllActuators(MediaTypeVersion);
                 });
+
+                HealthStartupFilter.InitializeAvailability(app.ApplicationServices);
             };
         }
     }

--- a/src/Management/src/EndpointBase/Info/Contributor/BuildInfoContributor.cs
+++ b/src/Management/src/EndpointBase/Info/Contributor/BuildInfoContributor.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Steeltoe.Management.Info;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Reflection;
 
@@ -21,8 +22,18 @@ namespace Steeltoe.Management.Endpoint.Info.Contributor
 
         public void Contribute(IInfoBuilder builder)
         {
-            builder.WithInfo("applicationVersionInfo", _applicationInfo);
-            builder.WithInfo("steeltoeVersionInfo", _steeltoeInfo);
+            builder.WithInfo("applicationVersionInfo", GetImportantDetails(_applicationInfo));
+            builder.WithInfo("steeltoeVersionInfo", GetImportantDetails(_steeltoeInfo));
+        }
+
+        private Dictionary<string, string> GetImportantDetails(FileVersionInfo info)
+        {
+            return new Dictionary<string, string>
+            {
+                { "ProductName", info.ProductName },
+                { "FileVersion", info.FileVersion },
+                { "ProductVersion", info.ProductVersion }
+            };
         }
     }
 }

--- a/src/Management/src/EndpointCore/AllActuatorsStartupFilter.cs
+++ b/src/Management/src/EndpointCore/AllActuatorsStartupFilter.cs
@@ -4,6 +4,7 @@
 
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Steeltoe.Management.Endpoint.Health;
 using System;
 
 namespace Steeltoe.Management.Endpoint
@@ -28,6 +29,8 @@ namespace Steeltoe.Management.Endpoint
                     var builder = endpoints.MapAllActuators();
                     _configureConventions?.Invoke(builder);
                 });
+
+                HealthStartupFilter.InitializeAvailability(app.ApplicationServices);
             };
         }
     }

--- a/src/Management/src/KubernetesCore/KubernetesActuatorsStartupFilter.cs
+++ b/src/Management/src/KubernetesCore/KubernetesActuatorsStartupFilter.cs
@@ -5,6 +5,7 @@
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Steeltoe.Management.Endpoint;
+using Steeltoe.Management.Endpoint.Health;
 using System;
 
 namespace Steeltoe.Management.Kubernetes
@@ -27,6 +28,7 @@ namespace Steeltoe.Management.Kubernetes
                 {
                     endpoints.MapAllActuators(MediaTypeVersion);
                 });
+                HealthStartupFilter.InitializeAvailability(app.ApplicationServices);
             };
         }
     }


### PR DESCRIPTION
Move `ApplicationAvailability` initialization to a separate method so it can be called by any other `IStartupFilter`
Reduce the noise on the BuildInfoContributor