### PR TITLE
Allow disabling health status as HTTP status

### DIFF
--- a/src/Management/src/EndpointBase/Health/HealthEndpointOptions.cs
+++ b/src/Management/src/EndpointBase/Health/HealthEndpointOptions.cs
@@ -47,5 +47,7 @@ namespace Steeltoe.Management.Endpoint.Health
         public EndpointClaim Claim { get; set; }
 
         public string Role { get; set; }
+
+        public bool HttpStatusFromHealth { get; set; } = true;
     }
 }

--- a/src/Management/src/EndpointCore/Health/HealthEndpointMiddleware.cs
+++ b/src/Management/src/EndpointCore/Health/HealthEndpointMiddleware.cs
@@ -60,7 +60,8 @@ namespace Steeltoe.Management.Endpoint.Health
         protected internal string DoRequest(HttpContext context)
         {
             var result = _endpoint.Invoke(new CoreSecurityContext(context));
-            if (((HealthEndpointOptions)_mgmtOptions.FirstOrDefault().EndpointOptions.FirstOrDefault(o => o is HealthEndpointOptions)).HttpStatusFromHealth)
+            var managementOptions = _mgmtOptions.OptionsForContext(context.Request.Path, _logger);
+            if (((HealthEndpointOptions)managementOptions.EndpointOptions.FirstOrDefault(o => o is HealthEndpointOptions)).HttpStatusFromHealth)
             {
                 context.Response.StatusCode = ((HealthEndpoint)_endpoint).GetStatusCode(result);
             }

--- a/src/Management/src/EndpointCore/Health/HealthEndpointMiddleware.cs
+++ b/src/Management/src/EndpointCore/Health/HealthEndpointMiddleware.cs
@@ -12,6 +12,7 @@ using Steeltoe.Management.EndpointCore;
 using Steeltoe.Management.EndpointCore.ContentNegotiation;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace Steeltoe.Management.Endpoint.Health
@@ -59,7 +60,11 @@ namespace Steeltoe.Management.Endpoint.Health
         protected internal string DoRequest(HttpContext context)
         {
             var result = _endpoint.Invoke(new CoreSecurityContext(context));
-            context.Response.StatusCode = ((HealthEndpoint)_endpoint).GetStatusCode(result);
+            if (((HealthEndpointOptions)_mgmtOptions.FirstOrDefault().EndpointOptions.FirstOrDefault(o => o is HealthEndpointOptions)).HttpStatusFromHealth)
+            {
+                context.Response.StatusCode = ((HealthEndpoint)_endpoint).GetStatusCode(result);
+            }
+
             return Serialize(result);
         }
     }

--- a/src/Management/src/EndpointOwin/Health/HealthEndpointOwinMiddleware.cs
+++ b/src/Management/src/EndpointOwin/Health/HealthEndpointOwinMiddleware.cs
@@ -10,6 +10,7 @@ using Steeltoe.Management.Endpoint.Health;
 using Steeltoe.Management.Endpoint.Security;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace Steeltoe.Management.EndpointOwin.Health
@@ -40,7 +41,12 @@ namespace Steeltoe.Management.EndpointOwin.Health
                 _logger?.LogTrace("Processing {SteeltoeEndpoint} request", typeof(HealthEndpoint));
                 var result = _endpoint.Invoke(new OwinSecurityContext(context));
                 context.Response.Headers.SetValues("Content-Type", new string[] { "application/vnd.spring-boot.actuator.v2+json;charset-UTF-8" });
-                context.Response.StatusCode = ((HealthEndpoint)_endpoint).GetStatusCode(result);
+
+                if (((HealthEndpointOptions)_mgmtOptions.FirstOrDefault().EndpointOptions.FirstOrDefault(o => o is HealthEndpointOptions)).HttpStatusFromHealth)
+                {
+                    context.Response.StatusCode = ((HealthEndpoint)_endpoint).GetStatusCode(result);
+                }
+
                 await context.Response.WriteAsync(Serialize(result)).ConfigureAwait(false);
             }
         }

--- a/src/Management/src/EndpointOwin/Health/HealthEndpointOwinMiddleware.cs
+++ b/src/Management/src/EndpointOwin/Health/HealthEndpointOwinMiddleware.cs
@@ -42,7 +42,8 @@ namespace Steeltoe.Management.EndpointOwin.Health
                 var result = _endpoint.Invoke(new OwinSecurityContext(context));
                 context.Response.Headers.SetValues("Content-Type", new string[] { "application/vnd.spring-boot.actuator.v2+json;charset-UTF-8" });
 
