### PR TITLE
Split actuator service registration

### DIFF
--- a/src/Management/src/EndpointBase/CloudFoundry/ServiceCollectionExtensions.cs
+++ b/src/Management/src/EndpointBase/CloudFoundry/ServiceCollectionExtensions.cs
@@ -1,0 +1,54 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Steeltoe.Management;
+using Steeltoe.Management.Endpoint.CloudFoundry;
+using System;
+using System.Linq;
+
+namespace Microsoft.Extensions.DependencyInjection
+{
+    /// <summary>
+    /// Add services used by the CloudFoundry actuator
+    /// </summary>
+    public static partial class ServiceCollectionExtensions
+    {
+        /// <summary>
+        /// Adds the services used by the Cloud Foundry actuator
+        /// </summary>
+        /// <param name="services">Reference to the service collection</param>
+        /// <param name="configuration">Reference to the configuration system</param>
+        /// <returns>A reference to the service collection</returns>
+        public static IServiceCollection AddCloudFoundryActuatorServices(this IServiceCollection services, IConfiguration configuration)
+        {
+            if (services == null)
+            {
+                throw new ArgumentNullException(nameof(services));
+            }
+
+            if (configuration == null)
+            {
+                throw new ArgumentNullException(nameof(configuration));
+            }
+
+            services.TryAddEnumerable(ServiceDescriptor.Singleton<IManagementOptions>(new CloudFoundryManagementOptions(configuration)));
+            services.TryAddSingleton(provider => provider.GetServices<IManagementOptions>().OfType<CloudFoundryManagementOptions>().First());
+
+            services.TryAddSingleton<ICloudFoundryOptions>(new CloudFoundryEndpointOptions(configuration));
+
+            services.TryAddSingleton(provider =>
+            {
+                var options = provider.GetService<ICloudFoundryOptions>();
+                var mgmtOptions = provider.GetServices<IManagementOptions>().OfType<CloudFoundryManagementOptions>().SingleOrDefault();
+                mgmtOptions.EndpointOptions.Add(options);
+
+                return new CloudFoundryEndpoint(options, mgmtOptions);
+            });
+
+            return services;
+        }
+    }
+}

--- a/src/Management/src/EndpointBase/DbMigrations/ServiceCollectionExtensions.cs
+++ b/src/Management/src/EndpointBase/DbMigrations/ServiceCollectionExtensions.cs
@@ -1,0 +1,44 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Steeltoe.Management;
+using Steeltoe.Management.Endpoint.DbMigrations;
+using System;
+
+namespace Microsoft.Extensions.DependencyInjection
+{
+    /// <summary>
+    /// Add services used by the DB Migrations actuator
+    /// </summary>
+    public static partial class ServiceCollectionExtensions
+    {
+        /// <summary>
+        /// Adds the services used by the DB Migrations actuator
+        /// </summary>
+        /// <param name="services">Reference to the service collection</param>
+        /// <param name="configuration">Reference to the configuration system</param>
+        /// <returns>A reference to the service collection</returns>
+        public static IServiceCollection AddDbMigrationsActuatorServices(this IServiceCollection services, IConfiguration configuration)
+        {
+            if (services == null)
+            {
+                throw new ArgumentNullException(nameof(services));
+            }
+
+            if (configuration == null)
+            {
+                throw new ArgumentNullException(nameof(configuration));
+            }
+
+            var options = new DbMigrationsEndpointOptions(configuration);
+            services.TryAddSingleton<IDbMigrationsOptions>(options);
+            services.TryAddEnumerable(ServiceDescriptor.Singleton(typeof(IEndpointOptions), options));
+            services.TryAddSingleton<DbMigrationsEndpoint>();
+
+            return services;
+        }
+    }
+}

--- a/src/Management/src/EndpointBase/Env/ServiceCollectionExtensions.cs
+++ b/src/Management/src/EndpointBase/Env/ServiceCollectionExtensions.cs
@@ -1,0 +1,44 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Steeltoe.Management;
+using Steeltoe.Management.Endpoint.Env;
+using System;
+
+namespace Microsoft.Extensions.DependencyInjection
+{
+    /// <summary>
+    /// Add services used by the Env actuator
+    /// </summary>
+    public static partial class ServiceCollectionExtensions
+    {
+        /// <summary>
+        /// Adds the services used by the Env actuator
+        /// </summary>
+        /// <param name="services">Reference to the service collection</param>
+        /// <param name="configuration">Reference to the configuration system</param>
+        /// <returns>A reference to the service collection</returns>
+        public static IServiceCollection AddEnvActuatorServices(this IServiceCollection services, IConfiguration configuration)
+        {
+            if (services == null)
+            {
+                throw new ArgumentNullException(nameof(services));
+            }
+
+            if (configuration == null)
+            {
+                throw new ArgumentNullException(nameof(configuration));
+            }
+
+            var options = new EnvEndpointOptions(configuration);
+            services.TryAddSingleton<IEnvOptions>(options);
+            services.TryAddEnumerable(ServiceDescriptor.Singleton(typeof(IEndpointOptions), options));
+            services.TryAddSingleton<EnvEndpoint>();
+
+            return services;
+        }
+    }
+}

--- a/src/Management/src/EndpointBase/Health/ServiceCollectionExtensions.cs
+++ b/src/Management/src/EndpointBase/Health/ServiceCollectionExtensions.cs
@@ -1,0 +1,44 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Steeltoe.Management;
+using Steeltoe.Management.Endpoint.Health;
+using System;
+
+namespace Microsoft.Extensions.DependencyInjection
+{
+    /// <summary>
+    /// Add services used by the Health actuator
+    /// </summary>
+    public static partial class ServiceCollectionExtensions
+    {
+        /// <summary>
+        /// Adds the services used by the Health actuator
+        /// </summary>
+        /// <param name="services">Reference to the service collection</param>
+        /// <param name="configuration">Reference to the configuration system</param>
+        /// <returns>A reference to the service collection</returns>
+        public static IServiceCollection AddHealthActuatorServices(this IServiceCollection services, IConfiguration configuration)
+        {
+            if (services == null)
+            {
+                throw new ArgumentNullException(nameof(services));
+            }
+
+            if (configuration == null)
+            {
+                throw new ArgumentNullException(nameof(configuration));
+            }
+
+            var options = new HealthEndpointOptions(configuration);
+            services.TryAddSingleton<IHealthOptions>(options);
+            services.TryAddEnumerable(ServiceDescriptor.Singleton(typeof(IEndpointOptions), options));
+            services.TryAddSingleton<HealthEndpoint>();
+
+            return services;
+        }
+    }
+}

