### PR TITLE
allow registration using ASP.NET Core urls

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -92,6 +92,7 @@ jobs:
       arguments: '--blame --no-build -c $(buildConfiguration) -maxcpucount:1 /p:CopyLocalLockFileAssemblies=true $(skipFilter) --collect:"XPlat Code Coverage" --settings coverlet.runsettings --logger trx --results-directory $(Build.SourcesDirectory)'
       publishTestResults: false
   - task: PublishTestResults@2
+    condition: always()
     inputs:
       testResultsFormat: VSTest
       testResultsFiles: '*.trx'

--- a/src/Discovery/src/ClientCore/ConfigurationUrlHelpers.cs
+++ b/src/Discovery/src/ClientCore/ConfigurationUrlHelpers.cs
@@ -1,0 +1,37 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Extensions.Configuration;
+using System;
+using System.Collections.Generic;
+
+namespace Steeltoe.Discovery.Client
+{
+    public static class ConfigurationUrlHelpers
+    {
+        public const string WILDCARD_HOST = "---asterisk---";
+
+        public static List<Uri> GetUrlsFromConfig(IConfiguration config)
+        {
+            var urls = config["urls"];
+            var uris = new List<Uri>();
+            if (!string.IsNullOrEmpty(urls))
+            {
+                var addresses = urls.Split(';');
+                foreach (var address in addresses)
+                {
+                    if (!Uri.TryCreate(address, UriKind.Absolute, out var uri)
+                            && (address.Contains("*") || address.Contains("::")))
+                    {
+                        Uri.TryCreate(address.Replace("*", WILDCARD_HOST).Replace("::", $"{WILDCARD_HOST}:"), UriKind.Absolute, out uri);
+                    }
+
+                    uris.Add(uri);
+                }
+            }
+
+            return uris;
+        }
+    }
+}