-                if (((HealthEndpointOptions)_mgmtOptions.FirstOrDefault().EndpointOptions.FirstOrDefault(o => o is HealthEndpointOptions)).HttpStatusFromHealth)
+                var managementOptions = _mgmtOptions.OptionsForContext(context.Request.Path.ToString(), _logger);
+                if (((HealthEndpointOptions)managementOptions.EndpointOptions.FirstOrDefault(o => o is HealthEndpointOptions)).HttpStatusFromHealth)
                 {
                     context.Response.StatusCode = ((HealthEndpoint)_endpoint).GetStatusCode(result);
                 }

--- a/src/Management/src/EndpointWeb/Handler/HealthHandler.cs
+++ b/src/Management/src/EndpointWeb/Handler/HealthHandler.cs
@@ -9,6 +9,7 @@ using Steeltoe.Management.Endpoint.Security;
 using Steeltoe.Management.EndpointWeb.Security;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Web;
 
 namespace Steeltoe.Management.Endpoint.Handler
@@ -33,7 +34,10 @@ namespace Steeltoe.Management.Endpoint.Handler
             var result = _endpoint.Invoke(new WebSecurityContext(context));
             context.Response.Headers.Set("Content-Type", "application/vnd.spring-boot.actuator.v2+json");
             context.Response.Write(Serialize(result));
-            context.Response.StatusCode = ((HealthEndpoint)_endpoint).GetStatusCode(result);
+            if (((HealthEndpointOptions)_mgmtOptions.FirstOrDefault().EndpointOptions.FirstOrDefault(o => o is HealthEndpointOptions)).HttpStatusFromHealth)
+            {
+                context.Response.StatusCode = ((HealthEndpoint)_endpoint).GetStatusCode(result);
+            }
         }
     }
 }

--- a/src/Management/src/EndpointWeb/Handler/HealthHandler.cs
+++ b/src/Management/src/EndpointWeb/Handler/HealthHandler.cs
@@ -34,7 +34,8 @@ namespace Steeltoe.Management.Endpoint.Handler
             var result = _endpoint.Invoke(new WebSecurityContext(context));
             context.Response.Headers.Set("Content-Type", "application/vnd.spring-boot.actuator.v2+json");
             context.Response.Write(Serialize(result));
-            if (((HealthEndpointOptions)_mgmtOptions.FirstOrDefault().EndpointOptions.FirstOrDefault(o => o is HealthEndpointOptions)).HttpStatusFromHealth)
+            var managementOptions = _mgmtOptions.OptionsForContext(context.Request.Path, _logger);
+            if (((HealthEndpointOptions)managementOptions.EndpointOptions.FirstOrDefault(o => o is HealthEndpointOptions)).HttpStatusFromHealth)
             {
                 context.Response.StatusCode = ((HealthEndpoint)_endpoint).GetStatusCode(result);
             }

--- a/src/Management/test/EndpointCore.Test/Health/EndpointMiddlewareTest.cs
+++ b/src/Management/test/EndpointCore.Test/Health/EndpointMiddlewareTest.cs
@@ -240,6 +240,20 @@ namespace Steeltoe.Management.Endpoint.Health.Test
                 Assert.NotNull(unknownJson);
                 Assert.Contains("\"status\":\"UP\"", unknownJson);
             }
+
+            builder = new WebHostBuilder()
+               .UseStartup<Startup>()
+               .ConfigureAppConfiguration((context, config) => config.AddInMemoryCollection(new Dictionary<string, string>(appSettings) { ["HealthCheckType"] = "down", ["management:endpoints:health:HttpStatusFromHealth"] = "false" }));
+
+            using (var server = new TestServer(builder))
+            {
+                var client = server.CreateClient();
+                var downResult = await client.GetAsync("http://localhost/cloudfoundryapplication/health");
+                Assert.Equal(HttpStatusCode.OK, downResult.StatusCode);
+                var downJson = await downResult.Content.ReadAsStringAsync();
+                Assert.NotNull(downJson);
+                Assert.Contains("\"status\":\"DOWN\"", downJson);
+            }
         }
 
         [Fact]

--- a/src/Management/test/EndpointOwin.Net4Test/Health/HealthEndpointOwinMiddlewareTest.cs
+++ b/src/Management/test/EndpointOwin.Net4Test/Health/HealthEndpointOwinMiddlewareTest.cs
@@ -66,6 +66,17 @@ namespace Steeltoe.Management.EndpointOwin.Health.Test
         }
 
         [Fact]
