### PR TITLE
Update Coverlet and SonarAnalyzer (2.x)

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -4,8 +4,5 @@
     <!-- <add key="SteeltoeDev" value="https://www.myget.org/F/steeltoedev/api/v3/index.json" /> -->
     <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
     <add key="DotnetCore" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
-    
-    <!-- for preview versions of Coverlet... use until next release after 1.3.0 hits nuget.org -->
-    <add key="coverletNightly" value="https://f.feedz.io/marcorossignoli/coverletunofficial/nuget/index.json" />
   </packageSources>
 </configuration>

--- a/src/CircuitBreaker/src/Hystrix.MetricsStreamAutofac/RabbitMetricsStreamPublisher.cs
+++ b/src/CircuitBreaker/src/Hystrix.MetricsStreamAutofac/RabbitMetricsStreamPublisher.cs
@@ -32,7 +32,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix.MetricsStream
             if (sslOption != null && sslOption.Enabled)
             {
                 logger?.LogInformation("Hystrix Metrics using TLS");
-                sslOption.Version = SslProtocols.Tls | SslProtocols.Tls11 | SslProtocols.Tls12;
+                sslOption.Version = SslProtocols.Tls12;
                 if (!this.options.Validate_Certificates)
                 {
                     logger?.LogInformation("Hystrix Metrics disabling certificate validation");

--- a/src/CircuitBreaker/src/Hystrix.MetricsStreamCore/RabbitMetricsStreamPublisher.cs
+++ b/src/CircuitBreaker/src/Hystrix.MetricsStreamCore/RabbitMetricsStreamPublisher.cs
@@ -32,7 +32,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix.MetricsStream
             if (sslOption != null && sslOption.Enabled)
             {
                 logger?.LogInformation("Hystrix Metrics using TLS");
-                sslOption.Version = SslProtocols.Tls | SslProtocols.Tls11 | SslProtocols.Tls12;
+                sslOption.Version = SslProtocols.Tls12;
                 if (!this.options.Validate_Certificates)
                 {
                     logger?.LogInformation("Hystrix Metrics disabling certificate validation");

--- a/src/Common/src/Common.Http/HttpClientHelper.cs
+++ b/src/Common/src/Common.Http/HttpClientHelper.cs
@@ -81,7 +81,9 @@ namespace Steeltoe.Common.Http
                 prevValidator = ServicePointManager.ServerCertificateValidationCallback;
 
                 // Disabling certificate validation is a bad idea, that's why it's off by default!
+#pragma warning disable S4830 // Server certificates should be verified during SSL/TLS connections
                 ServicePointManager.ServerCertificateValidationCallback = (sender, cert, chain, sslPolicyErrors) => true;
+#pragma warning restore S4830 // Server certificates should be verified during SSL/TLS connections
             }
         }
 

--- a/src/Common/src/Common/Discovery/IServiceInstanceProviderExtensions.cs
+++ b/src/Common/src/Common/Discovery/IServiceInstanceProviderExtensions.cs
@@ -4,9 +4,8 @@
 
 using Microsoft.Extensions.Caching.Distributed;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
-using System.Runtime.Serialization.Formatters.Binary;
+using System.Text.Json;
 using System.Threading.Tasks;
 
 namespace Steeltoe.Common.Discovery
@@ -18,7 +17,7 @@ namespace Steeltoe.Common.Discovery
             string serviceId,
             IDistributedCache distributedCache = null,
             DistributedCacheEntryOptions cacheOptions = null,
-            string serviceInstancesKeyPrefix = "ServiceInstances-")
+            string serviceInstancesKeyPrefix = "ServiceInstances:")
         {
             // if distributed cache was provided, just make the call back to the provider
             if (distributedCache != null)
@@ -47,18 +46,10 @@ namespace Steeltoe.Common.Discovery
             return inst.ToList();
         }
 
-        private static byte[] SerializeForCache(object data)
-        {
-            using var stream = new MemoryStream();
-            new BinaryFormatter().Serialize(stream, data);
-            return stream.ToArray();
-        }
+        private static byte[] SerializeForCache(object data) => JsonSerializer.SerializeToUtf8Bytes(data);
 
         private static T DeserializeFromCache<T>(byte[] data)
             where T : class
