### PR TITLE
Publish single file

### DIFF
--- a/src/Connectors/src/CloudFoundry/CloudFoundryConnector.cs
+++ b/src/Connectors/src/CloudFoundry/CloudFoundryConnector.cs
@@ -1,0 +1,17 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+namespace Steeltoe.Connector.CloudFoundry
+{
+    public static class CloudFoundryConnector
+    {
+        /// <summary>
+        /// Use this method to ensure Steeltoe.Connector.CloudFoundry is loaded
+        /// </summary>
+        public static void EnsureAssemblyIsLoaded()
+        {
+            // no-op
+        }
+    }
+}


### PR DESCRIPTION
Enhancements to help with #544 

- Writes to console if it looks like publishSingleFile=true was used (Assembly.Location is `""`) when trying to load all relevant assemblies from disk
- For Connectors, adds `CloudFoundryConnector.EnsureAssemblyIsLoaded()` for an optional no-op reference that makes sure the assembly is included
- For Discovery, allows multi-client registration with `AddServiceDiscovery` for config-driven client selection similar to `AddDiscoveryClient`