### PR TITLE
OAuth Service URL Fallback (3.x version)

### DIFF
--- a/src/Security/src/Authentication.CloudFoundryCore/AuthenticationBuilderExtensions.cs
+++ b/src/Security/src/Authentication.CloudFoundryCore/AuthenticationBuilderExtensions.cs
@@ -55,6 +55,7 @@ namespace Steeltoe.Security.Authentication.CloudFoundry
             {
                 var securitySection = config.GetSection(CloudFoundryDefaults.SECURITY_CLIENT_SECTION_PREFIX);
                 securitySection.Bind(options);
+                options.SetEndpoints(GetAuthDomain(securitySection));
 
                 var info = config.GetSingletonServiceInfo<SsoServiceInfo>();
                 CloudFoundryOAuthConfigurer.Configure(info, options);
@@ -222,6 +223,7 @@ namespace Steeltoe.Security.Authentication.CloudFoundry
                 var cloudFoundryOptions = new CloudFoundryJwtBearerOptions();
                 var securitySection = config.GetSection(CloudFoundryDefaults.SECURITY_CLIENT_SECTION_PREFIX);
                 securitySection.Bind(cloudFoundryOptions);
+                cloudFoundryOptions.SetEndpoints(GetAuthDomain(securitySection));
 
                 var info = config.GetSingletonServiceInfo<SsoServiceInfo>();
                 CloudFoundryJwtBearerConfigurer.Configure(info, options, cloudFoundryOptions);
@@ -300,5 +302,8 @@ namespace Steeltoe.Security.Authentication.CloudFoundry
             });
             return builder;
         }
+
+        private static string GetAuthDomain(IConfigurationSection configurationSection) =>
+            configurationSection.GetValue<string>(nameof(SsoServiceInfo.AuthDomain));
     }
 }

--- a/src/Security/src/Authentication.CloudFoundryCore/CloudFoundryJwtBearerOptions.cs
+++ b/src/Security/src/Authentication.CloudFoundryCore/CloudFoundryJwtBearerOptions.cs
@@ -10,13 +10,13 @@ namespace Steeltoe.Security.Authentication.CloudFoundry
     {
         public CloudFoundryJwtBearerOptions()
         {
-            var authURL = "http://" + CloudFoundryDefaults.OAuthServiceUrl;
             ClaimsIssuer = CloudFoundryDefaults.AuthenticationScheme;
-            JwtKeyUrl = authURL + CloudFoundryDefaults.JwtTokenUri;
             SaveToken = true;
             TokenValidationParameters.ValidateAudience = false;
             TokenValidationParameters.ValidateIssuer = true;
             TokenValidationParameters.ValidateLifetime = true;
+
+            SetEndpoints("http://" + CloudFoundryDefaults.OAuthServiceUrl);
         }
 
         public string JwtKeyUrl { get; set; }
@@ -30,6 +30,12 @@ namespace Steeltoe.Security.Authentication.CloudFoundry
         {
             get { return Validate_Certificates; }
             set { Validate_Certificates = value; }
+        }
+
+        public void SetEndpoints(string authDomain)
+        {
+            JwtKeyUrl = (!string.IsNullOrWhiteSpace(authDomain)) ?
+                authDomain + CloudFoundryDefaults.JwtTokenUri : JwtKeyUrl;
         }
     }
 }

