### PR TITLE
Fix error message; fix finding binder in current directory

### DIFF
--- a/src/Messaging/src/RabbitMQ/Connection/CachingConnectionFactory.cs
+++ b/src/Messaging/src/RabbitMQ/Connection/CachingConnectionFactory.cs
@@ -385,7 +385,7 @@ namespace Steeltoe.Messaging.RabbitMQ.Connection
 
         public void ChannelShutdownCompleted(object sender, RC.ShutdownEventArgs args)
         {
-            _closeExceptionLogger.Log(_logger, "Channel shutdown", args.Cause);
+            _closeExceptionLogger.Log(_logger, "Channel shutdown", args);
             ChannelListener.OnShutDown(args);
         }
 

--- a/src/Stream/src/StreamBase/Binder/DefaultBinderTypeRegistry.cs
+++ b/src/Stream/src/StreamBase/Binder/DefaultBinderTypeRegistry.cs
@@ -165,11 +165,8 @@ namespace Steeltoe.Stream.Binder
         {
             var paths = new List<string>();
             paths.AddRange(Directory.GetFiles(RuntimeEnvironment.GetRuntimeDirectory(), "*.dll"));
-            if (!Environment.CurrentDirectory.Equals(directory, StringComparison.InvariantCultureIgnoreCase))
-            {
-                paths.AddRange(Directory.GetFiles(directory, "*.dll"));
-            }
-
+            paths.AddRange(Directory.GetFiles(directory, "*.dll"));
+          
             return new PathAssemblyResolver(paths);
         }
 

--- a/src/Stream/src/StreamBase/Binder/DefaultBinderTypeRegistry.cs
+++ b/src/Stream/src/StreamBase/Binder/DefaultBinderTypeRegistry.cs
@@ -166,7 +166,6 @@ namespace Steeltoe.Stream.Binder
             var paths = new List<string>();
             paths.AddRange(Directory.GetFiles(RuntimeEnvironment.GetRuntimeDirectory(), "*.dll"));
             paths.AddRange(Directory.GetFiles(directory, "*.dll"));
-          
             return new PathAssemblyResolver(paths);
         }
 


### PR DESCRIPTION
* Sometimes the cause on shutdowneventArgs is empty, but the replyText and Status have information which is exposed by ToString() - this leaves a better error message when failures occur (such as reading from an exchange that doesn't exist)
* We exclude the CurrentDirectory (which is added by default in the constructor) for testing. But this interferes with generic hosts when the binder is in the current directory. 