### PR TITLE
Fix for service registration in services

### DIFF
--- a/src/Management/src/EndpointCore/Metrics/EndpointServiceCollectionExtensions.cs
+++ b/src/Management/src/EndpointCore/Metrics/EndpointServiceCollectionExtensions.cs
@@ -98,6 +98,16 @@ namespace Steeltoe.Management.Endpoint.Metrics
                 services.TryAddEnumerable(ServiceDescriptor.Singleton<IDiagnosticObserver, AspNetCoreHostingObserver>());
             }
 
+            if (observerOptions.HttpClientCore)
+            {
+                services.TryAddEnumerable(ServiceDescriptor.Singleton<IDiagnosticObserver, HttpClientCoreObserver>());
+            }
+
+            if (observerOptions.HttpClientDesktop)
+            {
+                services.TryAddEnumerable(ServiceDescriptor.Singleton<IDiagnosticObserver, HttpClientDesktopObserver>());
+            }
+
             if (observerOptions.GCEvents)
             {
                 services.TryAddEnumerable(ServiceDescriptor.Singleton<EventListener, GCEventsListener>());


### PR DESCRIPTION
Management:Metrics:Observer:HttpClientCore and
Management:Metrics:Observer:HttpClientDesktop are taken into account
when AddPrometheusActuator, AddMetricsActuator are called.

Addresses #527