--- a/src/Management/src/EndpointBase/HeapDump/ServiceCollectionExtensions.cs
+++ b/src/Management/src/EndpointBase/HeapDump/ServiceCollectionExtensions.cs
@@ -1,0 +1,44 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Steeltoe.Management;
+using Steeltoe.Management.Endpoint.HeapDump;
+using System;
+
+namespace Microsoft.Extensions.DependencyInjection
+{
+    /// <summary>
+    /// Add services used by the HeapDump actuator
+    /// </summary>
+    public static partial class ServiceCollectionExtensions
+    {
+        /// <summary>
+        /// Adds the services used by the Heap Dump actuator
+        /// </summary>
+        /// <param name="services">Reference to the service collection</param>
+        /// <param name="configuration">Reference to the configuration system</param>
+        /// <returns>A reference to the service collection</returns>
+        public static IServiceCollection AddHeapDumpActuatorServices(this IServiceCollection services, IConfiguration configuration)
+        {
+            if (services == null)
+            {
+                throw new ArgumentNullException(nameof(services));
+            }
+
+            if (configuration == null)
+            {
+                throw new ArgumentNullException(nameof(configuration));
+            }
+
+            var options = new HeapDumpEndpointOptions(configuration);
+            services.TryAddSingleton<IHeapDumpOptions>(options);
+            services.TryAddEnumerable(ServiceDescriptor.Singleton(typeof(IEndpointOptions), options));
+            services.TryAddSingleton<HeapDumpEndpoint>();
+
+            return services;
+        }
+    }
+}

--- a/src/Management/src/EndpointBase/Hypermedia/ServiceCollectionExtensions.cs
+++ b/src/Management/src/EndpointBase/Hypermedia/ServiceCollectionExtensions.cs
@@ -1,0 +1,44 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Steeltoe.Management;
+using Steeltoe.Management.Endpoint.Hypermedia;
+using System;
+
+namespace Microsoft.Extensions.DependencyInjection
+{
+    /// <summary>
+    /// Add services used by the Hypermedia actuator
+    /// </summary>
+    public static partial class ServiceCollectionExtensions
+    {
+        /// <summary>
+        /// Adds the services used by the Hypermedia actuator
+        /// </summary>
+        /// <param name="services">Reference to the service collection</param>
+        /// <param name="configuration">Reference to the configuration system</param>
+        /// <returns>A reference to the service collection</returns>
+        public static IServiceCollection AddHypermediaActuatorServices(this IServiceCollection services, IConfiguration configuration)
+        {
+            if (services == null)
+            {
+                throw new ArgumentNullException(nameof(services));
+            }
+
+            if (configuration == null)
+            {
+                throw new ArgumentNullException(nameof(configuration));
+            }
+
+            var options = new HypermediaEndpointOptions(configuration);
+            services.TryAddSingleton<IActuatorHypermediaOptions>(options);
+            services.TryAddEnumerable(ServiceDescriptor.Singleton(typeof(IEndpointOptions), options));
+            services.TryAddSingleton<ActuatorEndpoint>();
+
+            return services;
+        }
+    }
+}

--- a/src/Management/src/EndpointBase/Info/ServiceCollectionExtensions.cs
+++ b/src/Management/src/EndpointBase/Info/ServiceCollectionExtensions.cs
@@ -1,0 +1,44 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Steeltoe.Management;
+using Steeltoe.Management.Endpoint.Info;
+using System;
+
+namespace Microsoft.Extensions.DependencyInjection
+{
+    /// <summary>
+    /// Add services used by the Info actuator
+    /// </summary>
+    public static partial class ServiceCollectionExtensions
+    {
+        /// <summary>
+        /// Adds the services used by the Info actuator
+        /// </summary>
+        /// <param name="services">Reference to the service collection</param>
+        /// <param name="configuration">Reference to the configuration system</param>
+        /// <returns>A reference to the service collection</returns>
+        public static IServiceCollection AddInfoActuatorServices(this IServiceCollection services, IConfiguration configuration)
+        {
+            if (services == null)
+            {
+                throw new ArgumentNullException(nameof(services));
+            }
+
+            if (configuration == null)
+            {
+                throw new ArgumentNullException(nameof(configuration));
+            }
+
+            var options = new InfoEndpointOptions(configuration);
+            services.TryAddSingleton<IInfoOptions>(options);
+            services.TryAddEnumerable(ServiceDescriptor.Singleton(typeof(IEndpointOptions), options));
+            services.TryAddSingleton<InfoEndpoint>();
+
+            return services;
+        }
+    }
+}

--- a/src/Management/src/EndpointBase/Loggers/ServiceCollectionExtensions.cs
+++ b/src/Management/src/EndpointBase/Loggers/ServiceCollectionExtensions.cs
@@ -1,0 +1,44 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Steeltoe.Management;
+using Steeltoe.Management.Endpoint.Loggers;
+using System;
+
+namespace Microsoft.Extensions.DependencyInjection
+{
+    /// <summary>
+    /// Add services used by the Loggers actuator
+    /// </summary>
+    public static partial class ServiceCollectionExtensions
+    {
+        /// <summary>
+        /// Adds the services used by the Loggers actuator
+        /// </summary>
+        /// <param name="services">Reference to the service collection</param>
+        /// <param name="configuration">Reference to the configuration system</param>
+        /// <returns>A reference to the service collection</returns>
+        public static IServiceCollection AddLoggersActuatorServices(this IServiceCollection services, IConfiguration configuration)
+        {
+            if (services == null)
+            {
+                throw new ArgumentNullException(nameof(services));
+            }
+
+            if (configuration == null)
+            {
+                throw new ArgumentNullException(nameof(configuration));
+            }
+
+            var options = new LoggersEndpointOptions(configuration);
+            services.TryAddSingleton<ILoggersOptions>(options);
+            services.TryAddEnumerable(ServiceDescriptor.Singleton(typeof(IEndpointOptions), options));
+            services.TryAddSingleton<LoggersEndpoint>();
+
+            return services;
+        }
+    }
+}

--- a/src/Management/src/EndpointBase/Mappings/ServiceCollectionExtensions.cs
+++ b/src/Management/src/EndpointBase/Mappings/ServiceCollectionExtensions.cs
@@ -1,0 +1,44 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Steeltoe.Management;
+using Steeltoe.Management.Endpoint.Mappings;
+using System;
+
+namespace Microsoft.Extensions.DependencyInjection
+{
+    /// <summary>
+    /// Add services used by the Mappings actuator
+    /// </summary>
+    public static partial class ServiceCollectionExtensions
+    {
+        /// <summary>
+        /// Adds the services used by the Mappings actuator
+        /// </summary>
+        /// <param name="services">Reference to the service collection</param>
+        /// <param name="configuration">Reference to the configuration system</param>
+        /// <returns>A reference to the service collection</returns>
+        public static IServiceCollection AddMappingsActuatorServices(this IServiceCollection services, IConfiguration configuration)
+        {
+            if (services == null)
+            {
+                throw new ArgumentNullException(nameof(services));
+            }
+
+            if (configuration == null)
+            {
+                throw new ArgumentNullException(nameof(configuration));
+            }
+
+            var options = new MappingsEndpointOptions(configuration);
+            services.TryAddSingleton<IMappingsOptions>(options);
+            services.TryAddEnumerable(ServiceDescriptor.Singleton(typeof(IEndpointOptions), options));
+            services.TryAddSingleton<MappingsEndpoint>();
+
+            return services;
+        }
+    }
+}

