### PR TITLE
Support a generic Config Server binding service name/type

### DIFF
--- a/src/Configuration/src/ConfigServerBase/ConfigurationSettingsHelper.cs
+++ b/src/Configuration/src/ConfigServerBase/ConfigurationSettingsHelper.cs
@@ -15,6 +15,7 @@ namespace Steeltoe.Extensions.Configuration.ConfigServer
         private const string VCAP_APPLICATION_PREFIX = "vcap:application";
         private const string VCAP_SERVICES_CONFIGSERVER_PREFIX = "vcap:services:p-config-server:0";
         private const string VCAP_SERVICES_CONFIGSERVER30_PREFIX = "vcap:services:p.config-server:0";
+        private const string VCAP_SERVICES_CONFIGSERVERALT_PREFIX = "vcap:services:config-server:0";
 
         public static void Initialize(string configPrefix, ConfigServerClientSettings settings, IConfiguration config)
         {
@@ -184,6 +185,7 @@ namespace Steeltoe.Extensions.Configuration.ConfigServer
                ConfigServerClientSettings.DEFAULT_CLIENT_SECRET,
                VCAP_SERVICES_CONFIGSERVER_PREFIX,
                VCAP_SERVICES_CONFIGSERVER30_PREFIX,
+               VCAP_SERVICES_CONFIGSERVERALT_PREFIX,
                configPrefix);
         }
 
@@ -195,6 +197,7 @@ namespace Steeltoe.Extensions.Configuration.ConfigServer
                 ConfigServerClientSettings.DEFAULT_CLIENT_ID,
                 VCAP_SERVICES_CONFIGSERVER_PREFIX,
                 VCAP_SERVICES_CONFIGSERVER30_PREFIX,
+                VCAP_SERVICES_CONFIGSERVERALT_PREFIX,
                 configPrefix);
         }
 
@@ -206,6 +209,7 @@ namespace Steeltoe.Extensions.Configuration.ConfigServer
                 ConfigServerClientSettings.DEFAULT_ACCESS_TOKEN_URI,
                 VCAP_SERVICES_CONFIGSERVER_PREFIX,
                 VCAP_SERVICES_CONFIGSERVER30_PREFIX,
+                VCAP_SERVICES_CONFIGSERVERALT_PREFIX,
                 configPrefix);
         }
 
@@ -228,7 +232,8 @@ namespace Steeltoe.Extensions.Configuration.ConfigServer
                 def,
                 configPrefix,
                 VCAP_SERVICES_CONFIGSERVER_PREFIX,
-                VCAP_SERVICES_CONFIGSERVER30_PREFIX);
+                VCAP_SERVICES_CONFIGSERVER30_PREFIX,
+                VCAP_SERVICES_CONFIGSERVERALT_PREFIX);
         }
 
         /// <summary>

