### PR TITLE
Use app's configuration when adding Serilog to a hostbuilder

### DIFF
--- a/src/Logging/src/DynamicSerilogBase/Properties/AssemblyInfo.cs
+++ b/src/Logging/src/DynamicSerilogBase/Properties/AssemblyInfo.cs
@@ -1,0 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Steeltoe.Extensions.Logging.DynamicSerilogCore")]

--- a/src/Logging/src/DynamicSerilogBase/SerilogConfigurationExtensions.cs
+++ b/src/Logging/src/DynamicSerilogBase/SerilogConfigurationExtensions.cs
@@ -4,11 +4,26 @@
 
 using Serilog;
 using Serilog.Configuration;
+using Serilog.Core;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
 
 namespace Steeltoe.Extensions.Logging.DynamicSerilog
 {
     internal static class SerilogConfigurationExtensions
     {
         public static LoggerConfiguration SerilogConsole(this LoggerSinkConfiguration sinkConfiguration) => sinkConfiguration.Console();
+
+        internal static LoggerConfiguration AddConsoleIfNoSinksFound(this LoggerConfiguration loggerConfiguration)
+        {
+            var configuredSinksField = loggerConfiguration.GetType().GetField("_logEventSinks", BindingFlags.NonPublic | BindingFlags.Instance);
+            if (configuredSinksField.GetValue(loggerConfiguration) is not List<ILogEventSink> configuredSinks || !configuredSinks.Any())
+            {
+                loggerConfiguration.WriteTo.Console();
+            }
+
+            return loggerConfiguration;
+        }
     }
 }

--- a/src/Logging/src/DynamicSerilogBase/SerilogConfigurationExtensions.cs
+++ b/src/Logging/src/DynamicSerilogBase/SerilogConfigurationExtensions.cs
@@ -2,28 +2,25 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.Extensions.Configuration;
 using Serilog;
-using Serilog.Configuration;
-using Serilog.Core;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
 
 namespace Steeltoe.Extensions.Logging.DynamicSerilog
 {
     internal static class SerilogConfigurationExtensions
     {
-        public static LoggerConfiguration SerilogConsole(this LoggerSinkConfiguration sinkConfiguration) => sinkConfiguration.Console();
+        /// <summary>
+        /// Create a new LoggerConfiguration that reads from IConfiguration and adds a Console Sink
+        /// </summary>
+        /// <param name="configuration"><see cref="IConfiguration"/></param>
+        /// <returns>What Steeltoe considers to be a default <see cref="LoggerConfiguration" /></returns>
+        internal static LoggerConfiguration GetDefaultSerilogConfiguration(IConfiguration configuration) => new LoggerConfiguration().ReadFrom.Configuration(configuration).WriteToConsole();
 
-        internal static LoggerConfiguration AddConsoleIfNoSinksFound(this LoggerConfiguration loggerConfiguration)
-        {
-            var configuredSinksField = loggerConfiguration.GetType().GetField("_logEventSinks", BindingFlags.NonPublic | BindingFlags.Instance);
-            if (configuredSinksField.GetValue(loggerConfiguration) is not List<ILogEventSink> configuredSinks || !configuredSinks.Any())
-            {
-                loggerConfiguration.WriteTo.Console();
-            }
-
-            return loggerConfiguration;
-        }
+        /// <summary>
+        /// Calls .WriteTo.Console() for now, could be enhanced (via reflection) to make sure there's only one ConsoleSink
+        /// </summary>
+        /// <param name="loggerConfiguration"><see cref="LoggerConfiguration"/></param>
+        /// <returns><see cref="LoggerConfiguration" /> that writes to console</returns>
+        internal static LoggerConfiguration WriteToConsole(this LoggerConfiguration loggerConfiguration) => loggerConfiguration.WriteTo.Console();
     }
 }