--- a/src/Management/src/EndpointBase/Metrics/ServiceCollectionExtensions.cs
+++ b/src/Management/src/EndpointBase/Metrics/ServiceCollectionExtensions.cs
@@ -1,0 +1,70 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Steeltoe.Management;
+using Steeltoe.Management.Endpoint.Metrics;
+using System;
+
+namespace Microsoft.Extensions.DependencyInjection
+{
+    /// <summary>
+    /// Add services used by the Metrics actuator
+    /// </summary>
+    public static partial class ServiceCollectionExtensions
+    {
+        /// <summary>
+        /// Adds the services used by the Metrics actuator
+        /// </summary>
+        /// <param name="services">Reference to the service collection</param>
+        /// <param name="configuration">Reference to the configuration system</param>
+        /// <returns>A reference to the service collection</returns>
+        public static IServiceCollection AddMetricsActuatorServices(this IServiceCollection services, IConfiguration configuration)
+        {
+            if (services == null)
+            {
+                throw new ArgumentNullException(nameof(services));
+            }
+
+            if (configuration == null)
+            {
+                throw new ArgumentNullException(nameof(configuration));
+            }
+
+            var options = new MetricsEndpointOptions(configuration);
+            services.TryAddSingleton<IMetricsEndpointOptions>(options);
+            services.TryAddEnumerable(ServiceDescriptor.Singleton(typeof(IEndpointOptions), options));
+            services.TryAddSingleton<MetricsEndpoint>();
+
+            return services;
+        }
+
+        /// <summary>
+        /// Adds the services used by the Prometheus actuator
+        /// </summary>
+        /// <param name="services">Reference to the service collection</param>
+        /// <param name="configuration">Reference to the configuration system</param>
+        /// <returns>A reference to the service collection</returns>
+        public static IServiceCollection AddPrometheusActuatorServices(this IServiceCollection services, IConfiguration configuration)
+        {
+            if (services == null)
+            {
+                throw new ArgumentNullException(nameof(services));
+            }
+
+            if (configuration == null)
+            {
+                throw new ArgumentNullException(nameof(configuration));
+            }
+
+            var options = new PrometheusEndpointOptions(configuration);
+            services.TryAddSingleton<IPrometheusEndpointOptions>(options);
+            services.TryAddEnumerable(ServiceDescriptor.Singleton(typeof(IEndpointOptions), options));
+            services.TryAddSingleton<PrometheusScraperEndpoint>();
+
+            return services;
+        }
+    }
+}

--- a/src/Management/src/EndpointBase/Refresh/ServiceCollectionExtensions.cs
+++ b/src/Management/src/EndpointBase/Refresh/ServiceCollectionExtensions.cs
@@ -1,0 +1,44 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Steeltoe.Management;
+using Steeltoe.Management.Endpoint.Refresh;
+using System;
+
+namespace Microsoft.Extensions.DependencyInjection
+{
+    /// <summary>
+    /// Add services used by the Refresh actuator
+    /// </summary>
+    public static partial class ServiceCollectionExtensions
+    {
+        /// <summary>
+        /// Adds the services used by the Refresh actuator
+        /// </summary>
+        /// <param name="services">Reference to the service collection</param>
+        /// <param name="configuration">Reference to the configuration system</param>
+        /// <returns>A reference to the service collection</returns>
+        public static IServiceCollection AddRefreshActuatorServices(this IServiceCollection services, IConfiguration configuration)
+        {
+            if (services == null)
+            {
+                throw new ArgumentNullException(nameof(services));
+            }
+
+            if (configuration == null)
+            {
+                throw new ArgumentNullException(nameof(configuration));
+            }
+
+            var options = new RefreshEndpointOptions(configuration);
+            services.TryAddSingleton<IRefreshOptions>(options);
+            services.TryAddEnumerable(ServiceDescriptor.Singleton(typeof(IEndpointOptions), options));
+            services.TryAddSingleton<RefreshEndpoint>();
+
+            return services;
+        }
+    }
+}

--- a/src/Management/src/EndpointBase/Steeltoe.Management.EndpointBase.csproj
+++ b/src/Management/src/EndpointBase/Steeltoe.Management.EndpointBase.csproj
@@ -16,6 +16,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Diagnostics.NETCore.Client" Version="0.2.61701" />
     <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="$(ExtensionsVersion)" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(ExtensionsVersion)" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="$(ExtensionsVersion)" />
     <PackageReference Include="Microsoft.DiaSymReader" Version="$(SymReaderVersion)" />
     <PackageReference Include="Microsoft.DiaSymReader.PortablePdb" Version="$(SymReaderPortableVersion)" />

--- a/src/Management/src/EndpointBase/ThreadDump/ServiceCollectionExtensions.cs
+++ b/src/Management/src/EndpointBase/ThreadDump/ServiceCollectionExtensions.cs
@@ -1,0 +1,60 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Steeltoe.Management;
+using Steeltoe.Management.Endpoint;
+using Steeltoe.Management.Endpoint.ThreadDump;
+using System;
+
+namespace Microsoft.Extensions.DependencyInjection
+{
+    /// <summary>
+    /// Add services used by the ThreadDump actuator
+    /// </summary>
+    public static partial class ServiceCollectionExtensions
+    {
+        /// <summary>
+        /// Adds the services used by the Thread Dump actuator
+        /// </summary>
+        /// <param name="services">Reference to the service collection</param>
+        /// <param name="configuration">Reference to the configuration system</param>
+        /// <param name="version">The media version to use</param>
+        /// <returns>A reference to the service collection</returns>
+        public static IServiceCollection AddThreadDumpActuatorServices(this IServiceCollection services, IConfiguration configuration, MediaTypeVersion version)
+        {
+            if (services == null)
+            {
+                throw new ArgumentNullException(nameof(services));
+            }
+
+            if (configuration == null)
+            {
+                throw new ArgumentNullException(nameof(configuration));
+            }
+
+            var options = new ThreadDumpEndpointOptions(configuration);
+            if (version == MediaTypeVersion.V1)
+            {
+                services.TryAddSingleton<ThreadDumpEndpoint>();
+            }
+            else
+            {
+                if (options.Id == "dump")
+                {
+                    options.Id = "threaddump";
+                }
+
+                services.TryAddSingleton<ThreadDumpEndpoint_v2>();
+            }
+
+            services.TryAddSingleton<IThreadDumpOptions>(options);
+            services.TryAddSingleton<IThreadDumper, ThreadDumper>();
+            services.TryAddEnumerable(ServiceDescriptor.Singleton(typeof(IEndpointOptions), options));
+
+            return services;
+        }
+    }
+}

