### PR TITLE
Support/Test 2.x with Net5

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -78,6 +78,10 @@ jobs:
     displayName: 'Use .NET 3.1 SDK'
     inputs:
       version: 3.1.x
+  - task: UseDotNet@2
+    displayName: 'Use .NET 5 SDK'
+    inputs:
+      version: 5.0.x
   - task: PowerShell@2
     displayName: 'Get GemFire NativeClient assemblies'
     inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -69,12 +69,10 @@ jobs:
     inputs:
       version: 2.0.x
   - task: UseDotNet@2
-    condition: eq( variables['sonarAnalyze'], 'true' )
     displayName: 'Use .NET 2.1 SDK'
     inputs:
       version: 2.1.x
   - task: UseDotNet@2
-    condition: eq( variables['sonarAnalyze'], 'true' )
     displayName: 'Use .NET 3.1 SDK'
     inputs:
       version: 3.1.x

--- a/src/CircuitBreaker/test/Hystrix.MetricsEventsCore.Test/Startup.cs
+++ b/src/CircuitBreaker/test/Hystrix.MetricsEventsCore.Test/Startup.cs
@@ -35,7 +35,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix.MetricsEvents.Test
         public void Configure(IApplicationBuilder app)
         {
             app.UseHystrixRequestContext();
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1 || NET5_0
             app.UseRouting();
             app.UseEndpoints(endpoints =>
             {

--- a/src/CircuitBreaker/test/Hystrix.MetricsEventsCore.Test/Steeltoe.CircuitBreaker.Hystrix.MetricsEventsCore.Test.csproj
+++ b/src/CircuitBreaker/test/Hystrix.MetricsEventsCore.Test/Steeltoe.CircuitBreaker.Hystrix.MetricsEventsCore.Test.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />
@@ -19,7 +19,7 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.1'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net461' OR '$(TargetFramework)' == 'netcoreapp2.1'">
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="$(AspNetCoreVersion)" />
   </ItemGroup>
 

--- a/src/CircuitBreaker/test/Hystrix.MetricsStreamCore.Test/Steeltoe.CircuitBreaker.Hystrix.MetricsStreamCore.Test.csproj
+++ b/src/CircuitBreaker/test/Hystrix.MetricsStreamCore.Test/Steeltoe.CircuitBreaker.Hystrix.MetricsStreamCore.Test.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />
@@ -16,7 +16,7 @@
     </None>
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.1'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net461' OR '$(TargetFramework)' == 'netcoreapp2.1'">
     <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="$(AspNetCoreVersion)" />
   </ItemGroup>
   <ItemGroup>

--- a/src/CircuitBreaker/test/HystrixBase.Test/Steeltoe.CircuitBreaker.HystrixBase.Test.csproj
+++ b/src/CircuitBreaker/test/HystrixBase.Test/Steeltoe.CircuitBreaker.HystrixBase.Test.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />

--- a/src/CircuitBreaker/test/HystrixCore.Test/Steeltoe.CircuitBreaker.HystrixCore.Test.csproj
+++ b/src/CircuitBreaker/test/HystrixCore.Test/Steeltoe.CircuitBreaker.HystrixCore.Test.csproj
@@ -1,16 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedtest.props" />
   <Import Project="..\..\..\..\targetframework.props" />
 
-  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.1'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net461' OR '$(TargetFramework)' == 'netcoreapp2.1'">
     <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="$(AspNetCoreVersion)" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">

--- a/src/Common/src/Common/Extensions/UriExtensions.cs
+++ b/src/Common/src/Common/Extensions/UriExtensions.cs
@@ -56,7 +56,7 @@ namespace Steeltoe.Common.Extensions
                 if (!string.IsNullOrEmpty(pair))
                 {
                     var kvp = pair.Split('=');
-                    result.Add(kvp[0], WebUtility.UrlDecode(kvp[1]));
+                    result.Add(WebUtility.UrlDecode(kvp[0]), WebUtility.UrlDecode(kvp[1]));
                 }
             }
 

--- a/src/Common/test/Common.Hosting.Test/Steeltoe.Common.Hosting.Test.csproj
+++ b/src/Common/test/Common.Hosting.Test/Steeltoe.Common.Hosting.Test.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0;</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp3.1;net461;netcoreapp2.1;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net461;netcoreapp2.1;net5.0;</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />
@@ -24,7 +24,7 @@
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="$(AspNetCoreVersion)" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.1'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net461' OR '$(TargetFramework)' == 'netcoreapp2.1'">
     <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="$(AspNetCoreVersion)" />
   </ItemGroup>

--- a/src/Common/test/Common.Http.Test/Steeltoe.Common.Http.Test.csproj
+++ b/src/Common/test/Common.Http.Test/Steeltoe.Common.Http.Test.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Common/test/Common.Net.Test/Steeltoe.Common.Net.Test.csproj
+++ b/src/Common/test/Common.Net.Test/Steeltoe.Common.Net.Test.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Common/test/Common.Security.Test/Steeltoe.Common.Security.Test.csproj
+++ b/src/Common/test/Common.Security.Test/Steeltoe.Common.Security.Test.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Common/test/Common.Test/Steeltoe.Common.Test.csproj
+++ b/src/Common/test/Common.Test/Steeltoe.Common.Test.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Configuration/src/CloudFoundryCore/CloudFoundryHostBuilderExtensions.cs
+++ b/src/Configuration/src/CloudFoundryCore/CloudFoundryHostBuilderExtensions.cs
@@ -49,7 +49,7 @@ namespace Steeltoe.Extensions.Configuration.CloudFoundry
             return webHostBuilder;
         }
 
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1 || NET5_0
         /// <summary>
         /// Enable the application to listen on port(s) provided by the environment at runtime
         /// </summary>

--- a/src/Configuration/test/CloudFoundryBase.Test/Steeltoe.Extensions.Configuration.CloudFoundryBase.Test.csproj
+++ b/src/Configuration/test/CloudFoundryBase.Test/Steeltoe.Extensions.Configuration.CloudFoundryBase.Test.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Configuration/test/CloudFoundryCore.Test/Steeltoe.Extensions.Configuration.CloudFoundryCore.Test.csproj
+++ b/src/Configuration/test/CloudFoundryCore.Test/Steeltoe.Extensions.Configuration.CloudFoundryCore.Test.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />
@@ -21,7 +21,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="$(AspNetCoreVersion)" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.1'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net461' OR '$(TargetFramework)' == 'netcoreapp2.1'">
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="$(AspNetCoreVersion)" />
   </ItemGroup>

--- a/src/Configuration/test/CloudFoundryCore.Test/TestServerStartup.cs
+++ b/src/Configuration/test/CloudFoundryCore.Test/TestServerStartup.cs
@@ -16,7 +16,7 @@ namespace Steeltoe.Extensions.Configuration.CloudFoundry.Test
 
         public void Configure(IApplicationBuilder app)
         {
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1 || NET5_0
             app.UseRouting();
 #else
             app.UseMvc();

--- a/src/Configuration/test/ConfigServer.ITest/Steeltoe.Extensions.Configuration.ConfigServer.ITest.csproj
+++ b/src/Configuration/test/ConfigServer.ITest/Steeltoe.Extensions.Configuration.ConfigServer.ITest.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />
@@ -20,7 +20,7 @@
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="$(ExtensionsVersion)" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.1'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net461' OR '$(TargetFramework)' == 'netcoreapp2.1'">
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="$(AspNetCoreVersion)" />
   </ItemGroup>
 

--- a/src/Configuration/test/ConfigServer.ITest/TestServerStartup.cs
+++ b/src/Configuration/test/ConfigServer.ITest/TestServerStartup.cs
@@ -28,7 +28,7 @@ namespace Steeltoe.Extensions.Configuration.ConfigServer.ITest
         public void Configure(IApplicationBuilder app)
         {
             var config = app.ApplicationServices.GetServices<IConfiguration>();
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1 || NET5_0
             app.UseRouting();
             app.UseEndpoints(endpoints =>
             {

--- a/src/Configuration/test/ConfigServerBase.Test/Steeltoe.Extensions.Configuration.ConfigServerBase.Test.csproj
+++ b/src/Configuration/test/ConfigServerBase.Test/Steeltoe.Extensions.Configuration.ConfigServerBase.Test.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Configuration/test/ConfigServerCore.Test/ConfigServerConfigurationBuilderExtensionsCoreTest.cs
+++ b/src/Configuration/test/ConfigServerCore.Test/ConfigServerConfigurationBuilderExtensionsCoreTest.cs
@@ -33,7 +33,7 @@ namespace Steeltoe.Extensions.Configuration.ConfigServerCore.Test
         {
             // Arrange
             IConfigurationBuilder configurationBuilder = new ConfigurationBuilder();
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1 || NET5_0
             IHostEnvironment env = null;
 #else
             IHostingEnvironment env = null;

--- a/src/Configuration/test/ConfigServerCore.Test/Steeltoe.Extensions.Configuration.ConfigServerCore.Test.csproj
+++ b/src/Configuration/test/ConfigServerCore.Test/Steeltoe.Extensions.Configuration.ConfigServerCore.Test.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />
@@ -21,7 +21,7 @@
     <ProjectReference Include="..\ConfigServerBase.Test\Steeltoe.Extensions.Configuration.ConfigServerBase.Test.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.1'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net461' OR '$(TargetFramework)' == 'netcoreapp2.1'">
     <PackageReference Include="Microsoft.AspNetCore" Version="$(AspNetCoreVersion)" />
   </ItemGroup>
 

--- a/src/Configuration/test/PlaceholderBase.Test/Steeltoe.Extensions.Configuration.PlaceholderBase.Test.csproj
+++ b/src/Configuration/test/PlaceholderBase.Test/Steeltoe.Extensions.Configuration.PlaceholderBase.Test.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Configuration/test/PlaceholderCore.Test/Steeltoe.Extensions.Configuration.PlaceholderCore.Test.csproj
+++ b/src/Configuration/test/PlaceholderCore.Test/Steeltoe.Extensions.Configuration.PlaceholderCore.Test.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Configuration/test/RandomValuesBase.Test/Steeltoe.Extensions.Configuration.RandomValueBase.Test.csproj
+++ b/src/Configuration/test/RandomValuesBase.Test/Steeltoe.Extensions.Configuration.RandomValueBase.Test.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Connectors/src/Connector.EFCore/EntityFrameworkCoreTypeLocator.cs
+++ b/src/Connectors/src/Connector.EFCore/EntityFrameworkCoreTypeLocator.cs
@@ -19,13 +19,24 @@ namespace Steeltoe.CloudFoundry.Connector.EFCore
         /// <summary>
         /// Gets a list of supported fully-qualifed names for compatible DbContextOptionsExtentions used to configure EntityFrameworkCore
         /// </summary>
-        public static string[] MySqlEntityTypeNames { get; internal set; } = new string[] { "MySQL.Data.EntityFrameworkCore.Extensions.MySQLDbContextOptionsExtensions", "Microsoft.EntityFrameworkCore.MySqlDbContextOptionsExtensions", "Microsoft.EntityFrameworkCore.MySQLDbContextOptionsExtensions" };
+        public static string[] MySqlEntityTypeNames { get; internal set; } = new string[]
+            {
+                "MySQL.Data.EntityFrameworkCore.Extensions.MySQLDbContextOptionsExtensions",
+                "Microsoft.EntityFrameworkCore.MySqlDbContextOptionsExtensions",
+                "Microsoft.EntityFrameworkCore.MySQLDbContextOptionsExtensions",
+                "Microsoft.EntityFrameworkCore.MySqlDbContextOptionsBuilderExtensions"
+            };
 
         /// <summary>
-        /// Gets the type used to configure EntityFramework Core with MySql
+        /// Gets the type used to configure EntityFramework Core with MySQL
         /// </summary>
         /// <exception cref="ConnectorException">When type is not found</exception>
         public static Type MySqlDbContextOptionsType => ConnectorHelpers.FindTypeOrThrow(MySqlEntityAssemblies, MySqlEntityTypeNames, "DbContextOptionsBuilder", "a MySql EntityFramework Core assembly");
+
+        /// <summary>
+        /// Gets the ServerVersion base type used to identify MySQL Server versions (introduced in v5.0)
+        /// </summary>
+        public static Type MySqlVersionType => ConnectorHelpers.FindType(new[] { "Pomelo.EntityFrameworkCore.MySql" }, new[] { "Microsoft.EntityFrameworkCore.ServerVersion" });
 
         /// <summary>
         /// Gets a list of supported PostgreSQL Entity Framework Core Assemblies
@@ -35,7 +46,7 @@ namespace Steeltoe.CloudFoundry.Connector.EFCore
         /// <summary>
         /// Gets a list of supported fully-qualifed names for compatible DbContextOptionsExtentions used to configure EntityFrameworkCore
         /// </summary>
-        public static string[] PostgreSqlEntityTypeNames { get; internal set; } = new string[] { "Microsoft.EntityFrameworkCore.NpgsqlDbContextOptionsExtensions" };
+        public static string[] PostgreSqlEntityTypeNames { get; internal set; } = new string[] { "Microsoft.EntityFrameworkCore.NpgsqlDbContextOptionsExtensions", "Microsoft.EntityFrameworkCore.NpgsqlDbContextOptionsBuilderExtensions" };
 
         /// <summary>
         /// Gets the type used to configure EntityFramework Core with PostgreSQL

--- a/src/Connectors/src/Connector.EFCore/MySqlDbContextOptionsExtensions.cs
+++ b/src/Connectors/src/Connector.EFCore/MySqlDbContextOptionsExtensions.cs
@@ -13,7 +13,29 @@ namespace Steeltoe.CloudFoundry.Connector.MySql.EFCore
 {
     public static class MySqlDbContextOptionsExtensions
     {
+        /// <summary>
+        /// Configure Entity Framework Core to use a MySQL database
+        /// </summary>
+        /// <param name="optionsBuilder"><see cref="DbContextOptionsBuilder"/></param>
+        /// <param name="config">Application configuration</param>
+        /// <param name="mySqlOptionsAction">An action for customizing the MySqlDbContextOptionsBuilder</param>
+        /// <returns><see cref="DbContextOptionsBuilder"/>, configured to use MySQL</returns>
+        /// <remarks>
+        ///   When used with EF Core 5.0, this method may result in the use of ServerVersion.AutoDetect(), which opens an extra connection to the server.<para />
+        ///   Pass in a ServerVersion to avoid the extra DB Connection - see https://github.com/PomeloFoundation/Pomelo.EntityFrameworkCore.MySql/issues/1088#issuecomment-726091533
+        /// </remarks>
         public static DbContextOptionsBuilder UseMySql(this DbContextOptionsBuilder optionsBuilder, IConfiguration config, object mySqlOptionsAction = null)
+            => UseMySql(optionsBuilder, config, serverVersion: null, mySqlOptionsAction);
+
+        /// <summary>
+        /// Configure Entity Framework Core to use a MySQL database
+        /// </summary>
+        /// <param name="optionsBuilder"><see cref="DbContextOptionsBuilder"/></param>
+        /// <param name="config">Application configuration</param>
+        /// <param name="serverVersion">The version of MySQL/MariaDB to connect to (introduced in EF Core 5.0)</param>
+        /// <param name="mySqlOptionsAction">An action for customizing the MySqlDbContextOptionsBuilder</param>
+        /// <returns><see cref="DbContextOptionsBuilder"/>, configured to use MySQL</returns>
+        public static DbContextOptionsBuilder UseMySql(this DbContextOptionsBuilder optionsBuilder, IConfiguration config, object serverVersion, object mySqlOptionsAction = null)
         {
             if (optionsBuilder == null)
             {
@@ -27,10 +49,34 @@ namespace Steeltoe.CloudFoundry.Connector.MySql.EFCore
 
             var connection = GetConnection(config);
 
-            return DoUseMySql(optionsBuilder, connection, mySqlOptionsAction);
+            return DoUseMySql(optionsBuilder, connection, mySqlOptionsAction, serverVersion);
         }
 
+        /// <summary>
+        /// Configure Entity Framework Core to use a MySQL database identified by a named service binding
+        /// </summary>
+        /// <param name="optionsBuilder"><see cref="DbContextOptionsBuilder"/></param>
+        /// <param name="config">Application configuration</param>
+        /// <param name="serviceName">The name of the service binding to use</param>
+        /// <param name="mySqlOptionsAction">An action for customizing the MySqlDbContextOptionsBuilder</param>
+        /// <returns><see cref="DbContextOptionsBuilder"/>, configured to use MySQL</returns>
+        /// <remarks>
+        ///   When used with EF Core 5.0, this method may result in the use of ServerVersion.AutoDetect(), which opens an extra connection to the server.<para />
+        ///   Pass in a ServerVersion to avoid the extra DB Connection - see https://github.com/PomeloFoundation/Pomelo.EntityFrameworkCore.MySql/issues/1088#issuecomment-726091533
+        /// </remarks>
         public static DbContextOptionsBuilder UseMySql(this DbContextOptionsBuilder optionsBuilder, IConfiguration config, string serviceName, object mySqlOptionsAction = null)
+            => UseMySql(optionsBuilder, config, serviceName, null, mySqlOptionsAction);
+
+        /// <summary>
+        /// Configure Entity Framework Core to use a MySQL database identified by a named service binding
+        /// </summary>
+        /// <param name="optionsBuilder"><see cref="DbContextOptionsBuilder"/></param>
+        /// <param name="config">Application configuration</param>
+        /// <param name="serviceName">The name of the service binding to use</param>
+        /// <param name="serverVersion">The version of MySQL/MariaDB to connect to (introduced in EF Core 5.0)</param>
+        /// <param name="mySqlOptionsAction">An action for customizing the MySqlDbContextOptionsBuilder</param>
+        /// <returns><see cref="DbContextOptionsBuilder"/>, configured to use MySQL</returns>
+        public static DbContextOptionsBuilder UseMySql(this DbContextOptionsBuilder optionsBuilder, IConfiguration config, string serviceName, object serverVersion, object mySqlOptionsAction = null)
         {
             if (optionsBuilder == null)
             {
@@ -49,10 +95,19 @@ namespace Steeltoe.CloudFoundry.Connector.MySql.EFCore
 
             var connection = GetConnection(config, serviceName);
 
-            return DoUseMySql(optionsBuilder, connection, mySqlOptionsAction);
+            return DoUseMySql(optionsBuilder, connection, mySqlOptionsAction, serverVersion);
         }
 
-        public static DbContextOptionsBuilder<TContext> UseMySql<TContext>(this DbContextOptionsBuilder<TContext> optionsBuilder, IConfiguration config, object mySqlOptionsAction = null)
+        /// <summary>
+        /// Configure Entity Framework Core to use a MySQL database
+        /// </summary>
+        /// <typeparam name="TContext">Type of <see cref="DbContext"/></typeparam>
+        /// <param name="optionsBuilder"><see cref="DbContextOptionsBuilder"/></param>
+        /// <param name="config">Application configuration</param>
+        /// <param name="mySqlOptionsAction">An action for customizing the MySqlDbContextOptionsBuilder</param>
+        /// <param name="serverVersion">The version of MySQL/MariaDB to connect to (introduced in EF Core 5.0)</param>
+        /// <returns><see cref="DbContextOptionsBuilder"/>, configured to use MySQL</returns>
+        public static DbContextOptionsBuilder<TContext> UseMySql<TContext>(this DbContextOptionsBuilder<TContext> optionsBuilder, IConfiguration config, object mySqlOptionsAction = null, object serverVersion = null)
             where TContext : DbContext
         {
             if (optionsBuilder == null)
@@ -67,10 +122,20 @@ namespace Steeltoe.CloudFoundry.Connector.MySql.EFCore
 
             var connection = GetConnection(config);
 
-            return DoUseMySql<TContext>(optionsBuilder, connection, mySqlOptionsAction);
+            return DoUseMySql(optionsBuilder, connection, mySqlOptionsAction, serverVersion);
         }
 
-        public static DbContextOptionsBuilder<TContext> UseMySql<TContext>(this DbContextOptionsBuilder<TContext> optionsBuilder, IConfiguration config, string serviceName, object mySqlOptionsAction = null)
+        /// <summary>
+        /// Configure Entity Framework Core to use a MySQL database identified by a named service binding
+        /// </summary>
+        /// <typeparam name="TContext">Type of <see cref="DbContext"/></typeparam>
+        /// <param name="optionsBuilder"><see cref="DbContextOptionsBuilder"/></param>
+        /// <param name="config">Application configuration</param>
+        /// <param name="serviceName">The name of the service binding to use</param>
+        /// <param name="mySqlOptionsAction">An action for customizing the MySqlDbContextOptionsBuilder</param>
+        /// <param name="serverVersion">The version of MySQL/MariaDB to connect to (introduced in EF Core 5.0)</param>
+        /// <returns><see cref="DbContextOptionsBuilder"/>, configured to use MySQL</returns>
+        public static DbContextOptionsBuilder<TContext> UseMySql<TContext>(this DbContextOptionsBuilder<TContext> optionsBuilder, IConfiguration config, string serviceName, object mySqlOptionsAction = null, object serverVersion = null)
             where TContext : DbContext
         {
             if (optionsBuilder == null)
@@ -90,28 +155,7 @@ namespace Steeltoe.CloudFoundry.Connector.MySql.EFCore
 
             var connection = GetConnection(config, serviceName);
 
-            return DoUseMySql<TContext>(optionsBuilder, connection, mySqlOptionsAction);
-        }
-
-        private static MethodInfo FindUseSqlMethod(Type type, Type[] parameterTypes)
-        {
-            var typeInfo = type.GetTypeInfo();
-            var declaredMethods = typeInfo.DeclaredMethods;
-
-            foreach (var ci in declaredMethods)
-            {
-                var parameters = ci.GetParameters();
-                if (parameters.Length == 3 &&
-                    ci.Name.Equals("UseMySQL", StringComparison.InvariantCultureIgnoreCase) &&
-                    parameters[0].ParameterType.Equals(parameterTypes[0]) &&
-                    parameters[1].ParameterType.Equals(parameterTypes[1]) &&
-                    ci.IsPublic && ci.IsStatic)
-                {
-                    return ci;
-                }
-            }
-
-            return null;
+            return DoUseMySql(optionsBuilder, connection, mySqlOptionsAction, serverVersion);
         }
 
         private static string GetConnection(IConfiguration config, string serviceName = null)
@@ -127,17 +171,33 @@ namespace Steeltoe.CloudFoundry.Connector.MySql.EFCore
             return factory.CreateConnectionString();
         }
 
-        private static DbContextOptionsBuilder DoUseMySql(DbContextOptionsBuilder builder, string connection, object mySqlOptionsAction = null)
+        private static DbContextOptionsBuilder DoUseMySql(DbContextOptionsBuilder builder, string connection, object mySqlOptionsAction = null, object serverVersion = null)
         {
             var extensionType = EntityFrameworkCoreTypeLocator.MySqlDbContextOptionsType;
 
-            var useMethod = FindUseSqlMethod(extensionType, new Type[] { typeof(DbContextOptionsBuilder), typeof(string) });
+            MethodInfo useMethod;
+            object[] parms;
+
+            // the signature changed in 5.0 to require a param of type ServerVersion - use the presence of this new type to select the signature
+            if (EntityFrameworkCoreTypeLocator.MySqlVersionType == null)
+            {
+                useMethod = FindUseSqlMethod(extensionType, new Type[] { typeof(DbContextOptionsBuilder), typeof(string) });
+                parms = new object[] { builder, connection, mySqlOptionsAction };
+            }
+            else
+            {
+                // If the server version wasn't passed in, use the EF Core lib to autodetect it (this is the part that creates an extra connection)
+                serverVersion ??= ConnectorHelpers.FindMethod(EntityFrameworkCoreTypeLocator.MySqlVersionType, "AutoDetect", new Type[] { typeof(string) }).Invoke(null, new[] { connection });
+                useMethod = FindUseSqlMethod(extensionType, new Type[] { typeof(DbContextOptionsBuilder), typeof(string), EntityFrameworkCoreTypeLocator.MySqlVersionType, typeof(Action<DbContextOptionsBuilder>) });
+                parms = new object[] { builder, connection, serverVersion, mySqlOptionsAction };
+            }
+
             if (extensionType == null)
             {
                 throw new ConnectorException("Unable to find UseMySql extension, are you missing MySql EntityFramework Core assembly");
             }
 
-            var result = ConnectorHelpers.Invoke(useMethod, null, new object[] { builder, connection, mySqlOptionsAction });
+            var result = ConnectorHelpers.Invoke(useMethod, null, parms);
             if (result == null)
             {
                 throw new ConnectorException(string.Format("Failed to invoke UseMySql extension, connection: {0}", connection));
@@ -146,10 +206,29 @@ namespace Steeltoe.CloudFoundry.Connector.MySql.EFCore
             return (DbContextOptionsBuilder)result;
         }
 
-        private static DbContextOptionsBuilder<TContext> DoUseMySql<TContext>(DbContextOptionsBuilder<TContext> builder, string connection, object mySqlOptionsAction = null)
+        private static DbContextOptionsBuilder<TContext> DoUseMySql<TContext>(DbContextOptionsBuilder<TContext> builder, string connection, object mySqlOptionsAction = null, object serverVersion = null)
             where TContext : DbContext
+                => (DbContextOptionsBuilder<TContext>)DoUseMySql((DbContextOptionsBuilder)builder, connection, mySqlOptionsAction, serverVersion);
+
+        private static MethodInfo FindUseSqlMethod(Type type, Type[] parameterTypes)
         {
-            return (DbContextOptionsBuilder<TContext>)DoUseMySql((DbContextOptionsBuilder)builder, connection, mySqlOptionsAction);
+            var typeInfo = type.GetTypeInfo();
+            var declaredMethods = typeInfo.DeclaredMethods;
+
+            foreach (var ci in declaredMethods)
+            {
+                var parameters = ci.GetParameters();
+                if ((parameters.Length == 3 || parameters.Length == parameterTypes.Length) &&
+                    ci.Name.Equals("UseMySQL", StringComparison.InvariantCultureIgnoreCase) &&
+                    parameters[0].ParameterType.Equals(parameterTypes[0]) &&
+                    parameters[1].ParameterType.Equals(parameterTypes[1]) &&
+                    ci.IsPublic && ci.IsStatic)
+                {
+                    return ci;
+                }
+            }
+
+            return null;
         }
     }
 }

--- a/src/Connectors/test/Connector.EF6Core.Net4Test/Steeltoe.CloudFoundry.Connector.EF6Core.Test.csproj
+++ b/src/Connectors/test/Connector.EF6Core.Net4Test/Steeltoe.CloudFoundry.Connector.EF6Core.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net461;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Connectors/test/Connector.EFCore.Test/EntityFrameworkCoreTypeLocatorTest.cs
+++ b/src/Connectors/test/Connector.EFCore.Test/EntityFrameworkCoreTypeLocatorTest.cs
@@ -74,7 +74,11 @@ namespace Steeltoe.CloudFoundry.Connector.EFCore.Test
             Assert.NotNull(type);
         }
 
+#if NETCOREAPP3_1
         [Fact]
+#else
+        [Fact(Skip = "Revisit when Oracle has support for EF Core 5.0")]
+#endif
         public void Options_Found_In_OracleEF_Assembly()
         {
             // arrange ~ narrow the assembly list to one specific nuget package

--- a/src/Connectors/test/Connector.EFCore.Test/MySqlDbContextOptionsExtensionsTest.cs
+++ b/src/Connectors/test/Connector.EFCore.Test/MySqlDbContextOptionsExtensionsTest.cs
@@ -3,9 +3,14 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+#if NET5_0
+using MySqlConnector;
+#else
 using MySql.Data.MySqlClient;
+#endif
 using Steeltoe.CloudFoundry.Connector.EFCore.Test;
 using Steeltoe.CloudFoundry.Connector.Test;
 using Steeltoe.Extensions.Configuration.CloudFoundry;
@@ -91,6 +96,30 @@ namespace Steeltoe.CloudFoundry.Connector.MySql.EFCore.Test
             var config = new ConfigurationBuilder().Build();
 
             // Act and Assert
+#if NET5_0
+            services.AddDbContext<GoodDbContext>(options => options.UseMySql(config, serverVersion: MySqlServerVersion.LatestSupportedServerVersion));
+#else
+            services.AddDbContext<GoodDbContext>(options => options.UseMySql(config));
+#endif
+
+            var service = services.BuildServiceProvider().GetService<GoodDbContext>();
+            Assert.NotNull(service);
+            var con = service.Database.GetDbConnection();
+            Assert.NotNull(con);
+            Assert.NotNull(con as MySqlConnection);
+        }
+
+#if NET5_0
+        // Run a MySQL server with Docker to match creds below with this command
+        // docker run --name steeltoe-mysql -p 3306:3306 -e MYSQL_DATABASE=steeltoe -e MYSQL_ROOT_PASSWORD=steeltoe mysql
+        [Fact(Skip = "Requires a running MySQL server to support AutoDetect")]
+        public void AddDbContext_NoVCAPs_AddsDbContext_WithMySqlConnection_AutodetectOn5_0()
+        {
+            // Arrange
+            IServiceCollection services = new ServiceCollection();
+            var config = new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string> { { "mysql:client:database", "steeltoe2" }, { "mysql:client:username", "root" }, { "mysql:client:password", "steeltoe" } }).Build();
+
+            // Act and Assert
             services.AddDbContext<GoodDbContext>(options => options.UseMySql(config));
 
             var service = services.BuildServiceProvider().GetService<GoodDbContext>();
@@ -99,6 +128,7 @@ namespace Steeltoe.CloudFoundry.Connector.MySql.EFCore.Test
             Assert.NotNull(con);
             Assert.NotNull(con as MySqlConnection);
         }
+#endif
 
         [Fact]
         public void AddDbContext_WithServiceName_NoVCAPs_ThrowsConnectorException()
@@ -150,7 +180,11 @@ namespace Steeltoe.CloudFoundry.Connector.MySql.EFCore.Test
             var config = builder.Build();
 
             // Act
+#if NET5_0
+            services.AddDbContext<GoodDbContext>(options => options.UseMySql(config, "spring-cloud-broker-db2", serverVersion: MySqlServerVersion.LatestSupportedServerVersion));
+#else
             services.AddDbContext<GoodDbContext>(options => options.UseMySql(config, "spring-cloud-broker-db2"));
+#endif
 
             // Assert
             var built = services.BuildServiceProvider();
@@ -183,7 +217,11 @@ namespace Steeltoe.CloudFoundry.Connector.MySql.EFCore.Test
             var config = builder.Build();
 
             // Act and Assert
+#if NET5_0
+            services.AddDbContext<GoodDbContext>(options => options.UseMySql(config, serverVersion: MySqlServerVersion.LatestSupportedServerVersion));
+#else
             services.AddDbContext<GoodDbContext>(options => options.UseMySql(config));
+#endif
 
             var built = services.BuildServiceProvider();
             var service = built.GetService<GoodDbContext>();

--- a/src/Connectors/test/Connector.EFCore.Test/SqlServerDbContextOptionsExtensionsTest.cs
+++ b/src/Connectors/test/Connector.EFCore.Test/SqlServerDbContextOptionsExtensionsTest.cs
@@ -2,6 +2,9 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
+#if !NET461 && !NETCOREAPP2_1
+using Microsoft.Data.SqlClient;
+#endif
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -9,7 +12,9 @@ using Steeltoe.CloudFoundry.Connector.EFCore.Test;
 using Steeltoe.CloudFoundry.Connector.Test;
 using Steeltoe.Extensions.Configuration.CloudFoundry;
 using System;
+#if NET461 || NETCOREAPP2_1
 using System.Data.SqlClient;
+#endif
 using Xunit;
 
 namespace Steeltoe.CloudFoundry.Connector.SqlServer.EFCore.Test

--- a/src/Connectors/test/Connector.EFCore.Test/Steeltoe.CloudFoundry.Connector.EFCore.Test.csproj
+++ b/src/Connectors/test/Connector.EFCore.Test/Steeltoe.CloudFoundry.Connector.EFCore.Test.csproj
@@ -21,15 +21,15 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="$(EFCoreTestVersion)" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="$(EFCoreTestVersion)" />
-
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="$(EFCoreTestVersion)" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="$(NpgsqlEFCoreVersion)" />
-    <PackageReference Include="Oracle.EntityFrameworkCore" Version="2.19.0-beta4" />
 
     <!--<PackageReference Include="MySql.Data.EntityFrameworkCore" Version="$(MySqlV6)" />-->
     <!--<PackageReference Include="MySql.Data.EntityFrameworkCore" Version="$(MySqlV8)" />-->
     <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="$(PomeloEFCoreVersion)" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' != 'net5.0'">
+    <!--Oracle doesn't work with EF Core 5.0 yet-->
+    <PackageReference Include="Oracle.EntityFrameworkCore" Version="$(OracleEFCoreVersion)" />
   </ItemGroup>
 </Project>

--- a/src/Connectors/test/ConnectorBase.Test/Steeltoe.CloudFoundry.ConnectorBase.Test.csproj
+++ b/src/Connectors/test/ConnectorBase.Test/Steeltoe.CloudFoundry.ConnectorBase.Test.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Connectors/test/ConnectorCore.Test/Steeltoe.CloudFoundry.ConnectorCore.Test.csproj
+++ b/src/Connectors/test/ConnectorCore.Test/Steeltoe.CloudFoundry.ConnectorCore.Test.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Discovery/test/ClientCore.Test/DiscoveryHostBuilderExtensionsTest.cs
+++ b/src/Discovery/test/ClientCore.Test/DiscoveryHostBuilderExtensionsTest.cs
@@ -68,7 +68,7 @@ namespace Steeltoe.Discovery.Client.Test
             Assert.IsType<DiscoveryClientStartupFilter>(filter);
         }
 
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1 || NET5_0
         [Fact]
         public async Task AddServiceDiscovery_IHostBuilder_IStartupFilterFires()
         {

--- a/src/Discovery/test/ClientCore.Test/DiscoveryServiceCollectionExtensionsTest.cs
+++ b/src/Discovery/test/ClientCore.Test/DiscoveryServiceCollectionExtensionsTest.cs
@@ -6,7 +6,7 @@ using Consul;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1 || NET5_0
 using Microsoft.Extensions.Hosting;
 #endif
 using Steeltoe.CloudFoundry.Connector;
@@ -124,7 +124,7 @@ namespace Steeltoe.Discovery.Client.Test
 
             var services = new ServiceCollection();
             services.AddOptions();
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1 || NET5_0
             services.AddSingleton<IHostApplicationLifetime>(new TestApplicationLifetime());
 #else
             services.AddSingleton<IApplicationLifetime>(new TestApplicationLifetime());
@@ -153,7 +153,7 @@ namespace Steeltoe.Discovery.Client.Test
             var config = new ConfigurationBuilder().AddInMemoryCollection(appsettings).Build();
             var services = new ServiceCollection();
             services.AddOptions();
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1 || NET5_0
             services.AddSingleton<IHostApplicationLifetime>(new TestApplicationLifetime());
 #else
             services.AddSingleton<IApplicationLifetime>(new TestApplicationLifetime());
@@ -206,7 +206,7 @@ namespace Steeltoe.Discovery.Client.Test
             };
 
             var services = new ServiceCollection();
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1 || NET5_0
             services.AddSingleton<IHostApplicationLifetime>(new TestApplicationLifetime());
 #else
             services.AddSingleton<IApplicationLifetime>(new TestApplicationLifetime());
@@ -232,7 +232,7 @@ namespace Steeltoe.Discovery.Client.Test
             };
 
             var services = new ServiceCollection();
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1 || NET5_0
             services.AddSingleton<IHostApplicationLifetime>(new TestApplicationLifetime());
 #else
             services.AddSingleton<IApplicationLifetime>(new TestApplicationLifetime());
@@ -261,7 +261,7 @@ namespace Steeltoe.Discovery.Client.Test
             };
 
             var services = new ServiceCollection();
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1 || NET5_0
             services.AddSingleton<IHostApplicationLifetime>(new TestApplicationLifetime());
 #else
             services.AddSingleton<IApplicationLifetime>(new TestApplicationLifetime());
@@ -290,7 +290,7 @@ namespace Steeltoe.Discovery.Client.Test
             };
 
             var services = new ServiceCollection();
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1 || NET5_0
             services.AddSingleton<IHostApplicationLifetime>(new TestApplicationLifetime());
 #else
             services.AddSingleton<IApplicationLifetime>(new TestApplicationLifetime());
@@ -303,7 +303,7 @@ namespace Steeltoe.Discovery.Client.Test
         {
             // Arrange
             var services = new ServiceCollection();
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1 || NET5_0
             services.AddSingleton<IHostApplicationLifetime>(new TestApplicationLifetime());
 #else
             services.AddSingleton<IApplicationLifetime>(new TestApplicationLifetime());
@@ -343,7 +343,7 @@ namespace Steeltoe.Discovery.Client.Test
             var hprovider = new TestClientHandlerProvider();
             services.AddSingleton<IEurekaDiscoveryClientHandlerProvider>(hprovider);
 
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1 || NET5_0
             services.AddSingleton<IHostApplicationLifetime>(new TestApplicationLifetime());
 #else
             services.AddSingleton<IApplicationLifetime>(new TestApplicationLifetime());

--- a/src/Discovery/test/ClientCore.Test/Steeltoe.Discovery.ClientCore.Test.csproj
+++ b/src/Discovery/test/ClientCore.Test/Steeltoe.Discovery.ClientCore.Test.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />
@@ -20,7 +20,7 @@
     <ProjectReference Include="..\..\src\ClientCore\Steeltoe.Discovery.ClientCore.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.1'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net461' OR '$(TargetFramework)' == 'netcoreapp2.1'">
     <PackageReference Include="Microsoft.AspNetCore" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="$(LoggingVersion)" />
   </ItemGroup>

--- a/src/Discovery/test/ClientCore.Test/TestApplicationLifetime.cs
+++ b/src/Discovery/test/ClientCore.Test/TestApplicationLifetime.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1 || NET5_0
 using Microsoft.Extensions.Hosting;
 #else
 using Microsoft.AspNetCore.Hosting;
@@ -12,7 +12,7 @@ using System.Threading;
 
 namespace Steeltoe.Discovery.Client.Test
 {
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1 || NET5_0
     public class TestApplicationLifetime : IHostApplicationLifetime
     {
         public CancellationToken ApplicationStarted => throw new NotImplementedException();

--- a/src/Discovery/test/ConsulBase.Test/Steeltoe.Discovery.ConsulBase.Test.csproj
+++ b/src/Discovery/test/ConsulBase.Test/Steeltoe.Discovery.ConsulBase.Test.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Discovery/test/EurekaBase.Test/Steeltoe.Discovery.EurekaBase.Test.csproj
+++ b/src/Discovery/test/EurekaBase.Test/Steeltoe.Discovery.EurekaBase.Test.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Logging/test/DynamicLogger.Test/Steeltoe.Extensions.Logging.DynamicLogger.Test.csproj
+++ b/src/Logging/test/DynamicLogger.Test/Steeltoe.Extensions.Logging.DynamicLogger.Test.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />
@@ -16,11 +16,9 @@
     </None>
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.1'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net461' OR '$(TargetFramework)' == 'netcoreapp2.1'">
     <PackageReference Include="Microsoft.AspNetCore" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="$(LoggingVersion)" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Logging/test/SerilogDynamicLoggerCore.Test/Steeltoe.Extensions.Logging.SerilogDynamicLoggerCore.Test.csproj
+++ b/src/Logging/test/SerilogDynamicLoggerCore.Test/Steeltoe.Extensions.Logging.SerilogDynamicLoggerCore.Test.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />
@@ -24,7 +24,7 @@
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
     <PackageReference Include="Serilog.Exceptions" Version="5.0.0" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.1'">
+  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.1' AND '$(TargetFramework)' != 'net5.0'">
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="$(AspNetCoreVersion)" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">

--- a/src/Management/test/CloudFoundryCore.Test/CloudFoundryServiceCollectionExtensionsTest.cs
+++ b/src/Management/test/CloudFoundryCore.Test/CloudFoundryServiceCollectionExtensionsTest.cs
@@ -3,7 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.AspNetCore.Builder;
-#if !NETCOREAPP3_1
+#if !NETCOREAPP3_1 && !NET5_0
 using Microsoft.AspNetCore.Builder.Internal;
 #endif
 using Microsoft.AspNetCore.Cors.Infrastructure;

--- a/src/Management/test/CloudFoundryCore.Test/Steeltoe.Management.CloudFoundryCore.Test.csproj
+++ b/src/Management/test/CloudFoundryCore.Test/Steeltoe.Management.CloudFoundryCore.Test.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />
@@ -15,7 +15,7 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.1'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net461' OR '$(TargetFramework)' == 'netcoreapp2.1'">
     <PackageReference Include="Microsoft.AspNetCore" Version="$(AspNetCoreVersion)" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Management/test/EndpointBase.Test/Env/EnvEndpointTest.cs
+++ b/src/Management/test/EndpointBase.Test/Env/EnvEndpointTest.cs
@@ -21,11 +21,11 @@ namespace Steeltoe.Management.Endpoint.Env.Test
         {
             IEnvOptions options = null;
             IConfiguration configuration = null;
-        #if NETCOREAPP3_1
+#if NETCOREAPP3_1 || NET5_0
             IHostEnvironment env = null;
-        #else
+#else
             IHostingEnvironment env = null;
-        #endif
+#endif
 
             Assert.Throws<ArgumentNullException>(() => new EnvEndpoint(options, configuration, env));
 

--- a/src/Management/test/EndpointBase.Test/Steeltoe.Management.EndpointBase.Test.csproj
+++ b/src/Management/test/EndpointBase.Test/Steeltoe.Management.EndpointBase.Test.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Management/test/EndpointCore.Test/Env/EndpointMiddlewareTest.cs
+++ b/src/Management/test/EndpointCore.Test/Env/EndpointMiddlewareTest.cs
@@ -33,7 +33,7 @@ namespace Steeltoe.Management.Endpoint.Env.Test
             ["management:endpoints:path"] = "/cloudfoundryapplication"
         };
 
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1 || NET5_0
         private readonly IHostEnvironment host = HostingHelpers.GetHostingEnvironment();
 #else
         private readonly Microsoft.Extensions.Hosting.IHostingEnvironment host = (Microsoft.Extensions.Hosting.IHostingEnvironment)HostingHelpers.GetHostingEnvironment();

--- a/src/Management/test/EndpointCore.Test/Env/EndpointServiceCollectionTest.cs
+++ b/src/Management/test/EndpointCore.Test/Env/EndpointServiceCollectionTest.cs
@@ -34,7 +34,7 @@ namespace Steeltoe.Management.Endpoint.Env.Test
         public void AddEnvActuator_AddsCorrectServices()
         {
             var services = new ServiceCollection();
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1 || NET5_0
             var host = HostingHelpers.GetHostingEnvironment();
             services.AddSingleton<IHostEnvironment>(host);
 #else

--- a/src/Management/test/EndpointCore.Test/Mappings/Startup.cs
+++ b/src/Management/test/EndpointCore.Test/Mappings/Startup.cs
@@ -28,7 +28,7 @@ namespace Steeltoe.Management.Endpoint.Mappings.Test
         {
             app.UseMappingsActuator();
 
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1 || NET5_0
             app.UseRouting();
             app.UseEndpoints(endpoints =>
             {

--- a/src/Management/test/EndpointCore.Test/SpringBootAdminClient/SpringBootAdminClientExtensionTests.cs
+++ b/src/Management/test/EndpointCore.Test/SpringBootAdminClient/SpringBootAdminClientExtensionTests.cs
@@ -59,7 +59,7 @@ namespace Steeltoe.Management.EndpointCore.Test.SpringBootAdminClient
         private MyAppLifeTime AddApplicationLifetime(ServiceCollection services)
         {
             var appLifeTime = new MyAppLifeTime();
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1 || NET5_0
             services.TryAddSingleton<IHostApplicationLifetime>(appLifeTime);
 #else
             services.TryAddSingleton<IApplicationLifetime>(appLifeTime);
@@ -68,7 +68,7 @@ namespace Steeltoe.Management.EndpointCore.Test.SpringBootAdminClient
         }
 
         private class MyAppLifeTime :
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1 || NET5_0
             IHostApplicationLifetime
 #else
 #pragma warning disable CS0618 // Needed for 2.x

--- a/src/Management/test/EndpointCore.Test/Steeltoe.Management.EndpointCore.Test.csproj
+++ b/src/Management/test/EndpointCore.Test/Steeltoe.Management.EndpointCore.Test.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />
@@ -46,7 +46,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="$(ExtensionsVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="$(ExtensionsVersion)" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.1'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net461' OR '$(TargetFramework)' == 'netcoreapp2.1'">
     <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="$(AspNetCoreVersion)" />
   </ItemGroup>

--- a/src/Management/test/ExporterBase.Test/Steeltoe.Management.ExporterBase.Test.csproj
+++ b/src/Management/test/ExporterBase.Test/Steeltoe.Management.ExporterBase.Test.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />
@@ -18,7 +18,7 @@
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="$(ExtensionsVersion)" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.1'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net461' OR '$(TargetFramework)' == 'netcoreapp2.1'">
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="$(AspNetCoreVersion)" />
   </ItemGroup>
 </Project>

--- a/src/Management/test/ExporterCore.Test/Steeltoe.Management.ExporterCore.Test.csproj
+++ b/src/Management/test/ExporterCore.Test/Steeltoe.Management.ExporterCore.Test.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />
@@ -18,7 +18,7 @@
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="$(ExtensionsVersion)" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.1'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net461' OR '$(TargetFramework)' == 'netcoreapp2.1'">
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="$(AspNetCoreVersion)" />
   </ItemGroup>
 </Project>

--- a/src/Management/test/OpenCensus.Test/Steeltoe.Management.OpenCensus.Test.csproj
+++ b/src/Management/test/OpenCensus.Test/Steeltoe.Management.OpenCensus.Test.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>Unit test project for OpenCensus</Description>
-    <TargetFrameworks>net46;netcoreapp2.1</TargetFrameworks>
-    <TargetFrameworks Condition="$(OS) != 'Windows_NT'">netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net46;netcoreapp2.1;net5.0</TargetFrameworks>
+    <TargetFrameworks Condition="$(OS) != 'Windows_NT'">netcoreapp2.1;net5.0</TargetFrameworks>
     <AssemblyName>OpenCensus.Tests</AssemblyName>
     <PackageId>OpenCensus.Tests</PackageId>
     <PackageTags>OpenCensus;Tracing;Management;Monitoring</PackageTags>

--- a/src/Management/test/TaskCore.Test/Steeltoe.Management.TaskCore.Test.csproj
+++ b/src/Management/test/TaskCore.Test/Steeltoe.Management.TaskCore.Test.csproj
@@ -1,16 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedtest.props" />
   <Import Project="..\..\..\..\targetframework.props" />
 
-  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.1'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net461' OR '$(TargetFramework)' == 'netcoreapp2.1'">
     <PackageReference Include="Microsoft.AspNetCore" Version="$(AspNetCoreVersion)" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Management/test/TracingBase.Test/Observer/HttpClientCoreObserverTest.cs
+++ b/src/Management/test/TracingBase.Test/Observer/HttpClientCoreObserverTest.cs
@@ -69,7 +69,11 @@ namespace Steeltoe.Management.Tracing.Observer.Test
             obs.ProcessEvent(HttpClientCoreObserver.STOP_EVENT, new { Request = request });
             var span = GetCurrentSpan(tracing.Tracer);
             Assert.Null(span);
+#if NET5_0
+            Assert.DoesNotContain(request.Options, o => o.Key == HttpClientCoreObserver.SPANCONTEXT_KEY);
+#else
             Assert.False(request.Properties.TryGetValue(HttpClientCoreObserver.SPANCONTEXT_KEY, out var context));
+#endif
         }
 
         [Fact]
@@ -84,12 +88,20 @@ namespace Steeltoe.Management.Tracing.Observer.Test
             obs.ProcessEvent(HttpClientCoreObserver.EXCEPTION_EVENT, new { Request = request });
             var span = GetCurrentSpan(tracing.Tracer);
             Assert.Null(span);
+#if NET5_0
+            Assert.DoesNotContain(request.Options, o => o.Key == HttpClientCoreObserver.SPANCONTEXT_KEY);
+#else
             Assert.False(request.Properties.TryGetValue(HttpClientCoreObserver.SPANCONTEXT_KEY, out var context));
+#endif
 
             obs.ProcessEvent(HttpClientCoreObserver.EXCEPTION_EVENT, new { Request = request, Exception = new Exception() });
             span = GetCurrentSpan(tracing.Tracer);
             Assert.Null(span);
+#if NET5_0
+            Assert.DoesNotContain(request.Options, o => o.Key == HttpClientCoreObserver.SPANCONTEXT_KEY);
+#else
             Assert.False(request.Properties.TryGetValue(HttpClientCoreObserver.SPANCONTEXT_KEY, out context));
+#endif
         }
 
         [Fact]
@@ -103,7 +115,11 @@ namespace Steeltoe.Management.Tracing.Observer.Test
 
             var span = GetCurrentSpan(tracing.Tracer);
             Assert.NotNull(span);
-            Assert.True(request.Properties.TryGetValue(HttpClientCoreObserver.SPANCONTEXT_KEY, out var context));
+#if NET5_0
+            var context = request.Options.First(o => o.Key == HttpClientCoreObserver.SPANCONTEXT_KEY).Value;
+#else
+            Assert.True(request.Properties.TryGetValue(HttpClientCoreObserver.SPANCONTEXT_KEY, out object context));
+#endif
             var spanContext = context as HttpClientTracingObserver.SpanContext;
             Assert.NotNull(spanContext);
             Assert.Equal(span, spanContext.Active);
@@ -116,7 +132,11 @@ namespace Steeltoe.Management.Tracing.Observer.Test
             var response = GetHttpResponseMessage(HttpStatusCode.InternalServerError);
             obs.ProcessEvent(HttpClientCoreObserver.STOP_EVENT, new { Request = request, Response = response, RequestTaskStatus = TaskStatus.RanToCompletion });
             Assert.True(span.HasEnded);
+#if NET5_0
+            Assert.DoesNotContain(request.Options, o => o.Key == HttpClientCoreObserver.SPANCONTEXT_KEY);
+#else
             Assert.False(request.Properties.TryGetValue(HttpClientCoreObserver.SPANCONTEXT_KEY, out var ctx));
+#endif
 
             var spanData = span.ToSpanData();
             var attributes = spanData.Attributes.AttributeMap;
@@ -143,7 +163,11 @@ namespace Steeltoe.Management.Tracing.Observer.Test
 
             var span = GetCurrentSpan(tracing.Tracer);
             Assert.NotNull(span);
+#if NET5_0
+            var context = request.Options.FirstOrDefault(o => o.Key == HttpClientCoreObserver.SPANCONTEXT_KEY).Value;
+#else
             Assert.True(request.Properties.TryGetValue(HttpClientCoreObserver.SPANCONTEXT_KEY, out var context));
+#endif
             var spanContext = context as HttpClientTracingObserver.SpanContext;
             Assert.NotNull(spanContext);
             Assert.Equal(span, spanContext.Active);
@@ -153,7 +177,11 @@ namespace Steeltoe.Management.Tracing.Observer.Test
             var response = GetHttpResponseMessage(HttpStatusCode.OK);
             obs.ProcessEvent(HttpClientCoreObserver.STOP_EVENT, new { Request = request, Response = response, RequestTaskStatus = TaskStatus.RanToCompletion });
             Assert.True(span.HasEnded);
+#if NET5_0
+            Assert.DoesNotContain(request.Options, o => o.Key == HttpClientCoreObserver.SPANCONTEXT_KEY);
+#else
             Assert.False(request.Properties.TryGetValue(HttpClientCoreObserver.SPANCONTEXT_KEY, out var ctx));
+#endif
 
             var spanData = span.ToSpanData();
             var attributes = spanData.Attributes.AttributeMap;
@@ -178,7 +206,11 @@ namespace Steeltoe.Management.Tracing.Observer.Test
 
             var span = GetCurrentSpan(tracing.Tracer);
             Assert.NotNull(span);
+#if NET5_0
+            var context = request.Options.FirstOrDefault(o => o.Key == HttpClientCoreObserver.SPANCONTEXT_KEY).Value;
+#else
             Assert.True(request.Properties.TryGetValue(HttpClientCoreObserver.SPANCONTEXT_KEY, out var context));
+#endif
             var spanContext = context as HttpClientTracingObserver.SpanContext;
             Assert.NotNull(spanContext);
             Assert.Equal(span, spanContext.Active);

--- a/src/Management/test/TracingBase.Test/Steeltoe.Management.TracingBase.Test.csproj
+++ b/src/Management/test/TracingBase.Test/Steeltoe.Management.TracingBase.Test.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />
@@ -18,7 +18,7 @@
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="$(ExtensionsVersion)" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.1'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net461' OR '$(TargetFramework)' == 'netcoreapp2.1'">
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="$(AspNetCoreVersion)" />
   </ItemGroup>
 </Project>

--- a/src/Management/test/TracingCore.Test/Steeltoe.Management.TracingCore.Test.csproj
+++ b/src/Management/test/TracingCore.Test/Steeltoe.Management.TracingCore.Test.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />
@@ -18,7 +18,7 @@
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="$(ExtensionsVersion)" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.1'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net461' OR '$(TargetFramework)' == 'netcoreapp2.1'">
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="$(AspNetCoreVersion)" />
   </ItemGroup>
 </Project>

--- a/src/Security/test/Authentication.CloudFoundryBase.Test/CloudFoundryHelperTest.cs
+++ b/src/Security/test/Authentication.CloudFoundryBase.Test/CloudFoundryHelperTest.cs
@@ -2,11 +2,11 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-#if !NETCOREAPP3_1
+#if !NETCOREAPP3_1 && !NET5_0
 using Newtonsoft.Json.Linq;
 #endif
 using System;
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1 || NET5_0
 using System.Text.Json;
 #endif
 using Xunit;
@@ -40,7 +40,7 @@ namespace Steeltoe.Security.Authentication.CloudFoundry.Test
         public void GetExpTime_FindsTime()
         {
             var info = TestHelpers.GetValidTokenInfoRequestResponse();
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1 || NET5_0
             var payload = JsonDocument.Parse(info).RootElement;
 #else
             var payload = JObject.Parse(info);
@@ -53,7 +53,7 @@ namespace Steeltoe.Security.Authentication.CloudFoundry.Test
         public void GetIssueTime_FindsTime()
         {
             var info = TestHelpers.GetValidTokenInfoRequestResponse();
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1 || NET5_0
             var payload = JsonDocument.Parse(info).RootElement;
 #else
             var payload = JObject.Parse(info);
@@ -66,7 +66,7 @@ namespace Steeltoe.Security.Authentication.CloudFoundry.Test
         public void GetScopes_FindsScopes()
         {
             var info = TestHelpers.GetValidTokenInfoRequestResponse();
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1 || NET5_0
             var payload = JsonDocument.Parse(info).RootElement;
 #else
             var payload = JObject.Parse(info);

--- a/src/Security/test/Authentication.CloudFoundryBase.Test/Steeltoe.Security.Authentication.CloudFoundryBase.Test.csproj
+++ b/src/Security/test/Authentication.CloudFoundryBase.Test/Steeltoe.Security.Authentication.CloudFoundryBase.Test.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Security/test/Authentication.CloudFoundryCore.Test/CloudFoundryOAuthHandlerTest.cs
+++ b/src/Security/test/Authentication.CloudFoundryCore.Test/CloudFoundryOAuthHandlerTest.cs
@@ -7,7 +7,7 @@ using Microsoft.AspNetCore.Authentication.OAuth;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-#if !NETCOREAPP3_1
+#if !NETCOREAPP3_1 && !NET5_0
 using Newtonsoft.Json.Linq;
 #endif
 using System.Linq;
@@ -15,7 +15,7 @@ using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Security.Claims;
 using System.Text.Encodings.Web;
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1 || NET5_0
 using System.Text.Json;
 #endif
 using Xunit;
@@ -117,7 +117,7 @@ namespace Steeltoe.Security.Authentication.CloudFoundry.Test
 
             var testHandler = GetTestHandler(opts);
 
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1 || NET5_0
             var payload = JsonDocument.Parse(TestHelpers.GetValidTokenInfoRequestResponse());
             var tokens = OAuthTokenResponse.Success(payload);
 #else
@@ -140,7 +140,7 @@ namespace Steeltoe.Security.Authentication.CloudFoundry.Test
             };
             var testHandler = GetTestHandler(opts);
 
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1 || NET5_0
             var payload = JsonDocument.Parse(TestHelpers.GetValidTokenInfoRequestResponse());
             var tokens = OAuthTokenResponse.Success(payload);
 #else
@@ -176,7 +176,7 @@ namespace Steeltoe.Security.Authentication.CloudFoundry.Test
 
             var identity = new ClaimsIdentity();
 
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1 || NET5_0
             var payload = JsonDocument.Parse(TestHelpers.GetValidTokenInfoRequestResponse());
             var tokens = OAuthTokenResponse.Success(payload);
 #else

--- a/src/Security/test/Authentication.CloudFoundryCore.Test/CloudFoundryOpenIdConnectConfigurerTest.cs
+++ b/src/Security/test/Authentication.CloudFoundryCore.Test/CloudFoundryOpenIdConnectConfigurerTest.cs
@@ -27,7 +27,7 @@ namespace Steeltoe.Security.Authentication.CloudFoundry.Test
             Assert.Equal(CloudFoundryDefaults.ClientId, oidcOptions.ClientId);
             Assert.Equal(CloudFoundryDefaults.ClientSecret, oidcOptions.ClientSecret);
             Assert.Equal(new PathString(CloudFoundryDefaults.CallbackPath), oidcOptions.CallbackPath);
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1 || NET5_0
             Assert.Equal(19, oidcOptions.ClaimActions.Count());
 #else
             Assert.Equal(21, oidcOptions.ClaimActions.Count());
@@ -57,7 +57,7 @@ namespace Steeltoe.Security.Authentication.CloudFoundry.Test
             Assert.Equal("secret", oidcOptions.ClientSecret);
             Assert.Equal(new PathString(CloudFoundryDefaults.CallbackPath), oidcOptions.CallbackPath);
             Assert.Null(oidcOptions.BackchannelHttpHandler);
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1 || NET5_0
             Assert.Equal(19, oidcOptions.ClaimActions.Count());
 #else
             Assert.Equal(21, oidcOptions.ClaimActions.Count());

--- a/src/Security/test/Authentication.CloudFoundryCore.Test/CloudFoundryOpenIdConnectOptionsTest.cs
+++ b/src/Security/test/Authentication.CloudFoundryCore.Test/CloudFoundryOpenIdConnectOptionsTest.cs
@@ -22,7 +22,7 @@ namespace Steeltoe.Security.Authentication.CloudFoundry.Test
             Assert.Equal(CloudFoundryDefaults.ClientSecret, opts.ClientSecret);
             Assert.Equal(new PathString("/signin-cloudfoundry"), opts.CallbackPath);
             Assert.True(opts.ValidateCertificates);
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1 || NET5_0
             Assert.Equal(19, opts.ClaimActions.Count());
 #else
             Assert.Equal(21, opts.ClaimActions.Count());

--- a/src/Security/test/Authentication.CloudFoundryCore.Test/CloudFoundryScopeClaimActionTest.cs
+++ b/src/Security/test/Authentication.CloudFoundryCore.Test/CloudFoundryScopeClaimActionTest.cs
@@ -2,11 +2,11 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-#if !NETCOREAPP3_1
+#if !NETCOREAPP3_1 && !NET5_0
 using Newtonsoft.Json.Linq;
 #endif
 using System.Security.Claims;
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1 || NET5_0
 using System.Text.Json;
 #endif
 using Xunit;
@@ -19,7 +19,7 @@ namespace Steeltoe.Security.Authentication.CloudFoundry.Test
         public void Run_AddsClaims()
         {
             var resp = TestHelpers.GetValidTokenInfoRequestResponse();
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1 || NET5_0
             var payload = JsonDocument.Parse(resp).RootElement;
 #else
             var payload = JObject.Parse(resp);

--- a/src/Security/test/Authentication.CloudFoundryCore.Test/MyTestCloudFoundryHandler.cs
+++ b/src/Security/test/Authentication.CloudFoundryCore.Test/MyTestCloudFoundryHandler.cs
@@ -30,7 +30,7 @@ namespace Steeltoe.Security.Authentication.CloudFoundry.Test
 
         public async Task<OAuthTokenResponse> TestExchangeCodeAsync(string code, string redirectUri)
         {
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1 || NET5_0
             return await ExchangeCodeAsync(new OAuthCodeExchangeContext(new AuthenticationProperties(), code, redirectUri));
 #else
             return await ExchangeCodeAsync(code, redirectUri);

--- a/src/Security/test/Authentication.CloudFoundryCore.Test/Steeltoe.Security.Authentication.CloudFoundryCore.Test.csproj
+++ b/src/Security/test/Authentication.CloudFoundryCore.Test/Steeltoe.Security.Authentication.CloudFoundryCore.Test.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Security/test/DataProtection.CredHubBase.Test/Steeltoe.Security.DataProtection.CredHubBase.Test.csproj
+++ b/src/Security/test/DataProtection.CredHubBase.Test/Steeltoe.Security.DataProtection.CredHubBase.Test.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Security/test/DataProtection.CredHubCore.Test/Steeltoe.Security.DataProtection.CredHubCore.Test.csproj
+++ b/src/Security/test/DataProtection.CredHubCore.Test/Steeltoe.Security.DataProtection.CredHubCore.Test.csproj
@@ -1,16 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedtest.props" />
   <Import Project="..\..\..\..\targetframework.props" />
 
-  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.1'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net461' OR '$(TargetFramework)' == 'netcoreapp2.1'">
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="$(AspNetCoreVersion)" />
   </ItemGroup>
 

--- a/src/Security/test/DataProtection.RedisCore.Test/Steeltoe.Security.DataProtection.RedisCore.Test.csproj
+++ b/src/Security/test/DataProtection.RedisCore.Test/Steeltoe.Security.DataProtection.RedisCore.Test.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />

--- a/versions.props
+++ b/versions.props
@@ -7,9 +7,9 @@
     <CSharpVersion>4.5.0</CSharpVersion>
     <DriveInfoVersion>4.3.1</DriveInfoVersion>
     <EFCoreVersion>2.0.0</EFCoreVersion>
-    <EFCoreTestVersion>2.1.2</EFCoreTestVersion>
-    <HttpVersion>4.3.3</HttpVersion>
-    <HttpClientVersion>4.3.3</HttpClientVersion>
+    <HttpVersion>4.3.4</HttpVersion>
+    <WinHttpHandlerVersion>4.7.0</WinHttpHandlerVersion>
+    <HttpClientVersion>4.3.4</HttpClientVersion>
     <JwtTokensVersion>5.2.2</JwtTokensVersion>
     <SymReaderVersion>1.2.0</SymReaderVersion>
     <SymReaderPortableVersion>1.4.0</SymReaderPortableVersion>
@@ -24,8 +24,6 @@
     <MySqlV6>6.10.7</MySqlV6>
     <MySqlV8>8.0.14</MySqlV8>
     <NpgsqlVersion>4.0.0</NpgsqlVersion>
-    <NpgsqlEFCoreVersion>2.1.0</NpgsqlEFCoreVersion>
-    <PomeloEFCoreVersion>2.0.1</PomeloEFCoreVersion>
     <SqlClientVersion>4.5.0</SqlClientVersion>
     <MicrosoftExtensionsRedisVersion>2.2.0</MicrosoftExtensionsRedisVersion>
     <StackExchangeVersion>2.0.513</StackExchangeVersion>
@@ -38,8 +36,8 @@
     <HttpExtensionsVersion>2.1.0</HttpExtensionsVersion>
     <DiagnosticsExtensionsVersion>2.2.5</DiagnosticsExtensionsVersion>
     <JsonNetVersion>11.0.2</JsonNetVersion>
-    <MockHttpVersion>5.0.0</MockHttpVersion>
-    <MoqVersion>4.8.2</MoqVersion>
+    <MockHttpVersion>6.0.0</MockHttpVersion>
+    <MoqVersion>4.13.1</MoqVersion>
     <OpenCensusVersion>0.1.0-alpha-42253</OpenCensusVersion>
     <RabbitClientVersion>5.0.1</RabbitClientVersion>
     <ReactiveVersion>4.1.5</ReactiveVersion>
@@ -55,26 +53,42 @@
     <HealthChecksRedisVersion>2.2.3</HealthChecksRedisVersion>
     <HealthChecksSqlServerVersion>2.2.0</HealthChecksSqlServerVersion>
 
-    <SonarAnalyzerVersion>7.17.0.9346</SonarAnalyzerVersion>
+    <SonarAnalyzerVersion>8.0.0.9566</SonarAnalyzerVersion>
     <SourceLinkGitHubVersion>1.0.0</SourceLinkGitHubVersion>
     <StyleCopVersion>1.1.118</StyleCopVersion>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.1' OR '$(TargetFramework)' == 'netcoreapp3.1'">
-    <AspNetCoreVersion>3.1.0</AspNetCoreVersion>
-    <EF6Version>6.3.0</EF6Version>
-    <ExtensionsVersion>3.1.0</ExtensionsVersion>
-    <HealthChecksVersion>3.1.0</HealthChecksVersion>
-    <LoggingVersion>3.1.0</LoggingVersion>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'net461' OR '$(TargetFramework)' == 'netcoreapp2.1'">
     <AspNetVersion>5.2.4</AspNetVersion>
     <OwinVersion>4.0.0</OwinVersion>
     <OwinOAuthVersion>4.0.0</OwinOAuthVersion>
     <AspNetCoreVersion>2.1.0</AspNetCoreVersion>
+    <EFCoreTestVersion>2.1.0</EFCoreTestVersion>
     <EF6Version>6.2.0</EF6Version>
+    <NpgsqlEFCoreVersion>2.1.0</NpgsqlEFCoreVersion>
+    <PomeloEFCoreVersion>2.1.0</PomeloEFCoreVersion>
+    <OracleEFCoreVersion>2.19.30</OracleEFCoreVersion>
     <ExtensionsVersion>2.2.0</ExtensionsVersion>
     <HealthChecksVersion>2.2.0</HealthChecksVersion>
     <LoggingVersion>2.2.0</LoggingVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1' OR '$(TargetFramework)' == 'netstandard2.1'">
+    <AspNetCoreVersion>3.1.0</AspNetCoreVersion>
+    <EFCoreTestVersion>3.1.6</EFCoreTestVersion>
+    <EF6Version>6.3.0</EF6Version>
+    <NpgsqlEFCoreVersion>3.1.0</NpgsqlEFCoreVersion>
+    <PomeloEFCoreVersion>3.1.0</PomeloEFCoreVersion>
+    <OracleEFCoreVersion>3.19.80</OracleEFCoreVersion>
+    <ExtensionsVersion>3.1.0</ExtensionsVersion>
+    <HealthChecksVersion>3.1.0</HealthChecksVersion>
+    <LoggingVersion>3.1.0</LoggingVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net5.0'">
+    <AspNetCoreVersion>5.0.0</AspNetCoreVersion>
+    <EFCoreTestVersion>5.0.0</EFCoreTestVersion>
+    <EF6Version>6.4.0</EF6Version>
+    <NpgsqlEFCoreVersion>5.0.0</NpgsqlEFCoreVersion>
+    <PomeloEFCoreVersion>5.0.0-alpha.2</PomeloEFCoreVersion>
+    <ExtensionsVersion>5.0.0</ExtensionsVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Add support for EF Core 5.0 (MySQL & Postgres)

Run tests with .NET 5 (and EF 5) -- bring #534 to 2.x