--- a/src/Discovery/src/ClientCore/ConfigurationUrlHelpers.cs
+++ b/src/Discovery/src/ClientCore/ConfigurationUrlHelpers.cs
@@ -12,7 +12,7 @@ namespace Steeltoe.Discovery.Client
     {
         public const string WILDCARD_HOST = "---asterisk---";
 
-        public static List<Uri> GetUrlsFromConfig(IConfiguration config)
+        public static List<Uri> GetAspNetCoreUrls(this IConfiguration config)
         {
             var urls = config["urls"];
             var uris = new List<Uri>();

--- a/src/Discovery/src/ClientCore/DiscoveryServiceCollectionExtensions.cs
+++ b/src/Discovery/src/ClientCore/DiscoveryServiceCollectionExtensions.cs
@@ -170,7 +170,7 @@ namespace Steeltoe.Discovery.Client
             {
                 options.NetUtils = new InetUtils(netOptions);
                 options.ApplyNetUtils();
-                options.ApplyConfigUrls(config);
+                options.ApplyConfigUrls(ConfigurationUrlHelpers.GetUrlsFromConfig(config), ConfigurationUrlHelpers.WILDCARD_HOST);
             });
             services.TryAddSingleton(serviceProvider =>
             {
@@ -225,6 +225,8 @@ namespace Steeltoe.Discovery.Client
                 options.NetUtils = new InetUtils(netOptions);
                 options.ApplyNetUtils();
                 EurekaPostConfigurer.UpdateConfiguration(config, einfo, options);
+                options.ApplyConfigUrls(ConfigurationUrlHelpers.GetUrlsFromConfig(config), ConfigurationUrlHelpers.WILDCARD_HOST);
+                options.SetInstanceId(config);
             });
             services.TryAddSingleton(serviceProvider =>
             {

--- a/src/Discovery/src/ClientCore/DiscoveryServiceCollectionExtensions.cs
+++ b/src/Discovery/src/ClientCore/DiscoveryServiceCollectionExtensions.cs
@@ -170,6 +170,7 @@ namespace Steeltoe.Discovery.Client
             {
                 options.NetUtils = new InetUtils(netOptions);
                 options.ApplyNetUtils();
+                options.ApplyConfigUrls(config);
             });
             services.TryAddSingleton(serviceProvider =>
             {

--- a/src/Discovery/src/ClientCore/DiscoveryServiceCollectionExtensions.cs
+++ b/src/Discovery/src/ClientCore/DiscoveryServiceCollectionExtensions.cs
@@ -170,7 +170,7 @@ namespace Steeltoe.Discovery.Client
             {
                 options.NetUtils = new InetUtils(netOptions);
                 options.ApplyNetUtils();
-                options.ApplyConfigUrls(ConfigurationUrlHelpers.GetUrlsFromConfig(config), ConfigurationUrlHelpers.WILDCARD_HOST);
+                options.ApplyConfigUrls(config.GetAspNetCoreUrls(), ConfigurationUrlHelpers.WILDCARD_HOST);
             });
             services.TryAddSingleton(serviceProvider =>
             {
@@ -225,7 +225,7 @@ namespace Steeltoe.Discovery.Client
                 options.NetUtils = new InetUtils(netOptions);
                 options.ApplyNetUtils();
                 EurekaPostConfigurer.UpdateConfiguration(config, einfo, options);
-                options.ApplyConfigUrls(ConfigurationUrlHelpers.GetUrlsFromConfig(config), ConfigurationUrlHelpers.WILDCARD_HOST);
+                options.ApplyConfigUrls(config.GetAspNetCoreUrls(), ConfigurationUrlHelpers.WILDCARD_HOST);
                 options.SetInstanceId(config);
             });
             services.TryAddSingleton(serviceProvider =>

--- a/src/Discovery/src/EurekaBase/EurekaInstanceOptions.cs
+++ b/src/Discovery/src/EurekaBase/EurekaInstanceOptions.cs
@@ -2,7 +2,11 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.Extensions.Configuration;
 using Steeltoe.Common.Discovery;
+using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Steeltoe.Discovery.Eureka
 {
@@ -12,6 +16,9 @@ namespace Steeltoe.Discovery.Eureka
 
         public new const string Default_StatusPageUrlPath = "/info";
         public new const string Default_HealthCheckUrlPath = "/health";
+
+        internal const int DEFAULT_NONSECUREPORT = 80;
+        internal const int DEFAULT_SECUREPORT = 443;
 
         public EurekaInstanceOptions()
         {
@@ -26,71 +33,41 @@ namespace Steeltoe.Discovery.Eureka
         // eureka:instance:appGroup
         public virtual string AppGroup
         {
-            get
-            {
-                return AppGroupName;
-            }
+            get => AppGroupName;
 
-            set
-            {
-                AppGroupName = value;
-            }
+            set => AppGroupName = value;
         }
 
         // eureka:instance:instanceEnabledOnInit
         public virtual bool InstanceEnabledOnInit
         {
-            get
-            {
-                return IsInstanceEnabledOnInit;
-            }
+            get => IsInstanceEnabledOnInit;
 
-            set
-            {
-                IsInstanceEnabledOnInit = value;
-            }
+            set => IsInstanceEnabledOnInit = value;
         }
 
         // eureka:instance:port
         public virtual int Port
         {
-            get
-            {
-                return NonSecurePort;
-            }
+            get => NonSecurePort;
 
-            set
-            {
-                NonSecurePort = value;
-            }
+            set => NonSecurePort = value;
         }
 
         // eureka:instance:nonSecurePortEnabled
         public virtual bool NonSecurePortEnabled
         {
-            get
-            {
-                return IsNonSecurePortEnabled;
-            }
+            get => IsNonSecurePortEnabled;
 
-            set
-            {
-                IsNonSecurePortEnabled = value;
-            }
+            set => IsNonSecurePortEnabled = value;
         }
 
         // eureka:instance:vipAddress
         public virtual string VipAddress
         {
-            get
-            {
-                return VirtualHostName;
-            }
+            get => VirtualHostName;
 
-            set
-            {
-                VirtualHostName = value;
-            }
+            set => VirtualHostName = value;
         }
 
         // eureka:instance:secureVipAddress
@@ -124,10 +101,7 @@ namespace Steeltoe.Discovery.Eureka
                 return _thisHostAddress;
             }
 
-            set
-            {
-                _ipAddress = value;
-            }
+            set => _ipAddress = value;
         }
 
         private string _hostName;
@@ -161,6 +135,55 @@ namespace Steeltoe.Discovery.Eureka
             }
 
             return _thisHostName;
+        }
+
+        public void ApplyConfigUrls(List<Uri> addresses, string wildcard_hostname)
+        {
+            // try to pull some values out of server config to override defaults, but only if registration method hasn't been set
+            // if registration method has been set, the user probably wants to define their own behavior
+            if (addresses.Any() && string.IsNullOrEmpty(RegistrationMethod))
+            {
+                foreach (var address in addresses)
+                {
+                    if (address.Scheme == "http" && Port == DEFAULT_NONSECUREPORT)
+                    {
+                        Port = address.Port;
+                    }
+                    else if (address.Scheme == "https" && SecurePort == DEFAULT_SECUREPORT)
+                    {
+                        SecurePort = address.Port;
+                    }
+
+                    if (!address.Host.Equals(wildcard_hostname) && !address.Host.Equals("0.0.0.0"))
+                    {
+                        HostName = address.Host;
+                    }
+                }
+            }
+        }
+
+        public void SetInstanceId(IConfiguration config)
+        {
+            var defaultId = GetHostName(false) + ":" + EurekaInstanceOptions.Default_Appname + ":" + EurekaInstanceOptions.Default_NonSecurePort;
+            if (defaultId.Equals(InstanceId))
+            {
+                var springInstanceId = config.GetValue<string>(EurekaPostConfigurer.SPRING_APPLICATION_INSTANCEID_KEY);
+                if (!string.IsNullOrEmpty(springInstanceId))
+                {
+                    InstanceId = springInstanceId;
+                }
+                else
+                {
+                    if (SecurePortEnabled)
+                    {
+                        InstanceId = GetHostName(false) + ":" + AppName + ":" + SecurePort;
+                    }
+                    else
+                    {
+                        InstanceId = GetHostName(false) + ":" + AppName + ":" + NonSecurePort;
+                    }
+                }
+            }
         }
     }
 }

