### PR TITLE
RabbitMQ Connector -> ConnectionFactory/Options Integration

### DIFF
--- a/src/Messaging/Messaging.sln
+++ b/src/Messaging/Messaging.sln
@@ -40,6 +40,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Steeltoe.Messaging.Messagin
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Steeltoe.Common.Expression", "..\Common\src\Common.Expression\Steeltoe.Common.Expression.csproj", "{F1ED43DD-569E-4D2E-9A45-3ADDDA9E24DF}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Steeltoe.Connector.ConnectorBase", "..\Connectors\src\ConnectorBase\Steeltoe.Connector.ConnectorBase.csproj", "{BB0F1D84-8BA4-4B1C-A1EC-C645CD720BAD}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -90,6 +92,10 @@ Global
 		{F1ED43DD-569E-4D2E-9A45-3ADDDA9E24DF}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F1ED43DD-569E-4D2E-9A45-3ADDDA9E24DF}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F1ED43DD-569E-4D2E-9A45-3ADDDA9E24DF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BB0F1D84-8BA4-4B1C-A1EC-C645CD720BAD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BB0F1D84-8BA4-4B1C-A1EC-C645CD720BAD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BB0F1D84-8BA4-4B1C-A1EC-C645CD720BAD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BB0F1D84-8BA4-4B1C-A1EC-C645CD720BAD}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -106,6 +112,7 @@ Global
 		{9E884AF4-6F7E-48FF-85CE-C4AD6967C4F1} = {6B21DB1B-B017-4432-8F04-55CC34DE524C}
 		{D252B729-BA69-4D4D-95A3-AAF2877124F9} = {D77F3F56-2B76-45CC-A3DF-6B4C46F09546}
 		{F1ED43DD-569E-4D2E-9A45-3ADDDA9E24DF} = {2134CB62-4A32-4A3F-9AA5-C06B603D38FB}
+		{BB0F1D84-8BA4-4B1C-A1EC-C645CD720BAD} = {2134CB62-4A32-4A3F-9AA5-C06B603D38FB}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {7FBBA8CC-A3A6-4965-A47D-9C88091F1D84}

--- a/src/Messaging/Messaging.sln
+++ b/src/Messaging/Messaging.sln
@@ -40,7 +40,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Steeltoe.Messaging.Messagin
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Steeltoe.Common.Expression", "..\Common\src\Common.Expression\Steeltoe.Common.Expression.csproj", "{F1ED43DD-569E-4D2E-9A45-3ADDDA9E24DF}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Steeltoe.Connector.ConnectorBase", "..\Connectors\src\ConnectorBase\Steeltoe.Connector.ConnectorBase.csproj", "{BB0F1D84-8BA4-4B1C-A1EC-C645CD720BAD}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Steeltoe.Connector.ConnectorCore", "..\Connectors\src\ConnectorCore\Steeltoe.Connector.ConnectorCore.csproj", "{93F3DE37-70FB-4B0B-8CB4-BEB9F0A9597B}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -92,10 +92,10 @@ Global
 		{F1ED43DD-569E-4D2E-9A45-3ADDDA9E24DF}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F1ED43DD-569E-4D2E-9A45-3ADDDA9E24DF}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F1ED43DD-569E-4D2E-9A45-3ADDDA9E24DF}.Release|Any CPU.Build.0 = Release|Any CPU
