### PR TITLE
RabbitMQ Test Dependency

### DIFF
--- a/src/Messaging/Messaging.sln
+++ b/src/Messaging/Messaging.sln
@@ -42,6 +42,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Steeltoe.Common.Expression"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Steeltoe.Connector.ConnectorCore", "..\Connectors\src\ConnectorCore\Steeltoe.Connector.ConnectorCore.csproj", "{93F3DE37-70FB-4B0B-8CB4-BEB9F0A9597B}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Steeltoe.Connector.CloudFoundry", "..\Connectors\src\CloudFoundry\Steeltoe.Connector.CloudFoundry.csproj", "{914FDB20-8615-4340-AEFD-37CED7E25D68}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -96,6 +98,10 @@ Global
 		{93F3DE37-70FB-4B0B-8CB4-BEB9F0A9597B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{93F3DE37-70FB-4B0B-8CB4-BEB9F0A9597B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{93F3DE37-70FB-4B0B-8CB4-BEB9F0A9597B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{914FDB20-8615-4340-AEFD-37CED7E25D68}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{914FDB20-8615-4340-AEFD-37CED7E25D68}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{914FDB20-8615-4340-AEFD-37CED7E25D68}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{914FDB20-8615-4340-AEFD-37CED7E25D68}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -113,6 +119,7 @@ Global
 		{D252B729-BA69-4D4D-95A3-AAF2877124F9} = {D77F3F56-2B76-45CC-A3DF-6B4C46F09546}
 		{F1ED43DD-569E-4D2E-9A45-3ADDDA9E24DF} = {2134CB62-4A32-4A3F-9AA5-C06B603D38FB}
 		{93F3DE37-70FB-4B0B-8CB4-BEB9F0A9597B} = {2134CB62-4A32-4A3F-9AA5-C06B603D38FB}
+		{914FDB20-8615-4340-AEFD-37CED7E25D68} = {2134CB62-4A32-4A3F-9AA5-C06B603D38FB}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {7FBBA8CC-A3A6-4965-A47D-9C88091F1D84}

--- a/src/Messaging/test/RabbitMQ.Test/Extensions/RabbitServiceExtensionsTest.cs
+++ b/src/Messaging/test/RabbitMQ.Test/Extensions/RabbitServiceExtensionsTest.cs
@@ -568,7 +568,7 @@ namespace Steeltoe.Messaging.RabbitMQ.Extensions
         {
             ""p-rabbitmq"": [{
                 ""credentials"": {
-                    ""uri"": ""amqp://Dd6O1BPXUHdrmzbP:7E1LxXnlH2hhlPVt@" + $"192.168.0.90:3306" + @"/cf_b4f8d2fa_a3ea_4e3a_a0e8_2cd040790355""
+                    ""uri"": ""amqp://Dd6O1BPXUHdrmzbP:7E1LxXnlH2hhlPVt@192.168.0.90:3306/cf_b4f8d2fa_a3ea_4e3a_a0e8_2cd040790355""
                 },
                 ""syslog_drain_url"": null,
                 ""label"": ""p-rabbitmq"",

--- a/src/Messaging/test/RabbitMQ.Test/Extensions/RabbitServiceExtensionsTest.cs
+++ b/src/Messaging/test/RabbitMQ.Test/Extensions/RabbitServiceExtensionsTest.cs
@@ -513,14 +513,12 @@ namespace Steeltoe.Messaging.RabbitMQ.Extensions
         [Fact]
         public void ConfigureRabbitOptions_OverrideAddressWithServiceInfo()
         {
-            var host = "192.168.0.90";
-            var port = 3306;
             var usernamePrefix = "spring:rabbitmq:username";
             var passwordPrefix = "spring:rabbitmq:password";
             var services = new ServiceCollection();
 
             Environment.SetEnvironmentVariable("VCAP_APPLICATION", TestHelpers.VCAP_APPLICATION);
-            Environment.SetEnvironmentVariable("VCAP_SERVICES", GetCloudFoundryRabbitMqConfiguration(host, port));
+            Environment.SetEnvironmentVariable("VCAP_SERVICES", GetCloudFoundryRabbitMqConfiguration());
 
             var appsettings = new Dictionary<string, string>()
             {
@@ -541,18 +539,16 @@ namespace Steeltoe.Messaging.RabbitMQ.Extensions
 
             Assert.Equal(appsettings[usernamePrefix], rabbitOptions.Username);
             Assert.Equal(appsettings[passwordPrefix], rabbitOptions.Password);
-            Assert.Equal($"{host}:{port}", rabbitOptions.Addresses);
+            Assert.Equal($"192.168.0.90:3306", rabbitOptions.Addresses);
         }
 
         [Fact]
         public void AddRabbitConnectionFactory_AddRabbitConnector()
         {
-            var host = "192.168.0.90";
-            var port = 3306;
             var services = new ServiceCollection();
 
             Environment.SetEnvironmentVariable("VCAP_APPLICATION", TestHelpers.VCAP_APPLICATION);
-            Environment.SetEnvironmentVariable("VCAP_SERVICES", GetCloudFoundryRabbitMqConfiguration(host, port));
+            Environment.SetEnvironmentVariable("VCAP_SERVICES", GetCloudFoundryRabbitMqConfiguration());
 
             var configurationBuilder = new ConfigurationBuilder();
             configurationBuilder.AddCloudFoundry();
@@ -564,15 +560,15 @@ namespace Steeltoe.Messaging.RabbitMQ.Extensions
             var provider = services.BuildServiceProvider();
             var rabbitConnectionFactory = provider.GetRequiredService<IConnectionFactory>();
 
-            Assert.Equal(host, rabbitConnectionFactory.Host);
-            Assert.Equal(port, rabbitConnectionFactory.Port);
+            Assert.Equal("192.168.0.90", rabbitConnectionFactory.Host);
+            Assert.Equal(3306, rabbitConnectionFactory.Port);
         }
 
-        private static string GetCloudFoundryRabbitMqConfiguration(string host, int port) => @"
+        private static string GetCloudFoundryRabbitMqConfiguration() => @"
         {
             ""p-rabbitmq"": [{
                 ""credentials"": {
-                    ""uri"": ""amqp://Dd6O1BPXUHdrmzbP:7E1LxXnlH2hhlPVt@" + $"{host}:{port}" + @"/cf_b4f8d2fa_a3ea_4e3a_a0e8_2cd040790355""
+                    ""uri"": ""amqp://Dd6O1BPXUHdrmzbP:7E1LxXnlH2hhlPVt@" + $"192.168.0.90:3306" + @"/cf_b4f8d2fa_a3ea_4e3a_a0e8_2cd040790355""
                 },
                 ""syslog_drain_url"": null,
                 ""label"": ""p-rabbitmq"",

--- a/src/Messaging/test/RabbitMQ.Test/Steeltoe.Messaging.RabbitMQ.Test.csproj
+++ b/src/Messaging/test/RabbitMQ.Test/Steeltoe.Messaging.RabbitMQ.Test.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\Configuration\src\CloudFoundryBase\Steeltoe.Extensions.Configuration.CloudFoundryBase.csproj" />
+    <ProjectReference Include="..\..\..\Connectors\src\CloudFoundry\Steeltoe.Connector.CloudFoundry.csproj" />
     <ProjectReference Include="..\..\..\Connectors\src\ConnectorCore\Steeltoe.Connector.ConnectorCore.csproj" />
     <ProjectReference Include="..\..\src\RabbitMQ\Steeltoe.Messaging.RabbitMQ.csproj" />
   </ItemGroup>


### PR DESCRIPTION
The RabbitMQ Connector integration (in tests) was working, but contained inaccurate host/port information. Adding project reference to `Steeltoe.Connector.CloudFoundry` allows the Cloud Foundry RabbitMQ service configuration properties to be retained within registered connection service (RabbitMQ.Client -> IConnectionFactory).