--- a/src/Management/src/EndpointBase/Trace/ServiceCollectionExtensions.cs
+++ b/src/Management/src/EndpointBase/Trace/ServiceCollectionExtensions.cs
@@ -1,0 +1,56 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Steeltoe.Management;
+using Steeltoe.Management.Endpoint;
+using Steeltoe.Management.Endpoint.Trace;
+using System;
+
+namespace Microsoft.Extensions.DependencyInjection
+{
+    /// <summary>
+    /// Add services used by the Trace actuator
+    /// </summary>
+    public static partial class ServiceCollectionExtensions
+    {
+        /// <summary>
+        /// Adds the services used by the Trace actuator
+        /// </summary>
+        /// <param name="services">Reference to the service collection</param>
+        /// <param name="configuration">Reference to the configuration system</param>
+        /// <param name="version">The media version to use</param>
+        /// <returns>A reference to the service collection</returns>
+        public static IServiceCollection AddTraceActuatorServices(this IServiceCollection services, IConfiguration configuration, MediaTypeVersion version)
+        {
+            if (services == null)
+            {
+                throw new ArgumentNullException(nameof(services));
+            }
+
+            if (configuration == null)
+            {
+                throw new ArgumentNullException(nameof(configuration));
+            }
+
+            switch (version)
+            {
+                case MediaTypeVersion.V1:
+                    var options = new TraceEndpointOptions(configuration);
+                    services.TryAddSingleton<ITraceOptions>(options);
+                    services.TryAddSingleton<TraceEndpoint>();
+                    services.TryAddEnumerable(ServiceDescriptor.Singleton(typeof(IEndpointOptions), options));
+                    break;
+                default:
+                    var options2 = new HttpTraceEndpointOptions(configuration);
+                    services.TryAddSingleton<ITraceOptions>(options2);
+                    services.TryAddEnumerable(ServiceDescriptor.Singleton(typeof(IEndpointOptions), options2));
+                    break;
+            }
+
+            return services;
+        }
+    }
+}

--- a/src/Management/src/EndpointCore/ActuatorServiceCollectionExtensions.cs
+++ b/src/Management/src/EndpointCore/ActuatorServiceCollectionExtensions.cs
@@ -18,19 +18,18 @@ using Steeltoe.Management.Endpoint.Refresh;
 using Steeltoe.Management.Endpoint.ThreadDump;
 using Steeltoe.Management.Endpoint.Trace;
 using System;
+using System.Diagnostics.CodeAnalysis;
 using EndpointServiceCollectionExtensions = Steeltoe.Management.Endpoint.HeapDump.EndpointServiceCollectionExtensions;
 
 namespace Steeltoe.Management.Endpoint
 {
     public static class ActuatorServiceCollectionExtensions
     {
+        [Obsolete("No longer in use. Retained for binary compatibility")]
+        [ExcludeFromCodeCoverage]
         public static void RegisterEndpointOptions(this IServiceCollection services, IEndpointOptions options)
         {
-            var mgmtOptions = services.BuildServiceProvider().GetServices<IManagementOptions>();
-            foreach (var mgmtOption in mgmtOptions)
-            {
-                mgmtOption.EndpointOptions.Add(options);
-            }
+            // the code that was running here is now handled in ActuatorRouteBuilderExtensions
         }
 
         public static void AddAllActuators(this IServiceCollection services, IConfiguration config = null, MediaTypeVersion version = MediaTypeVersion.V2)

--- a/src/Management/src/EndpointCore/CloudFoundry/EndpointServiceCollectionExtensions.cs
+++ b/src/Management/src/EndpointCore/CloudFoundry/EndpointServiceCollectionExtensions.cs
@@ -4,9 +4,7 @@
 
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
 using System;
-using System.Linq;
 
 namespace Steeltoe.Management.Endpoint.CloudFoundry
 {
@@ -25,20 +23,7 @@ namespace Steeltoe.Management.Endpoint.CloudFoundry
                 throw new ArgumentNullException(nameof(config));
             }
 
-            services.TryAddEnumerable(ServiceDescriptor.Singleton<IManagementOptions>(new CloudFoundryManagementOptions(config)));
-            services.TryAddSingleton(provider => provider.GetServices<IManagementOptions>().OfType<CloudFoundryManagementOptions>().First());
-
-            services.TryAddSingleton<ICloudFoundryOptions>(new CloudFoundryEndpointOptions(config));
-
-            services.TryAddSingleton(provider =>
-            {
-                var options = provider.GetService<ICloudFoundryOptions>();
-                var mgmtOptions = provider.GetServices<IManagementOptions>().OfType<CloudFoundryManagementOptions>().SingleOrDefault();
-                mgmtOptions.EndpointOptions.Add(options);
-
-                return new CloudFoundryEndpoint(options, mgmtOptions);
-            });
-
+            services.AddCloudFoundryActuatorServices(config);
             services.AddActuatorEndpointMapping<CloudFoundryEndpoint>();
         }
     }

--- a/src/Management/src/EndpointCore/DbMigrations/EndpointServiceCollectionExtensions.cs
+++ b/src/Management/src/EndpointCore/DbMigrations/EndpointServiceCollectionExtensions.cs
@@ -4,7 +4,6 @@
 
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
 using Steeltoe.Management.Endpoint.Hypermedia;
 using System;
 
@@ -31,10 +30,7 @@ namespace Steeltoe.Management.Endpoint.DbMigrations
             }
 
             services.AddActuatorManagementOptions(config);
-            var options = new DbMigrationsEndpointOptions(config);
-            services.TryAddSingleton<IDbMigrationsOptions>(options);
-            services.RegisterEndpointOptions(options);
-            services.TryAddSingleton<DbMigrationsEndpoint>();
+            services.AddDbMigrationsActuatorServices(config);
             services.AddActuatorEndpointMapping<DbMigrationsEndpoint>();
         }
     }

--- a/src/Management/src/EndpointCore/Env/EndpointServiceCollectionExtensions.cs
+++ b/src/Management/src/EndpointCore/Env/EndpointServiceCollectionExtensions.cs
@@ -44,10 +44,7 @@ namespace Steeltoe.Management.Endpoint.Env
             });
 
             services.AddActuatorManagementOptions(config);
-            var options = new EnvEndpointOptions(config);
-            services.TryAddSingleton<IEnvOptions>(options);
-            services.RegisterEndpointOptions(options);
-            services.TryAddSingleton<EnvEndpoint>();
+            services.AddEnvActuatorServices(config);
             services.AddActuatorEndpointMapping<EnvEndpoint>();
         }
     }

--- a/src/Management/src/EndpointCore/Health/EndpointServiceCollectionExtensions.cs
+++ b/src/Management/src/EndpointCore/Health/EndpointServiceCollectionExtensions.cs
@@ -68,10 +68,8 @@ namespace Steeltoe.Management.Endpoint.Health
             }
 
             services.AddActuatorManagementOptions(config);
+            services.AddHealthActuatorServices(config);
 
-            var options = new HealthEndpointOptions(config);
-            services.TryAddSingleton<IHealthOptions>(options);
-            services.RegisterEndpointOptions(options);
             AddHealthContributors(services, contributors);
 
             services.TryAddSingleton(aggregator);

--- a/src/Management/src/EndpointCore/HeapDump/EndpointServiceCollectionExtensions.cs
+++ b/src/Management/src/EndpointCore/HeapDump/EndpointServiceCollectionExtensions.cs
@@ -40,10 +40,7 @@ namespace Steeltoe.Management.Endpoint.HeapDump
             if (IsHeapDumpSupported())
             {
                 services.AddActuatorManagementOptions(config);
-
-                var options = new HeapDumpEndpointOptions(config);
-                services.TryAddSingleton<IHeapDumpOptions>(options);
-                services.RegisterEndpointOptions(options);
+                services.AddHeapDumpActuatorServices(config);
 
                 if (Platform.IsWindows)
                 {
@@ -54,7 +51,6 @@ namespace Steeltoe.Management.Endpoint.HeapDump
                     services.TryAddSingleton<IHeapDumper, LinuxHeapDumper>();
                 }
 
-                services.TryAddSingleton<HeapDumpEndpoint>();
                 services.AddActuatorEndpointMapping<HeapDumpEndpoint>();
             }
         }