-		{BB0F1D84-8BA4-4B1C-A1EC-C645CD720BAD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{BB0F1D84-8BA4-4B1C-A1EC-C645CD720BAD}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{BB0F1D84-8BA4-4B1C-A1EC-C645CD720BAD}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{BB0F1D84-8BA4-4B1C-A1EC-C645CD720BAD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{93F3DE37-70FB-4B0B-8CB4-BEB9F0A9597B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{93F3DE37-70FB-4B0B-8CB4-BEB9F0A9597B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{93F3DE37-70FB-4B0B-8CB4-BEB9F0A9597B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{93F3DE37-70FB-4B0B-8CB4-BEB9F0A9597B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -112,7 +112,7 @@ Global
 		{9E884AF4-6F7E-48FF-85CE-C4AD6967C4F1} = {6B21DB1B-B017-4432-8F04-55CC34DE524C}
 		{D252B729-BA69-4D4D-95A3-AAF2877124F9} = {D77F3F56-2B76-45CC-A3DF-6B4C46F09546}
 		{F1ED43DD-569E-4D2E-9A45-3ADDDA9E24DF} = {2134CB62-4A32-4A3F-9AA5-C06B603D38FB}
-		{BB0F1D84-8BA4-4B1C-A1EC-C645CD720BAD} = {2134CB62-4A32-4A3F-9AA5-C06B603D38FB}
+		{93F3DE37-70FB-4B0B-8CB4-BEB9F0A9597B} = {2134CB62-4A32-4A3F-9AA5-C06B603D38FB}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {7FBBA8CC-A3A6-4965-A47D-9C88091F1D84}

--- a/src/Messaging/src/RabbitMQ/Extensions/RabbitServicesExtensions.cs
+++ b/src/Messaging/src/RabbitMQ/Extensions/RabbitServicesExtensions.cs
@@ -8,6 +8,8 @@ using Microsoft.Extensions.DependencyInjection.Extensions;
 using Steeltoe.Common.Contexts;
 using Steeltoe.Common.Expression.Internal.Contexts;
 using Steeltoe.Common.Lifecycle;
+using Steeltoe.Connector;
+using Steeltoe.Connector.Services;
 using Steeltoe.Messaging.Converter;
 using Steeltoe.Messaging.Handler.Attributes.Support;
 using Steeltoe.Messaging.RabbitMQ.Config;
@@ -240,6 +242,17 @@ namespace Steeltoe.Messaging.RabbitMQ.Extensions
         public static IServiceCollection ConfigureRabbitOptions(this IServiceCollection services, IConfiguration config)
         {
             services.Configure<RabbitOptions>(config.GetSection(RabbitOptions.PREFIX));
+
+            services.PostConfigure<RabbitOptions>(options =>
+            {
+                var serviceInfo = config.GetServiceInfos<RabbitMQServiceInfo>().FirstOrDefault();
+
+                if (serviceInfo is not null)
+                {
+                    options.Addresses = $"{serviceInfo.Host}:{serviceInfo.Port}";
+                }
+            });
+
             return services;
         }
 

--- a/src/Messaging/src/RabbitMQ/Steeltoe.Messaging.RabbitMQ.csproj
+++ b/src/Messaging/src/RabbitMQ/Steeltoe.Messaging.RabbitMQ.csproj
@@ -16,6 +16,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\..\Common\src\Common.Expression\Steeltoe.Common.Expression.csproj" />
     <ProjectReference Include="..\..\..\Common\src\Common.RetryPolly\Steeltoe.Common.RetryPolly.csproj" />
+    <ProjectReference Include="..\..\..\Connectors\src\ConnectorBase\Steeltoe.Connector.ConnectorBase.csproj" />
     <ProjectReference Include="..\MessagingBase\Steeltoe.Messaging.MessagingBase.csproj" />
   </ItemGroup>
 

--- a/src/Messaging/src/RabbitMQ/Steeltoe.Messaging.RabbitMQ.csproj
+++ b/src/Messaging/src/RabbitMQ/Steeltoe.Messaging.RabbitMQ.csproj
@@ -16,7 +16,6 @@
   <ItemGroup>
     <ProjectReference Include="..\..\..\Common\src\Common.Expression\Steeltoe.Common.Expression.csproj" />
     <ProjectReference Include="..\..\..\Common\src\Common.RetryPolly\Steeltoe.Common.RetryPolly.csproj" />
-    <ProjectReference Include="..\..\..\Connectors\src\ConnectorBase\Steeltoe.Connector.ConnectorBase.csproj" />
     <ProjectReference Include="..\MessagingBase\Steeltoe.Messaging.MessagingBase.csproj" />
   </ItemGroup>
 

--- a/src/Messaging/test/RabbitMQ.Test/Steeltoe.Messaging.RabbitMQ.Test.csproj
+++ b/src/Messaging/test/RabbitMQ.Test/Steeltoe.Messaging.RabbitMQ.Test.csproj
@@ -15,6 +15,8 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\..\Configuration\src\CloudFoundryBase\Steeltoe.Extensions.Configuration.CloudFoundryBase.csproj" />
+    <ProjectReference Include="..\..\..\Connectors\src\ConnectorCore\Steeltoe.Connector.ConnectorCore.csproj" />
     <ProjectReference Include="..\..\src\RabbitMQ\Steeltoe.Messaging.RabbitMQ.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
Adding ability to leverage Host/Port from existing RabbitMQ connection established by `Steeltoe.Connector.RabbitMQ` within RabbitMQ Options and ConnectionFactory.