--- a/src/Discovery/src/EurekaBase/EurekaInstanceOptions.cs
+++ b/src/Discovery/src/EurekaBase/EurekaInstanceOptions.cs
@@ -152,6 +152,8 @@ namespace Steeltoe.Discovery.Eureka
                     else if (address.Scheme == "https" && SecurePort == DEFAULT_SECUREPORT)
                     {
                         SecurePort = address.Port;
+                        SecurePortEnabled = true;
+                        NonSecurePortEnabled = false;
                     }
 
                     if (!address.Host.Equals(wildcard_hostname) && !address.Host.Equals("0.0.0.0"))
@@ -164,8 +166,8 @@ namespace Steeltoe.Discovery.Eureka
 
         public void SetInstanceId(IConfiguration config)
         {
-            var defaultId = GetHostName(false) + ":" + EurekaInstanceOptions.Default_Appname + ":" + EurekaInstanceOptions.Default_NonSecurePort;
-            if (defaultId.Equals(InstanceId))
+            var defaultIdEnding = ":" + EurekaInstanceOptions.Default_Appname + ":" + EurekaInstanceOptions.Default_NonSecurePort;
+            if (InstanceId.EndsWith(defaultIdEnding))
             {
                 var springInstanceId = config.GetValue<string>(EurekaPostConfigurer.SPRING_APPLICATION_INSTANCEID_KEY);
                 if (!string.IsNullOrEmpty(springInstanceId))

--- a/src/Discovery/src/EurekaBase/EurekaInstanceOptions.cs
+++ b/src/Discovery/src/EurekaBase/EurekaInstanceOptions.cs
@@ -139,7 +139,7 @@ namespace Steeltoe.Discovery.Eureka
 
         public void ApplyConfigUrls(List<Uri> addresses, string wildcard_hostname)
         {
-            // try to pull some values out of server config to override defaults, but only if registration method hasn't been set
+            // only use addresses from config if there are any and registration method hasn't been set
             // if registration method has been set, the user probably wants to define their own behavior
             if (addresses.Any() && string.IsNullOrEmpty(RegistrationMethod))
             {

--- a/src/Discovery/test/EurekaBase.Test/EurekaInstanceOptionsTest.cs
+++ b/src/Discovery/test/EurekaBase.Test/EurekaInstanceOptionsTest.cs
@@ -220,7 +220,7 @@ namespace Steeltoe.Discovery.Eureka.Test
             var config = new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string>() { { "urls", "https://myapp:1234;http://0.0.0.0:1233;http://::1233;http://*:1233" } }).Build();
             var instOpts = new EurekaInstanceOptions();
 
-            instOpts.ApplyConfigUrls(ConfigurationUrlHelpers.GetUrlsFromConfig(config), ConfigurationUrlHelpers.WILDCARD_HOST);
+            instOpts.ApplyConfigUrls(config.GetAspNetCoreUrls(), ConfigurationUrlHelpers.WILDCARD_HOST);
 
             Assert.Equal("myapp", instOpts.HostName);
             Assert.Equal(1234, instOpts.SecurePort);

--- a/src/Discovery/test/EurekaBase.Test/EurekaInstanceOptionsTest.cs
+++ b/src/Discovery/test/EurekaBase.Test/EurekaInstanceOptionsTest.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.Configuration;
 using Moq;
 using Steeltoe.Common;
 using Steeltoe.Common.Net;
+using Steeltoe.Discovery.Client;
 using Steeltoe.Discovery.Eureka.AppInfo;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -211,6 +212,19 @@ namespace Steeltoe.Discovery.Eureka.Test
             // assert
             Assert.NotNull(opts.HostName);
             Assert.InRange(noSlowReverseDNSQuery.ElapsedMilliseconds, 0, 1500); // testing with an actual reverse dns query results in around 5000 ms
+        }
+
+        [Fact]
+        public void UpdateConfigurationFindsUrls()
+        {
+            var config = new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string>() { { "urls", "https://myapp:1234;http://0.0.0.0:1233;http://::1233;http://*:1233" } }).Build();
+            var instOpts = new EurekaInstanceOptions();
+
+            instOpts.ApplyConfigUrls(ConfigurationUrlHelpers.GetUrlsFromConfig(config), ConfigurationUrlHelpers.WILDCARD_HOST);
+
+            Assert.Equal("myapp", instOpts.HostName);
+            Assert.Equal(1234, instOpts.SecurePort);
+            Assert.Equal(1233, instOpts.Port);
         }
     }
 }

