### PR TITLE
UseCloudHosting with 'port;port' in env var PORT

### DIFF
--- a/src/Common/src/Common.Hosting/HostBuilderExtensions.cs
+++ b/src/Common/src/Common.Hosting/HostBuilderExtensions.cs
@@ -54,11 +54,25 @@ namespace Steeltoe.Common.Hosting
             var urls = new List<string>();
 
             var portStr = Environment.GetEnvironmentVariable("PORT") ?? Environment.GetEnvironmentVariable("SERVER_PORT");
+            var aspnetUrls = Environment.GetEnvironmentVariable("ASPNETCORE_URLS");
             if (!string.IsNullOrWhiteSpace(portStr))
             {
                 if (int.TryParse(portStr, out var port))
                 {
                     urls.Add($"http://*:{port}");
+                }
+                else if (portStr.Contains(";"))
+                {
+                    if (!string.IsNullOrEmpty(aspnetUrls))
+                    {
+                        urls.AddRange(aspnetUrls.Split(';'));
+                    }
+                    else
+                    {
+                        var ports = portStr.Split(';');
+                        urls.Add($"http://*:{ports[0]}");
+                        urls.Add($"https://*:{ports[1]}");
+                    }
                 }
             }
             else

--- a/src/Common/test/Common.Hosting.Test/HostBuilderExtensionsTest.cs
+++ b/src/Common/test/Common.Hosting.Test/HostBuilderExtensionsTest.cs
@@ -61,6 +61,45 @@ namespace Steeltoe.Common.Hosting.Test
         }
 
         [Fact]
+        public void UseCloudHosting_ReadsTyePorts()
+        {
+            // Arrange
+            Environment.SetEnvironmentVariable("PORT", "80;443");
+            var hostBuilder = new WebHostBuilder()
+                                .UseStartup<TestServerStartup>()
+                                .UseKestrel();
+
+            // Act
+            hostBuilder.UseCloudHosting();
+            var server = hostBuilder.Build();
+
+            // Assert
+            var addresses = server.ServerFeatures.Get<IServerAddressesFeature>();
+            Assert.Contains("http://*:80", addresses.Addresses);
+            Assert.Contains("https://*:443", addresses.Addresses);
+        }
+
+        [Fact]
+        public void UseCloudHosting_SeesTyePortsAndUsesAspNetCoreURL()
+        {
+            // Arrange
+            Environment.SetEnvironmentVariable("ASPNETCORE_URLS", "http://*:80;https://*:443");
+            Environment.SetEnvironmentVariable("PORT", "88;4443");
+            var hostBuilder = new WebHostBuilder()
+                                .UseStartup<TestServerStartup>()
+                                .UseKestrel();
+
+            // Act
+            hostBuilder.UseCloudHosting();
+            var server = hostBuilder.Build();
+
+            // Assert
+            var addresses = server.ServerFeatures.Get<IServerAddressesFeature>();
+            Assert.Contains("http://*:80", addresses.Addresses);
+            Assert.Contains("https://*:443", addresses.Addresses);
+        }
+
+        [Fact]
         public void UseCloudHosting_UsesServerPort()
         {
             // Arrange


### PR DESCRIPTION
#548  Allow `UseCloudHosting()` to better handle the way Tye assigns ports. There could be room for discussion around prioritizing values in an env variable named `ASPNETCORE_URLS`, but changes there might be better for a larger-than-patch release

Sample assignments from Tye:
```
 -e "ASPNETCORE_URLS=http://*:80;https://*:443"
 -e "HTTPS_PORT=57284"
 -e "PORT=80;443"
 -e "PROXY_PORT=80:57283;443:57284"
```