--- a/src/Management/src/EndpointCore/Hypermedia/EndpointServiceCollectionExtensions.cs
+++ b/src/Management/src/EndpointCore/Hypermedia/EndpointServiceCollectionExtensions.cs
@@ -26,16 +26,7 @@ namespace Steeltoe.Management.Endpoint.Hypermedia
             }
 
             services.AddActuatorManagementOptions(config);
-            services.TryAddSingleton<IActuatorHypermediaOptions>(provider =>
-                {
-                    var mgmtOptions = provider
-                        .GetServices<IManagementOptions>().Single(m => m.GetType() == typeof(ActuatorManagementOptions));
-                    var opts = new HypermediaEndpointOptions(config);
-                    mgmtOptions.EndpointOptions.Add(opts);
-                    return opts;
-                });
-
-            services.TryAddSingleton<ActuatorEndpoint>();
+            services.AddHypermediaActuatorServices(config);
             services.AddActuatorEndpointMapping<ActuatorEndpoint>();
         }
 

--- a/src/Management/src/EndpointCore/Info/EndpointServiceCollectionExtensions.cs
+++ b/src/Management/src/EndpointCore/Info/EndpointServiceCollectionExtensions.cs
@@ -54,13 +54,10 @@ namespace Steeltoe.Management.Endpoint.Info
             }
 
             services.AddActuatorManagementOptions(config);
-
-            var options = new InfoEndpointOptions(config);
-            services.TryAddSingleton<IInfoOptions>(options);
-            services.RegisterEndpointOptions(options);
-            AddContributors(services, contributors);
-            services.TryAddSingleton<InfoEndpoint>();
+            services.AddInfoActuatorServices(config);
             services.AddActuatorEndpointMapping<InfoEndpoint>();
+
+            AddContributors(services, contributors);
         }
 
         private static void AddContributors(IServiceCollection services, params IInfoContributor[] contributors)

--- a/src/Management/src/EndpointCore/Loggers/EndpointServiceCollectionExtensions.cs
+++ b/src/Management/src/EndpointCore/Loggers/EndpointServiceCollectionExtensions.cs
@@ -4,7 +4,6 @@
 
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
 using Steeltoe.Management.Endpoint.Hypermedia;
 using System;
 
@@ -31,11 +30,7 @@ namespace Steeltoe.Management.Endpoint.Loggers
             }
 
             services.AddActuatorManagementOptions(config);
-
-            var options = new LoggersEndpointOptions(config);
-            services.TryAddSingleton<ILoggersOptions>(options);
-            services.RegisterEndpointOptions(options);
-            services.TryAddSingleton<LoggersEndpoint>();
+            services.AddLoggersActuatorServices(config);
             services.AddActuatorEndpointMapping<LoggersEndpoint>();
         }
     }

--- a/src/Management/src/EndpointCore/Mappings/EndpointServiceCollectionExtensions.cs
+++ b/src/Management/src/EndpointCore/Mappings/EndpointServiceCollectionExtensions.cs
@@ -31,12 +31,10 @@ namespace Steeltoe.Management.Endpoint.Mappings
             }
 
             services.AddActuatorManagementOptions(config);
-            var options = new MappingsEndpointOptions(config);
-            services.TryAddSingleton<IMappingsOptions>(options);
-            services.RegisterEndpointOptions(options);
-            services.TryAddSingleton<IRouteMappings, RouteMappings>();
-            services.TryAddSingleton<MappingsEndpoint>();
+            services.AddMappingsActuatorServices(config);
             services.AddActuatorEndpointMapping<MappingsEndpoint>();
+
+            services.TryAddSingleton<IRouteMappings, RouteMappings>();
         }
     }
 }

--- a/src/Management/src/EndpointCore/Metrics/EndpointServiceCollectionExtensions.cs
+++ b/src/Management/src/EndpointCore/Metrics/EndpointServiceCollectionExtensions.cs
@@ -39,10 +39,7 @@ namespace Steeltoe.Management.Endpoint.Metrics
             services.TryAddEnumerable(ServiceDescriptor.Singleton<IHostedService, DiagnosticServices>());
 
             services.AddActuatorManagementOptions(config);
-
-            var options = new MetricsEndpointOptions(config);
-            services.TryAddSingleton<IMetricsEndpointOptions>(options);
-            services.RegisterEndpointOptions(options);
+            services.AddMetricsActuatorServices(config);
 
             var observerOptions = new MetricsObserverOptions(config);
             services.TryAddSingleton<IMetricsObserverOptions>(observerOptions);
@@ -53,7 +50,6 @@ namespace Steeltoe.Management.Endpoint.Metrics
             services.AddOpenTelemetry();
 
             services.TryAddSingleton((provider) => provider.GetServices<MetricExporter>().OfType<SteeltoeExporter>().SingleOrDefault());
-            services.TryAddSingleton<MetricsEndpoint>();
             services.AddActuatorEndpointMapping<MetricsEndpoint>();
         }
 
@@ -81,15 +77,12 @@ namespace Steeltoe.Management.Endpoint.Metrics
             var observerOptions = new MetricsObserverOptions(config);
             services.TryAddSingleton<IMetricsObserverOptions>(observerOptions);
 
-            var options = new PrometheusEndpointOptions(config);
-            services.TryAddSingleton<IPrometheusEndpointOptions>(options);
-            services.RegisterEndpointOptions(options);
+            services.AddPrometheusActuatorServices(config);
 
             AddMetricsObservers(services, observerOptions);
             services.TryAddEnumerable(ServiceDescriptor.Singleton<MetricExporter, PrometheusExporter>());
             services.AddOpenTelemetry();
             services.TryAddSingleton((provider) => provider.GetServices<MetricExporter>().OfType<PrometheusExporter>().SingleOrDefault());
-            services.TryAddSingleton<PrometheusScraperEndpoint>();
             services.AddActuatorEndpointMapping<PrometheusScraperEndpoint>();
         }
 

--- a/src/Management/src/EndpointCore/Refresh/EndpointServiceCollectionExtensions.cs
+++ b/src/Management/src/EndpointCore/Refresh/EndpointServiceCollectionExtensions.cs
@@ -4,7 +4,6 @@
 
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
 using Steeltoe.Management.Endpoint.Hypermedia;
 using System;
 
@@ -31,10 +30,7 @@ namespace Steeltoe.Management.Endpoint.Refresh
             }
 
             services.AddActuatorManagementOptions(config);
-            var options = new RefreshEndpointOptions(config);
-            services.TryAddSingleton<IRefreshOptions>(options);
-            services.RegisterEndpointOptions(options);
-            services.TryAddSingleton<RefreshEndpoint>();
+            services.AddRefreshActuatorServices(config);
             services.AddActuatorEndpointMapping<RefreshEndpoint>();
         }
     }

