### PR TITLE
Fix long running tests with timeout

### DIFF
--- a/src/Messaging/src/RabbitMQ/Connection/CachingConnectionFactory.cs
+++ b/src/Messaging/src/RabbitMQ/Connection/CachingConnectionFactory.cs
@@ -112,6 +112,24 @@ namespace Steeltoe.Messaging.RabbitMQ.Connection
             ServiceName = DEFAULT_SERVICE_NAME;
         }
 
+        public CachingConnectionFactory(string hostNameArg, int port, RC.IConnectionFactory connectionFactory, ILoggerFactory loggerFactory = null)
+           : base(connectionFactory, loggerFactory)
+        {
+            var hostname = hostNameArg;
+            if (string.IsNullOrEmpty(hostname))
+            {
+                hostname = GetDefaultHostName();
+            }
+
+            _connection = new ChannelCachingConnectionProxy(this, null, loggerFactory?.CreateLogger<ChannelCachingConnectionProxy>());
+            Host = hostname;
+            Port = port;
+            PublisherConnectionFactory = new CachingConnectionFactory(_rabbitConnectionFactory, true, CachingMode.CHANNEL, loggerFactory);
+            PublisherCallbackChannelFactory = new DefaultPublisherCallbackFactory(loggerFactory);
+            InitCacheWaterMarks();
+            ServiceName = DEFAULT_SERVICE_NAME;
+        }
+
         public CachingConnectionFactory(Uri uri, ILoggerFactory loggerFactory = null)
             : this(uri, CachingMode.CHANNEL, loggerFactory)
         {

--- a/src/Messaging/src/RabbitMQ/Connection/RabbitUtils.cs
+++ b/src/Messaging/src/RabbitMQ/Connection/RabbitUtils.cs
@@ -90,7 +90,7 @@ namespace Steeltoe.Messaging.RabbitMQ.Connection
             }
             catch (Exception ex)
             {
-                logger.LogError(ex, "Error during TxCommit");
+                logger?.LogError(ex, "Error during TxCommit");
                 throw RabbitExceptionTranslator.ConvertRabbitAccessException(ex);
             }
         }
@@ -108,7 +108,7 @@ namespace Steeltoe.Messaging.RabbitMQ.Connection
             }
             catch (Exception ex)
             {
-                logger.LogError(ex, "Error during TxCommit");
+                logger?.LogError(ex, "Error during TxCommit");
                 throw RabbitExceptionTranslator.ConvertRabbitAccessException(ex);
             }
         }

--- a/src/Stream/src/BinderRabbitMQ/RabbitMessageChannelBinder.cs
+++ b/src/Stream/src/BinderRabbitMQ/RabbitMessageChannelBinder.cs
@@ -84,7 +84,7 @@ namespace Steeltoe.Stream.Binder.Rabbit
 
         protected ILogger _logger;
 
-        public Steeltoe.Messaging.RabbitMQ.Connection.IConnectionFactory ConnectionFactory { get; }
+        public SteeltoeConnectionFactory ConnectionFactory { get; }
 
         public RabbitOptions RabbitConnectionOptions { get; }
 


### PR DESCRIPTION
`TestLateBinding `sets up a proxy that is not running to test the "broker down" condition- however the long default timeout on the RabbitMQ Client makes the test run more than 30 minutes long. Setting a shorter timeout, and resetting the connectionfactory before clean up resolves this issue. 
Shorter timeout also helps `TestMultiplexOnPartitionedConsumerWithMultipleDestinations`.