### PR TITLE
SBA and PublishSingleFile-compatible BuildInfo

### DIFF
--- a/src/Management/src/EndpointBase/DbMigrations/DbMigrationsEndpoint.cs
+++ b/src/Management/src/EndpointBase/DbMigrations/DbMigrationsEndpoint.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
@@ -77,9 +78,10 @@ namespace Steeltoe.Management.Endpoint.DbMigrations
                     .Where(type => !type.IsAbstract && type.AsType() != _dbContextType && _dbContextType.GetTypeInfo().IsAssignableFrom(type.AsType()))
                     .Select(typeInfo => typeInfo.AsType())
                     .ToList();
+            var scope = _container.CreateScope().ServiceProvider;
             foreach (var contextType in knownEfContexts)
             {
-                var dbContext = _container.GetService(contextType);
+                var dbContext = scope.GetService(contextType);
                 if (dbContext == null)
                 {
                     continue;

--- a/src/Management/src/EndpointBase/Health/ServiceCollectionExtensions.cs
+++ b/src/Management/src/EndpointBase/Health/ServiceCollectionExtensions.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Extensions.DependencyInjection
             var options = new HealthEndpointOptions(configuration);
             services.TryAddSingleton<IHealthOptions>(options);
             services.TryAddEnumerable(ServiceDescriptor.Singleton(typeof(IEndpointOptions), options));
-            services.TryAddSingleton<HealthEndpoint>();
+            services.TryAddScoped<HealthEndpoint>();
 
             return services;
         }

--- a/src/Management/src/EndpointCore/SpringBootAdminClient/SpringBootAdminClientOptions.cs
+++ b/src/Management/src/EndpointCore/SpringBootAdminClient/SpringBootAdminClientOptions.cs
@@ -45,7 +45,7 @@ namespace Steeltoe.Management.Endpoint.SpringBootAdminClient
 
             // Require base path to be supplied directly, in the config, or in the app instance info
             BasePath ??= GetBasePath(config) ?? appInfo?.Uris?.FirstOrDefault() ?? throw new NullReferenceException($"Please set {PREFIX}:BasePath in order to register with Spring Boot Admin");
-            ApplicationName ??= appInfo.ApplicationName;
+            ApplicationName ??= appInfo.ApplicationNameInContext(SteeltoeComponent.Management);
         }
 
         private string GetBasePath(IConfiguration config)

--- a/src/Management/test/EndpointCore.Test/Info/EndpointMiddlewareTest.cs
+++ b/src/Management/test/EndpointCore.Test/Info/EndpointMiddlewareTest.cs
@@ -69,7 +69,7 @@ namespace Steeltoe.Management.Endpoint.Info.Test
             var dict = await client.GetFromJsonAsync<Dictionary<string, Dictionary<string, object>>>("http://localhost/management/infomanagement", GetSerializerOptions());
             Assert.NotNull(dict);
 
-            Assert.Equal(5, dict.Count);
+            Assert.Equal(6, dict.Count);
             Assert.True(dict.ContainsKey("application"));
             Assert.True(dict.ContainsKey("NET"));
             Assert.True(dict.ContainsKey("git"));


### PR DESCRIPTION
Fix BuildInfo with publishSingleFile #572 and providing build:version to Spring Boot Admin #581

Testing both changes also led to:
- using ApplicationNameInContext to reduce/eliminate registering with "Steeltoe" as the app name
- use a scope for DbMigrations endpoint (found runtime error on GenericHost apps)
- use Scoped HealthEndpoint (found runtime error on GenericHost apps)