### PR TITLE
DetermineAddresses returns null when none configured

### DIFF
--- a/src/Messaging/src/RabbitMQ/Config/RabbitOptions.cs
+++ b/src/Messaging/src/RabbitMQ/Config/RabbitOptions.cs
@@ -60,7 +60,7 @@ namespace Steeltoe.Messaging.RabbitMQ.Config
             var parsed = ParsedAddresses;
             if (parsed.Count == 0)
             {
-                return Host + ":" + Port;
+                return null;
             }
 
             var addressStrings = new List<string>();


### PR DESCRIPTION
See [#537]