--- a/src/Discovery/test/EurekaBase.Test/EurekaInstanceOptionsTest.cs
+++ b/src/Discovery/test/EurekaBase.Test/EurekaInstanceOptionsTest.cs
@@ -215,16 +215,36 @@ namespace Steeltoe.Discovery.Eureka.Test
         }
 
         [Fact]
-        public void UpdateConfigurationFindsUrls()
+        public void UpdateConfigurationFindsHttpUrl()
+        {
+            var config = new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string>() { { "urls", "http://myapp:1233" } }).Build();
+            var instOpts = new EurekaInstanceOptions();
+
+            instOpts.ApplyConfigUrls(config.GetAspNetCoreUrls(), ConfigurationUrlHelpers.WILDCARD_HOST);
+            instOpts.SetInstanceId(config);
+
+            Assert.Equal("myapp", instOpts.HostName);
+            Assert.Equal(1233, instOpts.Port);
+            Assert.False(instOpts.SecurePortEnabled);
+            Assert.True(instOpts.NonSecurePortEnabled);
+            Assert.EndsWith(":unknown:1233", instOpts.InstanceId);
+        }
+
+        [Fact]
+        public void UpdateConfigurationFindsUrlsPicksHttps()
         {
             var config = new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string>() { { "urls", "https://myapp:1234;http://0.0.0.0:1233;http://::1233;http://*:1233" } }).Build();
             var instOpts = new EurekaInstanceOptions();
 
             instOpts.ApplyConfigUrls(config.GetAspNetCoreUrls(), ConfigurationUrlHelpers.WILDCARD_HOST);
+            instOpts.SetInstanceId(config);
 
             Assert.Equal("myapp", instOpts.HostName);
             Assert.Equal(1234, instOpts.SecurePort);
             Assert.Equal(1233, instOpts.Port);
+            Assert.True(instOpts.SecurePortEnabled);
+            Assert.False(instOpts.NonSecurePortEnabled);
+            Assert.EndsWith(":unknown:1234", instOpts.InstanceId);
         }
     }
 }