--- a/src/Configuration/test/ConfigServerBase.Test/ConfigServerConfigurationBuilderExtensionsTest.cs
+++ b/src/Configuration/test/ConfigServerBase.Test/ConfigServerConfigurationBuilderExtensionsTest.cs
@@ -15,6 +15,29 @@ namespace Steeltoe.Extensions.Configuration.ConfigServer.Test
 {
     public class ConfigServerConfigurationBuilderExtensionsTest
     {
+        private const string VcapApplication = @" 
+                {
+                    ""application_id"": ""fa05c1a9-0fc1-4fbd-bae1-139850dec7a3"",
+                    ""application_name"": ""foo"",
+                    ""application_uris"": [
+                        ""foo.10.244.0.34.xip.io""
+                    ],
+                    ""application_version"": ""fb8fbcc6-8d58-479e-bcc7-3b4ce5a7f0ca"",
+                    ""limits"": {
+                        ""disk"": 1024,
+                        ""fds"": 16384,
+                        ""mem"": 256
+                    },
+                    ""name"": ""foo"",
+                    ""space_id"": ""06450c72-4669-4dc6-8096-45f9777db68a"",
+                    ""space_name"": ""my-space"",
+                    ""uris"": [
+                        ""foo.10.244.0.34.xip.io""
+                    ],
+                    ""users"": null,
+                    ""version"": ""fb8fbcc6-8d58-479e-bcc7-3b4ce5a7f0ca""
+                }";
+
         [Fact]
         public void AddConfigServer_ThrowsIfConfigBuilderNull()
         {
@@ -326,35 +349,7 @@ namespace Steeltoe.Extensions.Configuration.ConfigServer.Test
             Assert.Equal("myPassword", settings.Password);
         }
 
-        [Fact]
-        public void AddConfigServer_VCAP_SERVICES_Override_Defaults()
-        {
-            // Arrange
-            var configurationBuilder = new ConfigurationBuilder();
-            const string vcap_application = @" 
-                {
-                    ""application_id"": ""fa05c1a9-0fc1-4fbd-bae1-139850dec7a3"",
-                    ""application_name"": ""foo"",
-                    ""application_uris"": [
-                        ""foo.10.244.0.34.xip.io""
-                    ],
-                    ""application_version"": ""fb8fbcc6-8d58-479e-bcc7-3b4ce5a7f0ca"",
-                    ""limits"": {
-                        ""disk"": 1024,
-                        ""fds"": 16384,
-                        ""mem"": 256
-                    },
-                    ""name"": ""foo"",
-                    ""space_id"": ""06450c72-4669-4dc6-8096-45f9777db68a"",
-                    ""space_name"": ""my-space"",
-                    ""uris"": [
-                        ""foo.10.244.0.34.xip.io""
-                    ],
-                    ""users"": null,
-                    ""version"": ""fb8fbcc6-8d58-479e-bcc7-3b4ce5a7f0ca""
-                }";
-
-            const string vcap_services = @"
+        private const string VCAPServicesV2 = @"
                 {
                     ""p-config-server"": [
                     {
@@ -378,8 +373,68 @@ namespace Steeltoe.Extensions.Configuration.ConfigServer.Test
                         ]
                     }]
                 }";
-            Environment.SetEnvironmentVariable("VCAP_APPLICATION", vcap_application);
-            Environment.SetEnvironmentVariable("VCAP_SERVICES", vcap_services);
+
+        private const string VCAPServicesV3 = @"
+                {
+                    ""p.config-server"": [
+                    {
+                        ""name"": ""config-server"",
+                        ""instance_name"": ""config-server"",
+                        ""binding_name"": null,
+                        ""credentials"": {
+                            ""uri"": ""https://uri-from-vcap-services"",
+                            ""client_secret"": ""some-secret"",
+                            ""client_id"": ""some-client-id"",
+                            ""access_token_uri"": ""https://uaa-uri-from-vcap-services/oauth/token""
+                        },
+                        ""syslog_drain_url"": null,
+                        ""volume_mounts"": [],
+                        ""label"": ""p-config-server"",
+                        ""plan"": ""standard"",
+                        ""provider"": null,
+                        ""tags"": [
+                            ""configuration"",
+                            ""spring-cloud""
+                        ]
+                    }]
+                }";
+
+        private const string VCAPServicesAlt = @"
+                {
+                    ""config-server"": [
+                    {
+                        ""name"": ""config-server"",
+                        ""instance_name"": ""config-server"",
+                        ""binding_name"": null,
+                        ""credentials"": {
+                            ""uri"": ""https://uri-from-vcap-services"",
+                            ""client_secret"": ""some-secret"",
+                            ""client_id"": ""some-client-id"",
+                            ""access_token_uri"": ""https://uaa-uri-from-vcap-services/oauth/token""
+                        },
+                        ""syslog_drain_url"": null,
+                        ""volume_mounts"": [],
+                        ""label"": ""p-config-server"",
+                        ""plan"": ""standard"",
+                        ""provider"": null,
+                        ""tags"": [
+                            ""configuration"",
+                            ""spring-cloud""
+                        ]
+                    }]
+                }";
+
+        [Theory]
+        [InlineData(VCAPServicesV2)]
+        [InlineData(VCAPServicesV3)]
+        [InlineData(VCAPServicesAlt)]
+        public void AddConfigServer_VCAP_SERVICES_Override_Defaults(string vcapservices)
+        {
+            // Arrange
+            var configurationBuilder = new ConfigurationBuilder();
+
+            Environment.SetEnvironmentVariable("VCAP_APPLICATION", VcapApplication);
+            Environment.SetEnvironmentVariable("VCAP_SERVICES", vcapservices);
             var settings = new ConfigServerClientSettings() { Uri = "https://uri-from-settings" };
 
             // Act


### PR DESCRIPTION
Support a 3rd option for service binding type/name

Small enough to include in 2.5.0, then merge forward to 3.0.1
By customer request https://steeltoeteam.slack.com/archives/C0ENXS0M8/p1600877535002200