### PR TITLE
Write lowercase values with BooleanStringJsonConverter

### DIFF
--- a/src/Common/src/Common.Http/Serialization/BoolStringJsonConverter.cs
+++ b/src/Common/src/Common.Http/Serialization/BoolStringJsonConverter.cs
@@ -19,7 +19,7 @@ namespace Steeltoe.Common.Http.Serialization
 
         public override void Write(Utf8JsonWriter writer, bool value, JsonSerializerOptions options)
         {
-            writer.WriteStringValue(value.ToString());
+            writer.WriteStringValue(value.ToString().ToLower());
         }
     }
 }


### PR DESCRIPTION
Adjustment for #435 

As far as I can tell, this converter is only used on `JsonInstanceInfo.IsCoordinatingDiscoveryServer` and `JsonPortWrapper.Enabled`. Our test data for both is all lowercase. We _could_ add a param to toggle this behavior, but with no other usage I don't have a strong opinion on whether that's necessary