--- a/src/Logging/src/DynamicSerilogBase/SerilogDynamicProvider.cs
+++ b/src/Logging/src/DynamicSerilogBase/SerilogDynamicProvider.cs
@@ -71,7 +71,7 @@ namespace Steeltoe.Extensions.Logging.DynamicSerilog
             _globalLogger = logger ?? new Serilog.LoggerConfiguration()
                 .MinimumLevel.ControlledBy(loggingLevelSwitch)
                 .ReadFrom.Configuration(configuration)
-                .WriteTo.SerilogConsole() // Add a console in case one is not configured
+                .AddConsoleIfNoSinksFound() // Add a console in case one is not configured
                 .CreateLogger();
         }
 

--- a/src/Logging/src/DynamicSerilogBase/SerilogDynamicProvider.cs
+++ b/src/Logging/src/DynamicSerilogBase/SerilogDynamicProvider.cs
@@ -68,11 +68,10 @@ namespace Steeltoe.Extensions.Logging.DynamicSerilog
             _loggerSwitches.GetOrAdd("Default", loggingLevelSwitch);
 
             // Add a global logger that will be the root of all other added loggers
-            _globalLogger = logger ?? new Serilog.LoggerConfiguration()
-                .MinimumLevel.ControlledBy(loggingLevelSwitch)
-                .ReadFrom.Configuration(configuration)
-                .AddConsoleIfNoSinksFound() // Add a console in case one is not configured
-                .CreateLogger();
+            _globalLogger = logger ??
+                SerilogConfigurationExtensions.GetDefaultSerilogConfiguration(configuration)
+                    .MinimumLevel.ControlledBy(loggingLevelSwitch)
+                    .CreateLogger();
         }
 
         public ILogger CreateLogger(string categoryName)