--- a/src/Management/src/EndpointCore/ThreadDump/EndpointServiceCollectionExtensions.cs
+++ b/src/Management/src/EndpointCore/ThreadDump/EndpointServiceCollectionExtensions.cs
@@ -4,7 +4,6 @@
 
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
 using Steeltoe.Management.Endpoint.Hypermedia;
 using System;
 using System.Runtime.InteropServices;
@@ -36,37 +35,17 @@ namespace Steeltoe.Management.Endpoint.ThreadDump
                 throw new ArgumentNullException(nameof(config));
             }
 
-            if (IsThreadDumpSupported())
+            services.AddActuatorManagementOptions(config);
+            services.AddThreadDumpActuatorServices(config, version);
+
+            if (version == MediaTypeVersion.V1)
             {
-                services.AddActuatorManagementOptions(config);
-                var options = new ThreadDumpEndpointOptions(config);
-                if (version == MediaTypeVersion.V1)
-                {
-                    services.TryAddSingleton<ThreadDumpEndpoint>();
-                    services.AddActuatorEndpointMapping<ThreadDumpEndpoint>();
-                }
-                else
-                {
-                    if (options.Id == "dump")
-                    {
-                        options.Id = "threaddump";
-                    }
-
-                    services.TryAddSingleton<ThreadDumpEndpoint_v2>();
-                    services.AddActuatorEndpointMapping<ThreadDumpEndpoint_v2>();
-                }
-
-                services.TryAddSingleton<IThreadDumpOptions>(options);
-                services.RegisterEndpointOptions(options);
-                services.TryAddSingleton<IThreadDumper, ThreadDumper>();
+                services.AddActuatorEndpointMapping<ThreadDumpEndpoint>();
             }
-        }
-
-        private static bool IsThreadDumpSupported()
-        {
-            return
-                RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ||
-                RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
+            else
+            {
+                services.AddActuatorEndpointMapping<ThreadDumpEndpoint_v2>();
+            }
         }
     }
 }

--- a/src/Management/src/EndpointCore/Trace/EndpointServiceCollectionExtensions.cs
+++ b/src/Management/src/EndpointCore/Trace/EndpointServiceCollectionExtensions.cs
@@ -48,23 +48,18 @@ namespace Steeltoe.Management.Endpoint.Trace
             services.TryAddSingleton<IDiagnosticsManager, DiagnosticsManager>();
             services.TryAddEnumerable(ServiceDescriptor.Singleton<IHostedService, DiagnosticServices>());
             services.AddActuatorManagementOptions(config);
+            services.AddTraceActuatorServices(config, version);
+
             switch (version)
             {
                 case MediaTypeVersion.V1:
                     services.TryAddEnumerable(ServiceDescriptor.Singleton<IDiagnosticObserver, TraceDiagnosticObserver>());
                     services.TryAddSingleton<ITraceRepository>((p) => p.GetServices<IDiagnosticObserver>().OfType<TraceDiagnosticObserver>().Single());
-                    var options = new TraceEndpointOptions(config);
-                    services.TryAddSingleton<ITraceOptions>(options);
-                    services.RegisterEndpointOptions(options);
-                    services.TryAddSingleton<TraceEndpoint>();
                     services.AddActuatorEndpointMapping<TraceEndpoint>();
                     break;
                 default:
                     services.TryAddEnumerable(ServiceDescriptor.Singleton<IDiagnosticObserver, HttpTraceDiagnosticObserver>());
-                    var options2 = new HttpTraceEndpointOptions(config);
-                    services.TryAddSingleton<ITraceOptions>(options2);
-                    services.RegisterEndpointOptions(options2);
-                    services.TryAddSingleton(p => new HttpTraceEndpoint(options2, p.GetServices<IDiagnosticObserver>().OfType<HttpTraceDiagnosticObserver>().Single()));
+                    services.TryAddSingleton(p => new HttpTraceEndpoint(p.GetService<ITraceOptions>(), p.GetServices<IDiagnosticObserver>().OfType<HttpTraceDiagnosticObserver>().Single()));
                     services.AddActuatorEndpointMapping<HttpTraceEndpoint>();
                     break;
             }

--- a/src/Management/test/EndpointBase.Test/CloudFoundry/ServiceCollectionTests.cs
+++ b/src/Management/test/EndpointBase.Test/CloudFoundry/ServiceCollectionTests.cs
@@ -1,0 +1,30 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using Xunit;
+
+namespace Steeltoe.Management.Endpoint.Test.CloudFoundry
+{
+    public class ServiceCollectionTests
+    {
+        [Fact]
+        public void AddCloudFoundryActuatorServices_ThrowsOnNulls()
+        {
+            // Arrange
+            IServiceCollection services = null;
+            IServiceCollection services2 = new ServiceCollection();
+            IConfigurationRoot config = null;
+
+            // Act and Assert
+            var ex = Assert.Throws<ArgumentNullException>(() => ServiceCollectionExtensions.AddCloudFoundryActuatorServices(services, config));
+            Assert.Contains(nameof(services), ex.Message);
+
+            var ex2 = Assert.Throws<ArgumentNullException>(() => ServiceCollectionExtensions.AddCloudFoundryActuatorServices(services2, config));
+            Assert.Contains(nameof(config), ex2.Message);
+        }
+    }
+}

--- a/src/Management/test/EndpointBase.Test/DbMigrations/ServiceCollectionTests.cs
+++ b/src/Management/test/EndpointBase.Test/DbMigrations/ServiceCollectionTests.cs
@@ -1,0 +1,30 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using Xunit;
+
+namespace Steeltoe.Management.Endpoint.Test.DbMigrations
+{
+    public class ServiceCollectionTests
+    {
+        [Fact]
+        public void AddDbMigrationsActuatorServices_ThrowsOnNulls()
+        {
+            // Arrange
+            IServiceCollection services = null;
+            IServiceCollection services2 = new ServiceCollection();
+            IConfigurationRoot config = null;
+
+            // Act and Assert
+            var ex = Assert.Throws<ArgumentNullException>(() => ServiceCollectionExtensions.AddDbMigrationsActuatorServices(services, config));
+            Assert.Contains(nameof(services), ex.Message);
+
+            var ex2 = Assert.Throws<ArgumentNullException>(() => ServiceCollectionExtensions.AddDbMigrationsActuatorServices(services2, config));
+            Assert.Contains(nameof(config), ex2.Message);
+        }
+    }
+}

--- a/src/Management/test/EndpointBase.Test/Env/ServiceCollectionTests.cs
+++ b/src/Management/test/EndpointBase.Test/Env/ServiceCollectionTests.cs
@@ -1,0 +1,30 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using Xunit;
+
+namespace Steeltoe.Management.Endpoint.Test.Env
+{
+    public class ServiceCollectionTests
+    {
+        [Fact]
+        public void AddEnvActuatorServices_ThrowsOnNulls()
+        {
+            // Arrange
+            IServiceCollection services = null;
+            IServiceCollection services2 = new ServiceCollection();
+            IConfigurationRoot config = null;
+
+            // Act and Assert
+            var ex = Assert.Throws<ArgumentNullException>(() => ServiceCollectionExtensions.AddEnvActuatorServices(services, config));
+            Assert.Contains(nameof(services), ex.Message);
+
+            var ex2 = Assert.Throws<ArgumentNullException>(() => ServiceCollectionExtensions.AddEnvActuatorServices(services2, config));
+            Assert.Contains(nameof(config), ex2.Message);
+        }
+    }
+}