--- a/src/Security/src/Authentication.CloudFoundryCore/CloudFoundryOAuthOptions.cs
+++ b/src/Security/src/Authentication.CloudFoundryCore/CloudFoundryOAuthOptions.cs
@@ -35,15 +35,10 @@ namespace Steeltoe.Security.Authentication.CloudFoundry
 
         public CloudFoundryOAuthOptions()
         {
-            var authURL = "http://" + CloudFoundryDefaults.OAuthServiceUrl;
             ClaimsIssuer = CloudFoundryDefaults.AuthenticationScheme;
             ClientId = CloudFoundryDefaults.ClientId;
             ClientSecret = CloudFoundryDefaults.ClientSecret;
             CallbackPath = new PathString(CloudFoundryDefaults.CallbackPath);
-            AuthorizationEndpoint = authURL + CloudFoundryDefaults.AuthorizationUri;
-            TokenEndpoint = authURL + CloudFoundryDefaults.AccessTokenUri;
-            UserInformationEndpoint = authURL + CloudFoundryDefaults.UserInfoUri;
-            TokenInfoUrl = authURL + CloudFoundryDefaults.CheckTokenUri;
             SaveTokens = true;
 
             ClaimActions.MapJsonKey(ClaimTypes.NameIdentifier, "user_id");
@@ -54,6 +49,19 @@ namespace Steeltoe.Security.Authentication.CloudFoundry
             ClaimActions.MapScopes();
 
             SignInScheme = CookieAuthenticationDefaults.AuthenticationScheme;
+
+            SetEndpoints("http://" + CloudFoundryDefaults.OAuthServiceUrl);
+        }
+
+        public void SetEndpoints(string authDomain)
+        {
+            if (!string.IsNullOrWhiteSpace(authDomain))
+            {
+                AuthorizationEndpoint = authDomain + CloudFoundryDefaults.AuthorizationUri;
+                TokenEndpoint = authDomain + CloudFoundryDefaults.AccessTokenUri;
+                UserInformationEndpoint = authDomain + CloudFoundryDefaults.UserInfoUri;
+                TokenInfoUrl = authDomain + CloudFoundryDefaults.CheckTokenUri;
+            }
         }
 
         internal AuthServerOptions BaseOptions()

--- a/src/Security/test/Authentication.CloudFoundryCore.Test/CloudFoundryJwtBearerOptionsTest.cs
+++ b/src/Security/test/Authentication.CloudFoundryCore.Test/CloudFoundryJwtBearerOptionsTest.cs
@@ -8,15 +8,41 @@ namespace Steeltoe.Security.Authentication.CloudFoundry.Test
 {
     public class CloudFoundryJwtBearerOptionsTest
     {
+        private const string DEFAULT_JWT_TOKEN_URL =
+            "http://" + CloudFoundryDefaults.OAuthServiceUrl + CloudFoundryDefaults.JwtTokenUri;
+
+        public static TheoryData<string, string> SetEndpointsData()
+        {
+            var data = new TheoryData<string, string>();
+            var newDomain = "http://not-the-original-domain";
+
+            data.Add(string.Empty, DEFAULT_JWT_TOKEN_URL);
+            data.Add("   ", DEFAULT_JWT_TOKEN_URL);
+            data.Add(default, DEFAULT_JWT_TOKEN_URL);
+            data.Add(newDomain, newDomain + CloudFoundryDefaults.JwtTokenUri);
+
+            return data;
+        }
+
         [Fact]
         public void DefaultConstructor_SetsupDefaultOptions()
         {
             var opts = new CloudFoundryJwtBearerOptions();
 
-            var authURL = "http://" + CloudFoundryDefaults.OAuthServiceUrl;
             Assert.Equal(CloudFoundryDefaults.AuthenticationScheme, opts.ClaimsIssuer);
-            Assert.Equal(authURL + CloudFoundryDefaults.JwtTokenUri, opts.JwtKeyUrl);
+            Assert.Equal(DEFAULT_JWT_TOKEN_URL, opts.JwtKeyUrl);
             Assert.True(opts.SaveToken);
+        }
+
+        [Theory]
+        [MemberData(nameof(SetEndpointsData))]
+        public void SetEndpoints_WithNewDomain_ReturnsExpected(string newDomain, string expectedUrl)
+        {
+            var options = new CloudFoundryJwtBearerOptions();
+
+            options.SetEndpoints(newDomain);
+
+            Assert.Equal(expectedUrl, options.JwtKeyUrl);
         }
     }
 }