--- a/src/Discovery/test/EurekaBase.Test/EurekaPostConfigurerTest.cs
+++ b/src/Discovery/test/EurekaBase.Test/EurekaPostConfigurerTest.cs
@@ -4,6 +4,7 @@
 
 using Microsoft.Extensions.Configuration;
 using Steeltoe.CloudFoundry.Connector;
+using Steeltoe.CloudFoundry.Connector.App;
 using Steeltoe.CloudFoundry.Connector.Services;
 using Steeltoe.Common;
 using Steeltoe.Extensions.Configuration.CloudFoundry;
@@ -878,6 +879,19 @@ namespace Steeltoe.Discovery.Eureka.Test
             Assert.Equal("ac923014-93a5-4aee-b934-a043b241868b", map[EurekaPostConfigurer.CF_APP_GUID]);
             Assert.Equal("1", map[EurekaPostConfigurer.CF_INSTANCE_INDEX]);
             Assert.Equal(EurekaPostConfigurer.UNKNOWN_ZONE, map[EurekaPostConfigurer.ZONE]);
+        }
+
+        [Fact]
+        public void UpdateConfigurationFindsUrls()
+        {
+            var config = new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string>() { { "urls", "https://myapp:1234;http://0.0.0.0:1233;http://::1233;http://*:1233" } }).Build();
+            var instOpts = new EurekaInstanceOptions();
+
+            EurekaPostConfigurer.UpdateConfiguration(config, null, instOpts);
+
+            Assert.Equal("myapp", instOpts.HostName);
+            Assert.Equal(1234, instOpts.SecurePort);
+            Assert.Equal(1233, instOpts.Port);
         }
     }
 }

--- a/src/Discovery/test/EurekaBase.Test/EurekaPostConfigurerTest.cs
+++ b/src/Discovery/test/EurekaBase.Test/EurekaPostConfigurerTest.cs
@@ -32,6 +32,7 @@ namespace Steeltoe.Discovery.Eureka.Test
 
             var instOpts = new EurekaInstanceOptions();
             EurekaPostConfigurer.UpdateConfiguration(root, instOpts);
+            instOpts.SetInstanceId(root);
 
             Assert.Equal("bar", instOpts.AppName);
             Assert.Equal("instance", instOpts.InstanceId);
@@ -84,6 +85,7 @@ namespace Steeltoe.Discovery.Eureka.Test
             var instOpts = new EurekaInstanceOptions();
 
             EurekaPostConfigurer.UpdateConfiguration(root, instOpts);
+            instOpts.SetInstanceId(root);
 
             Assert.Equal("bar", instOpts.AppName);
             Assert.EndsWith("bar:80", instOpts.InstanceId, StringComparison.OrdinalIgnoreCase);
@@ -879,19 +881,6 @@ namespace Steeltoe.Discovery.Eureka.Test
             Assert.Equal("ac923014-93a5-4aee-b934-a043b241868b", map[EurekaPostConfigurer.CF_APP_GUID]);
             Assert.Equal("1", map[EurekaPostConfigurer.CF_INSTANCE_INDEX]);
             Assert.Equal(EurekaPostConfigurer.UNKNOWN_ZONE, map[EurekaPostConfigurer.ZONE]);
-        }
-
-        [Fact]
-        public void UpdateConfigurationFindsUrls()
-        {
-            var config = new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string>() { { "urls", "https://myapp:1234;http://0.0.0.0:1233;http://::1233;http://*:1233" } }).Build();
-            var instOpts = new EurekaInstanceOptions();
-
-            EurekaPostConfigurer.UpdateConfiguration(config, null, instOpts);
-
-            Assert.Equal("myapp", instOpts.HostName);
-            Assert.Equal(1234, instOpts.SecurePort);
-            Assert.Equal(1233, instOpts.Port);
         }
     }
 }

--- a/src/Discovery/test/EurekaBase.Test/Steeltoe.Discovery.EurekaBase.Test.csproj
+++ b/src/Discovery/test/EurekaBase.Test/Steeltoe.Discovery.EurekaBase.Test.csproj
@@ -17,6 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\src\ClientCore\Steeltoe.Discovery.ClientCore.csproj" />
     <ProjectReference Include="..\..\src\EurekaBase\Steeltoe.Discovery.EurekaBase.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
Allow (as a default) use of the urls ASP.NET Core is listening on when registering with a service registry #443 and #442

Defaults to HTTPS when present