### PR TITLE
Use JsonSerializer instead of BinaryFormatter 

### DIFF
--- a/src/Common/src/Common/Discovery/IServiceInstanceProviderExtensions.cs
+++ b/src/Common/src/Common/Discovery/IServiceInstanceProviderExtensions.cs
@@ -4,9 +4,8 @@
 
 using Microsoft.Extensions.Caching.Distributed;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
-using System.Runtime.Serialization.Formatters.Binary;
+using System.Text.Json;
 using System.Threading.Tasks;
 
 namespace Steeltoe.Common.Discovery
@@ -18,7 +17,7 @@ namespace Steeltoe.Common.Discovery
             string serviceId,
             IDistributedCache distributedCache = null,
             DistributedCacheEntryOptions cacheOptions = null,
-            string serviceInstancesKeyPrefix = "ServiceInstances-")
+            string serviceInstancesKeyPrefix = "ServiceInstances:")
         {
             // if distributed cache was provided, just make the call back to the provider
             if (distributedCache != null)
@@ -47,18 +46,10 @@ namespace Steeltoe.Common.Discovery
             return inst.ToList();
         }
 
-        private static byte[] SerializeForCache(object data)
-        {
-            using var stream = new MemoryStream();
-            new BinaryFormatter().Serialize(stream, data);
-            return stream.ToArray();
-        }
+        private static byte[] SerializeForCache(object data) => JsonSerializer.SerializeToUtf8Bytes(data);
 
         private static T DeserializeFromCache<T>(byte[] data)
             where T : class
-        {
-            using var stream = new MemoryStream(data);
-            return new BinaryFormatter().Deserialize(stream) as T;
-        }
+                => JsonSerializer.Deserialize<T>(data);
     }
 }

--- a/src/Common/src/Common/Discovery/SerializableIServiceInstance.cs
+++ b/src/Common/src/Common/Discovery/SerializableIServiceInstance.cs
@@ -10,6 +10,14 @@ namespace Steeltoe.Common.Discovery
     [Serializable]
     public class SerializableIServiceInstance : IServiceInstance
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SerializableIServiceInstance"/> class.
+        /// For use with JsonSerializer
+        /// </summary>
+        public SerializableIServiceInstance()
+        {
+        }
+
         public SerializableIServiceInstance(IServiceInstance instance)
         {
             ServiceId = instance.ServiceId;

--- a/src/Common/src/Common/Steeltoe.Common.csproj
+++ b/src/Common/src/Common/Steeltoe.Common.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="$(ExtensionsVersion)" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="$(SystemDiagnosticsVersion)" />
     <PackageReference Include="System.Reflection.MetadataLoadContext" Version="$(SystemReflectionVersion)" />
+    <PackageReference Include="System.Text.Json" Version="$(SystemJsonVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/versions.props
+++ b/versions.props
@@ -78,6 +78,6 @@
     <AspNetCoreVersion>3.1.0</AspNetCoreVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'net5.0'">
-    <AspNetCoreVersion>5.0.0-rc.2.20475.17</AspNetCoreVersion>
+    <AspNetCoreVersion>5.0.0</AspNetCoreVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Use JsonSerializer instead of BinaryFormatter when for caching of service info with load balancer #530
Also changes a character in the cache key name to avoid collisions with previous versions