### PR TITLE
Add support for EF Core 5.0

### DIFF
--- a/src/Common/src/Common/Extensions/UriExtensions.cs
+++ b/src/Common/src/Common/Extensions/UriExtensions.cs
@@ -56,7 +56,7 @@ namespace Steeltoe.Common.Extensions
                 if (!string.IsNullOrEmpty(pair))
                 {
                     var kvp = pair.Split('=');
-                    result.Add(kvp[0], WebUtility.UrlDecode(kvp[1]));
+                    result.Add(WebUtility.UrlDecode(kvp[0]), WebUtility.UrlDecode(kvp[1]));
                 }
             }
 

--- a/src/Connectors/src/Connector.EFCore/EntityFrameworkCoreTypeLocator.cs
+++ b/src/Connectors/src/Connector.EFCore/EntityFrameworkCoreTypeLocator.cs
@@ -20,13 +20,24 @@ namespace Steeltoe.Connector.EFCore
         /// <summary>
         /// Gets a list of supported fully-qualifed names for compatible DbContextOptionsExtentions used to configure EntityFrameworkCore
         /// </summary>
-        public static string[] MySqlEntityTypeNames { get; internal set; } = new string[] { "MySQL.Data.EntityFrameworkCore.Extensions.MySQLDbContextOptionsExtensions", "Microsoft.EntityFrameworkCore.MySqlDbContextOptionsExtensions", "Microsoft.EntityFrameworkCore.MySQLDbContextOptionsExtensions" };
+        public static string[] MySqlEntityTypeNames { get; internal set; } = new string[]
+            {
+                "MySQL.Data.EntityFrameworkCore.Extensions.MySQLDbContextOptionsExtensions",
+                "Microsoft.EntityFrameworkCore.MySqlDbContextOptionsExtensions",
+                "Microsoft.EntityFrameworkCore.MySQLDbContextOptionsExtensions",
+                "Microsoft.EntityFrameworkCore.MySqlDbContextOptionsBuilderExtensions"
+            };
 
         /// <summary>
-        /// Gets the type used to configure EntityFramework Core with MySql
+        /// Gets the type used to configure EntityFramework Core with MySQL
         /// </summary>
         /// <exception cref="ConnectorException">When type is not found</exception>
         public static Type MySqlDbContextOptionsType => ReflectionHelpers.FindTypeOrThrow(MySqlEntityAssemblies, MySqlEntityTypeNames, "DbContextOptionsBuilder", "a MySql EntityFramework Core assembly");
+
+        /// <summary>
+        /// Gets the ServerVersion base type used to identify MySQL Server versions (introduced in v5.0)
+        /// </summary>
+        public static Type MySqlVersionType => ReflectionHelpers.FindType(new[] { "Pomelo.EntityFrameworkCore.MySql" }, new[] { "Microsoft.EntityFrameworkCore.ServerVersion" });
 
         /// <summary>
         /// Gets a list of supported PostgreSQL Entity Framework Core Assemblies
@@ -36,7 +47,7 @@ namespace Steeltoe.Connector.EFCore
         /// <summary>
         /// Gets a list of supported fully-qualifed names for compatible DbContextOptionsExtentions used to configure EntityFrameworkCore
         /// </summary>
-        public static string[] PostgreSqlEntityTypeNames { get; internal set; } = new string[] { "Microsoft.EntityFrameworkCore.NpgsqlDbContextOptionsExtensions" };
+        public static string[] PostgreSqlEntityTypeNames { get; internal set; } = new string[] { "Microsoft.EntityFrameworkCore.NpgsqlDbContextOptionsExtensions", "Microsoft.EntityFrameworkCore.NpgsqlDbContextOptionsBuilderExtensions" };
 
         /// <summary>
         /// Gets the type used to configure EntityFramework Core with PostgreSQL