--- a/src/Logging/src/DynamicSerilogBase/SerilogHostBuilderExtensions.cs
+++ b/src/Logging/src/DynamicSerilogBase/SerilogHostBuilderExtensions.cs
@@ -27,10 +27,14 @@ namespace Steeltoe.Extensions.Logging.DynamicSerilog
             return hostBuilder
                 .ConfigureLogging((hostContext, logBuilder) =>
                 {
-                    var loggerConfiguration = new LoggerConfiguration();
+                    var loggerConfiguration = new LoggerConfiguration().ReadFrom.Configuration(hostContext.Configuration);
                     if (configureLogger is object)
                     {
                         configureLogger(hostContext, loggerConfiguration);
+                    }
+                    else
+                    {
+                        loggerConfiguration.WriteTo.Console();
                     }
 
                     logBuilder.AddDynamicSerilog(loggerConfiguration, preserveStaticLogger, preserveDefaultConsole);

--- a/src/Logging/src/DynamicSerilogBase/SerilogHostBuilderExtensions.cs
+++ b/src/Logging/src/DynamicSerilogBase/SerilogHostBuilderExtensions.cs
@@ -27,7 +27,7 @@ namespace Steeltoe.Extensions.Logging.DynamicSerilog
             return hostBuilder
                 .ConfigureLogging((hostContext, logBuilder) =>
                 {
-                    var loggerConfiguration = new LoggerConfiguration().ReadFrom.Configuration(hostContext.Configuration);
+                    var loggerConfiguration = SerilogConfigurationExtensions.GetDefaultSerilogConfiguration(hostContext.Configuration);
                     if (configureLogger is object)
                     {
                         configureLogger(hostContext, loggerConfiguration);

--- a/src/Logging/src/DynamicSerilogBase/SerilogHostBuilderExtensions.cs
+++ b/src/Logging/src/DynamicSerilogBase/SerilogHostBuilderExtensions.cs
@@ -32,10 +32,6 @@ namespace Steeltoe.Extensions.Logging.DynamicSerilog
                     {
                         configureLogger(hostContext, loggerConfiguration);
                     }
-                    else
-                    {
-                        loggerConfiguration.WriteTo.Console();
-                    }
 
                     logBuilder.AddDynamicSerilog(loggerConfiguration, preserveStaticLogger, preserveDefaultConsole);
                 });

--- a/src/Logging/src/DynamicSerilogBase/SerilogLoggingBuilderExtensions.cs
+++ b/src/Logging/src/DynamicSerilogBase/SerilogLoggingBuilderExtensions.cs
@@ -55,7 +55,8 @@ namespace Steeltoe.Extensions.Logging.DynamicSerilog
 
             var configuration = builder.Services.BuildServiceProvider().GetRequiredService<IConfiguration>();
             var serilogOptions = new SerilogOptions(configuration);
-            loggerConfiguration ??= new LoggerConfiguration().ReadFrom.Configuration(configuration).WriteTo.Console();
+            loggerConfiguration ??= new LoggerConfiguration().ReadFrom.Configuration(configuration);
+            loggerConfiguration.AddConsoleIfNoSinksFound();
 
             // Add a level switch that controls the "Default" level at the root
             var levelSwitch = new LoggingLevelSwitch(serilogOptions.MinimumLevel.Default);

--- a/src/Logging/src/DynamicSerilogBase/SerilogLoggingBuilderExtensions.cs
+++ b/src/Logging/src/DynamicSerilogBase/SerilogLoggingBuilderExtensions.cs
@@ -23,10 +23,7 @@ namespace Steeltoe.Extensions.Logging.DynamicSerilog
         /// <param name="builder">The <see cref="ILoggingBuilder"/> for configuring the LoggerFactory</param>
         /// <param name="preserveDefaultConsole">When true, do not remove Microsoft's ConsoleLoggerProvider</param>
         /// <returns>The configured <see cref="ILoggingBuilder"/></returns>
-        public static ILoggingBuilder AddDynamicSerilog(this ILoggingBuilder builder, bool preserveDefaultConsole = false)
-        {
-            return builder.AddDynamicSerilog(null, false, preserveDefaultConsole);
-        }
+        public static ILoggingBuilder AddDynamicSerilog(this ILoggingBuilder builder, bool preserveDefaultConsole = false) => builder.AddDynamicSerilog(null, false, preserveDefaultConsole);
 
         /// <summary>
         /// Add Serilog, wrapped in a <see cref="IDynamicLoggerProvider"/> that supports
@@ -55,8 +52,7 @@ namespace Steeltoe.Extensions.Logging.DynamicSerilog
 
             var configuration = builder.Services.BuildServiceProvider().GetRequiredService<IConfiguration>();
             var serilogOptions = new SerilogOptions(configuration);
-            loggerConfiguration ??= new LoggerConfiguration().ReadFrom.Configuration(configuration);
-            loggerConfiguration.AddConsoleIfNoSinksFound();
+            loggerConfiguration ??= SerilogConfigurationExtensions.GetDefaultSerilogConfiguration(configuration);
 
             // Add a level switch that controls the "Default" level at the root
             var levelSwitch = new LoggingLevelSwitch(serilogOptions.MinimumLevel.Default);

--- a/src/Logging/src/DynamicSerilogBase/SerilogLoggingBuilderExtensions.cs
+++ b/src/Logging/src/DynamicSerilogBase/SerilogLoggingBuilderExtensions.cs
@@ -53,8 +53,9 @@ namespace Steeltoe.Extensions.Logging.DynamicSerilog
                 }
             }
 
-            var serilogOptions = new SerilogOptions(builder.Services.BuildServiceProvider().GetRequiredService<IConfiguration>());
-            loggerConfiguration ??= new LoggerConfiguration().WriteTo.Console();
+            var configuration = builder.Services.BuildServiceProvider().GetRequiredService<IConfiguration>();
+            var serilogOptions = new SerilogOptions(configuration);
+            loggerConfiguration ??= new LoggerConfiguration().ReadFrom.Configuration(configuration).WriteTo.Console();
 
             // Add a level switch that controls the "Default" level at the root
             var levelSwitch = new LoggingLevelSwitch(serilogOptions.MinimumLevel.Default);

--- a/src/Logging/src/DynamicSerilogCore/SerilogWebHostBuilderExtensions.cs
+++ b/src/Logging/src/DynamicSerilogCore/SerilogWebHostBuilderExtensions.cs
@@ -27,10 +27,14 @@ namespace Steeltoe.Extensions.Logging.DynamicSerilog
             return hostBuilder
                 .ConfigureLogging((hostContext, logBuilder) =>
                 {
-                    var loggerConfiguration = new LoggerConfiguration();
+                    var loggerConfiguration = new LoggerConfiguration().ReadFrom.Configuration(hostContext.Configuration);
                     if (configureLogger is object)
                     {
                         configureLogger(hostContext, loggerConfiguration);
+                    }
+                    else
+                    {
+                        loggerConfiguration.WriteTo.Console();
                     }
 
                     logBuilder.AddDynamicSerilog(loggerConfiguration, preserveStaticLogger, preserveDefaultConsole);

--- a/src/Logging/src/DynamicSerilogCore/SerilogWebHostBuilderExtensions.cs
+++ b/src/Logging/src/DynamicSerilogCore/SerilogWebHostBuilderExtensions.cs
@@ -27,7 +27,7 @@ namespace Steeltoe.Extensions.Logging.DynamicSerilog
             return hostBuilder
                 .ConfigureLogging((hostContext, logBuilder) =>
                 {
-                    var loggerConfiguration = new LoggerConfiguration().ReadFrom.Configuration(hostContext.Configuration);
+                    var loggerConfiguration = SerilogConfigurationExtensions.GetDefaultSerilogConfiguration(hostContext.Configuration);
                     if (configureLogger is object)
                     {
                         configureLogger(hostContext, loggerConfiguration);

--- a/src/Logging/src/DynamicSerilogCore/SerilogWebHostBuilderExtensions.cs
+++ b/src/Logging/src/DynamicSerilogCore/SerilogWebHostBuilderExtensions.cs
@@ -32,10 +32,6 @@ namespace Steeltoe.Extensions.Logging.DynamicSerilog
                     {
                         configureLogger(hostContext, loggerConfiguration);
                     }
-                    else
-                    {
-                        loggerConfiguration.WriteTo.Console();
-                    }
 
                     logBuilder.AddDynamicSerilog(loggerConfiguration, preserveStaticLogger, preserveDefaultConsole);
                 });

--- a/src/Logging/test/DynamicSerilogCore.Test/Steeltoe.Extensions.Logging.DynamicSerilogCore.Test.csproj
+++ b/src/Logging/test/DynamicSerilogCore.Test/Steeltoe.Extensions.Logging.DynamicSerilogCore.Test.csproj
@@ -17,8 +17,9 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="$(AspNetCoreVersion)" />
-    <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="$(ExtensionsVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="$(ExtensionsVersion)" />
+    <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
     <PackageReference Include="Serilog.Exceptions" Version="5.0.0" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Logging/test/DynamicSerilogCore.Test/Steeltoe.Extensions.Logging.DynamicSerilogCore.Test.csproj
+++ b/src/Logging/test/DynamicSerilogCore.Test/Steeltoe.Extensions.Logging.DynamicSerilogCore.Test.csproj
@@ -21,6 +21,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="$(ExtensionsVersion)" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
     <PackageReference Include="Serilog.Exceptions" Version="5.0.0" />
+    <PackageReference Include="Serilog.Sinks.Debug" Version="2.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\DynamicSerilogCore\Steeltoe.Extensions.Logging.DynamicSerilogCore.csproj" />


### PR DESCRIPTION
Use configuration from the hostcontext for Serilog config, add a console sink if no LoggerConfiguration action was provided #607