### PR TITLE
Disambiguate EF6Autofac extension names

### DIFF
--- a/src/Connectors/src/Connector.EF6Autofac/MySqlDbContextContainerBuilderExtensions.cs
+++ b/src/Connectors/src/Connector.EF6Autofac/MySqlDbContextContainerBuilderExtensions.cs
@@ -21,7 +21,19 @@ namespace Steeltoe.CloudFoundry.Connector.EF6Autofac
         /// <param name="config">Your app config</param>
         /// <param name="serviceName">Name of service instance</param>
         /// <returns><see cref="IRegistrationBuilder{TLimit, TActivatorData, TRegistrationStyle}"/></returns>
+        [Obsolete("Use RegisterMySqlDbContext instead")]
         public static IRegistrationBuilder<object, SimpleActivatorData, SingleRegistrationStyle> RegisterDbContext<TContext>(this ContainerBuilder container, IConfiguration config, string serviceName = null)
+            => container.RegisterMySqlDbContext<TContext>(config, serviceName);
+
+        /// <summary>
+        /// Add your MySql-based DbContext to the ContainerBuilder
+        /// </summary>
+        /// <typeparam name="TContext">Your DbContext</typeparam>
+        /// <param name="container">Autofac <see cref="ContainerBuilder" /></param>
+        /// <param name="config">Your app config</param>
+        /// <param name="serviceName">Name of service instance</param>
+        /// <returns><see cref="IRegistrationBuilder{TLimit, TActivatorData, TRegistrationStyle}"/></returns>
+        public static IRegistrationBuilder<object, SimpleActivatorData, SingleRegistrationStyle> RegisterMySqlDbContext<TContext>(this ContainerBuilder container, IConfiguration config, string serviceName = null)
         {
             if (container == null)
             {

--- a/src/Connectors/src/Connector.EF6Autofac/OracleDbContextContainerBuilderExtensions.cs
+++ b/src/Connectors/src/Connector.EF6Autofac/OracleDbContextContainerBuilderExtensions.cs
@@ -21,7 +21,19 @@ namespace Steeltoe.CloudFoundry.Connector.EF6Autofac
         /// <param name="config">Your app config</param>
         /// <param name="serviceName">Name of service instance</param>
         /// <returns><see cref="IRegistrationBuilder{TLimit, TActivatorData, TRegistrationStyle}"/></returns>
+        [Obsolete("Use RegisterOracleDbContext instead")]
         public static IRegistrationBuilder<object, SimpleActivatorData, SingleRegistrationStyle> RegisterDbContext<TContext>(this ContainerBuilder container, IConfiguration config, string serviceName = null)
+            => container.RegisterOracleDbContext<TContext>(config, serviceName);
+
+        /// <summary>
+        /// Add your Oracle-based DbContext to the ContainerBuilder
+        /// </summary>
+        /// <typeparam name="TContext">Your DbContext</typeparam>
+        /// <param name="container">Autofac <see cref="ContainerBuilder" /></param>
+        /// <param name="config">Your app config</param>
+        /// <param name="serviceName">Name of service instance</param>
+        /// <returns><see cref="IRegistrationBuilder{TLimit, TActivatorData, TRegistrationStyle}"/></returns>
+        public static IRegistrationBuilder<object, SimpleActivatorData, SingleRegistrationStyle> RegisterOracleDbContext<TContext>(this ContainerBuilder container, IConfiguration config, string serviceName = null)
         {
             if (container == null)
             {

--- a/src/Connectors/src/Connector.EF6Autofac/SqlServerDbContextContainerBuilderExtensions.cs
+++ b/src/Connectors/src/Connector.EF6Autofac/SqlServerDbContextContainerBuilderExtensions.cs
@@ -21,7 +21,19 @@ namespace Steeltoe.CloudFoundry.Connector.EF6Autofac
         /// <param name="config">Your app config</param>
         /// <param name="serviceName">Name of service instance</param>
         /// <returns><see cref="IRegistrationBuilder{TLimit, TActivatorData, TRegistrationStyle}"/></returns>
+        [Obsolete("Use RegisterSqlServerDbContext instead")]
         public static IRegistrationBuilder<object, SimpleActivatorData, SingleRegistrationStyle> RegisterDbContext<TContext>(this ContainerBuilder container, IConfiguration config, string serviceName = null)
+            => container.RegisterSqlServerDbContext<TContext>(config, serviceName);
+
+        /// <summary>
+        /// Add your SqlServer-based DbContext to the ContainerBuilder
+        /// </summary>
+        /// <typeparam name="TContext">Your DbContext</typeparam>
+        /// <param name="container">Autofac <see cref="ContainerBuilder" /></param>
+        /// <param name="config">Your app config</param>
+        /// <param name="serviceName">Name of service instance</param>
+        /// <returns><see cref="IRegistrationBuilder{TLimit, TActivatorData, TRegistrationStyle}"/></returns>
+        public static IRegistrationBuilder<object, SimpleActivatorData, SingleRegistrationStyle> RegisterSqlServerDbContext<TContext>(this ContainerBuilder container, IConfiguration config, string serviceName = null)
         {
             if (container == null)
             {

--- a/src/Connectors/test/Connector.EF6Autofac.Net4Test/MySqlDbContextContainerBuilderExtensionsTest.cs
+++ b/src/Connectors/test/Connector.EF6Autofac.Net4Test/MySqlDbContextContainerBuilderExtensionsTest.cs
@@ -18,7 +18,8 @@ namespace Steeltoe.CloudFoundry.Connector.EF6Autofac.Test
             IConfiguration config = new ConfigurationBuilder().Build();
 
             // act & assert
-            Assert.Throws<ArgumentNullException>(() => MySqlDbContextContainerBuilderExtensions.RegisterDbContext<GoodMySqlDbContext>(null, config));
+            var ex = Assert.Throws<ArgumentNullException>(() => MySqlDbContextContainerBuilderExtensions.RegisterMySqlDbContext<GoodMySqlDbContext>(null, config));
+            Assert.Equal("container", ex.ParamName);
         }
 
         [Fact]
@@ -28,7 +29,8 @@ namespace Steeltoe.CloudFoundry.Connector.EF6Autofac.Test
             var cb = new ContainerBuilder();
 
             // act & assert
-            Assert.Throws<ArgumentNullException>(() => MySqlDbContextContainerBuilderExtensions.RegisterDbContext<GoodMySqlDbContext>(cb, null));
+            var ex = Assert.Throws<ArgumentNullException>(() => MySqlDbContextContainerBuilderExtensions.RegisterMySqlDbContext<GoodMySqlDbContext>(cb, null));
+            Assert.Equal("config", ex.ParamName);
         }
 
         [Fact]
@@ -39,7 +41,7 @@ namespace Steeltoe.CloudFoundry.Connector.EF6Autofac.Test
             IConfiguration config = new ConfigurationBuilder().Build();
 
             // act
-            var regBuilder = MySqlDbContextContainerBuilderExtensions.RegisterDbContext<GoodMySqlDbContext>(container, config);
+            var regBuilder = container.RegisterMySqlDbContext<GoodMySqlDbContext>(config);
             var services = container.Build();
             var dbConn = services.Resolve<GoodMySqlDbContext>();
 

--- a/src/Connectors/test/Connector.EF6Autofac.Net4Test/OracleDbContextContainerBuilderExtensionsTest.cs
+++ b/src/Connectors/test/Connector.EF6Autofac.Net4Test/OracleDbContextContainerBuilderExtensionsTest.cs
@@ -18,7 +18,8 @@ namespace Steeltoe.CloudFoundry.Connector.EF6Autofac.Test
             IConfiguration config = new ConfigurationBuilder().Build();
 
             // act & assert
-            Assert.Throws<ArgumentNullException>(() => OracleDbContextContainerBuilderExtensions.RegisterDbContext<GoodOracleDbContextcs>(null, config));
+            var ex = Assert.Throws<ArgumentNullException>(() => OracleDbContextContainerBuilderExtensions.RegisterOracleDbContext<GoodOracleDbContextcs>(null, config));
+            Assert.Equal("container", ex.ParamName);
         }
 
         [Fact]
@@ -28,7 +29,8 @@ namespace Steeltoe.CloudFoundry.Connector.EF6Autofac.Test
             var cb = new ContainerBuilder();
 
             // act & assert
-            Assert.Throws<ArgumentNullException>(() => OracleDbContextContainerBuilderExtensions.RegisterDbContext<GoodOracleDbContextcs>(cb, null));
+            var ex = Assert.Throws<ArgumentNullException>(() => OracleDbContextContainerBuilderExtensions.RegisterOracleDbContext<GoodOracleDbContextcs>(cb, null));
+            Assert.Equal("config", ex.ParamName);
         }
 
         [Fact]
@@ -39,7 +41,7 @@ namespace Steeltoe.CloudFoundry.Connector.EF6Autofac.Test
             IConfiguration config = new ConfigurationBuilder().Build();
 
             // act
-            _ = OracleDbContextContainerBuilderExtensions.RegisterDbContext<GoodOracleDbContextcs>(container, config);
+            _ = container.RegisterOracleDbContext<GoodOracleDbContextcs>(config);
             var services = container.Build();
             var dbConn = services.Resolve<GoodOracleDbContextcs>();
 

--- a/src/Connectors/test/Connector.EF6Autofac.Net4Test/SqlServerDbContextContainerBuilderExtensionsTest.cs
+++ b/src/Connectors/test/Connector.EF6Autofac.Net4Test/SqlServerDbContextContainerBuilderExtensionsTest.cs
@@ -18,7 +18,8 @@ namespace Steeltoe.CloudFoundry.Connector.EF6Autofac.Test
             IConfiguration config = new ConfigurationBuilder().Build();
 
             // act & assert
-            Assert.Throws<ArgumentNullException>(() => SqlServerDbContextContainerBuilderExtensions.RegisterDbContext<GoodSqlServerDbContext>(null, config));
+            var ex = Assert.Throws<ArgumentNullException>(() => SqlServerDbContextContainerBuilderExtensions.RegisterSqlServerDbContext<GoodSqlServerDbContext>(null, config));
+            Assert.Equal("container", ex.ParamName);
         }
 
         [Fact]
@@ -28,7 +29,8 @@ namespace Steeltoe.CloudFoundry.Connector.EF6Autofac.Test
             var cb = new ContainerBuilder();
 
             // act & assert
-            Assert.Throws<ArgumentNullException>(() => SqlServerDbContextContainerBuilderExtensions.RegisterDbContext<GoodSqlServerDbContext>(cb, null));
+            var ex = Assert.Throws<ArgumentNullException>(() => SqlServerDbContextContainerBuilderExtensions.RegisterSqlServerDbContext<GoodSqlServerDbContext>(cb, null));
+            Assert.Equal("config", ex.ParamName);
         }
 
         [Fact]
@@ -39,7 +41,7 @@ namespace Steeltoe.CloudFoundry.Connector.EF6Autofac.Test
             IConfiguration config = new ConfigurationBuilder().Build();
 
             // act
-            var regBuilder = SqlServerDbContextContainerBuilderExtensions.RegisterDbContext<GoodSqlServerDbContext>(container, config);
+            var regBuilder = container.RegisterSqlServerDbContext<GoodSqlServerDbContext>(config);
             var services = container.Build();
             var dbConn = services.Resolve<GoodSqlServerDbContext>();
 


### PR DESCRIPTION
The extensions we added a while back for using Connectors with Entity Framework and Autofac were far more difficult to use than they should have been due to the names used. These changes obsolete the old extensions and add new names that will work much better #495 