### PR TITLE
K8s config handle "__" as ":"

### DIFF
--- a/src/Configuration/src/KubernetesBase/KubernetesConfigMapProvider.cs
+++ b/src/Configuration/src/KubernetesBase/KubernetesConfigMapProvider.cs
@@ -65,6 +65,8 @@ namespace Steeltoe.Extensions.Configuration.Kubernetes
             }
         }
 
+        private static string NormalizeKey(string key) => key.Replace("__", ":");
+
         private void EnableReloading()
         {
             if (Settings.ReloadSettings.ConfigMaps && !Polling)
@@ -119,7 +121,7 @@ namespace Steeltoe.Extensions.Configuration.Kubernetes
             {
                 foreach (var data in item?.Data)
                 {
-                    configMapContents[data.Key] = data.Value;
+                    configMapContents[NormalizeKey(data.Key)] = data.Value;
                 }
             }
 

--- a/src/Configuration/src/KubernetesBase/KubernetesSecretProvider.cs
+++ b/src/Configuration/src/KubernetesBase/KubernetesSecretProvider.cs
@@ -73,6 +73,8 @@ namespace Steeltoe.Extensions.Configuration.Kubernetes
             }
         }
 
+        private static string NormalizeKey(string key) => key.Replace("__", ":");
+
         private void EnableReloading()
         {
             if (Settings.ReloadSettings.Secrets)
@@ -131,7 +133,7 @@ namespace Steeltoe.Extensions.Configuration.Kubernetes
             {
                 foreach (var data in item.Data)
                 {
-                    secretContents[data.Key] = Encoding.UTF8.GetString(data.Value);
+                    secretContents[NormalizeKey(data.Key)] = Encoding.UTF8.GetString(data.Value);
                 }
             }
 


### PR DESCRIPTION
When `__` is found in the key of a configmap entry, treat it like a colon  #584