-        {
-            using var stream = new MemoryStream(data);
-            return new BinaryFormatter().Deserialize(stream) as T;
-        }
+                => JsonSerializer.Deserialize<T>(data);
     }
 }

--- a/src/Common/src/Common/Discovery/SerializableIServiceInstance.cs
+++ b/src/Common/src/Common/Discovery/SerializableIServiceInstance.cs
@@ -10,6 +10,14 @@ namespace Steeltoe.Common.Discovery
     [Serializable]
     public class SerializableIServiceInstance : IServiceInstance
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SerializableIServiceInstance"/> class.
+        /// For use with JsonSerializer
+        /// </summary>
+        public SerializableIServiceInstance()
+        {
+        }
+
         public SerializableIServiceInstance(IServiceInstance instance)
         {
             ServiceId = instance.ServiceId;

--- a/src/Common/src/Common/Steeltoe.Common.csproj
+++ b/src/Common/src/Common/Steeltoe.Common.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(ExtensionsVersion)" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="$(ExtensionsVersion)" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="$(SystemDiagnosticsVersion)" />
+    <PackageReference Include="System.Text.Json" Version="$(SystemJsonVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Connectors/src/ConnectorAutofac/RedisContainerBuilderExtensions.cs
+++ b/src/Connectors/src/ConnectorAutofac/RedisContainerBuilderExtensions.cs
@@ -85,7 +85,7 @@ namespace Steeltoe.CloudFoundry.ConnectorAutofac
                 : config.GetSingletonServiceInfo<RedisServiceInfo>();
 
             var redisConfig = new RedisCacheConnectorOptions(config);
-            var factory = new RedisServiceConnectorFactory(info, redisConfig, redisImplementation, redisOptions, initializer ?? null);
+            var factory = new RedisServiceConnectorFactory(info, redisConfig, redisImplementation, redisOptions, initializer);
             container.Register(c => new RedisHealthContributor(factory, redisImplementation, c.ResolveOptional<ILogger<RedisHealthContributor>>())).As<IHealthContributor>();
             return container.Register(c => factory.Create(null)).As(redisInterface, redisImplementation);
         }

--- a/src/Connectors/src/ConnectorBase/Cache/RedisCacheConfigurationExtensions.cs
+++ b/src/Connectors/src/ConnectorBase/Cache/RedisCacheConfigurationExtensions.cs
@@ -58,7 +58,7 @@ namespace Steeltoe.CloudFoundry.Connector.Redis
             var initializer = ConnectorHelpers.FindMethod(redisConnection, "Connect");
 
             var info = serviceName == null ? config.GetSingletonServiceInfo<RedisServiceInfo>() : config.GetRequiredServiceInfo<RedisServiceInfo>(serviceName);
-            return new RedisServiceConnectorFactory(info, connectorOptions, redisConnection, redisOptions, initializer ?? null);
+            return new RedisServiceConnectorFactory(info, connectorOptions, redisConnection, redisOptions, initializer);
         }
     }
 }

--- a/src/Connectors/src/ConnectorCore/RedisCacheServiceCollectionExtensions.cs
+++ b/src/Connectors/src/ConnectorCore/RedisCacheServiceCollectionExtensions.cs
@@ -216,7 +216,7 @@ namespace Steeltoe.CloudFoundry.Connector.Redis
             var initializer = RedisTypeLocator.StackExchangeInitializer;
 
             var redisConfig = new RedisCacheConnectorOptions(config);
-            var factory = new RedisServiceConnectorFactory(info, redisConfig, redisImplementation, redisOptions, initializer ?? null);
+            var factory = new RedisServiceConnectorFactory(info, redisConfig, redisImplementation, redisOptions, initializer);
             services.Add(new ServiceDescriptor(redisInterface, factory.Create, contextLifetime));
             services.Add(new ServiceDescriptor(redisImplementation, factory.Create, contextLifetime));
             if (!services.Any(s => s.ServiceType == typeof(HealthCheckService)) || addSteeltoeHealthChecks)