--- a/src/Management/test/EndpointBase.Test/Health/ServiceCollectionTests.cs
+++ b/src/Management/test/EndpointBase.Test/Health/ServiceCollectionTests.cs
@@ -1,0 +1,30 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using Xunit;
+
+namespace Steeltoe.Management.Endpoint.Test.Health
+{
+    public class ServiceCollectionTests
+    {
+        [Fact]
+        public void AddHealthActuatorServices_ThrowsOnNulls()
+        {
+            // Arrange
+            IServiceCollection services = null;
+            IServiceCollection services2 = new ServiceCollection();
+            IConfigurationRoot config = null;
+
+            // Act and Assert
+            var ex = Assert.Throws<ArgumentNullException>(() => ServiceCollectionExtensions.AddHealthActuatorServices(services, config));
+            Assert.Contains(nameof(services), ex.Message);
+
+            var ex2 = Assert.Throws<ArgumentNullException>(() => ServiceCollectionExtensions.AddHealthActuatorServices(services2, config));
+            Assert.Contains(nameof(config), ex2.Message);
+        }
+    }
+}

--- a/src/Management/test/EndpointBase.Test/HeapDump/ServiceCollectionTests.cs
+++ b/src/Management/test/EndpointBase.Test/HeapDump/ServiceCollectionTests.cs
@@ -1,0 +1,30 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using Xunit;
+
+namespace Steeltoe.Management.Endpoint.Test.HeapDump
+{
+    public class ServiceCollectionTests
+    {
+        [Fact]
+        public void AddHeapDumpActuatorServices_ThrowsOnNulls()
+        {
+            // Arrange
+            IServiceCollection services = null;
+            IServiceCollection services2 = new ServiceCollection();
+            IConfigurationRoot config = null;
+
+            // Act and Assert
+            var ex = Assert.Throws<ArgumentNullException>(() => ServiceCollectionExtensions.AddHeapDumpActuatorServices(services, config));
+            Assert.Contains(nameof(services), ex.Message);
+
+            var ex2 = Assert.Throws<ArgumentNullException>(() => ServiceCollectionExtensions.AddHeapDumpActuatorServices(services2, config));
+            Assert.Contains(nameof(config), ex2.Message);
+        }
+    }
+}

--- a/src/Management/test/EndpointBase.Test/Hypermedia/ServiceCollectionTests.cs
+++ b/src/Management/test/EndpointBase.Test/Hypermedia/ServiceCollectionTests.cs
@@ -1,0 +1,30 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using Xunit;
+
+namespace Steeltoe.Management.Endpoint.Test.Hypermedia
+{
+    public class ServiceCollectionTests
+    {
+        [Fact]
+        public void AddHypermediaActuatorServices_ThrowsOnNulls()
+        {
+            // Arrange
+            IServiceCollection services = null;
+            IServiceCollection services2 = new ServiceCollection();
+            IConfigurationRoot config = null;
+
+            // Act and Assert
+            var ex = Assert.Throws<ArgumentNullException>(() => ServiceCollectionExtensions.AddHypermediaActuatorServices(services, config));
+            Assert.Contains(nameof(services), ex.Message);
+
+            var ex2 = Assert.Throws<ArgumentNullException>(() => ServiceCollectionExtensions.AddHypermediaActuatorServices(services2, config));
+            Assert.Contains(nameof(config), ex2.Message);
+        }
+    }
+}

--- a/src/Management/test/EndpointBase.Test/Info/ServiceCollectionTests.cs
+++ b/src/Management/test/EndpointBase.Test/Info/ServiceCollectionTests.cs
@@ -1,0 +1,30 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using Xunit;
+
+namespace Steeltoe.Management.Endpoint.Test.Info
+{
+    public class ServiceCollectionTests
+    {
+        [Fact]
+        public void AddInfoActuatorServices_ThrowsOnNulls()
+        {
+            // Arrange
+            IServiceCollection services = null;
+            IServiceCollection services2 = new ServiceCollection();
+            IConfigurationRoot config = null;
+
+            // Act and Assert
+            var ex = Assert.Throws<ArgumentNullException>(() => ServiceCollectionExtensions.AddInfoActuatorServices(services, config));
+            Assert.Contains(nameof(services), ex.Message);
+
+            var ex2 = Assert.Throws<ArgumentNullException>(() => ServiceCollectionExtensions.AddInfoActuatorServices(services2, config));
+            Assert.Contains(nameof(config), ex2.Message);
+        }
+    }
+}

--- a/src/Management/test/EndpointBase.Test/Loggers/ServiceCollectionTests.cs
+++ b/src/Management/test/EndpointBase.Test/Loggers/ServiceCollectionTests.cs
@@ -1,0 +1,30 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using Xunit;
+
+namespace Steeltoe.Management.Endpoint.Test.Loggers
+{
+    public class ServiceCollectionTests
+    {
+        [Fact]
+        public void AddLoggersActuatorServices_ThrowsOnNulls()
+        {
+            // Arrange
+            IServiceCollection services = null;
+            IServiceCollection services2 = new ServiceCollection();
+            IConfigurationRoot config = null;
+
+            // Act and Assert
+            var ex = Assert.Throws<ArgumentNullException>(() => ServiceCollectionExtensions.AddLoggersActuatorServices(services, config));
+            Assert.Contains(nameof(services), ex.Message);
+
+            var ex2 = Assert.Throws<ArgumentNullException>(() => ServiceCollectionExtensions.AddLoggersActuatorServices(services2, config));
+            Assert.Contains(nameof(config), ex2.Message);
+        }
+    }
+}

--- a/src/Management/test/EndpointBase.Test/Mappings/ServiceCollectionTests.cs
+++ b/src/Management/test/EndpointBase.Test/Mappings/ServiceCollectionTests.cs
@@ -1,0 +1,30 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using Xunit;
+
+namespace Steeltoe.Management.Endpoint.Test.Mappings
+{
+    public class ServiceCollectionTests
+    {
+        [Fact]
+        public void AddMappingsActuatorServices_ThrowsOnNulls()
+        {
+            // Arrange
+            IServiceCollection services = null;
+            IServiceCollection services2 = new ServiceCollection();
+            IConfigurationRoot config = null;
+
+            // Act and Assert
+            var ex = Assert.Throws<ArgumentNullException>(() => ServiceCollectionExtensions.AddMappingsActuatorServices(services, config));
+            Assert.Contains(nameof(services), ex.Message);
+
+            var ex2 = Assert.Throws<ArgumentNullException>(() => ServiceCollectionExtensions.AddMappingsActuatorServices(services2, config));
+            Assert.Contains(nameof(config), ex2.Message);
+        }
+    }
+}