+        public async void HealthHttpCall_AlwaysOK()
+        {
+            using var server = TestServer.Create<StartupOK>();
+            var client = server.HttpClient;
+
+            // check the health... expect OK status with unknown detail
+            var result = await client.GetAsync("http://localhost/cloudfoundryapplication/unknown");
+            await AssertHealthResponseAsync(HttpStatusCode.OK, HealthStatus.UNKNOWN, result);
+        }
+
+        [Fact]
         public void HealthEndpointMiddleware_PathAndVerbMatching_ReturnsExpected()
         {
             var opts = new HealthEndpointOptions();

--- a/src/Management/test/EndpointOwin.Net4Test/Health/StartupOK.cs
+++ b/src/Management/test/EndpointOwin.Net4Test/Health/StartupOK.cs
@@ -1,0 +1,31 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Extensions.Configuration;
+using Owin;
+using Steeltoe.Common.HealthChecks;
+using Steeltoe.Management.Endpoint.Health;
+using Steeltoe.Management.Endpoint.Health.Test;
+using Steeltoe.Management.EndpointOwin.Test;
+using System.Collections.Generic;
+
+namespace Steeltoe.Management.EndpointOwin.Health.Test
+{
+    public class StartupOK
+    {
+        public void Configuration(IAppBuilder app)
+        {
+            var builder = new ConfigurationBuilder();
+            var settings = new Dictionary<string, string>(OwinTestHelpers.Appsettings)
+            {
+                { "management:endpoints:health:HttpStatusFromHealth", "false" }
+            };
+            builder.AddInMemoryCollection(settings);
+            var config = builder.Build();
+
+            app.UseHealthActuator(config);
+            app.UseHealthActuator(new HealthEndpointOptions { Id = "unknown" }, new DefaultHealthAggregator(), new List<IHealthContributor> { new UnknownContributor() });
+        }
+    }
+}

--- a/src/Management/test/EndpointWeb.Net4Test/ActuatorHandlerTest.cs
+++ b/src/Management/test/EndpointWeb.Net4Test/ActuatorHandlerTest.cs
@@ -92,10 +92,48 @@ namespace Steeltoe.Management.EndpointWeb.Test
 
             Assert.NotEmpty(response.Content);
             Assert.Contains("status", response.Content);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         }
 
         [Fact]
-        public async void HealthHandler_ReturnsDetailsd()
+        public async void HealthHandler_Returns503WhenDown()
+        {
+            var settings = new Settings(DefaultTestSettingsConfig.DefaultSettings)
+            {
+                { "unhealthy", "true" }
+            };
+
+            using var server = new TestServer(settings);
+            var client = server.HttpClient;
+
+            var response = await client.GetAsync("http://localhost/management/health", "GET");
+
+            Assert.NotEmpty(response.Content);
+            Assert.Contains("status", response.Content);
+            Assert.Equal(HttpStatusCode.ServiceUnavailable, response.StatusCode);
+        }
+
+        [Fact]
+        public async void HealthHandler_CanReturn200WhenDown()
+        {
+            var settings = new Settings(DefaultTestSettingsConfig.DefaultSettings)
+            {
+                { "unhealthy", "true" },
+                { "management:endpoints:health:HttpStatusFromHealth", "false" }
+            };
+
+            using var server = new TestServer(settings);
+            var client = server.HttpClient;
+
+            var response = await client.GetAsync("http://localhost/management/health", "GET");
+
+            Assert.NotEmpty(response.Content);
+            Assert.Contains("status", response.Content);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        }
+
+        [Fact]
+        public async void HealthHandler_ReturnsDetails()
         {
             var settings = DefaultTestSettingsConfig.DefaultSettings;
 

--- a/src/Management/test/EndpointWeb.Net4Test/ConfiguredHealthContributor.cs
+++ b/src/Management/test/EndpointWeb.Net4Test/ConfiguredHealthContributor.cs
@@ -1,0 +1,36 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Extensions.Configuration;
+using Steeltoe.Common.HealthChecks;
+
+namespace Steeltoe.Management.EndpointWeb.Test
+{
+    internal class ConfiguredHealthContributor : IHealthContributor
+    {
+        private IConfiguration _config;
+
+        public string Id => "config-based";
+
+        public ConfiguredHealthContributor(IConfiguration config)
+        {
+            _config = config;
+        }
+
+        public HealthCheckResult Health()
+        {
+            var health = new HealthCheckResult();
+            if (_config.GetValue<bool>("unhealthy"))
+            {
+                health.Status = HealthStatus.DOWN;
+            }
+            else
+            {
+                health.Status = HealthStatus.UP;
+            }
+
+            return health;
+        }
+    }
+}

--- a/src/Management/test/EndpointWeb.Net4Test/ManagementConfig.cs
+++ b/src/Management/test/EndpointWeb.Net4Test/ManagementConfig.cs
@@ -27,7 +27,7 @@ namespace Steeltoe.Management.EndpointWeb.Test
 
         private static IEnumerable<IHealthContributor> GetHealthContributors(IConfiguration configuration)
         {
-            var healthContributors = new List<IHealthContributor> { new DiskSpaceContributor(), };
+            var healthContributors = new List<IHealthContributor> { new DiskSpaceContributor(), new ConfiguredHealthContributor(configuration) };
 
             return healthContributors;
         }


### PR DESCRIPTION
Add a setting that can disable use of health status for HTTP status so that IIS doesn't scrub data in the response body #418