--- a/src/Connectors/test/Connector.EFCore.Test/EntityFrameworkCoreTypeLocatorTest.cs
+++ b/src/Connectors/test/Connector.EFCore.Test/EntityFrameworkCoreTypeLocatorTest.cs
@@ -74,10 +74,10 @@ namespace Steeltoe.CloudFoundry.Connector.EFCore.Test
             Assert.NotNull(type);
         }
 
-#if NETCOREAPP3_1
-        [Fact]
-#else
+#if NET5_0
         [Fact(Skip = "Revisit when Oracle has support for EF Core 5.0")]
+#else
+        [Fact]
 #endif
         public void Options_Found_In_OracleEF_Assembly()
         {

--- a/src/Connectors/test/Connector.EFCore.Test/MySqlDbContextOptionsExtensionsTest.cs
+++ b/src/Connectors/test/Connector.EFCore.Test/MySqlDbContextOptionsExtensionsTest.cs
@@ -15,6 +15,7 @@ using Steeltoe.CloudFoundry.Connector.EFCore.Test;
 using Steeltoe.CloudFoundry.Connector.Test;
 using Steeltoe.Extensions.Configuration.CloudFoundry;
 using System;
+using System.Collections.Generic;
 using Xunit;
 
 namespace Steeltoe.CloudFoundry.Connector.MySql.EFCore.Test

--- a/src/Connectors/test/Connector.EFCore.Test/Steeltoe.CloudFoundry.Connector.EFCore.Test.csproj
+++ b/src/Connectors/test/Connector.EFCore.Test/Steeltoe.CloudFoundry.Connector.EFCore.Test.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Management/src/ExporterBase/Metrics/CloudFoundryForwarder/CloudFoundryForwarderExporter.cs
+++ b/src/Management/src/ExporterBase/Metrics/CloudFoundryForwarder/CloudFoundryForwarderExporter.cs
@@ -21,7 +21,6 @@ namespace Steeltoe.Management.Exporter.Metrics.CloudFoundryForwarder
         private const int UNPROCESSABLE_ENTITY = 422;
         private const int PAYLOAD_TOO_LARGE = 413;
         private const int TOO_MANY_REQUESTS = 429;
-        private static HttpClient _httpClient;
 
         private readonly ILogger<CloudFoundryForwarderExporter> _logger;
         private readonly ICloudFoundryMetricWriter _metricFormatWriter;
@@ -29,6 +28,7 @@ namespace Steeltoe.Management.Exporter.Metrics.CloudFoundryForwarder
         private readonly CloudFoundryForwarderOptions _options;
         private readonly IStats _stats;
         private readonly IViewManager _viewManager;
+        private HttpClient _httpClient;
         private Thread _workerThread;
         private bool _shutdown = false;
 
@@ -37,7 +37,7 @@ namespace Steeltoe.Management.Exporter.Metrics.CloudFoundryForwarder
             _options = options;
             _stats = stats;
             _viewManager = stats.ViewManager;
-            _httpClient ??= GetHttpClient();
+            _httpClient ??= HttpClientHelper.GetHttpClient(_options.ValidateCertificates, _options.TimeoutSeconds * 1000);
             _logger = logger;
             if (options.MicrometerMetricWriter)
             {
@@ -232,11 +232,6 @@ namespace Steeltoe.Management.Exporter.Metrics.CloudFoundryForwarder
             }
 
             return new StringContent(string.Empty, Encoding.UTF8, "application/json");
-        }
-
-        protected internal HttpClient GetHttpClient()
-        {
-            return HttpClientHelper.GetHttpClient(_options.ValidateCertificates, _options.TimeoutSeconds * 1000);
         }
 
         protected internal void ResetMetrics()

