### PR TITLE
Setting Consul:Discovery:Port prevents use of ASP.NET Core Urls

### DIFF
--- a/src/Discovery/src/Consul/Discovery/ConsulDiscoveryOptions.cs
+++ b/src/Discovery/src/Consul/Discovery/ConsulDiscoveryOptions.cs
@@ -233,7 +233,7 @@ namespace Steeltoe.Discovery.Consul.Discovery
         {
             // try to pull some values out of server config to override defaults, but only if not using NetUtils
             // if NetUtils are configured, the user probably wants to define their own behavior
-            if (addresses.Any() && !UseNetUtils && UseAspNetCoreUrls)
+            if (addresses.Any() && !UseNetUtils && UseAspNetCoreUrls && Port == 0)
             {
                 // prefer https
                 var configAddress = addresses.FirstOrDefault(u => u.Scheme.Equals("https"));

--- a/src/Discovery/test/ClientBase.Test/DiscoveryServiceCollectionExtensionsTest.cs
+++ b/src/Discovery/test/ClientBase.Test/DiscoveryServiceCollectionExtensionsTest.cs
@@ -714,6 +714,30 @@ namespace Steeltoe.Discovery.Client.Test
         }
 
         [Fact]
+        public void AddDiscoveryClient_WithConsul_PreferPortOverUrl()
+        {
+            // Arrange
+            var appsettings = new Dictionary<string, string>
+            {
+                { "spring:application:name", "myName" },
+                { "urls", "https://myapp:1234;http://0.0.0.0:1233;http://::1233;http://*:1233" },
+                { "consul:discovery:register", "false" },
+                { "consul:discovery:deregister", "false" },
+                { "Consul:Discovery:Port", "8080" }
+            };
+            var config = new ConfigurationBuilder().AddInMemoryCollection(appsettings).Build();
+
+            var provider = new ServiceCollection().AddSingleton<IConfiguration>(config).AddOptions().AddDiscoveryClient(config).BuildServiceProvider();
+            var reg = provider.GetService<IConsulRegistration>();
+
+            Assert.NotNull(reg);
+            Assert.NotEqual("myapp", reg.Host);
+            Assert.Equal(8080, reg.Port);
+            Assert.NotNull(provider.GetService<IConsulServiceRegistrar>());
+            Assert.NotNull(provider.GetService<IHealthContributor>());
+        }
+
+        [Fact]
         public void AddServiceDiscovery_WithMultipleClientTypes_NotAllowed()
         {
             var serviceCollection = new ServiceCollection();


### PR DESCRIPTION
Use the presence of `Consul:Discovery:Port` as another reason _not_ to use the address(es) ASP.NET Core is listening on when registering with Consul  #529

Using `Consul:Discovery:HostName` in the decision does not appear practical as we can't tell what set that value when this check runs and the default scenario uses `DnsTools.ResolveHostName()` rather than something static