### PR TITLE
Actuators detect running on Cloud Foundry

### DIFF
--- a/src/Management/src/CloudFoundryCore/CloudFoundryActuatorsStartupFilter.cs
+++ b/src/Management/src/CloudFoundryCore/CloudFoundryActuatorsStartupFilter.cs
@@ -11,6 +11,7 @@ using System;
 
 namespace Steeltoe.Management.CloudFoundry
 {
+    [Obsolete("This class will be removed in a future release, Use Steeltoe.Management.Endpoint.AllActuatorsStartupFilter instead")]
     public class CloudFoundryActuatorsStartupFilter : IStartupFilter
     {
         public CloudFoundryActuatorsStartupFilter()

--- a/src/Management/src/CloudFoundryCore/CloudFoundryHostBuilderExtensions.cs
+++ b/src/Management/src/CloudFoundryCore/CloudFoundryHostBuilderExtensions.cs
@@ -20,6 +20,7 @@ namespace Steeltoe.Management.CloudFoundry
         /// </summary>
         /// <param name="webHostBuilder">Your Hostbuilder</param>
         /// <param name="buildCorsPolicy">Customize the CORS policy. </param>
+        [Obsolete("Cloud Foundry is now automatically supported, use AddAllActuators() instead")]
         public static IWebHostBuilder AddCloudFoundryActuators(this IWebHostBuilder webHostBuilder, Action<CorsPolicyBuilder> buildCorsPolicy = null)
             => webHostBuilder.AddCloudFoundryActuators(MediaTypeVersion.V2, buildCorsPolicy);
 
@@ -28,6 +29,7 @@ namespace Steeltoe.Management.CloudFoundry
         /// </summary>
         /// <param name="hostBuilder">Your Hostbuilder</param>
         /// <param name="buildCorsPolicy">Customize the CORS policy. </param>
+        [Obsolete("Cloud Foundry is now automatically supported, use AddAllActuators() instead")]
         public static IHostBuilder AddCloudFoundryActuators(this IHostBuilder hostBuilder, Action<CorsPolicyBuilder> buildCorsPolicy = null)
             => hostBuilder.AddCloudFoundryActuators(MediaTypeVersion.V2, buildCorsPolicy);
 
@@ -37,6 +39,7 @@ namespace Steeltoe.Management.CloudFoundry
         /// <param name="webHostBuilder">Your Hostbuilder</param>
         /// <param name="mediaTypeVersion">Spring Boot media type version to use with responses</param>
         /// <param name="buildCorsPolicy">Customize the CORS policy. </param>
+        [Obsolete("Cloud Foundry is now automatically supported, use AddAllActuators() instead")]
         public static IWebHostBuilder AddCloudFoundryActuators(this IWebHostBuilder webHostBuilder, MediaTypeVersion mediaTypeVersion, Action<CorsPolicyBuilder> buildCorsPolicy = null)
             => webHostBuilder
                 .ConfigureLogging((context, configureLogging) => configureLogging.AddDynamicConsole())
@@ -48,11 +51,13 @@ namespace Steeltoe.Management.CloudFoundry
         /// <param name="hostBuilder">Your Hostbuilder</param>
         /// <param name="mediaTypeVersion">Spring Boot media type version to use with responses</param>
         /// <param name="buildCorsPolicy">Customize the CORS policy. </param>
+        [Obsolete("Cloud Foundry is now automatically supported, use AddAllActuators() instead")]
         public static IHostBuilder AddCloudFoundryActuators(this IHostBuilder hostBuilder, MediaTypeVersion mediaTypeVersion, Action<CorsPolicyBuilder> buildCorsPolicy = null)
             => hostBuilder
                 .ConfigureLogging((context, configureLogging) => configureLogging.AddDynamicConsole())
                 .ConfigureServices((context, collection) => ConfigureServices(collection, context.Configuration, mediaTypeVersion, buildCorsPolicy));
 
+        [Obsolete("Cloud Foundry is now automatically supported, use AddAllActuators() instead")]
         private static void ConfigureServices(IServiceCollection collection, IConfiguration configuration, MediaTypeVersion mediaTypeVersion, Action<CorsPolicyBuilder> buildCorsPolicy)
         {
             collection.AddCloudFoundryActuators(configuration, mediaTypeVersion, buildCorsPolicy);

--- a/src/Management/src/CloudFoundryCore/CloudFoundryServiceCollectionExtensions.cs
+++ b/src/Management/src/CloudFoundryCore/CloudFoundryServiceCollectionExtensions.cs
@@ -19,15 +19,9 @@ namespace Steeltoe.Management.CloudFoundry
         /// <param name="services">Service collection</param>
         /// <param name="config">Application configuration. Retrieved from the <see cref="IServiceCollection"/> if not provided</param>
         /// <param name="buildCorsPolicy">Customize the CORS policy. </param>
+        [Obsolete("Cloud Foundry is now automatically supported, use AddAllActuators() instead")]
         public static void AddCloudFoundryActuators(this IServiceCollection services, IConfiguration config = null, Action<CorsPolicyBuilder> buildCorsPolicy = null)
-        {
-            if (services == null)
-            {
-                throw new ArgumentNullException(nameof(services));
-            }
-
-            services.AddCloudFoundryActuators(config, MediaTypeVersion.V2, buildCorsPolicy);
-        }
+            => services.AddCloudFoundryActuators(config, MediaTypeVersion.V2, buildCorsPolicy);
 
         /// <summary>
         /// Add Actuators to Microsoft DI
@@ -36,6 +30,7 @@ namespace Steeltoe.Management.CloudFoundry
         /// <param name="config">Application Configuration</param>
         /// <param name="version">Set response type version</param>
         /// <param name="buildCorsPolicy">Customize the CORS policy. </param>
+        [Obsolete("Cloud Foundry is now automatically supported, use AddAllActuators() instead")]
         public static void AddCloudFoundryActuators(this IServiceCollection services, IConfiguration config, MediaTypeVersion version, Action<CorsPolicyBuilder> buildCorsPolicy = null)
         {
             if (services == null)
@@ -43,27 +38,8 @@ namespace Steeltoe.Management.CloudFoundry
                 throw new ArgumentNullException(nameof(services));
             }
 
-            services.AddCors(setup =>
-            {
-                setup.AddPolicy("SteeltoeManagement", (policy) =>
-                    {
-                        policy
-                            .WithMethods("GET", "POST")
-                            .WithHeaders("Authorization", "X-Cf-App-Instance", "Content-Type");
-
-                        if (buildCorsPolicy != null)
-                        {
-                            buildCorsPolicy(policy);
-                        }
-                        else
-                        {
-                            policy.AllowAnyOrigin();
-                        }
-                    });
-            });
-
             services.AddCloudFoundryActuator(config);
-            services.AddAllActuators(config, version);
+            services.AddAllActuators(config, version, buildCorsPolicy);
         }
     }
 }

