### PR TITLE
Minor Eureka enhancements and Fix ApplicationInstanceInfo binding

### DIFF
--- a/src/Common/src/Common.Kubernetes/KubernetesApplicationOptions.cs
+++ b/src/Common/src/Common.Kubernetes/KubernetesApplicationOptions.cs
@@ -30,8 +30,6 @@ namespace Steeltoe.Common.Kubernetes
 
         public bool Enabled { get; set; } = true;
 
-        public string Name { get; set; }
-
         public override string ApplicationName => Name;
 
         public string NameSpace { get; set; } = "default";

--- a/src/Common/src/Common/ApplicationInstanceInfo.cs
+++ b/src/Common/src/Common/ApplicationInstanceInfo.cs
@@ -77,6 +77,13 @@ namespace Steeltoe.Common
             SecondChanceSetIdProperties(this.configuration);
         }
 
+        public ApplicationInstanceInfo(IConfiguration configuration, bool noPrefix)
+            : base(configuration, ApplicationRoot)
+        {
+            this.configuration = configuration;
+            SecondChanceSetIdProperties(this.configuration);
+        }
+
         public ApplicationInstanceInfo(IConfiguration configuration, string configPrefix)
             : base(configuration, BuildConfigString(configPrefix, ApplicationRoot))
         {
@@ -100,7 +107,9 @@ namespace Steeltoe.Common
             set { Application_Id = value; }
         }
 