--- a/src/Connectors/src/Connector.EFCore/MySqlDbContextOptionsExtensions.cs
+++ b/src/Connectors/src/Connector.EFCore/MySqlDbContextOptionsExtensions.cs
@@ -14,6 +14,17 @@ namespace Steeltoe.Connector.MySql.EFCore
 {
     public static class MySqlDbContextOptionsExtensions
     {
+        /// <summary>
+        /// Configure Entity Framework Core to use a MySQL database
+        /// </summary>
+        /// <param name="optionsBuilder"><see cref="DbContextOptionsBuilder"/></param>
+        /// <param name="config">Application configuration</param>
+        /// <param name="mySqlOptionsAction">An action for customizing the MySqlDbContextOptionsBuilder</param>
+        /// <returns><see cref="DbContextOptionsBuilder"/>, configured to use MySQL</returns>
+        /// <remarks>
+        ///   When used with EF Core 5.0, this method may result in the use of ServerVersion.AutoDetect(), which opens an extra connection to the server.<para />
+        ///   Pass in a ServerVersion to avoid the extra DB Connection - see https://github.com/PomeloFoundation/Pomelo.EntityFrameworkCore.MySql/issues/1088#issuecomment-726091533
+        /// </remarks>
         public static DbContextOptionsBuilder UseMySql(this DbContextOptionsBuilder optionsBuilder, IConfiguration config, object mySqlOptionsAction = null)
         {
             if (optionsBuilder == null)
@@ -31,6 +42,43 @@ namespace Steeltoe.Connector.MySql.EFCore
             return DoUseMySql(optionsBuilder, connection, mySqlOptionsAction);
         }
 
+        /// <summary>
+        /// Configure Entity Framework Core to use a MySQL database
+        /// </summary>
+        /// <param name="optionsBuilder"><see cref="DbContextOptionsBuilder"/></param>
+        /// <param name="config">Application configuration</param>
+        /// <param name="serverVersion">The version of MySQL/MariaDB to connect to (introduced in EF Core 5.0)</param>
+        /// <param name="mySqlOptionsAction">An action for customizing the MySqlDbContextOptionsBuilder</param>
+        /// <returns><see cref="DbContextOptionsBuilder"/>, configured to use MySQL</returns>
+        public static DbContextOptionsBuilder UseMySql(this DbContextOptionsBuilder optionsBuilder, IConfiguration config, object serverVersion, object mySqlOptionsAction = null)
+        {
+            if (optionsBuilder == null)
+            {
+                throw new ArgumentNullException(nameof(optionsBuilder));
+            }
+
+            if (config == null)
+            {
+                throw new ArgumentNullException(nameof(config));
+            }
+
+            var connection = GetConnection(config);
+
+            return DoUseMySql(optionsBuilder, connection, mySqlOptionsAction, serverVersion);
+        }
+
+        /// <summary>
+        /// Configure Entity Framework Core to use a MySQL database identified by a named service binding
+        /// </summary>
+        /// <param name="optionsBuilder"><see cref="DbContextOptionsBuilder"/></param>
+        /// <param name="config">Application configuration</param>
+        /// <param name="serviceName">The name of the service binding to use</param>
+        /// <param name="mySqlOptionsAction">An action for customizing the MySqlDbContextOptionsBuilder</param>
+        /// <returns><see cref="DbContextOptionsBuilder"/>, configured to use MySQL</returns>
+        /// <remarks>
+        ///   When used with EF Core 5.0, this method may result in the use of ServerVersion.AutoDetect(), which opens an extra connection to the server.<para />
+        ///   Pass in a ServerVersion to avoid the extra DB Connection - see https://github.com/PomeloFoundation/Pomelo.EntityFrameworkCore.MySql/issues/1088#issuecomment-726091533
+        /// </remarks>
         public static DbContextOptionsBuilder UseMySql(this DbContextOptionsBuilder optionsBuilder, IConfiguration config, string serviceName, object mySqlOptionsAction = null)
         {
             if (optionsBuilder == null)
@@ -53,7 +101,47 @@ namespace Steeltoe.Connector.MySql.EFCore
             return DoUseMySql(optionsBuilder, connection, mySqlOptionsAction);
         }
 
-        public static DbContextOptionsBuilder<TContext> UseMySql<TContext>(this DbContextOptionsBuilder<TContext> optionsBuilder, IConfiguration config, object mySqlOptionsAction = null)
+        /// <summary>
+        /// Configure Entity Framework Core to use a MySQL database identified by a named service binding
+        /// </summary>
+        /// <param name="optionsBuilder"><see cref="DbContextOptionsBuilder"/></param>
+        /// <param name="config">Application configuration</param>
+        /// <param name="serviceName">The name of the service binding to use</param>
+        /// <param name="serverVersion">The version of MySQL/MariaDB to connect to (introduced in EF Core 5.0)</param>
+        /// <param name="mySqlOptionsAction">An action for customizing the MySqlDbContextOptionsBuilder</param>
+        /// <returns><see cref="DbContextOptionsBuilder"/>, configured to use MySQL</returns>
+        public static DbContextOptionsBuilder UseMySql(this DbContextOptionsBuilder optionsBuilder, IConfiguration config, string serviceName, object serverVersion, object mySqlOptionsAction = null)
+        {
+            if (optionsBuilder == null)
+            {
+                throw new ArgumentNullException(nameof(optionsBuilder));
+            }
+
+            if (config == null)
+            {
+                throw new ArgumentNullException(nameof(config));
+            }
+
+            if (string.IsNullOrEmpty(serviceName))
+            {
+                throw new ArgumentException(nameof(serviceName));
+            }
+
+            var connection = GetConnection(config, serviceName);
+
+            return DoUseMySql(optionsBuilder, connection, mySqlOptionsAction, serverVersion);
+        }
+
+        /// <summary>
+        /// Configure Entity Framework Core to use a MySQL database
+        /// </summary>
+        /// <typeparam name="TContext">Type of <see cref="DbContext"/></typeparam>
+        /// <param name="optionsBuilder"><see cref="DbContextOptionsBuilder"/></param>
+        /// <param name="config">Application configuration</param>
+        /// <param name="mySqlOptionsAction">An action for customizing the MySqlDbContextOptionsBuilder</param>
+        /// <param name="serverVersion">The version of MySQL/MariaDB to connect to (introduced in EF Core 5.0)</param>
+        /// <returns><see cref="DbContextOptionsBuilder"/>, configured to use MySQL</returns>
+        public static DbContextOptionsBuilder<TContext> UseMySql<TContext>(this DbContextOptionsBuilder<TContext> optionsBuilder, IConfiguration config, object mySqlOptionsAction = null, object serverVersion = null)
             where TContext : DbContext
         {
             if (optionsBuilder == null)
@@ -68,10 +156,20 @@ namespace Steeltoe.Connector.MySql.EFCore
 
             var connection = GetConnection(config);
 
-            return DoUseMySql(optionsBuilder, connection, mySqlOptionsAction);
+            return DoUseMySql(optionsBuilder, connection, mySqlOptionsAction, serverVersion);
         }
 
-        public static DbContextOptionsBuilder<TContext> UseMySql<TContext>(this DbContextOptionsBuilder<TContext> optionsBuilder, IConfiguration config, string serviceName, object mySqlOptionsAction = null)
+        /// <summary>
+        /// Configure Entity Framework Core to use a MySQL database identified by a named service binding
+        /// </summary>
+        /// <typeparam name="TContext">Type of <see cref="DbContext"/></typeparam>
+        /// <param name="optionsBuilder"><see cref="DbContextOptionsBuilder"/></param>
+        /// <param name="config">Application configuration</param>
+        /// <param name="serviceName">The name of the service binding to use</param>
+        /// <param name="mySqlOptionsAction">An action for customizing the MySqlDbContextOptionsBuilder</param>
+        /// <param name="serverVersion">The version of MySQL/MariaDB to connect to (introduced in EF Core 5.0)</param>
+        /// <returns><see cref="DbContextOptionsBuilder"/>, configured to use MySQL</returns>
+        public static DbContextOptionsBuilder<TContext> UseMySql<TContext>(this DbContextOptionsBuilder<TContext> optionsBuilder, IConfiguration config, string serviceName, object mySqlOptionsAction = null, object serverVersion = null)
             where TContext : DbContext
         {
             if (optionsBuilder == null)
@@ -91,28 +189,7 @@ namespace Steeltoe.Connector.MySql.EFCore
 
             var connection = GetConnection(config, serviceName);
 
-            return DoUseMySql(optionsBuilder, connection, mySqlOptionsAction);
-        }
-
-        private static MethodInfo FindUseSqlMethod(Type type, Type[] parameterTypes)
-        {
-            var typeInfo = type.GetTypeInfo();
-            var declaredMethods = typeInfo.DeclaredMethods;
-
-            foreach (var ci in declaredMethods)
-            {
-                var parameters = ci.GetParameters();
-                if (parameters.Length == 3 &&
-                    ci.Name.Equals("UseMySQL", StringComparison.InvariantCultureIgnoreCase) &&
-                    parameters[0].ParameterType.Equals(parameterTypes[0]) &&
-                    parameters[1].ParameterType.Equals(parameterTypes[1]) &&
-                    ci.IsPublic && ci.IsStatic)
-                {
-                    return ci;
-                }
-            }
-
-            return null;
+            return DoUseMySql(optionsBuilder, connection, mySqlOptionsAction, serverVersion);
         }
 
         private static string GetConnection(IConfiguration config, string serviceName = null)
@@ -128,17 +205,33 @@ namespace Steeltoe.Connector.MySql.EFCore
             return factory.CreateConnectionString();
         }
 
-        private static DbContextOptionsBuilder DoUseMySql(DbContextOptionsBuilder builder, string connection, object mySqlOptionsAction = null)
+        private static DbContextOptionsBuilder DoUseMySql(DbContextOptionsBuilder builder, string connection, object mySqlOptionsAction = null, object serverVersion = null)
         {
             var extensionType = EntityFrameworkCoreTypeLocator.MySqlDbContextOptionsType;
 
-            var useMethod = FindUseSqlMethod(extensionType, new Type[] { typeof(DbContextOptionsBuilder), typeof(string) });
+            MethodInfo useMethod;
+            object[] parms;
+
+            // the signature changed in 5.0 to require a param of type ServerVersion - use the presence of this new type to select the signature
+            if (EntityFrameworkCoreTypeLocator.MySqlVersionType == null)
+            {
+                useMethod = FindUseSqlMethod(extensionType, new Type[] { typeof(DbContextOptionsBuilder), typeof(string) });
+                parms = new object[] { builder, connection, mySqlOptionsAction };
+            }
+            else
+            {
+                // If the server version wasn't passed in, use the EF Core lib to autodetect it (this is the part that creates an extra connection)
+                serverVersion ??= ReflectionHelpers.FindMethod(EntityFrameworkCoreTypeLocator.MySqlVersionType, "AutoDetect", new Type[] { typeof(string) }).Invoke(null, new[] { connection });
+                useMethod = FindUseSqlMethod(extensionType, new Type[] { typeof(DbContextOptionsBuilder), typeof(string), EntityFrameworkCoreTypeLocator.MySqlVersionType, typeof(Action<DbContextOptionsBuilder>) });
+                parms = new object[] { builder, connection, serverVersion, mySqlOptionsAction };
+            }
+
             if (extensionType == null)
             {
                 throw new ConnectorException("Unable to find UseMySql extension, are you missing MySql EntityFramework Core assembly");
             }
 
-            var result = ReflectionHelpers.Invoke(useMethod, null, new object[] { builder, connection, mySqlOptionsAction });
+            var result = ReflectionHelpers.Invoke(useMethod, null, parms);
             if (result == null)
             {
                 throw new ConnectorException(string.Format("Failed to invoke UseMySql extension, connection: {0}", connection));
@@ -147,10 +240,29 @@ namespace Steeltoe.Connector.MySql.EFCore
             return (DbContextOptionsBuilder)result;
         }
 
-        private static DbContextOptionsBuilder<TContext> DoUseMySql<TContext>(DbContextOptionsBuilder<TContext> builder, string connection, object mySqlOptionsAction = null)
+        private static DbContextOptionsBuilder<TContext> DoUseMySql<TContext>(DbContextOptionsBuilder<TContext> builder, string connection, object mySqlOptionsAction = null, object serverVersion = null)
             where TContext : DbContext
+                => (DbContextOptionsBuilder<TContext>)DoUseMySql((DbContextOptionsBuilder)builder, connection, mySqlOptionsAction, serverVersion);
+
+        private static MethodInfo FindUseSqlMethod(Type type, Type[] parameterTypes)
         {
-            return (DbContextOptionsBuilder<TContext>)DoUseMySql((DbContextOptionsBuilder)builder, connection, mySqlOptionsAction);
+            var typeInfo = type.GetTypeInfo();
+            var declaredMethods = typeInfo.DeclaredMethods;
+
+            foreach (var ci in declaredMethods)
+            {
+                var parameters = ci.GetParameters();
+                if ((parameters.Length == 3 || parameters.Length == parameterTypes.Length) &&
+                    ci.Name.Equals("UseMySQL", StringComparison.InvariantCultureIgnoreCase) &&
+                    parameters[0].ParameterType.Equals(parameterTypes[0]) &&
+                    parameters[1].ParameterType.Equals(parameterTypes[1]) &&
+                    ci.IsPublic && ci.IsStatic)
+                {
+                    return ci;
+                }
+            }
+
+            return null;
         }
     }
 }