--- a/src/Management/src/EndpointCore/AllActuatorsStartupFilter.cs
+++ b/src/Management/src/EndpointCore/AllActuatorsStartupFilter.cs
@@ -3,7 +3,11 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Cors.Infrastructure;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Steeltoe.Common;
+using Steeltoe.Management.Endpoint.CloudFoundry;
 using Steeltoe.Management.Endpoint.Health;
 using System;
 
@@ -22,6 +26,16 @@ namespace Steeltoe.Management.Endpoint
         {
             return app =>
             {
+                if (app.ApplicationServices.GetService<ICorsService>() != null)
+                {
+                    app.UseCors("SteeltoeManagement");
+                }
+
+                if (Platform.IsCloudFoundry)
+                {
+                    app.UseCloudFoundrySecurity();
+                }
+
                 next(app);
 
                 app.UseEndpoints(endpoints =>

--- a/src/Management/src/EndpointCore/CloudFoundry/CloudFoundrySecurityMiddleware.cs
+++ b/src/Management/src/EndpointCore/CloudFoundry/CloudFoundrySecurityMiddleware.cs
@@ -34,7 +34,7 @@ namespace Steeltoe.Management.Endpoint.CloudFoundry
         {
             _logger?.LogDebug("Invoke({0}) contextPath: {1}", context.Request.Path.Value, _mgmtOptions.Path);
 
-            bool isEndpointExposed = _mgmtOptions == null ? true : _options.IsExposed(_mgmtOptions);
+            var isEndpointExposed = _mgmtOptions == null || _options.IsExposed(_mgmtOptions);
 
             if (Platform.IsCloudFoundry
                 && isEndpointExposed
@@ -42,6 +42,7 @@ namespace Steeltoe.Management.Endpoint.CloudFoundry
             {
                 if (string.IsNullOrEmpty(_options.ApplicationId))
                 {
+                    _logger?.LogCritical("The Application Id could not be found. Make sure the Cloud Foundry Configuration Provider has been added to the application configuration.");
                     await ReturnError(context, new SecurityResult(HttpStatusCode.ServiceUnavailable, _base.APPLICATION_ID_MISSING_MESSAGE)).ConfigureAwait(false);
                     return;
                 }

--- a/src/Management/src/EndpointCore/ManagementHostBuilderExtensions.cs
+++ b/src/Management/src/EndpointCore/ManagementHostBuilderExtensions.cs
@@ -3,9 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Cors.Infrastructure;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
 using Steeltoe.Common.HealthChecks;
 using Steeltoe.Extensions.Logging;
@@ -235,13 +235,14 @@ namespace Steeltoe.Management.Endpoint
         /// <param name="hostBuilder">Your HostBuilder</param>
         /// <param name="configureEndpoints">Customize endpoint behavior. Useful for tailoring auth requirements</param>
         /// <param name="mediaTypeVersion">Specify the media type version to use in the response</param>
+        /// <param name="buildCorsPolicy">Customize the CORS policy. </param>
         /// <remarks>Does not add platform specific features (like for Cloud Foundry or Kubernetes)</remarks>
-        public static IHostBuilder AddAllActuators(this IHostBuilder hostBuilder, Action<IEndpointConventionBuilder> configureEndpoints = null, MediaTypeVersion mediaTypeVersion = MediaTypeVersion.V2)
+        public static IHostBuilder AddAllActuators(this IHostBuilder hostBuilder, Action<IEndpointConventionBuilder> configureEndpoints = null, MediaTypeVersion mediaTypeVersion = MediaTypeVersion.V2, Action<CorsPolicyBuilder> buildCorsPolicy = null)
             => hostBuilder
                 .AddDynamicLogging()
                 .ConfigureServices((context, collection) =>
                 {
-                    collection.AddAllActuators(context.Configuration, mediaTypeVersion);
+                    collection.AddAllActuators(context.Configuration, mediaTypeVersion, buildCorsPolicy);
                     ActivateActuatorEndpoints(collection, configureEndpoints);
                 });
 

--- a/src/Management/test/CloudFoundryCore.Test/CloudFoundryHostBuilderExtensionsTest.cs
+++ b/src/Management/test/CloudFoundryCore.Test/CloudFoundryHostBuilderExtensionsTest.cs
@@ -23,6 +23,7 @@ using Xunit;
 
 namespace Steeltoe.Management.CloudFoundry.Test
 {
+    [Obsolete]
     public class CloudFoundryHostBuilderExtensionsTest
     {
         private static readonly Dictionary<string, string> ManagementSettings = new Dictionary<string, string>()

--- a/src/Management/test/CloudFoundryCore.Test/CloudFoundryServiceCollectionExtensionsTest.cs
+++ b/src/Management/test/CloudFoundryCore.Test/CloudFoundryServiceCollectionExtensionsTest.cs
@@ -13,6 +13,7 @@ using Xunit;
 
 namespace Steeltoe.Management.CloudFoundry.Test
 {
+    [Obsolete]
     public class CloudFoundryServiceCollectionExtensionsTest
     {
         [Fact]

--- a/src/Management/test/EndpointCore.Test/ActuatorServiceCollectionExtensionsTest.cs
+++ b/src/Management/test/EndpointCore.Test/ActuatorServiceCollectionExtensionsTest.cs
@@ -1,0 +1,88 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Cors.Infrastructure;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Steeltoe.Extensions.Configuration.CloudFoundry;
+using Steeltoe.Management.Endpoint.CloudFoundry;
+using System;
+using Xunit;
+
+namespace Steeltoe.Management.Endpoint.Test
+{
+    public class ActuatorServiceCollectionExtensionsTest
+    {
+        [Fact]
+        public void AddAllActuators_ConfiguresCorsDefaults()
+        {
+            // arrange
+            var hostBuilder = new WebHostBuilder().Configure(config => { });
+
+            // act
+            var host = hostBuilder.ConfigureServices((context, services) => services.AddAllActuators(context.Configuration)).Build();
+            var options = new ApplicationBuilder(host.Services).ApplicationServices.GetService(typeof(IOptions<CorsOptions>)) as IOptions<CorsOptions>;
+
+            // assert
+            Assert.NotNull(options);
+            var policy = options.Value.GetPolicy("SteeltoeManagement");
+            Assert.True(policy.IsOriginAllowed("*"));
+            Assert.Contains(policy.Methods, m => m.Equals("GET"));
+            Assert.Contains(policy.Methods, m => m.Equals("POST"));
+        }
+
+        [Fact]
+        public void AddAllActuators_ConfiguresCorsCustom()
+        {
+            // arrange
+            var hostBuilder = new WebHostBuilder().Configure(config => { });
+
+            // act
+            var host = hostBuilder.ConfigureServices((context, services) => services.AddAllActuators(context.Configuration, (myPolicy) => myPolicy.WithOrigins("http://google.com"))).Build();
+            var options = new ApplicationBuilder(host.Services)
+                                .ApplicationServices.GetService(typeof(IOptions<CorsOptions>)) as IOptions<CorsOptions>;
+
+            // assert
+            Assert.NotNull(options);
+            var policy = options.Value.GetPolicy("SteeltoeManagement");
+            Assert.True(policy.IsOriginAllowed("http://google.com"));
+            Assert.False(policy.IsOriginAllowed("http://bing.com"));
+            Assert.False(policy.IsOriginAllowed("*"));
+            Assert.Contains(policy.Methods, m => m.Equals("GET"));
+            Assert.Contains(policy.Methods, m => m.Equals("POST"));
+        }
+
+        [Fact]
+        public void AddAllActuators_YesCFonCF()
+        {
+            // arrange
+            Environment.SetEnvironmentVariable("VCAP_APPLICATION", Steeltoe.TestHelpers.VCAP_APPLICATION);
+            var hostBuilder = new WebHostBuilder().Configure(config => { }).ConfigureAppConfiguration(cfg => cfg.AddCloudFoundry());
+
+            // act
+            var host = hostBuilder.ConfigureServices((context, services) => services.AddAllActuators(context.Configuration)).Build();
+
+            // assert
+            Assert.NotNull(host.Services.GetService<ICloudFoundryOptions>());
+            Assert.NotNull(host.Services.GetService<CloudFoundryEndpoint>());
+            Environment.SetEnvironmentVariable("VCAP_APPLICATION", null);
+        }
+
+        [Fact]
+        public void AddAllActuators_NoCFoffCF()
+        {
+            // arrange
+            var hostBuilder = new WebHostBuilder().Configure(config => { }).ConfigureAppConfiguration(cfg => cfg.AddCloudFoundry());
+
+            // act
+            var host = hostBuilder.ConfigureServices((context, services) => services.AddAllActuators(context.Configuration)).Build();
+
+            // assert
+            Assert.Null(host.Services.GetService<ICloudFoundryOptions>());
+            Assert.Null(host.Services.GetService<CloudFoundryEndpoint>());
+        }
+    }
+}

--- a/src/Management/test/EndpointCore.Test/Steeltoe.Management.EndpointCore.Test.csproj
+++ b/src/Management/test/EndpointCore.Test/Steeltoe.Management.EndpointCore.Test.csproj
@@ -33,6 +33,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\..\Configuration\src\CloudFoundryBase\Steeltoe.Extensions.Configuration.CloudFoundryBase.csproj" />
     <ProjectReference Include="..\..\..\Logging\src\DynamicSerilogBase\Steeltoe.Extensions.Logging.DynamicSerilogBase.csproj" />
     <ProjectReference Include="..\..\..\Logging\src\DynamicSerilogCore\Steeltoe.Extensions.Logging.DynamicSerilogCore.csproj" />
     <ProjectReference Include="..\..\src\EndpointCore\Steeltoe.Management.EndpointCore.csproj" />


### PR DESCRIPTION
Addresses #589 

Effectively makes the package `Steeltoe.Management.CloudFoundryCore` obsolete.