--- a/src/Management/test/EndpointBase.Test/Metrics/ServiceCollectionTests.cs
+++ b/src/Management/test/EndpointBase.Test/Metrics/ServiceCollectionTests.cs
@@ -1,0 +1,46 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using Xunit;
+
+namespace Steeltoe.Management.Endpoint.Test.Metrics
+{
+    public class ServiceCollectionTests
+    {
+        [Fact]
+        public void AddMetricsActuatorServices_ThrowsOnNulls()
+        {
+            // Arrange
+            IServiceCollection services = null;
+            IServiceCollection services2 = new ServiceCollection();
+            IConfigurationRoot config = null;
+
+            // Act and Assert
+            var ex = Assert.Throws<ArgumentNullException>(() => ServiceCollectionExtensions.AddMetricsActuatorServices(services, config));
+            Assert.Contains(nameof(services), ex.Message);
+
+            var ex2 = Assert.Throws<ArgumentNullException>(() => ServiceCollectionExtensions.AddMetricsActuatorServices(services2, config));
+            Assert.Contains(nameof(config), ex2.Message);
+        }
+
+        [Fact]
+        public void AddPrometheusActuatorServices_ThrowsOnNulls()
+        {
+            // Arrange
+            IServiceCollection services = null;
+            IServiceCollection services2 = new ServiceCollection();
+            IConfigurationRoot config = null;
+
+            // Act and Assert
+            var ex = Assert.Throws<ArgumentNullException>(() => ServiceCollectionExtensions.AddPrometheusActuatorServices(services, config));
+            Assert.Contains(nameof(services), ex.Message);
+
+            var ex2 = Assert.Throws<ArgumentNullException>(() => ServiceCollectionExtensions.AddPrometheusActuatorServices(services2, config));
+            Assert.Contains(nameof(config), ex2.Message);
+        }
+    }
+}

--- a/src/Management/test/EndpointBase.Test/Refresh/ServiceCollectionTests.cs
+++ b/src/Management/test/EndpointBase.Test/Refresh/ServiceCollectionTests.cs
@@ -1,0 +1,30 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using Xunit;
+
+namespace Steeltoe.Management.Endpoint.Test.Refresh
+{
+    public class ServiceCollectionTests
+    {
+        [Fact]
+        public void AddRefreshActuatorServices_ThrowsOnNulls()
+        {
+            // Arrange
+            IServiceCollection services = null;
+            IServiceCollection services2 = new ServiceCollection();
+            IConfigurationRoot config = null;
+
+            // Act and Assert
+            var ex = Assert.Throws<ArgumentNullException>(() => ServiceCollectionExtensions.AddRefreshActuatorServices(services, config));
+            Assert.Contains(nameof(services), ex.Message);
+
+            var ex2 = Assert.Throws<ArgumentNullException>(() => ServiceCollectionExtensions.AddRefreshActuatorServices(services2, config));
+            Assert.Contains(nameof(config), ex2.Message);
+        }
+    }
+}

--- a/src/Management/test/EndpointBase.Test/ThreadDump/ServiceCollectionTests.cs
+++ b/src/Management/test/EndpointBase.Test/ThreadDump/ServiceCollectionTests.cs
@@ -1,0 +1,30 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using Xunit;
+
+namespace Steeltoe.Management.Endpoint.Test.ThreadDump
+{
+    public class ServiceCollectionTests
+    {
+        [Fact]
+        public void AddThreadDumpActuatorServices_ThrowsOnNulls()
+        {
+            // Arrange
+            IServiceCollection services = null;
+            IServiceCollection services2 = new ServiceCollection();
+            IConfigurationRoot config = null;
+
+            // Act and Assert
+            var ex = Assert.Throws<ArgumentNullException>(() => ServiceCollectionExtensions.AddThreadDumpActuatorServices(services, config, MediaTypeVersion.V2));
+            Assert.Contains(nameof(services), ex.Message);
+
+            var ex2 = Assert.Throws<ArgumentNullException>(() => ServiceCollectionExtensions.AddThreadDumpActuatorServices(services2, config, MediaTypeVersion.V2));
+            Assert.Contains(nameof(config), ex2.Message);
+        }
+    }
+}

--- a/src/Management/test/EndpointBase.Test/Trace/ServiceCollectionTests.cs
+++ b/src/Management/test/EndpointBase.Test/Trace/ServiceCollectionTests.cs
@@ -1,0 +1,30 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using Xunit;
+
+namespace Steeltoe.Management.Endpoint.Test.Trace
+{
+    public class ServiceCollectionTests
+    {
+        [Fact]
+        public void AddTraceActuatorServices_ThrowsOnNulls()
+        {
+            // Arrange
+            IServiceCollection services = null;
+            IServiceCollection services2 = new ServiceCollection();
+            IConfigurationRoot config = null;
+
+            // Act and Assert
+            var ex = Assert.Throws<ArgumentNullException>(() => ServiceCollectionExtensions.AddTraceActuatorServices(services, config, MediaTypeVersion.V2));
+            Assert.Contains(nameof(services), ex.Message);
+
+            var ex2 = Assert.Throws<ArgumentNullException>(() => ServiceCollectionExtensions.AddTraceActuatorServices(services2, config, MediaTypeVersion.V2));
+            Assert.Contains(nameof(config), ex2.Message);
+        }
+    }
+}

--- a/src/Management/test/EndpointCore.Test/Hypermedia/EndpointMiddlewareTest.cs
+++ b/src/Management/test/EndpointCore.Test/Hypermedia/EndpointMiddlewareTest.cs
@@ -84,7 +84,7 @@ namespace Steeltoe.Management.Endpoint.Hypermedia.Test
             var json = await result.Content.ReadAsStringAsync();
 
             // assert
-            Assert.Equal("{\"type\":\"steeltoe\",\"_links\":{\"info\":{\"href\":\"http://localhost/actuator/info\",\"templated\":false},\"self\":{\"href\":\"http://localhost/actuator\",\"templated\":false}}}", json);
+            Assert.Equal("{\"type\":\"steeltoe\",\"_links\":{\"self\":{\"href\":\"http://localhost/actuator\",\"templated\":false},\"info\":{\"href\":\"http://localhost/actuator/info\",\"templated\":false}}}", json);
         }
 
         [Fact]
@@ -106,7 +106,7 @@ namespace Steeltoe.Management.Endpoint.Hypermedia.Test
             var json = await result.Content.ReadAsStringAsync();
 
             // assert
-            Assert.Equal("{\"type\":\"steeltoe\",\"_links\":{\"info\":{\"href\":\"http://localhost/info\",\"templated\":false},\"self\":{\"href\":\"http://localhost/\",\"templated\":false}}}", json);
+            Assert.Equal("{\"type\":\"steeltoe\",\"_links\":{\"self\":{\"href\":\"http://localhost/\",\"templated\":false},\"info\":{\"href\":\"http://localhost/info\",\"templated\":false}}}", json);
         }
 
         [Fact]


### PR DESCRIPTION
- Moved code from EnpointCore to EndpointBase

Addresses #553

With this change, some of the EndpointServiceCollectionExtensions classes in EndpointCore don't contain much code, they basically just call the new code in EndpointBase. Since some actuators add extra things, we keep them to keep things consistent across all the actuators. This also gives us a future extensibility point if there is code we want to add that is HTTP specific.