--- a/src/Connectors/src/Connector.EFCore/MySqlDbContextOptionsExtensions.cs
+++ b/src/Connectors/src/Connector.EFCore/MySqlDbContextOptionsExtensions.cs
@@ -26,21 +26,7 @@ namespace Steeltoe.Connector.MySql.EFCore
         ///   Pass in a ServerVersion to avoid the extra DB Connection - see https://github.com/PomeloFoundation/Pomelo.EntityFrameworkCore.MySql/issues/1088#issuecomment-726091533
         /// </remarks>
         public static DbContextOptionsBuilder UseMySql(this DbContextOptionsBuilder optionsBuilder, IConfiguration config, object mySqlOptionsAction = null)
-        {
-            if (optionsBuilder == null)
-            {
-                throw new ArgumentNullException(nameof(optionsBuilder));
-            }
-
-            if (config == null)
-            {
-                throw new ArgumentNullException(nameof(config));
-            }
-
-            var connection = GetConnection(config);
-
-            return DoUseMySql(optionsBuilder, connection, mySqlOptionsAction);
-        }
+            => UseMySql(optionsBuilder, config, serverVersion: null, mySqlOptionsAction);
 
         /// <summary>
         /// Configure Entity Framework Core to use a MySQL database
@@ -80,26 +66,7 @@ namespace Steeltoe.Connector.MySql.EFCore
         ///   Pass in a ServerVersion to avoid the extra DB Connection - see https://github.com/PomeloFoundation/Pomelo.EntityFrameworkCore.MySql/issues/1088#issuecomment-726091533
         /// </remarks>
         public static DbContextOptionsBuilder UseMySql(this DbContextOptionsBuilder optionsBuilder, IConfiguration config, string serviceName, object mySqlOptionsAction = null)
