### PR TITLE
Assist IDE to create members that start with underscore

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -55,6 +55,17 @@ csharp_new_line_before_finally = true
 csharp_new_line_before_members_in_object_initializers = true
 csharp_new_line_before_members_in_anonymous_types = true
 
+# Instance fields are camelCase and start with _
+# the symbol and style property reference the name of dotnet_naming_symbols and dotnet_naming_style
+dotnet_naming_rule.instance_fields_should_be_camel_case.severity = suggestion
+dotnet_naming_rule.instance_fields_should_be_camel_case.symbols = instance_fields
+dotnet_naming_rule.instance_fields_should_be_camel_case.style = instance_field_style
+ 
+dotnet_naming_symbols.instance_fields.applicable_kinds = field
+ 
+dotnet_naming_style.instance_field_style.capitalization = camel_case
+dotnet_naming_style.instance_field_style.required_prefix = _
+
 # CS0168: Variable is declared but never used
 dotnet_diagnostic.CS0168.severity = suggestion
 


### PR DESCRIPTION
* Coding guidelines state members should start with _
* Not enabled by default in Visual Studio
* Extend .editorconfig to support this