-        public virtual string ApplicationName => configuration?.GetValue(AppNameKey, DefaultAppName);
+        public virtual string Name { get; set; }
+
+        public virtual string ApplicationName => Name ?? configuration?.GetValue(AppNameKey, DefaultAppName);
 
         public string ApplicationNameInContext(SteeltoeComponent steeltoeComponent, string additionalSearchPath = null)
         {

--- a/src/Common/src/Common/IServiceCollectionExtensions.cs
+++ b/src/Common/src/Common/IServiceCollectionExtensions.cs
@@ -23,7 +23,7 @@ namespace Steeltoe.Common
             if (!appInfo.Any())
             {
                 var config = sp.GetRequiredService<IConfiguration>();
-                var newAppInfo = new ApplicationInstanceInfo(config);
+                var newAppInfo = new ApplicationInstanceInfo(config, true);
                 serviceCollection.AddSingleton(typeof(IApplicationInstanceInfo), newAppInfo);
                 return newAppInfo;
             }

--- a/src/Common/test/Common.Test/ApplicationInstanceInfoTest.cs
+++ b/src/Common/test/Common.Test/ApplicationInstanceInfoTest.cs
@@ -1,0 +1,74 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Extensions.Configuration;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Xunit;
+
+namespace Steeltoe.Common.Test
+{
+    public class ApplicationInstanceInfoTest
+    {
+        [Fact]
+        public void ConstructorSetsDefaults()
+        {
+            var builder = new ConfigurationBuilder();
+            var config = builder.Build();
+
+            var options = new ApplicationInstanceInfo(config, true);
+            Assert.Null(options.ApplicationId);
+            Assert.Equal(Assembly.GetEntryAssembly().GetName().Name, options.ApplicationName);
+            Assert.Null(options.ApplicationVersion);
+            Assert.Null(options.InstanceId);
+            Assert.Equal(-1, options.InstanceIndex);
+            Assert.Null(options.Uris);
+            Assert.Null(options.Version);
+            Assert.Null(options.InstanceIP);
+            Assert.Null(options.InternalIP);
+            Assert.Equal(-1, options.DiskLimit);
+            Assert.Equal(-1, options.FileDescriptorLimit);
+            Assert.Equal(-1, options.InstanceIndex);
+            Assert.Equal(-1, options.MemoryLimit);
+            Assert.Equal(-1, options.Port);
+        }
+
+        [Fact]
+        public void ConstructorReadsApplicationConfiguration()
+        {
+            // Arrange
+            var configJson = @"
+            {
+                ""Application"" : {
+                    ""Name"": ""my-app"",
+                    ""ApplicationId"": ""fa05c1a9-0fc1-4fbd-bae1-139850dec7a3"",
+                    ""Uris"": [
+                        ""my-app.10.244.0.34.xip.io"",
+                        ""my-app2.10.244.0.34.xip.io""
+                    ],
+                    ""Version"": ""fb8fbcc6-8d58-479e-bcc7-3b4ce5a7f0ca""
+                }
+            }";
+
+            var path = TestHelpers.CreateTempFile(configJson);
+            var directory = Path.GetDirectoryName(path);
+            var fileName = Path.GetFileName(path);
+            var builder = new ConfigurationBuilder();
+            builder.SetBasePath(directory);
+            builder.AddJsonFile(fileName);
+            var config = builder.Build();
+
+            var options = new ApplicationInstanceInfo(config, true);
+
+            Assert.Equal("fa05c1a9-0fc1-4fbd-bae1-139850dec7a3", options.ApplicationId);
+            Assert.Equal("my-app", options.ApplicationName);
+            Assert.NotNull(options.Uris);
+            Assert.Equal(2, options.Uris.Count());
+            Assert.Contains("my-app.10.244.0.34.xip.io", options.Uris);
+            Assert.Contains("my-app2.10.244.0.34.xip.io", options.Uris);
+            Assert.Equal("fb8fbcc6-8d58-479e-bcc7-3b4ce5a7f0ca", options.Version);
+        }
+    }
+}

--- a/src/Configuration/src/CloudFoundryBase/CloudFoundryApplicationOptions.cs
+++ b/src/Configuration/src/CloudFoundryBase/CloudFoundryApplicationOptions.cs
@@ -45,8 +45,6 @@ namespace Steeltoe.Extensions.Configuration.CloudFoundry
 
         public string CF_Api { get; set; }
 
-        public string Name { get; set; }
-
         public override string ApplicationName => Name;
 
         public string Start { get; set; }

--- a/src/Connectors/src/ConnectorBase/ServiceInfoCreator.cs
+++ b/src/Connectors/src/ConnectorBase/ServiceInfoCreator.cs
@@ -154,7 +154,7 @@ namespace Steeltoe.Connector
         {
             ServiceInfos.Clear();
 
-            var appInfo = new ApplicationInstanceInfo(Configuration);
+            var appInfo = new ApplicationInstanceInfo(Configuration, true);
             var serviceOpts = new ServicesOptions(Configuration);
 
             foreach (var service in serviceOpts.Services.SelectMany(s => s.Value))

--- a/src/Discovery/src/Eureka/EurekaPostConfigurer.cs
+++ b/src/Discovery/src/Eureka/EurekaPostConfigurer.cs
@@ -187,21 +187,8 @@ namespace Steeltoe.Discovery.Eureka
         {
             UpdateWithDefaults(si, instOptions);
             instOptions.PreferIpAddress = true;
-            if (int.TryParse(si.ApplicationInfo.Port, out var port))
-            {
-                instOptions.NonSecurePort = port;
-                instOptions.SecurePort = port;
-            }
-            else
-            {
-                if (si.ApplicationInfo.Port.Contains(";"))
-                {
-                    var ports = si.ApplicationInfo.Port.Split(";");
-                    instOptions.Port = int.Parse(ports[0]);
-                    instOptions.SecurePort = int.Parse(ports[1]);
-                }
-            }
-
+            instOptions.NonSecurePort = si.ApplicationInfo.Port;
+            instOptions.SecurePort = si.ApplicationInfo.Port;
             instOptions.InstanceId = si.ApplicationInfo.InternalIP + ":" + si.ApplicationInfo.InstanceId;
         }
 

--- a/src/Discovery/src/Eureka/Transport/EurekaHttpClient.cs
+++ b/src/Discovery/src/Eureka/Transport/EurekaHttpClient.cs
@@ -209,7 +209,15 @@ namespace Steeltoe.Discovery.Eureka.Transport
                     }
                     catch (Exception e)
                     {
-                        _logger?.LogInformation(e, "Response could not be deserialized");
+                        var responseBody = await response.Content.ReadAsStringAsync();
+                        if (response.IsSuccessStatusCode && string.IsNullOrEmpty(responseBody))
+                        {
+                            // request was successful but body was empty. This is OK, we don't need a response body
+                        }
+                        else
+                        {
+                            _logger?.LogError(e, "Failed to read heartbeat response. Response code: {responseCode}, Body: {responseBody}", response.StatusCode, responseBody);
+                        }
                     }
 
                     InstanceInfo infoResp = null;

--- a/src/Discovery/test/Eureka.Test/EurekaPostConfigurerTest.cs
+++ b/src/Discovery/test/Eureka.Test/EurekaPostConfigurerTest.cs
@@ -868,5 +868,19 @@ namespace Steeltoe.Discovery.Eureka.Test
             Assert.Equal("1", map[EurekaPostConfigurer.CF_INSTANCE_INDEX]);
             Assert.Equal(EurekaPostConfigurer.UNKNOWN_ZONE, map[EurekaPostConfigurer.ZONE]);
         }
+
+        [Fact]
+        public void UpdateConfigurationFindsUrls()
+        {
+            var config = new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string>() { { "urls", "https://myapp:1234;http://0.0.0.0:1233;http://::1233;http://*:1233" } }).Build();
+            var instOpts = new EurekaInstanceOptions();
+            var appInfo = new ApplicationInstanceInfo(config);
+
+            EurekaPostConfigurer.UpdateConfiguration(config, instOpts, appInfo);
+
+            Assert.Equal("myapp", instOpts.HostName);
+            Assert.Equal(1234, instOpts.SecurePort);
+            Assert.Equal(1233, instOpts.Port);
+        }
     }
 }


### PR DESCRIPTION
For Eureka:
- Better handling of empty `OK` response from heartbeat request
- Allow use of app addresses from "urls" in configuration
- Use secure port in app id if enabled

Port-related issues in Tye (Env variable `PORT` might be a semicolon delimited string) turned out to be related to bare/default `ApplicationInstanceInfo`  binding to the root of configuration instead of a base path. The last commit in this PR adds a new constructor that will result in binding `ApplicationInstanceInfo` to keys under `application` instead of the root