-        {
-            if (optionsBuilder == null)
-            {
-                throw new ArgumentNullException(nameof(optionsBuilder));
-            }
-
-            if (config == null)
-            {
-                throw new ArgumentNullException(nameof(config));
-            }
-
-            if (string.IsNullOrEmpty(serviceName))
-            {
-                throw new ArgumentException(nameof(serviceName));
-            }
-
-            var connection = GetConnection(config, serviceName);
-
-            return DoUseMySql(optionsBuilder, connection, mySqlOptionsAction);
-        }
+            => UseMySql(optionsBuilder, config, serviceName, null, mySqlOptionsAction);
 
         /// <summary>
         /// Configure Entity Framework Core to use a MySQL database identified by a named service binding

--- a/src/Connectors/test/Connector.EFCore.Test/EntityFrameworkCoreTypeLocatorTest.cs
+++ b/src/Connectors/test/Connector.EFCore.Test/EntityFrameworkCoreTypeLocatorTest.cs
@@ -74,7 +74,11 @@ namespace Steeltoe.Connector.EFCore.Test
             Assert.NotNull(type);
         }
 
+#if NETCOREAPP3_1
         [Fact]
+#else
+        [Fact(Skip = "Revisit when Oracle has support for EF Core 5.0")]
+#endif
         public void Options_Found_In_OracleEF_Assembly()
         {
             // arrange ~ narrow the assembly list to one specific nuget package

--- a/src/Connectors/test/Connector.EFCore.Test/SqlServerDbContextOptionsExtensionsTest.cs
+++ b/src/Connectors/test/Connector.EFCore.Test/SqlServerDbContextOptionsExtensionsTest.cs
@@ -2,13 +2,13 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.Data.SqlClient;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Steeltoe.Connector.EFCore.Test;
 using Steeltoe.Extensions.Configuration.CloudFoundry;
 using System;
-using System.Data.SqlClient;
 using Xunit;
 
 namespace Steeltoe.Connector.SqlServer.EFCore.Test

--- a/src/Connectors/test/Connector.EFCore.Test/Steeltoe.Connector.EFCore.Test.csproj
+++ b/src/Connectors/test/Connector.EFCore.Test/Steeltoe.Connector.EFCore.Test.csproj
@@ -18,11 +18,14 @@
 
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="$(EFCoreTestVersion)" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="$(NpgsqlEFCoreVersion)" />
-    <PackageReference Include="Oracle.EntityFrameworkCore" Version="2.19.0-beta4" />
 
     <!--<PackageReference Include="MySql.Data.EntityFrameworkCore" Version="$(MySqlV6)" />-->
     <!--<PackageReference Include="MySql.Data.EntityFrameworkCore" Version="$(MySqlV8)" />-->
     <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="$(PomeloEFCoreVersion)" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'"><!--Oracle doesn't work with EF Core 5.0 yet-->
+    <PackageReference Include="Oracle.EntityFrameworkCore" Version="$(OracleEFCoreVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/versions.props
+++ b/versions.props
@@ -7,7 +7,6 @@
     <CSharpVersion>4.5.0</CSharpVersion>
     <DriveInfoVersion>4.3.1</DriveInfoVersion>
     <EFCoreVersion>2.0.0</EFCoreVersion>
-    <EFCoreTestVersion>2.1.2</EFCoreTestVersion>
     <HttpVersion>4.3.4</HttpVersion>
     <WinHttpHandlerVersion>4.7.0</WinHttpHandlerVersion>
     <HttpClientVersion>4.3.3</HttpClientVersion>
@@ -27,8 +26,6 @@
     <MySqlV6>6.10.7</MySqlV6>
     <MySqlV8>8.0.14</MySqlV8>
     <NpgsqlVersion>4.0.0</NpgsqlVersion>
-    <NpgsqlEFCoreVersion>2.1.0</NpgsqlEFCoreVersion>
-    <PomeloEFCoreVersion>2.0.1</PomeloEFCoreVersion>
     <SqlClientVersion>4.5.0</SqlClientVersion>
     <MicrosoftExtensionsRedisVersion>2.2.0</MicrosoftExtensionsRedisVersion>
     <StackExchangeVersion>2.0.513</StackExchangeVersion>
@@ -76,8 +73,15 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
     <AspNetCoreVersion>3.1.0</AspNetCoreVersion>
+    <EFCoreTestVersion>3.1.6</EFCoreTestVersion>
+    <NpgsqlEFCoreVersion>3.1.0</NpgsqlEFCoreVersion>
+    <PomeloEFCoreVersion>3.1.0</PomeloEFCoreVersion>
+    <OracleEFCoreVersion>3.19.80</OracleEFCoreVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'net5.0'">
-    <AspNetCoreVersion>5.0.0-rc.2.20475.17</AspNetCoreVersion>
+    <AspNetCoreVersion>5.0.0</AspNetCoreVersion>
+    <EFCoreTestVersion>5.0.0</EFCoreTestVersion>
+    <NpgsqlEFCoreVersion>5.0.0</NpgsqlEFCoreVersion>
+    <PomeloEFCoreVersion>5.0.0-alpha.2</PomeloEFCoreVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
- Tests running netcoreapp3.1 now use EF Core 3.1 and net5.0 now use EF Core 5.0
- For Pomelo MySQL and Npgsql libraries, `DbContextOptionsExtensions` have been renamed `DbContextOptions*Builder*Extensions` 
- Pomelo MySQL also requires now specification of MySQL Server version

#533