--- a/src/Security/test/Authentication.CloudFoundryCore.Test/CloudFoundryOAuthBuilderTest.cs
+++ b/src/Security/test/Authentication.CloudFoundryCore.Test/CloudFoundryOAuthBuilderTest.cs
@@ -1,0 +1,64 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Steeltoe.Security.Authentication.CloudFoundry.Test
+{
+    public class CloudFoundryOAuthBuilderTest
+    {
+        [Fact]
+        public async Task ShouldKeepDefaultServiceUrlsIfAuthDomainNotPresent()
+        {
+            var expectedAuthoricationUrl = $"http://{CloudFoundryDefaults.OAuthServiceUrl}/oauth/authorize";
+            var webApplicationFactory = new TestApplicationFactory<TestServerStartup>();
+#if NETCOREAPP3_1 || NET5_0
+            var client = webApplicationFactory.CreateDefaultClient();
+#else
+            var client = webApplicationFactory.GetTestServer().CreateClient();
+#endif
+            var result = await client.GetAsync("http://localhost/");
+            var location = result.Headers.Location.ToString();
+
+            Assert.Equal(HttpStatusCode.Redirect, result.StatusCode);
+            Assert.StartsWith(expectedAuthoricationUrl, location, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public async Task ShouldAddAuthDomainToServiceUrlsIfPresent()
+        {
+            var authDomain = "http://this-config-server-url";
+            var expectedAuthorizationUrl = $"{authDomain}/oauth/authorize";
+            var expectedClientId = Guid.NewGuid().ToString();
+
+            var configuration = new Dictionary<string, string>
+            {
+                { "security:oauth2:client:authDomain", authDomain },
+                { "security:oauth2:client:clientId", expectedClientId },
+                { "security:oauth2:client:clientSecret", Guid.NewGuid().ToString() }
+            };
+
+            var webApplicationFactory = new TestApplicationFactory<TestServerStartup>(configuration);
+
+#if NETCOREAPP3_1 || NET5_0
+            var client = webApplicationFactory.CreateDefaultClient();
+#else
+            var client = webApplicationFactory.GetTestServer().CreateClient();
+#endif
+            var result = await client.GetAsync("http://localhost/");
+
+            var location = result.Headers.Location.ToString();
+
+            Assert.Equal(HttpStatusCode.Redirect, result.StatusCode);
+            Assert.StartsWith(expectedAuthorizationUrl, location, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains($"client_id={expectedClientId}", location);
+        }
+    }
+}

--- a/src/Security/test/Authentication.CloudFoundryCore.Test/CloudFoundryOAuthOptionsTest.cs
+++ b/src/Security/test/Authentication.CloudFoundryCore.Test/CloudFoundryOAuthOptionsTest.cs
@@ -12,24 +12,65 @@ namespace Steeltoe.Security.Authentication.CloudFoundry.Test
 {
     public class CloudFoundryOAuthOptionsTest
     {
+        private const string DEFAULT_OAUTH_URL = "http://" + CloudFoundryDefaults.OAuthServiceUrl;
+        private const string DEFAULT_ACCESSTOKEN_URL = DEFAULT_OAUTH_URL + CloudFoundryDefaults.AccessTokenUri;
+        private const string DEFAULT_AUTHORIZATION_URL = DEFAULT_OAUTH_URL + CloudFoundryDefaults.AuthorizationUri;
+        private const string DEFAULT_CHECKTOKEN_URL = DEFAULT_OAUTH_URL + CloudFoundryDefaults.CheckTokenUri;
+        private const string DEFAULT_USERINFO_URL = DEFAULT_OAUTH_URL + CloudFoundryDefaults.UserInfoUri;
+
+        public static TheoryData<string, string, string, string, string> SetEndpointsData()
+        {
+            var data = new TheoryData<string, string, string, string, string>();
+            var newDomain = "http://not-the-original-domain";
+            var newAccessTokenUrl = newDomain + CloudFoundryDefaults.AccessTokenUri;
+            var newAuthorizationUrl = newDomain + CloudFoundryDefaults.AuthorizationUri;
+            var newCheckTokenUrl = newDomain + CloudFoundryDefaults.CheckTokenUri;
+            var newUserInfoUrl = newDomain + CloudFoundryDefaults.UserInfoUri;
+
+            data.Add(string.Empty, default, default, default, default);
+            data.Add("   ", default, default, default, default);
+            data.Add(default, default, default, default, default);
+            data.Add(newDomain, newAccessTokenUrl, newAuthorizationUrl, newCheckTokenUrl, newUserInfoUrl);
+
+            return data;
+        }
+
         [Fact]
         public void DefaultConstructor_SetsupDefaultOptions()
         {
             var opts = new CloudFoundryOAuthOptions();
 
-            var authURL = "http://" + CloudFoundryDefaults.OAuthServiceUrl;
             Assert.Equal(CloudFoundryDefaults.AuthenticationScheme, opts.ClaimsIssuer);
             Assert.Equal(CloudFoundryDefaults.ClientId, opts.ClientId);
             Assert.Equal(CloudFoundryDefaults.ClientSecret, opts.ClientSecret);
             Assert.Equal(new PathString("/signin-cloudfoundry"), opts.CallbackPath);
-            Assert.Equal(authURL + CloudFoundryDefaults.AuthorizationUri, opts.AuthorizationEndpoint);
-            Assert.Equal(authURL + CloudFoundryDefaults.AccessTokenUri, opts.TokenEndpoint);
-            Assert.Equal(authURL + CloudFoundryDefaults.UserInfoUri, opts.UserInformationEndpoint);
-            Assert.Equal(authURL + CloudFoundryDefaults.CheckTokenUri, opts.TokenInfoUrl);
+            Assert.Equal(DEFAULT_ACCESSTOKEN_URL, opts.TokenEndpoint);
+            Assert.Equal(DEFAULT_AUTHORIZATION_URL, opts.AuthorizationEndpoint);
+            Assert.Equal(DEFAULT_CHECKTOKEN_URL, opts.TokenInfoUrl);
+            Assert.Equal(DEFAULT_USERINFO_URL, opts.UserInformationEndpoint);
             Assert.True(opts.ValidateCertificates);
             Assert.Equal(6, opts.ClaimActions.Count());
             Assert.Equal(CookieAuthenticationDefaults.AuthenticationScheme, opts.SignInScheme);
             Assert.True(opts.SaveTokens);
+        }
+
+        [Theory]
+        [MemberData(nameof(SetEndpointsData))]
+        public void SetEndpoints_WithNewDomain_ReturnsExpected(
+            string newDomain,
+            string expectedAccessTokenUrl,
+            string expectedAuthorizationUrl,
+            string expectedCheckTokenUrl,
+            string expectedUserInfoUrl)
+        {
+            var options = new CloudFoundryOAuthOptions();
+
+            options.SetEndpoints(newDomain);
+
+            Assert.Equal(expectedAccessTokenUrl ?? DEFAULT_ACCESSTOKEN_URL, options.TokenEndpoint);
+            Assert.Equal(expectedAuthorizationUrl ?? DEFAULT_AUTHORIZATION_URL, options.AuthorizationEndpoint);
+            Assert.Equal(expectedCheckTokenUrl ?? DEFAULT_CHECKTOKEN_URL, options.TokenInfoUrl);
+            Assert.Equal(expectedUserInfoUrl ?? DEFAULT_USERINFO_URL, options.UserInformationEndpoint);
         }
     }
 }

--- a/src/Security/test/Authentication.CloudFoundryCore.Test/Steeltoe.Security.Authentication.CloudFoundryCore.Test.csproj
+++ b/src/Security/test/Authentication.CloudFoundryCore.Test/Steeltoe.Security.Authentication.CloudFoundryCore.Test.csproj
@@ -18,7 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="$(AspNetCoreVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="RichardSzalay.MockHttp" Version="$(MockHttpVersion)" />
   </ItemGroup>
 </Project>

--- a/src/Security/test/Authentication.CloudFoundryCore.Test/TestApplicationFactory.cs
+++ b/src/Security/test/Authentication.CloudFoundryCore.Test/TestApplicationFactory.cs
@@ -1,0 +1,48 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+
+namespace Steeltoe.Security.Authentication.CloudFoundry.Test
+{
+    public class TestApplicationFactory<TStartup> : WebApplicationFactory<TStartup>
+        where TStartup : class
+    {
+        private readonly IReadOnlyDictionary<string, string> configuration;
+
+        public TestApplicationFactory(IReadOnlyDictionary<string, string> configuration = null)
+        {
+            this.configuration = configuration ?? ImmutableDictionary<string, string>.Empty;
+        }
+
+        protected override IHost CreateHost(IHostBuilder builder)
+        {
+            builder.UseContentRoot(Directory.GetCurrentDirectory());
+
+            return base.CreateHost(builder);
+        }
+
+        protected override IHostBuilder CreateHostBuilder()
+        {
+            var builder = Host.CreateDefaultBuilder()
+                .ConfigureWebHostDefaults(webHostBuilder =>
+                {
+                    webHostBuilder.UseStartup<TStartup>().UseTestServer();
+                })
+                .ConfigureAppConfiguration((hostingContext, config) =>
+                {
+                    config.AddInMemoryCollection(configuration);
+                });
+
+            return builder;
+        }
+    }
+}


### PR DESCRIPTION
Currently, if SSO service bindings are not found during CloudFoundry OAuth extension or CloudFoundry JWT Bearer extension, default URL are kept and not leveraging the current auth domain setting (if available). OAuth URL domains should default to Auth Domain app setting if SSO service bindings are not available.

Addresses #578 for 3.x