--- a/src/Management/src/ExporterCore/Tracing/Zipkin/ZipkinExporterServiceCollectionExtensions.cs
+++ b/src/Management/src/ExporterCore/Tracing/Zipkin/ZipkinExporterServiceCollectionExtensions.cs
@@ -56,7 +56,9 @@ namespace Steeltoe.Management.Exporter.Tracing
                 var client = new HttpClient(
                     new HttpClientHandler()
                     {
+#pragma warning disable S4830 // Server certificates should be verified during SSL/TLS connections
                         ServerCertificateCustomValidationCallback = (mesg, cert, chain, errors) => { return true; }
+#pragma warning restore S4830 // Server certificates should be verified during SSL/TLS connections
                     });
                 return new ZipkinTraceExporter(censusOpts, tracing.ExportComponent, client);
             }

--- a/src/Security/src/Authentication.CloudFoundryBase/CloudFoundryHelper.cs
+++ b/src/Security/src/Authentication.CloudFoundryBase/CloudFoundryHelper.cs
@@ -76,7 +76,9 @@ namespace Steeltoe.Security.Authentication.CloudFoundry
             {
                 var handler = new HttpClientHandler
                 {
+#pragma warning disable S4830 // Server certificates should be verified during SSL/TLS connections
                     ServerCertificateCustomValidationCallback = (sender, cert, chain, sslPolicyErrors) => true
+#pragma warning restore S4830 // Server certificates should be verified during SSL/TLS connections
                 };
                 return handler;
             }

--- a/src/Steeltoe.All.sln
+++ b/src/Steeltoe.All.sln
@@ -56,6 +56,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "_shared", "_shared", "{DC1B
 		..\sharedtest.props = ..\sharedtest.props
 		..\Steeltoe.ruleset = ..\Steeltoe.ruleset
 		..\stylecop.json = ..\stylecop.json
+		..\targetframework.props = ..\targetframework.props
 		..\versions.props = ..\versions.props
 	EndProjectSection
 EndProject

--- a/targetframework.props
+++ b/targetframework.props
@@ -1,9 +1,5 @@
 <Project>
-    <PropertyGroup Condition="! $(OS.Contains('Win')) AND '$(TargetFramework)'== 'net461'">
-        <FrameworkPathOverride>$(NuGetPackageRoot)microsoft.targetingpack.netframework.v4.6.1/1.0.1/lib/net461/</FrameworkPathOverride>
-        <RestoreAdditionalProjectSources>https://dotnet.myget.org/F/dotnet-core/api/v3/index.json</RestoreAdditionalProjectSources>
-    </PropertyGroup>
     <ItemGroup Condition="! $(OS.Contains('Win')) AND '$(TargetFramework)'== 'net461'">
-        <PackageReference Include="Microsoft.TargetingPack.NETFramework.v4.6.1"  Version="1.0.1" ExcludeAssets="All" PrivateAssets="All" />
+      <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
     </ItemGroup>
 </Project>

--- a/versions.props
+++ b/versions.props
@@ -31,7 +31,7 @@
     <AutofacVersion>4.6.1</AutofacVersion>
     <BouncyCastleVersion>1.8.4</BouncyCastleVersion>
     <ConsulVersion>0.7.2.6</ConsulVersion>
-    <CoverletVersion>3.0.0-preview.1</CoverletVersion>
+    <CoverletVersion>3.0.0</CoverletVersion>
     <HdrHistogramVersion>2.0.0</HdrHistogramVersion>
     <HttpExtensionsVersion>2.1.0</HttpExtensionsVersion>
     <DiagnosticsExtensionsVersion>2.2.5</DiagnosticsExtensionsVersion>
@@ -53,7 +53,7 @@
     <HealthChecksRedisVersion>2.2.3</HealthChecksRedisVersion>
     <HealthChecksSqlServerVersion>2.2.0</HealthChecksSqlServerVersion>
 
-    <SonarAnalyzerVersion>8.0.0.9566</SonarAnalyzerVersion>
+    <SonarAnalyzerVersion>8.16.0.25740</SonarAnalyzerVersion>
     <SourceLinkGitHubVersion>1.0.0</SourceLinkGitHubVersion>
     <StyleCopVersion>1.1.118</StyleCopVersion>
   </PropertyGroup>


### PR DESCRIPTION
- Update Coverlet to a GA version, drop the dev feed reference from nuget.config #563 
- Ignore or resolve several new warnings that show up as a result of the SonarAnalyzer update
- brings #535 to 2.x
