### PR TITLE
Async tests should return Task

### DIFF
--- a/src/CircuitBreaker/test/Hystrix.MetricsEventsCore.Test/Controllers/HystrixConfigStreamControllerTest.cs
+++ b/src/CircuitBreaker/test/Hystrix.MetricsEventsCore.Test/Controllers/HystrixConfigStreamControllerTest.cs
@@ -13,6 +13,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Net;
 using System.Net.Http;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Steeltoe.CircuitBreaker.Hystrix.MetricsEvents.Controllers.Test
@@ -28,7 +29,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix.MetricsEvents.Controllers.Test
         }
 
         [Fact]
-        public async void Endpoint_ReturnsHeaders()
+        public async Task Endpoint_ReturnsHeaders()
         {
             var builder = new WebHostBuilder().UseStartup<Startup>();
             using var server = new TestServer(builder);

--- a/src/CircuitBreaker/test/Hystrix.MetricsEventsCore.Test/Controllers/HystrixMetricsStreamControllerTest.cs
+++ b/src/CircuitBreaker/test/Hystrix.MetricsEventsCore.Test/Controllers/HystrixMetricsStreamControllerTest.cs
@@ -12,6 +12,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Net;
 using System.Net.Http;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Steeltoe.CircuitBreaker.Hystrix.MetricsEvents.Controllers.Test
@@ -27,7 +28,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix.MetricsEvents.Controllers.Test
         }
 
         [Fact]
-        public async void Endpoint_ReturnsHeaders()
+        public async Task Endpoint_ReturnsHeaders()
         {
             var builder = new WebHostBuilder().UseStartup<Startup>();
             using var server = new TestServer(builder);

--- a/src/CircuitBreaker/test/Hystrix.MetricsEventsCore.Test/Controllers/HystrixRequestEventStreamControllerTest.cs
+++ b/src/CircuitBreaker/test/Hystrix.MetricsEventsCore.Test/Controllers/HystrixRequestEventStreamControllerTest.cs
@@ -12,6 +12,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Net;
 using System.Net.Http;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Steeltoe.CircuitBreaker.Hystrix.MetricsEvents.Controllers.Test
@@ -27,7 +28,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix.MetricsEvents.Controllers.Test
         }
 
         [Fact]
-        public async void Endpoint_ReturnsHeaders()
+        public async Task Endpoint_ReturnsHeaders()
         {
             var builder = new WebHostBuilder().UseStartup<Startup>();
             using var server = new TestServer(builder);

--- a/src/CircuitBreaker/test/Hystrix.MetricsEventsCore.Test/Controllers/HystrixUtilizationStreamControllerTest.cs
+++ b/src/CircuitBreaker/test/Hystrix.MetricsEventsCore.Test/Controllers/HystrixUtilizationStreamControllerTest.cs
@@ -12,6 +12,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Net;
 using System.Net.Http;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Steeltoe.CircuitBreaker.Hystrix.MetricsEvents.Controllers.Test
@@ -27,7 +28,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix.MetricsEvents.Controllers.Test
         }
 
         [Fact]
-        public async void Endpoint_ReturnsHeaders()
+        public async Task Endpoint_ReturnsHeaders()
         {
             var builder = new WebHostBuilder().UseStartup<Startup>();
             using var server = new TestServer(builder);

--- a/src/CircuitBreaker/test/HystrixBase.Test/Config/HystrixConfigurationStreamTest.cs
+++ b/src/CircuitBreaker/test/HystrixBase.Test/Config/HystrixConfigurationStreamTest.cs
@@ -33,7 +33,6 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Config.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
         public void TestStreamHasData()
         {
             var commandShowsUp = new AtomicBoolean(false);
@@ -78,7 +77,6 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Config.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
         public void TestTwoSubscribersOneUnsubscribes()
         {
             var latch1 = new CountdownEvent(1);
@@ -154,7 +152,6 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Config.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
         public void TestTwoSubscribersBothUnsubscribe()
         {
             var latch1 = new CountdownEvent(1);
@@ -231,7 +228,6 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Config.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
         public void TestTwoSubscribersOneSlowOneFast()
         {
             var latch = new CountdownEvent(1);

--- a/src/CircuitBreaker/test/HystrixBase.Test/HystrixCircuitBreakerTest.cs
+++ b/src/CircuitBreaker/test/HystrixBase.Test/HystrixCircuitBreakerTest.cs
@@ -28,7 +28,6 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
         public async Task TestTripCircuitAsync()
         {
             var key = "cmd-A";
@@ -75,7 +74,6 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
         public async Task TestTripCircuitOnFailuresAboveThreshold()
         {
             var key = "cmd-B";
@@ -117,7 +115,6 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
         public async Task TestCircuitDoesNotTripOnFailuresBelowThreshold()
         {
             var key = "cmd-C";
@@ -159,7 +156,6 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
         public async Task TestTripCircuitOnTimeouts()
         {
             var key = "cmd-D";
@@ -191,7 +187,6 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
         public async Task TestTripCircuitOnTimeoutsAboveThreshold()
         {
             var key = "cmd-E";
@@ -238,7 +233,6 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
         public async Task TestSingleTestOnOpenCircuitAfterTimeWindow()
         {
             var key = "cmd-F";
@@ -281,7 +275,6 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
         public async Task TestCircuitClosedAfterSuccess()
         {
             var key = "cmd-G";
@@ -338,7 +331,6 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
         public async Task TestMultipleTimeWindowRetriesBeforeClosingCircuit()
         {
             var key = "cmd-H";

--- a/src/CircuitBreaker/test/HystrixBase.Test/HystrixCollapserTest.cs
+++ b/src/CircuitBreaker/test/HystrixBase.Test/HystrixCollapserTest.cs
@@ -36,7 +36,6 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
         public void TestTwoRequests()
         {
             var timer = new TestCollapserTimer(output);
@@ -67,7 +66,6 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
         public void TestMultipleBatches()
         {
             var timer = new TestCollapserTimer(output);
@@ -95,7 +93,6 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
         public void TestMaxRequestsInBatch()
         {
             var timer = new TestCollapserTimer(output);
@@ -125,7 +122,6 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
         public void TestRequestsOverTime()
         {
             var timer = new TestCollapserTimer(output);
@@ -163,7 +159,6 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
         public void TestDuplicateArgumentsWithRequestCachingOn()
         {
             var num = 10;
@@ -197,7 +192,6 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
         public void TestDuplicateArgumentsWithRequestCachingOff()
         {
             var num = 10;
@@ -268,7 +262,6 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Test
 
         // }
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
         public void TestUnsubscribeFromSomeDuplicateArgsDoesNotRemoveFromBatch()
         {
             var num = 10;
@@ -321,7 +314,6 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
         public void TestUnsubscribeOnOneDoesntKillBatch()
         {
             var timer = new TestCollapserTimer(output);
@@ -357,7 +349,6 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
         public void TestShardedRequests()
         {
             var timer = new TestCollapserTimer(output);
@@ -382,7 +373,6 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
         public void TestRequestScope()
         {
             var timer = new TestCollapserTimer(output);
@@ -412,7 +402,6 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
         public void TestGlobalScope()
         {
             var timer = new TestCollapserTimer(output);
@@ -440,7 +429,6 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
         public void TestErrorHandlingViaFutureException()
         {
             var timer = new TestCollapserTimer(output);
@@ -475,7 +463,6 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
         public void TestErrorHandlingWhenMapToResponseFails()
         {
             var timer = new TestCollapserTimer(output);
@@ -514,7 +501,6 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
         public void TestRequestVariableLifecycle1()
         {
             // do actual work
@@ -570,7 +556,6 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
         public void TestRequestVariableLifecycle2()
         {
             var timer = new TestCollapserTimer(output);
@@ -657,7 +642,6 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
         public void TestRequestCache1()
         {
             var timer = new TestCollapserTimer(output);
@@ -707,7 +691,6 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
         public void TestRequestCache2()
         {
             var timer = new TestCollapserTimer(output);
@@ -757,7 +740,6 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
         public void TestRequestCache3()
         {
             var timer = new TestCollapserTimer(output);
@@ -813,7 +795,6 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
         public void TestNoRequestCache3()
         {
             var timer = new TestCollapserTimer(output);
@@ -878,7 +859,6 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
         public void TestRequestCacheWithNullRequestArgument()
         {
             var commands = new ConcurrentQueue<HystrixCommand<List<string>>>();
@@ -918,7 +898,6 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
         public void TestRequestCacheWithCommandError()
         {
             var commands = new ConcurrentQueue<HystrixCommand<List<string>>>();
@@ -975,7 +954,6 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
         public void TestRequestCacheWithCommandTimeout()
         {
             var commands = new ConcurrentQueue<HystrixCommand<List<string>>>();
@@ -1031,7 +1009,6 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
         public async Task TestRequestWithCommandShortCircuited()
         {
             var timer = new TestCollapserTimer(output);
@@ -1072,7 +1049,6 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
         public void TestVoidResponseTypeFireAndForgetCollapsing1()
         {
             var timer = new TestCollapserTimer(output);
@@ -1093,7 +1069,6 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
         public void TestVoidResponseTypeFireAndForgetCollapsing2()
         {
             var timer = new TestCollapserTimer(output);
@@ -1121,7 +1096,6 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
         public void TestVoidResponseTypeFireAndForgetCollapsing3()
         {
             ICollapserTimer timer = new RealCollapserTimer();
@@ -1135,7 +1109,6 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
         public void TestEarlyUnsubscribeExecutedViaToObservable()
         {
             var timer = new TestCollapserTimer(output);
@@ -1216,7 +1189,6 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
         public void TestEarlyUnsubscribeExecutedViaObserve()
         {
             var timer = new TestCollapserTimer(output);
@@ -1296,7 +1268,6 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
         public void TestEarlyUnsubscribeFromAllCancelsBatch()
         {
             var timer = new TestCollapserTimer(output);
@@ -1373,7 +1344,6 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
         public void TestRequestThenCacheHitAndCacheHitUnsubscribed()
         {
             var timer = new TestCollapserTimer(output);
@@ -1453,7 +1423,6 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
         public void TestRequestThenCacheHitAndOriginalUnsubscribed()
         {
             // TODO:
@@ -1533,7 +1502,6 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
         public void TestRequestThenTwoCacheHitsOriginalAndOneCacheHitUnsubscribed()
         {
             var timer = new TestCollapserTimer(output);
@@ -1642,7 +1610,6 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
 
         public void TestRequestThenTwoCacheHitsAllUnsubscribed()
         {

--- a/src/CircuitBreaker/test/HystrixBase.Test/HystrixCommandMetricsTest.cs
+++ b/src/CircuitBreaker/test/HystrixBase.Test/HystrixCommandMetricsTest.cs
@@ -24,7 +24,6 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
         public void TestGetErrorPercentage()
         {
             var key = "cmd-metrics-A";
@@ -87,7 +86,6 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
         public void TestBadRequestsDoNotAffectErrorPercentage()
         {
             var key = "cmd-metrics-B";

--- a/src/CircuitBreaker/test/HystrixBase.Test/HystrixCommandTest.cs
+++ b/src/CircuitBreaker/test/HystrixBase.Test/HystrixCommandTest.cs
@@ -33,7 +33,6 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
         public void TestExecutionSuccess()
         {
             var command = GetCommand(ExecutionIsolationStrategy.THREAD, ExecutionResultTest.SUCCESS);
@@ -51,7 +50,6 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
         public void TestExecutionMultipleTimes()
         {
             var command = GetCommand(ExecutionIsolationStrategy.THREAD, ExecutionResultTest.SUCCESS);
@@ -84,7 +82,6 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
         public void TestExecutionHystrixFailureWithNoFallback()
         {
             var command = GetCommand(ExecutionIsolationStrategy.THREAD, ExecutionResultTest.HYSTRIX_FAILURE, FallbackResultTest.UNIMPLEMENTED);
@@ -109,7 +106,6 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
         public void TestExecutionFailureWithNoFallback()
         {
             var command = GetCommand(ExecutionIsolationStrategy.THREAD, ExecutionResultTest.FAILURE, FallbackResultTest.UNIMPLEMENTED);
@@ -134,7 +130,6 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
         public void TestExecutionFailureWithFallback()
         {
             var command = GetCommand(ExecutionIsolationStrategy.THREAD, ExecutionResultTest.FAILURE, FallbackResultTest.SUCCESS);
@@ -149,7 +144,6 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
         public void TestExecutionRejectionWithFallbackException()
         {
             var threads = new List<Thread>();
@@ -198,7 +192,6 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
         public void TestExecutionFailureWithFallbackFailure()
         {
             var command = GetCommand(ExecutionIsolationStrategy.THREAD, ExecutionResultTest.FAILURE, FallbackResultTest.FAILURE);
@@ -225,7 +218,6 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
         public void TestQueueSuccess()
         {
             var command = GetCommand(ExecutionIsolationStrategy.THREAD, ExecutionResultTest.SUCCESS);
@@ -240,7 +232,6 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
         public async Task TestQueueKnownFailureWithNoFallback()
         {
             var command = GetCommand(ExecutionIsolationStrategy.THREAD, ExecutionResultTest.HYSTRIX_FAILURE, FallbackResultTest.UNIMPLEMENTED);
@@ -265,7 +256,6 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
         public async Task TestQueueUnknownFailureWithNoFallback()
         {
             var command = GetCommand(ExecutionIsolationStrategy.THREAD, ExecutionResultTest.FAILURE, FallbackResultTest.UNIMPLEMENTED);
@@ -290,7 +280,6 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
         public void TestQueueFailureWithFallback()
         {
             var command = GetCommand(ExecutionIsolationStrategy.THREAD, ExecutionResultTest.FAILURE, FallbackResultTest.SUCCESS);
@@ -314,7 +303,6 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
         public async Task TestQueueFailureWithFallbackFailure()
         {
             var command = GetCommand(ExecutionIsolationStrategy.THREAD, ExecutionResultTest.FAILURE, FallbackResultTest.FAILURE);
@@ -338,7 +326,6 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
         public async Task TestObserveSuccess()
         {
             var command = GetCommand(ExecutionIsolationStrategy.THREAD, ExecutionResultTest.SUCCESS);
@@ -370,7 +357,6 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
         public void TestCallbackThreadForThreadIsolation()
         {
             var commandThread = new AtomicReference<Thread>();
@@ -430,7 +416,6 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
         public void TestCallbackThreadForSemaphoreIsolation()
         {
             var commandThread = new AtomicReference<Thread>();
@@ -476,7 +461,6 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
         public void TestCircuitBreakerReportsOpenIfForcedOpen()
         {
             var opts = new HystrixCommandOptions()
@@ -493,7 +477,6 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
         public void TestCircuitBreakerReportsClosedIfForcedClosed()
         {
             var opts = new HystrixCommandOptions()
@@ -510,7 +493,6 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
         public async Task TestCircuitBreakerAcrossMultipleCommandsButSameCircuitBreaker()
         {
             var key = HystrixCommandKeyDefault.AsKey("SharedCircuitBreaker");
@@ -584,7 +566,6 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
         public void TestExecutionSuccessWithCircuitBreakerDisabled()
         {
             var command = GetCircuitBreakerDisabledCommand(ExecutionIsolationStrategy.THREAD, ExecutionResultTest.SUCCESS);
@@ -598,7 +579,6 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
         public void TestExecutionTimeoutWithNoFallback()
         {
             var command = GetLatentCommand(ExecutionIsolationStrategy.THREAD, ExecutionResultTest.SUCCESS, 200, FallbackResultTest.UNIMPLEMENTED, 50);
@@ -639,7 +619,6 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
         public void TestExecutionTimeoutWithFallback()
         {
             var command = GetLatentCommand(ExecutionIsolationStrategy.THREAD, ExecutionResultTest.SUCCESS, 200, FallbackResultTest.SUCCESS, 50);
@@ -658,7 +637,6 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
         public void TestExecutionTimeoutFallbackFailure()
         {
             var command = GetLatentCommand(ExecutionIsolationStrategy.THREAD, ExecutionResultTest.SUCCESS, 200, FallbackResultTest.FAILURE, 50);
@@ -693,7 +671,6 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
         public void TestCountersOnExecutionTimeout()
         {
             var command = GetCommand(ExecutionIsolationStrategy.THREAD, ExecutionResultTest.SUCCESS, 200, FallbackResultTest.SUCCESS, 50);
@@ -718,7 +695,6 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
         public async Task TestQueuedExecutionTimeoutWithNoFallback()
         {
             var command = GetCommand(ExecutionIsolationStrategy.THREAD, ExecutionResultTest.SUCCESS, 200, FallbackResultTest.UNIMPLEMENTED, 50);
@@ -746,7 +722,6 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
         public async Task TestQueuedExecutionTimeoutWithFallback()
         {
             var command = GetCommand(ExecutionIsolationStrategy.THREAD, ExecutionResultTest.SUCCESS, 200, FallbackResultTest.SUCCESS, 50);
@@ -757,7 +732,6 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Test
             AssertSaneHystrixRequestLog(1);
         }
 
-        // [Trait("Category", "FlakyOnHostedAgents")]
         [Fact]
         public async Task TestQueuedExecutionTimeoutFallbackFailure()
         {
@@ -783,7 +757,6 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
         public void TestObservedExecutionTimeoutWithNoFallback()
         {
             var command = GetCommand(ExecutionIsolationStrategy.THREAD, ExecutionResultTest.SUCCESS, 200, FallbackResultTest.UNIMPLEMENTED, 50);
@@ -817,7 +790,6 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
         public void TestObservedExecutionTimeoutWithFallback()
         {
             var command = GetCommand(ExecutionIsolationStrategy.THREAD, ExecutionResultTest.SUCCESS, 200, FallbackResultTest.SUCCESS, 50);
@@ -830,7 +802,6 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
         public void TestObservedExecutionTimeoutFallbackFailure()
         {
             var command = GetCommand(ExecutionIsolationStrategy.THREAD, ExecutionResultTest.SUCCESS, 200, FallbackResultTest.FAILURE, 50);
@@ -862,7 +833,6 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
         public void TestShortCircuitFallbackCounter()
         {
             var circuitBreaker = new TestCircuitBreaker().SetForceShortCircuit(true);
@@ -885,7 +855,6 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
         public async Task TestRejectedThreadWithNoFallback()
         {
             var key = HystrixCommandKeyDefault.AsKey("Rejection-NoFallback");
@@ -947,7 +916,6 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
         public void TestRejectedThreadWithFallback()
         {
             var key = HystrixCommandKeyDefault.AsKey("Rejection-Fallback");
@@ -988,7 +956,6 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
         public async Task TestRejectedThreadWithFallbackFailure()
         {
             var circuitBreaker = new TestCircuitBreaker();
@@ -1047,7 +1014,6 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
         public async Task TestRejectedThreadUsingQueueSize()
         {
             var key = HystrixCommandKeyDefault.AsKey("Rejection-B");
@@ -1107,7 +1073,6 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
         public void TestDisabledTimeoutWorks()
         {
             var cmd = new CommandWithDisabledTimeout(100, 900);
@@ -1122,7 +1087,6 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
         public async Task TestFallbackSemaphore()
         {
             var circuitBreaker = new TestCircuitBreaker();
@@ -1172,7 +1136,6 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
         public async Task TestExecutionSemaphoreWithQueue()
         {
             var circuitBreaker = new TestCircuitBreaker();
@@ -1237,7 +1200,6 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
         public void TestExecutionSemaphoreWithExecution()
         {
             var circuitBreaker = new TestCircuitBreaker();
@@ -1313,7 +1275,6 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
         public void TestRejectedExecutionSemaphoreWithFallbackViaExecute()
         {
             var circuitBreaker = new TestCircuitBreaker();
@@ -1377,7 +1338,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
+
         public void TestRejectedExecutionSemaphoreWithFallbackViaObserve()
         {
             var circuitBreaker = new TestCircuitBreaker();
@@ -1869,7 +1830,6 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
         public void TestNoRequestCacheOnTimeoutThrowsException()
         {
             var circuitBreaker = new TestCircuitBreaker();
@@ -1947,7 +1907,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
+
         public void TestRequestCacheOnTimeoutCausesNullPointerException()
         {
             var circuitBreaker = new TestCircuitBreaker();
@@ -1987,7 +1947,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
+
         public void TestRequestCacheOnTimeoutThrowsException()
         {
             var circuitBreaker = new TestCircuitBreaker();
@@ -2065,7 +2025,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
+
         public async Task TestRequestCacheOnThreadRejectionThrowsException()
         {
             var circuitBreaker = new TestCircuitBreaker();
@@ -2553,7 +2513,6 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
         public void TestExecutionTimeoutValue()
         {
             var properties = new HystrixCommandOptions()
@@ -2573,7 +2532,6 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
         public void TestObservableTimeoutNoFallbackThreadContext()
         {
             var latch = new CountdownEvent(1);
@@ -2628,7 +2586,6 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
         public void TestExceptionConvertedToBadRequestExceptionInExecutionHookBypassesCircuitBreaker()
         {
             var circuitBreaker = new TestCircuitBreaker();
@@ -2655,7 +2612,6 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
         public void TestInterruptFutureOnTimeout()
         {
             // given
@@ -2670,7 +2626,6 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
         public void TestInterruptObserveOnTimeout()
         {
             // given
@@ -2685,7 +2640,6 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
         public void TestInterruptToObservableOnTimeout()
         {
             // given
@@ -2700,7 +2654,6 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
         public void TestCancelFutureWithInterruption()
         {
             // given
@@ -2727,20 +2680,17 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
         public void TestChainedCommand()
         {
             Assert.True(new TestChainedCommandPrimaryCommand(new TestCircuitBreaker()).Execute() == 2);
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
         public void TestSlowFallback()
         {
             Assert.True(new TestSlowFallbackPrimaryCommand(new TestCircuitBreaker()).Execute() == 1);
         }
 
-        // [Trait("Category", "FlakyOnHostedAgents")]
         [Fact]
         public void TestSemaphoreThreadSafety()
         {
@@ -2803,7 +2753,6 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
         public void TestCancelledTasksInQueueGetRemoved()
         {
             var key = HystrixCommandKeyDefault.AsKey("Cancellation-A");
@@ -3805,7 +3754,6 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
         public void TestExecutionHookThreadTimeoutNoFallbackRunSuccess()
         {
             AssertHooksOnFailure(
@@ -3830,7 +3778,6 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
         public void TestExecutionHookThreadTimeoutSuccessfulFallbackRunSuccess()
         {
             AssertHooksOnSuccess(
@@ -3855,7 +3802,6 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
         public void TestExecutionHookThreadTimeoutUnsuccessfulFallbackRunSuccess()
         {
             AssertHooksOnFailure(
@@ -3881,7 +3827,6 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
         public void TestExecutionHookThreadTimeoutNoFallbackRunFailure()
         {
             AssertHooksOnFailure(
@@ -3905,7 +3850,6 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
         public void TestExecutionHookThreadTimeoutSuccessfulFallbackRunFailure()
         {
             AssertHooksOnSuccess(
@@ -3930,7 +3874,6 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
         public void TestExecutionHookThreadTimeoutUnsuccessfulFallbackRunFailure()
         {
             AssertHooksOnFailure(
@@ -3956,7 +3899,6 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
         public void TestExecutionHookThreadPoolQueueFullNoFallback()
         {
             SingleThreadedPoolWithQueue pool = null;
@@ -3995,7 +3937,6 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
         public void TestExecutionHookThreadPoolQueueFullSuccessfulFallback()
         {
             SingleThreadedPoolWithQueue pool = null;
@@ -4038,7 +3979,6 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
         public void TestExecutionHookThreadPoolQueueFullUnsuccessfulFallback()
         {
             SingleThreadedPoolWithQueue pool = null;

--- a/src/CircuitBreaker/test/HystrixBase.Test/Metric/Consumer/CumulativeCommandEventCounterStreamTest.cs
+++ b/src/CircuitBreaker/test/HystrixBase.Test/Metric/Consumer/CumulativeCommandEventCounterStreamTest.cs
@@ -49,7 +49,6 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric.Consumer.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
         public void TestEmptyStreamProducesZeros()
         {
             var key = HystrixCommandKeyDefault.AsKey("CMD-CumulativeCounter-A");
@@ -68,8 +67,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric.Consumer.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
-        public async void TestSingleSuccess()
+        public async Task TestSingleSuccess()
         {
             var key = HystrixCommandKeyDefault.AsKey("CMD-CumulativeCounter-B");
 
@@ -90,8 +88,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric.Consumer.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
-        public async void TestSingleFailure()
+        public async Task TestSingleFailure()
         {
             var key = HystrixCommandKeyDefault.AsKey("CMD-CumulativeCounter-C");
 
@@ -113,8 +110,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric.Consumer.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
-        public async void TestSingleTimeout()
+        public async Task TestSingleTimeout()
         {
             var key = HystrixCommandKeyDefault.AsKey("CMD-CumulativeCounter-D");
             var latch = new CountdownEvent(1);
@@ -136,8 +132,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric.Consumer.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
-        public async void TestSingleBadRequest()
+        public async Task TestSingleBadRequest()
         {
             var key = HystrixCommandKeyDefault.AsKey("CMD-CumulativeCounter-E");
             var latch = new CountdownEvent(1);
@@ -159,8 +154,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric.Consumer.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
-        public async void TestRequestFromCache()
+        public async Task TestRequestFromCache()
         {
             var key = HystrixCommandKeyDefault.AsKey("CMD-CumulativeCounter-F");
             var latch = new CountdownEvent(1);
@@ -186,7 +180,6 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric.Consumer.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
         public void TestShortCircuited()
         {
             var key = HystrixCommandKeyDefault.AsKey("CMD-CumulativeCounter-G");
@@ -227,8 +220,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric.Consumer.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
-        public async void TestSemaphoreRejected()
+        public async Task TestSemaphoreRejected()
         {
             var key = HystrixCommandKeyDefault.AsKey("CMD-CumulativeCounter-H");
             var latch = new CountdownEvent(1);
@@ -275,7 +267,6 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric.Consumer.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
         public void TestThreadPoolRejected()
         {
             var key = HystrixCommandKeyDefault.AsKey("CMD-CumulativeCounter-I");
@@ -320,8 +311,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric.Consumer.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
-        public async void TestFallbackFailure()
+        public async Task TestFallbackFailure()
         {
             var key = HystrixCommandKeyDefault.AsKey("CMD-CumulativeCounter-J");
             var latch = new CountdownEvent(1);
@@ -344,8 +334,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric.Consumer.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
-        public async void TestFallbackMissing()
+        public async Task TestFallbackMissing()
         {
             var key = HystrixCommandKeyDefault.AsKey("CMD-CumulativeCounter-K");
             var latch = new CountdownEvent(1);
@@ -369,8 +358,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric.Consumer.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
-        public async void TestFallbackRejection()
+        public async Task TestFallbackRejection()
         {
             var key = HystrixCommandKeyDefault.AsKey("CMD-CumulativeCounter-L");
             var latch = new CountdownEvent(1);
@@ -417,7 +405,6 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric.Consumer.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
         public void TestCancelled()
         {
             var key = HystrixCommandKeyDefault.AsKey("CMD-CumulativeCounter-M");
@@ -462,7 +449,6 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric.Consumer.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
         public void TestCollapsed()
         {
             var key = HystrixCommandKeyDefault.AsKey("BatchCommand");
@@ -490,8 +476,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric.Consumer.Test
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnHostedAgents")]
-        public async void TestMultipleEventsOverTimeGetStoredAndNeverAgeOut()
+        public async Task TestMultipleEventsOverTimeGetStoredAndNeverAgeOut()
         {
             var key = HystrixCommandKeyDefault.AsKey("CMD-CumulativeCounter-N");
             var latch = new CountdownEvent(1);

--- a/src/CircuitBreaker/test/HystrixBase.Test/Metric/Consumer/CumulativeThreadPoolEventCounterStreamTest.cs
+++ b/src/CircuitBreaker/test/HystrixBase.Test/Metric/Consumer/CumulativeThreadPoolEventCounterStreamTest.cs
@@ -71,7 +71,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric.Consumer.Test
 
         [Fact]
         [Trait("Category", "FlakyOnHostedAgents")]
-        public async void TestSingleSuccess()
+        public async Task TestSingleSuccess()
         {
             var groupKey = HystrixCommandGroupKeyDefault.AsKey("Cumulative-ThreadPool-B");
             var threadPoolKey = HystrixThreadPoolKeyDefault.AsKey("Cumulative-ThreadPool-B");
@@ -96,7 +96,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric.Consumer.Test
 
         [Fact]
         [Trait("Category", "FlakyOnHostedAgents")]
-        public async void TestSingleFailure()
+        public async Task TestSingleFailure()
         {
             var groupKey = HystrixCommandGroupKeyDefault.AsKey("Cumulative-ThreadPool-C");
             var threadPoolKey = HystrixThreadPoolKeyDefault.AsKey("Cumulative-ThreadPool-C");
@@ -122,7 +122,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric.Consumer.Test
 
         [Fact]
         [Trait("Category", "FlakyOnHostedAgents")]
-        public async void TestSingleTimeout()
+        public async Task TestSingleTimeout()
         {
             var groupKey = HystrixCommandGroupKeyDefault.AsKey("Cumulative-ThreadPool-D");
             var threadPoolKey = HystrixThreadPoolKeyDefault.AsKey("Cumulative-ThreadPool-D");
@@ -146,7 +146,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric.Consumer.Test
 
         [Fact]
         [Trait("Category", "FlakyOnHostedAgents")]
-        public async void TestSingleBadRequest()
+        public async Task TestSingleBadRequest()
         {
             var groupKey = HystrixCommandGroupKeyDefault.AsKey("Cumulative-ThreadPool-E");
             var threadPoolKey = HystrixThreadPoolKeyDefault.AsKey("Cumulative-ThreadPool-E");
@@ -171,7 +171,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric.Consumer.Test
 
         [Fact]
         [Trait("Category", "FlakyOnHostedAgents")]
-        public async void TestRequestFromCache()
+        public async Task TestRequestFromCache()
         {
             var groupKey = HystrixCommandGroupKeyDefault.AsKey("Cumulative-ThreadPool-F");
             var threadPoolKey = HystrixThreadPoolKeyDefault.AsKey("Cumulative-ThreadPool-F");
@@ -202,7 +202,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric.Consumer.Test
 
         [Fact]
         [Trait("Category", "FlakyOnHostedAgents")]
-        public async void TestShortCircuited()
+        public async Task TestShortCircuited()
         {
             var groupKey = HystrixCommandGroupKeyDefault.AsKey("Cumulative-ThreadPool-G");
             var threadPoolKey = HystrixThreadPoolKeyDefault.AsKey("Cumulative-ThreadPool-G");
@@ -247,7 +247,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric.Consumer.Test
 
         [Fact]
         [Trait("Category", "FlakyOnHostedAgents")]
-        public async void TestSemaphoreRejected()
+        public async Task TestSemaphoreRejected()
         {
             var groupKey = HystrixCommandGroupKeyDefault.AsKey("Cumulative-ThreadPool-H");
             var threadPoolKey = HystrixThreadPoolKeyDefault.AsKey("Cumulative-ThreadPool-H");
@@ -347,7 +347,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric.Consumer.Test
 
         [Fact]
         [Trait("Category", "FlakyOnHostedAgents")]
-        public async void TestFallbackFailure()
+        public async Task TestFallbackFailure()
         {
             var groupKey = HystrixCommandGroupKeyDefault.AsKey("Cumulative-ThreadPool-J");
             var threadPoolKey = HystrixThreadPoolKeyDefault.AsKey("Cumulative-ThreadPool-J");
@@ -372,7 +372,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric.Consumer.Test
 
         [Fact]
         [Trait("Category", "FlakyOnHostedAgents")]
-        public async void TestFallbackMissing()
+        public async Task TestFallbackMissing()
         {
             var groupKey = HystrixCommandGroupKeyDefault.AsKey("Cumulative-ThreadPool-K");
             var threadPoolKey = HystrixThreadPoolKeyDefault.AsKey("Cumulative-ThreadPool-K");
@@ -398,7 +398,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric.Consumer.Test
 
         [Fact]
         [Trait("Category", "FlakyOnHostedAgents")]
-        public async void TestFallbackRejection()
+        public async Task TestFallbackRejection()
         {
             var groupKey = HystrixCommandGroupKeyDefault.AsKey("Cumulative-ThreadPool-L");
             var threadPoolKey = HystrixThreadPoolKeyDefault.AsKey("Cumulative-ThreadPool-L");
@@ -451,7 +451,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric.Consumer.Test
         // in a rolling window, take(20) would age out all counters.  in the cumulative count, we expect them to remain non-zero forever
         [Fact]
         [Trait("Category", "FlakyOnHostedAgents")]
-        public async void TestMultipleEventsOverTimeGetStoredAndDoNotAgeOut()
+        public async Task TestMultipleEventsOverTimeGetStoredAndDoNotAgeOut()
         {
             var groupKey = HystrixCommandGroupKeyDefault.AsKey("Cumulative-ThreadPool-M");
             var threadPoolKey = HystrixThreadPoolKeyDefault.AsKey("Cumulative-ThreadPool-M");

--- a/src/CircuitBreaker/test/HystrixBase.Test/Metric/Consumer/HealthCountsStreamTest.cs
+++ b/src/CircuitBreaker/test/HystrixBase.Test/Metric/Consumer/HealthCountsStreamTest.cs
@@ -66,7 +66,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric.Consumer.Test
 
         [Fact]
         [Trait("Category", "FlakyOnHostedAgents")]
-        public async void TestSingleSuccess()
+        public async Task TestSingleSuccess()
         {
             var key = HystrixCommandKeyDefault.AsKey("CMD-Health-B");
 
@@ -86,7 +86,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric.Consumer.Test
 
         [Fact]
         [Trait("Category", "FlakyOnHostedAgents")]
-        public async void TestSingleFailure()
+        public async Task TestSingleFailure()
         {
             var key = HystrixCommandKeyDefault.AsKey("CMD-Health-C");
 
@@ -107,7 +107,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric.Consumer.Test
         }
 
         [Fact]
-        public async void TestSingleTimeout()
+        public async Task TestSingleTimeout()
         {
             var key = HystrixCommandKeyDefault.AsKey("CMD-Health-D");
 
@@ -129,7 +129,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric.Consumer.Test
 
         [Fact]
         [Trait("Category", "FlakyOnHostedAgents")]
-        public async void TestSingleBadRequest()
+        public async Task TestSingleBadRequest()
         {
             var key = HystrixCommandKeyDefault.AsKey("CMD-Health-E");
 
@@ -151,7 +151,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric.Consumer.Test
 
         [Fact]
         [Trait("Category", "FlakyOnHostedAgents")]
-        public async void TestRequestFromCache()
+        public async Task TestRequestFromCache()
         {
             var key = HystrixCommandKeyDefault.AsKey("CMD-Health-F");
 
@@ -177,7 +177,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric.Consumer.Test
 
         [Fact]
         [Trait("Category", "FlakyOnHostedAgents")]
-        public async void TestShortCircuited()
+        public async Task TestShortCircuited()
         {
             var key = HystrixCommandKeyDefault.AsKey("CMD-Health-G");
 
@@ -218,7 +218,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric.Consumer.Test
 
         [Fact]
         [Trait("Category", "FlakyOnHostedAgents")]
-        public async void TestSemaphoreRejected()
+        public async Task TestSemaphoreRejected()
         {
             var key = HystrixCommandKeyDefault.AsKey("CMD-Health-H");
             var saturators = new List<Command>();
@@ -307,7 +307,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric.Consumer.Test
 
         [Fact]
         [Trait("Category", "FlakyOnHostedAgents")]
-        public async void TestFallbackFailure()
+        public async Task TestFallbackFailure()
         {
             var key = HystrixCommandKeyDefault.AsKey("CMD-Health-J");
 
@@ -329,7 +329,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric.Consumer.Test
 
         [Fact]
         [Trait("Category", "FlakyOnHostedAgents")]
-        public async void TestFallbackMissing()
+        public async Task TestFallbackMissing()
         {
             var key = HystrixCommandKeyDefault.AsKey("CMD-Health-K");
             var latch = new CountdownEvent(1);
@@ -349,7 +349,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric.Consumer.Test
 
         [Fact]
         [Trait("Category", "FlakyOnHostedAgents")]
-        public async void TestFallbackRejection()
+        public async Task TestFallbackRejection()
         {
             var key = HystrixCommandKeyDefault.AsKey("CMD-Health-L");
             var fallbackSaturators = new List<Command>();
@@ -392,7 +392,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric.Consumer.Test
 
         [Fact]
         [Trait("Category", "FlakyOnHostedAgents")]
-        public async void TestMultipleEventsOverTimeGetStoredAndAgeOut()
+        public async Task TestMultipleEventsOverTimeGetStoredAndAgeOut()
         {
             var key = HystrixCommandKeyDefault.AsKey("CMD-Health-M");
 

--- a/src/CircuitBreaker/test/HystrixBase.Test/Metric/Consumer/RollingCommandEventCounterStreamTest.cs
+++ b/src/CircuitBreaker/test/HystrixBase.Test/Metric/Consumer/RollingCommandEventCounterStreamTest.cs
@@ -65,7 +65,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric.Consumer.Test
 
         [Fact]
         [Trait("Category", "FlakyOnHostedAgents")]
-        public async void TestSingleSuccess()
+        public async Task TestSingleSuccess()
         {
             var key = HystrixCommandKeyDefault.AsKey("CMD-RollingCounter-B");
             var latch = new CountdownEvent(1);
@@ -88,7 +88,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric.Consumer.Test
 
         [Fact]
         [Trait("Category", "FlakyOnHostedAgents")]
-        public async void TestSingleFailure()
+        public async Task TestSingleFailure()
         {
             var key = HystrixCommandKeyDefault.AsKey("CMD-RollingCounter-C");
             var latch = new CountdownEvent(1);
@@ -113,7 +113,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric.Consumer.Test
 
         [Fact]
         [Trait("Category", "FlakyOnHostedAgents")]
-        public async void TestSingleTimeout()
+        public async Task TestSingleTimeout()
         {
             var key = HystrixCommandKeyDefault.AsKey("CMD-RollingCounter-D");
             var latch = new CountdownEvent(1);
@@ -136,7 +136,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric.Consumer.Test
 
         [Fact]
         [Trait("Category", "FlakyOnHostedAgents")]
-        public async void TestSingleBadRequest()
+        public async Task TestSingleBadRequest()
         {
             var key = HystrixCommandKeyDefault.AsKey("CMD-RollingCounter-E");
             var latch = new CountdownEvent(1);
@@ -161,7 +161,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric.Consumer.Test
 
         [Fact]
         [Trait("Category", "FlakyOnHostedAgents")]
-        public async void TestRequestFromCache()
+        public async Task TestRequestFromCache()
         {
             var key = HystrixCommandKeyDefault.AsKey("CMD-RollingCounter-F");
             var latch = new CountdownEvent(1);
@@ -189,7 +189,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric.Consumer.Test
         }
 
         [Fact]
-        public async void TestShortCircuited()
+        public async Task TestShortCircuited()
         {
             var key = HystrixCommandKeyDefault.AsKey("CMD-RollingCounter-G");
             var latch = new CountdownEvent(1);
@@ -234,7 +234,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric.Consumer.Test
 
         [Fact]
         [Trait("Category", "FlakyOnHostedAgents")]
-        public async void TestSemaphoreRejected()
+        public async Task TestSemaphoreRejected()
         {
             var key = HystrixCommandKeyDefault.AsKey("CMD-RollingCounter-H");
             var latch = new CountdownEvent(1);
@@ -285,7 +285,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric.Consumer.Test
 
         [Fact]
         [Trait("Category", "FlakyOnHostedAgents")]
-        public async void TestThreadPoolRejected()
+        public async Task TestThreadPoolRejected()
         {
             var key = HystrixCommandKeyDefault.AsKey("CMD-RollingCounter-I");
             var latch = new CountdownEvent(1);
@@ -334,7 +334,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric.Consumer.Test
 
         [Fact]
         [Trait("Category", "FlakyOnHostedAgents")]
-        public async void TestFallbackFailure()
+        public async Task TestFallbackFailure()
         {
             var key = HystrixCommandKeyDefault.AsKey("CMD-RollingCounter-J");
             var latch = new CountdownEvent(1);
@@ -360,7 +360,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric.Consumer.Test
 
         [Fact]
         [Trait("Category", "FlakyOnHostedAgents")]
-        public async void TestFallbackMissing()
+        public async Task TestFallbackMissing()
         {
             var key = HystrixCommandKeyDefault.AsKey("CMD-RollingCounter-K");
             var latch = new CountdownEvent(1);
@@ -385,7 +385,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric.Consumer.Test
 
         [Fact]
         [Trait("Category", "FlakyOnHostedAgents")]
-        public async void TestFallbackRejection()
+        public async Task TestFallbackRejection()
         {
             var key = HystrixCommandKeyDefault.AsKey("CMD-RollingCounter-L");
             var latch = new CountdownEvent(1);
@@ -462,7 +462,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric.Consumer.Test
 
         [Fact]
         [Trait("Category", "FlakyOnHostedAgents")]
-        public async void TestMultipleEventsOverTimeGetStoredAndAgeOut()
+        public async Task TestMultipleEventsOverTimeGetStoredAndAgeOut()
         {
             var key = HystrixCommandKeyDefault.AsKey("CMD-RollingCounter-M");
             var latch = new CountdownEvent(1);

--- a/src/CircuitBreaker/test/HystrixBase.Test/Metric/Consumer/RollingCommandLatencyDistributionStreamTest.cs
+++ b/src/CircuitBreaker/test/HystrixBase.Test/Metric/Consumer/RollingCommandLatencyDistributionStreamTest.cs
@@ -64,7 +64,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric.Consumer.Test
         }
 
         [Fact]
-        public async void TestSingleBucketGetsStored()
+        public async Task TestSingleBucketGetsStored()
         {
             var key = HystrixCommandKeyDefault.AsKey("CMD-Latency-B");
             var latch = new CountdownEvent(1);
@@ -96,7 +96,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric.Consumer.Test
         // FAILURE
         // TIMEOUT
         [Fact]
-        public async void TestSingleBucketWithMultipleEventTypes()
+        public async Task TestSingleBucketWithMultipleEventTypes()
         {
             var key = HystrixCommandKeyDefault.AsKey("CMD-Latency-C");
             var latch = new CountdownEvent(1);
@@ -123,7 +123,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric.Consumer.Test
         }
 
         [Fact]
-        public async void TestShortCircuitedCommandDoesNotGetLatencyTracked()
+        public async Task TestShortCircuitedCommandDoesNotGetLatencyTracked()
         {
             var key = HystrixCommandKeyDefault.AsKey("CMD-Latency-D");
             var latch = new CountdownEvent(1);
@@ -168,7 +168,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric.Consumer.Test
 
         [Fact]
         [Trait("Category", "FlakyOnHostedAgents")]
-        public async void TestThreadPoolRejectedCommandDoesNotGetLatencyTracked()
+        public async Task TestThreadPoolRejectedCommandDoesNotGetLatencyTracked()
         {
             var key = HystrixCommandKeyDefault.AsKey("CMD-Latency-E");
             var latch = new CountdownEvent(1);
@@ -205,7 +205,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric.Consumer.Test
 
         [Fact]
         [Trait("Category", "FlakyOnHostedAgents")]
-        public async void TestSemaphoreRejectedCommandDoesNotGetLatencyTracked()
+        public async Task TestSemaphoreRejectedCommandDoesNotGetLatencyTracked()
         {
             var key = HystrixCommandKeyDefault.AsKey("CMD-Latency-F");
             var latch = new CountdownEvent(1);
@@ -269,7 +269,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric.Consumer.Test
 
         [Fact]
         [Trait("Category", "FlakyOnHostedAgents")]
-        public async void TestMultipleBucketsBothGetStored()
+        public async Task TestMultipleBucketsBothGetStored()
         {
             var key = HystrixCommandKeyDefault.AsKey("CMD-Latency-H");
             var latch = new CountdownEvent(1);
@@ -302,7 +302,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric.Consumer.Test
         }
 
         [Fact]
-        public async void TestMultipleBucketsBothGetStoredAndThenAgeOut()
+        public async Task TestMultipleBucketsBothGetStoredAndThenAgeOut()
         {
             var key = HystrixCommandKeyDefault.AsKey("CMD-Latency-I");
             var latch = new CountdownEvent(1);

--- a/src/CircuitBreaker/test/HystrixBase.Test/Metric/Consumer/RollingCommandMaxConcurrencyStreamTest.cs
+++ b/src/CircuitBreaker/test/HystrixBase.Test/Metric/Consumer/RollingCommandMaxConcurrencyStreamTest.cs
@@ -273,7 +273,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric.Consumer.Test
 
         [Fact]
         [Trait("Category", "FlakyOnHostedAgents")]
-        public async void TestConcurrencyStreamProperlyFiltersOutSemaphoreRejections()
+        public async Task TestConcurrencyStreamProperlyFiltersOutSemaphoreRejections()
         {
             var key = HystrixCommandKeyDefault.AsKey("CMD-Concurrency-H");
             var latch = new CountdownEvent(1);

--- a/src/CircuitBreaker/test/HystrixBase.Test/Metric/Consumer/RollingThreadPoolEventCounterStreamTest.cs
+++ b/src/CircuitBreaker/test/HystrixBase.Test/Metric/Consumer/RollingThreadPoolEventCounterStreamTest.cs
@@ -67,7 +67,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric.Consumer.Test
 
         [Fact]
         [Trait("Category", "FlakyOnHostedAgents")]
-        public async void TestSingleSuccess()
+        public async Task TestSingleSuccess()
         {
             var groupKey = HystrixCommandGroupKeyDefault.AsKey("ThreadPool-B");
             var threadPoolKey = HystrixThreadPoolKeyDefault.AsKey("ThreadPool-B");
@@ -90,7 +90,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric.Consumer.Test
 
         [Fact]
         [Trait("Category", "FlakyOnHostedAgents")]
-        public async void TestSingleFailure()
+        public async Task TestSingleFailure()
         {
             var groupKey = HystrixCommandGroupKeyDefault.AsKey("ThreadPool-C");
             var threadPoolKey = HystrixThreadPoolKeyDefault.AsKey("ThreadPool-C");
@@ -113,7 +113,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric.Consumer.Test
 
         [Fact]
         [Trait("Category", "FlakyOnHostedAgents")]
-        public async void TestSingleTimeout()
+        public async Task TestSingleTimeout()
         {
             var groupKey = HystrixCommandGroupKeyDefault.AsKey("ThreadPool-D");
             var threadPoolKey = HystrixThreadPoolKeyDefault.AsKey("ThreadPool-D");
@@ -136,7 +136,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric.Consumer.Test
 
         [Fact]
         [Trait("Category", "FlakyOnHostedAgents")]
-        public async void TestSingleBadRequest()
+        public async Task TestSingleBadRequest()
         {
             var groupKey = HystrixCommandGroupKeyDefault.AsKey("ThreadPool-E");
             var threadPoolKey = HystrixThreadPoolKeyDefault.AsKey("ThreadPool-E");
@@ -159,7 +159,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric.Consumer.Test
 
         [Fact]
         [Trait("Category", "FlakyOnHostedAgents")]
-        public async void TestRequestFromCache()
+        public async Task TestRequestFromCache()
         {
             var groupKey = HystrixCommandGroupKeyDefault.AsKey("ThreadPool-F");
             var threadPoolKey = HystrixThreadPoolKeyDefault.AsKey("ThreadPool-F");
@@ -231,7 +231,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric.Consumer.Test
 
         [Fact]
         [Trait("Category", "FlakyOnHostedAgents")]
-        public async void TestSemaphoreRejected()
+        public async Task TestSemaphoreRejected()
         {
             var groupKey = HystrixCommandGroupKeyDefault.AsKey("ThreadPool-H");
             var threadPoolKey = HystrixThreadPoolKeyDefault.AsKey("ThreadPool-H");
@@ -281,7 +281,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric.Consumer.Test
 
         [Fact]
         [Trait("Category", "FlakyOnHostedAgents")]
-        public async void TestThreadPoolRejected()
+        public async Task TestThreadPoolRejected()
         {
             var groupKey = HystrixCommandGroupKeyDefault.AsKey("ThreadPool-I");
             var threadPoolKey = HystrixThreadPoolKeyDefault.AsKey("ThreadPool-I");
@@ -331,7 +331,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric.Consumer.Test
 
         [Fact]
         [Trait("Category", "FlakyOnHostedAgents")]
-        public async void TestFallbackFailure()
+        public async Task TestFallbackFailure()
         {
             var groupKey = HystrixCommandGroupKeyDefault.AsKey("ThreadPool-J");
             var threadPoolKey = HystrixThreadPoolKeyDefault.AsKey("ThreadPool-J");
@@ -355,7 +355,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric.Consumer.Test
 
         [Fact]
         [Trait("Category", "FlakyOnHostedAgents")]
-        public async void TestFallbackMissing()
+        public async Task TestFallbackMissing()
         {
             var groupKey = HystrixCommandGroupKeyDefault.AsKey("ThreadPool-K");
             var threadPoolKey = HystrixThreadPoolKeyDefault.AsKey("ThreadPool-K");
@@ -379,7 +379,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric.Consumer.Test
 
         [Fact]
         [Trait("Category", "FlakyOnHostedAgents")]
-        public async void TestFallbackRejection()
+        public async Task TestFallbackRejection()
         {
             var groupKey = HystrixCommandGroupKeyDefault.AsKey("ThreadPool-L");
             var threadPoolKey = HystrixThreadPoolKeyDefault.AsKey("ThreadPool-L");
@@ -425,7 +425,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric.Consumer.Test
 
         [Fact]
         [Trait("Category", "FlakyOnHostedAgents")]
-        public async void TestMultipleEventsOverTimeGetStoredAndAgeOut()
+        public async Task TestMultipleEventsOverTimeGetStoredAndAgeOut()
         {
             var groupKey = HystrixCommandGroupKeyDefault.AsKey("ThreadPool-M");
             var threadPoolKey = HystrixThreadPoolKeyDefault.AsKey("ThreadPool-M");

--- a/src/CircuitBreaker/test/HystrixBase.Test/Metric/Consumer/RollingThreadPoolMaxConcurrencyStreamTest.cs
+++ b/src/CircuitBreaker/test/HystrixBase.Test/Metric/Consumer/RollingThreadPoolMaxConcurrencyStreamTest.cs
@@ -367,7 +367,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Metric.Consumer.Test
 
         [Fact]
         [Trait("Category", "FlakyOnHostedAgents")]
-        public async void TestConcurrencyStreamProperlyFiltersOutSemaphoreRejections()
+        public async Task TestConcurrencyStreamProperlyFiltersOutSemaphoreRejections()
         {
             var groupKey = HystrixCommandGroupKeyDefault.AsKey("ThreadPool-Concurrency-I");
             var threadPoolKey = HystrixThreadPoolKeyDefault.AsKey("ThreadPool-Concurrency-I");

--- a/src/CircuitBreaker/test/HystrixCore.Test/HystrixRequestContextMiddlewareTest.cs
+++ b/src/CircuitBreaker/test/HystrixCore.Test/HystrixRequestContextMiddlewareTest.cs
@@ -14,7 +14,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Test
     public class HystrixRequestContextMiddlewareTest
     {
         [Fact]
-        public async void Invoke_CreatesContext_ThenDisposes()
+        public async Task Invoke_CreatesContext_ThenDisposes()
         {
             RequestDelegate del = (ctx) =>
             {

--- a/src/Common/test/Common.Http.Test/Discovery/DiscoveryHttpClientHandlerBaseTest.cs
+++ b/src/Common/test/Common.Http.Test/Discovery/DiscoveryHttpClientHandlerBaseTest.cs
@@ -5,6 +5,7 @@
 using Steeltoe.Common.Discovery;
 using Steeltoe.Discovery;
 using System;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Steeltoe.Common.Http.Test
@@ -62,7 +63,7 @@ namespace Steeltoe.Common.Http.Test
         }
 
         [Fact]
-        public async void LookupServiceAsync_NonDefaultPort_ReturnsOriginalURI()
+        public async Task LookupServiceAsync_NonDefaultPort_ReturnsOriginalURI()
         {
             // Arrange
             IDiscoveryClient client = new TestDiscoveryClient();
@@ -75,7 +76,7 @@ namespace Steeltoe.Common.Http.Test
         }
 
         [Fact]
-        public async void LookupServiceAsync_DoesntFindService_ReturnsOriginalURI()
+        public async Task LookupServiceAsync_DoesntFindService_ReturnsOriginalURI()
         {
             // Arrange
             IDiscoveryClient client = new TestDiscoveryClient();
@@ -88,7 +89,7 @@ namespace Steeltoe.Common.Http.Test
         }
 
         [Fact]
-        public async void LookupServiceAsync_FindsService_ReturnsURI()
+        public async Task LookupServiceAsync_FindsService_ReturnsURI()
         {
             // Arrange
             IDiscoveryClient client = new TestDiscoveryClient(new TestServiceInstance(new Uri("https://foundit:5555")));

--- a/src/Common/test/Common.Http.Test/LoadBalancer/LoadBalancerDelegatingHandlerTest.cs
+++ b/src/Common/test/Common.Http.Test/LoadBalancer/LoadBalancerDelegatingHandlerTest.cs
@@ -7,6 +7,7 @@ using System;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Steeltoe.Common.Http.LoadBalancer.Test
@@ -21,7 +22,7 @@ namespace Steeltoe.Common.Http.LoadBalancer.Test
         }
 
         [Fact]
-        public async void ResolvesUri_TracksStats_WithProvidedLoadBalancer()
+        public async Task ResolvesUri_TracksStats_WithProvidedLoadBalancer()
         {
             // arrange
             var httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, "https://replaceme/api");
@@ -38,7 +39,7 @@ namespace Steeltoe.Common.Http.LoadBalancer.Test
         }
 
         [Fact]
-        public async void DoesntTrackStats_WhenResolutionFails_WithProvidedLoadBalancer()
+        public async Task DoesntTrackStats_WhenResolutionFails_WithProvidedLoadBalancer()
         {
             // arrange
             var httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, "https://replaceme/api");
@@ -54,7 +55,7 @@ namespace Steeltoe.Common.Http.LoadBalancer.Test
         }
 
         [Fact]
-        public async void TracksStats_WhenRequestsGoWrong_WithProvidedLoadBalancer()
+        public async Task TracksStats_WhenRequestsGoWrong_WithProvidedLoadBalancer()
         {
             // arrange
             var httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, "https://replaceme/api");

--- a/src/Common/test/Common.Test/LoadBalancer/RoundRobinLoadBalancerTest.cs
+++ b/src/Common/test/Common.Test/LoadBalancer/RoundRobinLoadBalancerTest.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Steeltoe.Common.Discovery;
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Steeltoe.Common.LoadBalancer.Test
@@ -21,7 +22,7 @@ namespace Steeltoe.Common.LoadBalancer.Test
         }
 
         [Fact]
-        public async void ResolveServiceInstance_ResolvesAndIncrementsServiceIndex()
+        public async Task ResolveServiceInstance_ResolvesAndIncrementsServiceIndex()
         {
             // arrange
             var services = new List<ConfigurationServiceInstance>
@@ -52,7 +53,7 @@ namespace Steeltoe.Common.LoadBalancer.Test
         }
 
         [Fact]
-        public async void ResolveServiceInstance_ResolvesAndIncrementsServiceIndex_WithDistributedCache()
+        public async Task ResolveServiceInstance_ResolvesAndIncrementsServiceIndex_WithDistributedCache()
         {
             // arrange
             var services = new List<ConfigurationServiceInstance>

--- a/src/Configuration/test/ConfigServer.ITest/ConfigServerConfigurationExtensionsIntegrationTest.cs
+++ b/src/Configuration/test/ConfigServer.ITest/ConfigServerConfigurationExtensionsIntegrationTest.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.Configuration;
 using Steeltoe.Common;
 using System.IO;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Steeltoe.Extensions.Configuration.ConfigServer.ITest
@@ -68,7 +69,7 @@ namespace Steeltoe.Extensions.Configuration.ConfigServer.ITest
 
         [Fact]
         [Trait("Category", "Integration")]
-        public async void SpringCloudConfigServer_ReturnsExpectedDefaultData_AsInjectedOptions()
+        public async Task SpringCloudConfigServer_ReturnsExpectedDefaultData_AsInjectedOptions()
         {
             // These settings match the default java config server
             var appsettings = @"
@@ -116,7 +117,7 @@ namespace Steeltoe.Extensions.Configuration.ConfigServer.ITest
 
         [Fact]
         [Trait("Category", "Integration")]
-        public async void SpringCloudConfigServer_ConfiguredViaCloudfoundryEnv_ReturnsExpectedDefaultData_AsInjectedOptions()
+        public async Task SpringCloudConfigServer_ConfiguredViaCloudfoundryEnv_ReturnsExpectedDefaultData_AsInjectedOptions()
         {
             // Arrange
             var vcap_application = @" 
@@ -211,7 +212,7 @@ namespace Steeltoe.Extensions.Configuration.ConfigServer.ITest
 
         [Fact(Skip = "Requires matching PCF environment with SCCS provisioned")]
         [Trait("Category", "Integration")]
-        public async void SpringCloudConfigServer_ConfiguredViaCloudfoundryEnv()
+        public async Task SpringCloudConfigServer_ConfiguredViaCloudfoundryEnv()
         {
             // Arrange
             var vcap_application = @" 
@@ -401,7 +402,7 @@ namespace Steeltoe.Extensions.Configuration.ConfigServer.ITest
 
         [Fact]
         [Trait("Category", "Integration")]
-        public async void SpringCloudConfigServer_WithHealthEnabled_ReturnsHealth()
+        public async Task SpringCloudConfigServer_WithHealthEnabled_ReturnsHealth()
         {
             // These settings match the default java config server
             var appsettings = @"

--- a/src/Configuration/test/ConfigServerBase.Test/ConfigServerConfigurationProviderTest.cs
+++ b/src/Configuration/test/ConfigServerBase.Test/ConfigServerConfigurationProviderTest.cs
@@ -326,7 +326,7 @@ namespace Steeltoe.Extensions.Configuration.ConfigServer.Test
         }
 
         [Fact]
-        public async void RemoteLoadAsync_InvalidUri()
+        public async Task RemoteLoadAsync_InvalidUri()
         {
             // Arrange
             var provider = new ConfigServerConfigurationProvider(new ConfigServerClientSettings());
@@ -336,7 +336,7 @@ namespace Steeltoe.Extensions.Configuration.ConfigServer.Test
         }
 
         [Fact]
-        public async void RemoteLoadAsync_HostTimesOut()
+        public async Task RemoteLoadAsync_HostTimesOut()
         {
             // Arrange
             var provider = new ConfigServerConfigurationProvider(new ConfigServerClientSettings() { Timeout = 100 });
@@ -358,7 +358,7 @@ namespace Steeltoe.Extensions.Configuration.ConfigServer.Test
         }
 
         [Fact]
-        public async void RemoteLoadAsync_ConfigServerReturnsGreaterThanEqualBadRequest()
+        public async Task RemoteLoadAsync_ConfigServerReturnsGreaterThanEqualBadRequest()
         {
             // Arrange
             TestConfigServerStartup.Reset();
@@ -381,7 +381,7 @@ namespace Steeltoe.Extensions.Configuration.ConfigServer.Test
         }
 
         [Fact]
-        public async void RemoteLoadAsync_ConfigServerReturnsLessThanBadRequest()
+        public async Task RemoteLoadAsync_ConfigServerReturnsLessThanBadRequest()
         {
             // Arrange
             var envir = HostingHelpers.GetHostingEnvironment();
@@ -452,7 +452,7 @@ namespace Steeltoe.Extensions.Configuration.ConfigServer.Test
         }
 
         [Fact]
-        public async void RemoteLoadAsync_ConfigServerReturnsGood()
+        public async Task RemoteLoadAsync_ConfigServerReturnsGood()
         {
             // Arrange
             var environment = @"

--- a/src/Configuration/test/PlaceholderBase.Test/PlaceholderResolverConfigurationExtensionsTest.cs
+++ b/src/Configuration/test/PlaceholderBase.Test/PlaceholderResolverConfigurationExtensionsTest.cs
@@ -66,11 +66,9 @@ namespace Steeltoe.Extensions.Configuration.Placeholder.Test
             Assert.NotNull(provider._logger);
         }
 
+        // Mac issue https://github.com/dotnet/runtime/issues/30056
         [Fact]
-#if NET5_0
-        // https://github.com/dotnet/runtime/issues/30056
         [Trait("Category", "SkipOnMacOS")]
-#endif
         public void AddPlaceholderResolver_JsonAppSettingsResolvesPlaceholders()
         {
             // Arrange
@@ -103,11 +101,9 @@ namespace Steeltoe.Extensions.Configuration.Placeholder.Test
             Assert.Equal("myName", config["spring:cloud:config:name"]);
         }
 
+        // Mac issue https://github.com/dotnet/runtime/issues/30056
         [Fact]
-#if NET5_0
-        // https://github.com/dotnet/runtime/issues/30056
         [Trait("Category", "SkipOnMacOS")]
-#endif
         public void AddPlaceholderResolver_XmlAppSettingsResolvesPlaceholders()
         {
             // Arrange
@@ -139,11 +135,9 @@ namespace Steeltoe.Extensions.Configuration.Placeholder.Test
             Assert.Equal("myName", config["spring:cloud:config:name"]);
         }
 
+        // Mac issue https://github.com/dotnet/runtime/issues/30056
         [Fact]
-#if NET5_0
-        // https://github.com/dotnet/runtime/issues/30056
         [Trait("Category", "SkipOnMacOS")]
-#endif
         public void AddPlaceholderResolver_IniAppSettingsResolvesPlaceholders()
         {
             // Arrange
@@ -188,11 +182,9 @@ namespace Steeltoe.Extensions.Configuration.Placeholder.Test
             Assert.Equal("myName", config["spring:cloud:config:name"]);
         }
 
+        // Mac issue https://github.com/dotnet/runtime/issues/30056
         [Fact]
-#if NET5_0
-        // https://github.com/dotnet/runtime/issues/30056
         [Trait("Category", "SkipOnMacOS")]
-#endif
         public void AddPlaceholderResolver_HandlesRecursivePlaceHolders()
         {
             var appsettingsJson = @"

--- a/src/Configuration/test/PlaceholderBase.Test/PlaceholderResolverConfigurationExtensionsTest.cs
+++ b/src/Configuration/test/PlaceholderBase.Test/PlaceholderResolverConfigurationExtensionsTest.cs
@@ -67,6 +67,10 @@ namespace Steeltoe.Extensions.Configuration.Placeholder.Test
         }
 
         [Fact]
+#if NET5_0
+        // https://github.com/dotnet/runtime/issues/30056
+        [Trait("Category", "SkipOnMacOS")]
+#endif
         public void AddPlaceholderResolver_JsonAppSettingsResolvesPlaceholders()
         {
             // Arrange
@@ -100,6 +104,10 @@ namespace Steeltoe.Extensions.Configuration.Placeholder.Test
         }
 
         [Fact]
+#if NET5_0
+        // https://github.com/dotnet/runtime/issues/30056
+        [Trait("Category", "SkipOnMacOS")]
+#endif
         public void AddPlaceholderResolver_XmlAppSettingsResolvesPlaceholders()
         {
             // Arrange
@@ -132,6 +140,10 @@ namespace Steeltoe.Extensions.Configuration.Placeholder.Test
         }
 
         [Fact]
+#if NET5_0
+        // https://github.com/dotnet/runtime/issues/30056
+        [Trait("Category", "SkipOnMacOS")]
+#endif
         public void AddPlaceholderResolver_IniAppSettingsResolvesPlaceholders()
         {
             // Arrange
@@ -177,6 +189,10 @@ namespace Steeltoe.Extensions.Configuration.Placeholder.Test
         }
 
         [Fact]
+#if NET5_0
+        // https://github.com/dotnet/runtime/issues/30056
+        [Trait("Category", "SkipOnMacOS")]
+#endif
         public void AddPlaceholderResolver_HandlesRecursivePlaceHolders()
         {
             var appsettingsJson = @"

--- a/src/Configuration/test/PlaceholderBase.Test/PlaceholderResolverProviderTest.cs
+++ b/src/Configuration/test/PlaceholderBase.Test/PlaceholderResolverProviderTest.cs
@@ -126,11 +126,9 @@ namespace Steeltoe.Extensions.Configuration.Placeholder.Test
             Assert.Equal("nokeyvalue", val);
         }
 
+        // Mac issue https://github.com/dotnet/runtime/issues/30056
         [Fact]
-#if NET5_0
-        // https://github.com/dotnet/runtime/issues/30056
         [Trait("Category", "SkipOnMacOS")]
-#endif
         public void GetReloadToken_ReturnsExpected_NotifyChanges()
         {
             // Arrange
@@ -214,11 +212,9 @@ namespace Steeltoe.Extensions.Configuration.Placeholder.Test
             Assert.Equal("value1", holder.Configuration["key1"]);
         }
 
+        // Mac issue https://github.com/dotnet/runtime/issues/30056
         [Fact]
-#if NET5_0
-        // https://github.com/dotnet/runtime/issues/30056
         [Trait("Category", "SkipOnMacOS")]
-#endif
         public void Load_ReloadsConfiguration()
         {
             // Arrange

--- a/src/Configuration/test/PlaceholderBase.Test/PlaceholderResolverProviderTest.cs
+++ b/src/Configuration/test/PlaceholderBase.Test/PlaceholderResolverProviderTest.cs
@@ -127,6 +127,10 @@ namespace Steeltoe.Extensions.Configuration.Placeholder.Test
         }
 
         [Fact]
+#if NET5_0
+        // https://github.com/dotnet/runtime/issues/30056
+        [Trait("Category", "SkipOnMacOS")]
+#endif
         public void GetReloadToken_ReturnsExpected_NotifyChanges()
         {
             // Arrange
@@ -211,6 +215,10 @@ namespace Steeltoe.Extensions.Configuration.Placeholder.Test
         }
 
         [Fact]
+#if NET5_0
+        // https://github.com/dotnet/runtime/issues/30056
+        [Trait("Category", "SkipOnMacOS")]
+#endif
         public void Load_ReloadsConfiguration()
         {
             // Arrange

--- a/src/Discovery/test/Consul.Test/Discovery/ConsulDiscoveryClientTest.cs
+++ b/src/Discovery/test/Consul.Test/Discovery/ConsulDiscoveryClientTest.cs
@@ -23,7 +23,7 @@ namespace Steeltoe.Discovery.Consul.Discovery.Test
         }
 
         [Fact]
-        public async void AddInstancesToListAsync_AddsExpected()
+        public async Task AddInstancesToListAsync_AddsExpected()
         {
             var options = new ConsulDiscoveryOptions();
 
@@ -91,7 +91,7 @@ namespace Steeltoe.Discovery.Consul.Discovery.Test
         }
 
         [Fact]
-        public async void GetServicesAsync_ReturnsExpected()
+        public async Task GetServicesAsync_ReturnsExpected()
         {
             var options = new ConsulDiscoveryOptions();
 

--- a/src/Discovery/test/Consul.Test/Discovery/ConsulHealthContributorTest.cs
+++ b/src/Discovery/test/Consul.Test/Discovery/ConsulHealthContributorTest.cs
@@ -23,7 +23,7 @@ namespace Steeltoe.Discovery.Consul.Discovery.Test
         }
 
         [Fact]
-        public async void GetLeaderStatusAsync_ReturnsExpected()
+        public async Task GetLeaderStatusAsync_ReturnsExpected()
         {
             var statusResult = Task.FromResult("thestatus");
             var clientMoq = new Mock<IConsulClient>();
@@ -37,7 +37,7 @@ namespace Steeltoe.Discovery.Consul.Discovery.Test
         }
 
         [Fact]
-        public async void GetCatalogServicesAsync_ReturnsExpected()
+        public async Task GetCatalogServicesAsync_ReturnsExpected()
         {
             var queryResult = new QueryResult<Dictionary<string, string[]>>()
             {

--- a/src/Discovery/test/Consul.Test/Registry/ConsulServiceRegistryTest.cs
+++ b/src/Discovery/test/Consul.Test/Registry/ConsulServiceRegistryTest.cs
@@ -40,7 +40,7 @@ namespace Steeltoe.Discovery.Consul.Registry.Test
         }
 
         [Fact]
-        public async void RegisterAsync_CallsServiceRegister_AddsHeartbeatToScheduler()
+        public async Task RegisterAsync_CallsServiceRegister_AddsHeartbeatToScheduler()
         {
             var clientMoq = new Mock<IConsulClient>();
             var agentMoq = new Mock<IAgentEndpoint>();
@@ -83,7 +83,7 @@ namespace Steeltoe.Discovery.Consul.Registry.Test
         }
 
         [Fact]
-        public async void DeregisterAsync_CallsServiceDeregister_RemovesHeartbeatFromScheduler()
+        public async Task DeregisterAsync_CallsServiceDeregister_RemovesHeartbeatFromScheduler()
         {
             var clientMoq = new Mock<IConsulClient>();
             var agentMoq = new Mock<IAgentEndpoint>();
@@ -152,7 +152,7 @@ namespace Steeltoe.Discovery.Consul.Registry.Test
         }
 
         [Fact]
-        public async void SetStatusAsync_CallsConsulClient()
+        public async Task SetStatusAsync_CallsConsulClient()
         {
             var clientMoq = new Mock<IConsulClient>();
             var agentMoq = new Mock<IAgentEndpoint>();
@@ -193,7 +193,7 @@ namespace Steeltoe.Discovery.Consul.Registry.Test
         }
 
         [Fact]
-        public async void GetStatusAsync_ReturnsExpected()
+        public async Task GetStatusAsync_ReturnsExpected()
         {
             var opts = new ConsulDiscoveryOptions();
             var builder = new ConfigurationBuilder()

--- a/src/Discovery/test/Eureka.Test/DiscoveryClientTest.cs
+++ b/src/Discovery/test/Eureka.Test/DiscoveryClientTest.cs
@@ -36,7 +36,7 @@ namespace Steeltoe.Discovery.Eureka.Test
         }
 
         [Fact]
-        public async void FetchFullRegistryAsync_InvokesServer_ReturnsValidResponse()
+        public async System.Threading.Tasks.Task FetchFullRegistryAsync_InvokesServer_ReturnsValidResponse()
         {
             var json = @"
                 { 
@@ -126,7 +126,7 @@ namespace Steeltoe.Discovery.Eureka.Test
         }
 
         [Fact]
-        public async void FetchRegistryDeltaAsync_InvokesServer_ReturnsValidResponse()
+        public async System.Threading.Tasks.Task FetchRegistryDeltaAsync_InvokesServer_ReturnsValidResponse()
         {
             var json = @"
                 { 
@@ -230,7 +230,7 @@ namespace Steeltoe.Discovery.Eureka.Test
         }
 
         [Fact]
-        public async void RegisterAsync_ReturnsFalse_WhenNotOKStatusReturned()
+        public async System.Threading.Tasks.Task RegisterAsync_ReturnsFalse_WhenNotOKStatusReturned()
         {
             var envir = HostingHelpers.GetHostingEnvironment();
             TestConfigServerStartup.Response = string.Empty;
@@ -269,7 +269,7 @@ namespace Steeltoe.Discovery.Eureka.Test
         }
 
         [Fact]
-        public async void RegisterAsync_InvokesServerReturnsTrue_WhenOKStatusReturned()
+        public async System.Threading.Tasks.Task RegisterAsync_InvokesServerReturnsTrue_WhenOKStatusReturned()
         {
             var envir = HostingHelpers.GetHostingEnvironment();
             TestConfigServerStartup.Response = string.Empty;
@@ -309,7 +309,7 @@ namespace Steeltoe.Discovery.Eureka.Test
         }
 
         [Fact]
-        public async void RenewAsync_Registers_When404StatusReturned()
+        public async System.Threading.Tasks.Task RenewAsync_Registers_When404StatusReturned()
         {
             var envir = HostingHelpers.GetHostingEnvironment();
             TestConfigServerStartup.Response = string.Empty;
@@ -350,7 +350,7 @@ namespace Steeltoe.Discovery.Eureka.Test
         }
 
         [Fact]
-        public async void RenewAsync_ReturnsTrue_WhenOKStatusReturned()
+        public async System.Threading.Tasks.Task RenewAsync_ReturnsTrue_WhenOKStatusReturned()
         {
             var envir = HostingHelpers.GetHostingEnvironment();
             TestConfigServerStartup.Response = string.Empty;
@@ -384,7 +384,7 @@ namespace Steeltoe.Discovery.Eureka.Test
         }
 
         [Fact]
-        public async void UnRegisterAsync_InvokesServerReturnsTrue_WhenOKStatusReturned()
+        public async System.Threading.Tasks.Task UnRegisterAsync_InvokesServerReturnsTrue_WhenOKStatusReturned()
         {
             var envir = HostingHelpers.GetHostingEnvironment();
             TestConfigServerStartup.Response = string.Empty;

--- a/src/Discovery/test/Eureka.Test/Transport/EurekaHttpClientTest.cs
+++ b/src/Discovery/test/Eureka.Test/Transport/EurekaHttpClientTest.cs
@@ -47,7 +47,7 @@ namespace Steeltoe.Discovery.Eureka.Transport.Test
         }
 
         [Fact]
-        public async void Register_Throws_IfInstanceInfoNull()
+        public async System.Threading.Tasks.Task Register_Throws_IfInstanceInfoNull()
         {
             var config = new EurekaClientConfig();
             var client = new EurekaHttpClient(config);
@@ -56,7 +56,7 @@ namespace Steeltoe.Discovery.Eureka.Transport.Test
         }
 
         [Fact]
-        public async void RegisterAsync_ThrowsHttpRequestException_ServerTimeout()
+        public async System.Threading.Tasks.Task RegisterAsync_ThrowsHttpRequestException_ServerTimeout()
         {
             var config = new EurekaClientConfig()
             {
@@ -68,7 +68,7 @@ namespace Steeltoe.Discovery.Eureka.Transport.Test
         }
 
         [Fact]
-        public async void RegisterAsync_InvokesServer_ReturnsStatusCodeAndHeaders()
+        public async System.Threading.Tasks.Task RegisterAsync_InvokesServer_ReturnsStatusCodeAndHeaders()
         {
             var envir = HostingHelpers.GetHostingEnvironment();
             TestConfigServerStartup.Response = string.Empty;
@@ -94,7 +94,7 @@ namespace Steeltoe.Discovery.Eureka.Transport.Test
         }
 
         [Fact]
-        public async void RegisterAsync_SendsValidPOSTData()
+        public async System.Threading.Tasks.Task RegisterAsync_SendsValidPOSTData()
         {
             var envir = HostingHelpers.GetHostingEnvironment();
             TestConfigServerStartup.Response = string.Empty;
@@ -136,7 +136,7 @@ namespace Steeltoe.Discovery.Eureka.Transport.Test
         }
 
         [Fact]
-        public async void SendHeartbeat_Throws_IfAppNameNull()
+        public async System.Threading.Tasks.Task SendHeartbeat_Throws_IfAppNameNull()
         {
             var config = new EurekaClientConfig();
             var client = new EurekaHttpClient(config);
@@ -145,7 +145,7 @@ namespace Steeltoe.Discovery.Eureka.Transport.Test
         }
 
         [Fact]
-        public async void SendHeartbeat_Throws_IfIdNull()
+        public async System.Threading.Tasks.Task SendHeartbeat_Throws_IfIdNull()
         {
             var config = new EurekaClientConfig();
             var client = new EurekaHttpClient(config);
@@ -154,7 +154,7 @@ namespace Steeltoe.Discovery.Eureka.Transport.Test
         }
 
         [Fact]
-        public async void SendHeartbeat_Throws_IfInstanceInfoNull()
+        public async System.Threading.Tasks.Task SendHeartbeat_Throws_IfInstanceInfoNull()
         {
             var config = new EurekaClientConfig();
             var client = new EurekaHttpClient(config);
@@ -163,7 +163,7 @@ namespace Steeltoe.Discovery.Eureka.Transport.Test
         }
 
         [Fact]
-        public async void SendHeartBeatAsync_InvokesServer_ReturnsStatusCodeAndHeaders()
+        public async System.Threading.Tasks.Task SendHeartBeatAsync_InvokesServer_ReturnsStatusCodeAndHeaders()
         {
             var envir = HostingHelpers.GetHostingEnvironment();
             TestConfigServerStartup.Response = string.Empty;
@@ -198,7 +198,7 @@ namespace Steeltoe.Discovery.Eureka.Transport.Test
         }
 
         [Fact]
-        public async void GetApplicationsAsync_InvokesServer_ReturnsExpectedApplications()
+        public async System.Threading.Tasks.Task GetApplicationsAsync_InvokesServer_ReturnsExpectedApplications()
         {
             var json = @"
                 { 
@@ -275,7 +275,7 @@ namespace Steeltoe.Discovery.Eureka.Transport.Test
         }
 
         [Fact]
-        public async void GetVipAsync_Throws_IfVipAddressNull()
+        public async System.Threading.Tasks.Task GetVipAsync_Throws_IfVipAddressNull()
         {
             var config = new EurekaClientConfig();
             var client = new EurekaHttpClient(config);
@@ -284,7 +284,7 @@ namespace Steeltoe.Discovery.Eureka.Transport.Test
         }
 
         [Fact]
-        public async void GetSecureVipAsync_Throws_IfVipAddressNull()
+        public async System.Threading.Tasks.Task GetSecureVipAsync_Throws_IfVipAddressNull()
         {
             var config = new EurekaClientConfig();
             var client = new EurekaHttpClient(config);
@@ -293,7 +293,7 @@ namespace Steeltoe.Discovery.Eureka.Transport.Test
         }
 
         [Fact]
-        public async void GetApplicationAsync_Throws_IfAppNameNull()
+        public async System.Threading.Tasks.Task GetApplicationAsync_Throws_IfAppNameNull()
         {
             var config = new EurekaClientConfig();
             var client = new EurekaHttpClient(config);
@@ -302,7 +302,7 @@ namespace Steeltoe.Discovery.Eureka.Transport.Test
         }
 
         [Fact]
-        public async void GetApplicationAsync_InvokesServer_ReturnsExpectedApplications()
+        public async System.Threading.Tasks.Task GetApplicationAsync_InvokesServer_ReturnsExpectedApplications()
         {
             var json = @"
                 {
@@ -372,7 +372,7 @@ namespace Steeltoe.Discovery.Eureka.Transport.Test
         }
 
         [Fact]
-        public async void GetApplicationAsync__FirstServerFails_InvokesSecondServer_ReturnsExpectedApplications()
+        public async System.Threading.Tasks.Task GetApplicationAsync__FirstServerFails_InvokesSecondServer_ReturnsExpectedApplications()
         {
             var json = @"
                 {
@@ -443,7 +443,7 @@ namespace Steeltoe.Discovery.Eureka.Transport.Test
         }
 
         [Fact]
-        public async void GetInstanceAsync_Throws_IfAppNameNull()
+        public async System.Threading.Tasks.Task GetInstanceAsync_Throws_IfAppNameNull()
         {
             var config = new EurekaClientConfig();
             var client = new EurekaHttpClient(config);
@@ -452,7 +452,7 @@ namespace Steeltoe.Discovery.Eureka.Transport.Test
         }
 
         [Fact]
-        public async void GetInstanceAsync_Throws_IfAppNameNotNullAndIDNull()
+        public async System.Threading.Tasks.Task GetInstanceAsync_Throws_IfAppNameNotNullAndIDNull()
         {
             var config = new EurekaClientConfig();
             var client = new EurekaHttpClient(config);
@@ -461,7 +461,7 @@ namespace Steeltoe.Discovery.Eureka.Transport.Test
         }
 
         [Fact]
-        public async void GetInstanceAsync_Throws_IfIDNull()
+        public async System.Threading.Tasks.Task GetInstanceAsync_Throws_IfIDNull()
         {
             var config = new EurekaClientConfig();
             var client = new EurekaHttpClient(config);
@@ -470,7 +470,7 @@ namespace Steeltoe.Discovery.Eureka.Transport.Test
         }
 
         [Fact]
-        public async void GetInstanceAsync_InvokesServer_ReturnsExpectedInstances()
+        public async System.Threading.Tasks.Task GetInstanceAsync_InvokesServer_ReturnsExpectedInstances()
         {
             var json = @"
                 { 
@@ -534,7 +534,7 @@ namespace Steeltoe.Discovery.Eureka.Transport.Test
         }
 
         [Fact]
-        public async void GetInstanceAsync_FirstServerFails_InvokesSecondServer_ReturnsExpectedInstances()
+        public async System.Threading.Tasks.Task GetInstanceAsync_FirstServerFails_InvokesSecondServer_ReturnsExpectedInstances()
         {
             var json = @"
                 { 
@@ -599,7 +599,7 @@ namespace Steeltoe.Discovery.Eureka.Transport.Test
         }
 
         [Fact]
-        public async void CancelAsync_Throws_IfAppNameNull()
+        public async System.Threading.Tasks.Task CancelAsync_Throws_IfAppNameNull()
         {
             var config = new EurekaClientConfig();
             var client = new EurekaHttpClient(config);
@@ -608,7 +608,7 @@ namespace Steeltoe.Discovery.Eureka.Transport.Test
         }
 
         [Fact]
-        public async void CancelAsync_Throws_IfAppNameNotNullAndIDNull()
+        public async System.Threading.Tasks.Task CancelAsync_Throws_IfAppNameNotNullAndIDNull()
         {
             var config = new EurekaClientConfig();
             var client = new EurekaHttpClient(config);
@@ -617,7 +617,7 @@ namespace Steeltoe.Discovery.Eureka.Transport.Test
         }
 
         [Fact]
-        public async void CancelAsync_InvokesServer_ReturnsStatusCodeAndHeaders()
+        public async System.Threading.Tasks.Task CancelAsync_InvokesServer_ReturnsStatusCodeAndHeaders()
         {
             var envir = HostingHelpers.GetHostingEnvironment();
             TestConfigServerStartup.Response = string.Empty;
@@ -645,7 +645,7 @@ namespace Steeltoe.Discovery.Eureka.Transport.Test
         }
 
         [Fact]
-        public async void StatusUpdateAsync_Throws_IfAppNameNull()
+        public async System.Threading.Tasks.Task StatusUpdateAsync_Throws_IfAppNameNull()
         {
             var config = new EurekaClientConfig();
             var client = new EurekaHttpClient(config);
@@ -654,7 +654,7 @@ namespace Steeltoe.Discovery.Eureka.Transport.Test
         }
 
         [Fact]
-        public async void StatusUpdateAsync_Throws_IfIdNull()
+        public async System.Threading.Tasks.Task StatusUpdateAsync_Throws_IfIdNull()
         {
             var config = new EurekaClientConfig();
             var client = new EurekaHttpClient(config);
@@ -663,7 +663,7 @@ namespace Steeltoe.Discovery.Eureka.Transport.Test
         }
 
         [Fact]
-        public async void StatusUpdateAsync_Throws_IfInstanceInfoNull()
+        public async System.Threading.Tasks.Task StatusUpdateAsync_Throws_IfInstanceInfoNull()
         {
             var config = new EurekaClientConfig();
             var client = new EurekaHttpClient(config);
@@ -672,7 +672,7 @@ namespace Steeltoe.Discovery.Eureka.Transport.Test
         }
 
         [Fact]
-        public async void StatusUpdateAsync_InvokesServer_ReturnsStatusCodeAndHeaders()
+        public async System.Threading.Tasks.Task StatusUpdateAsync_InvokesServer_ReturnsStatusCodeAndHeaders()
         {
             var envir = HostingHelpers.GetHostingEnvironment();
             TestConfigServerStartup.Response = string.Empty;
@@ -703,7 +703,7 @@ namespace Steeltoe.Discovery.Eureka.Transport.Test
         }
 
         [Fact]
-        public async void DeleteStatusOverrideAsync_Throws_IfAppNameNull()
+        public async System.Threading.Tasks.Task DeleteStatusOverrideAsync_Throws_IfAppNameNull()
         {
             var config = new EurekaClientConfig();
             var client = new EurekaHttpClient(config);
@@ -712,7 +712,7 @@ namespace Steeltoe.Discovery.Eureka.Transport.Test
         }
 
         [Fact]
-        public async void DeleteStatusOverrideAsync_Throws_IfIdNull()
+        public async System.Threading.Tasks.Task DeleteStatusOverrideAsync_Throws_IfIdNull()
         {
             var config = new EurekaClientConfig();
             var client = new EurekaHttpClient(config);
@@ -721,7 +721,7 @@ namespace Steeltoe.Discovery.Eureka.Transport.Test
         }
 
         [Fact]
-        public async void DeleteStatusOverrideAsync_Throws_IfInstanceInfoNull()
+        public async System.Threading.Tasks.Task DeleteStatusOverrideAsync_Throws_IfInstanceInfoNull()
         {
             var config = new EurekaClientConfig();
             var client = new EurekaHttpClient(config);
@@ -730,7 +730,7 @@ namespace Steeltoe.Discovery.Eureka.Transport.Test
         }
 
         [Fact]
-        public async void DeleteStatusOverrideAsync_InvokesServer_ReturnsStatusCodeAndHeaders()
+        public async System.Threading.Tasks.Task DeleteStatusOverrideAsync_InvokesServer_ReturnsStatusCodeAndHeaders()
         {
             var envir = HostingHelpers.GetHostingEnvironment();
             TestConfigServerStartup.Response = string.Empty;

--- a/src/Security/test/Authentication.CloudFoundryBase.Test/CloudFoundryTokenKeyResolverTest.cs
+++ b/src/Security/test/Authentication.CloudFoundryBase.Test/CloudFoundryTokenKeyResolverTest.cs
@@ -6,6 +6,7 @@ using Microsoft.IdentityModel.Tokens;
 using System;
 using System.Linq;
 using System.Net.Http;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Steeltoe.Security.Authentication.CloudFoundry.Test
@@ -79,7 +80,7 @@ namespace Steeltoe.Security.Authentication.CloudFoundry.Test
         }
 
         [Fact]
-        public async void FetchKeySet_IssuesHttpRequest_ReturnsKeyset()
+        public async Task FetchKeySet_IssuesHttpRequest_ReturnsKeyset()
         {
             var keyset = "{ 'keys':[{'kid':'legacy-token-key','alg':'SHA256withRSA','value':'-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAk+7xH35bYBppsn54cBW+\nFlrveTe+3L4xl7ix13XK8eBcCmNOyBhNzhks6toDiRjrgw5QW76cFirVRFIVQkiZ\nsUwDyGOax3q8NOJyBFXiplIUScrx8aI0jkY/Yd6ixAc5yBSBfXThy4EF9T0xCyt4\nxWLYNXMRwe88Y+i+MEoLNXWRbhjJm76LN7rsdIxALbS0vJNWUDALWjtE6FeYX6uU\nL9msAzlCQkdnSvwMmr8Ij2O3IVMxHDJXOZinFqt9zVfXwO11o7ZmiskZnRz1/V0f\nvbUQAadkcDEUt1gk9cbrAhiipg8VWDMsC7VUXuekJZjme5f8oWTwpsgP6cTUzwSS\n6wIDAQAB\n-----END PUBLIC KEY-----','kty':'RSA','use':'sig','n':'AJPu8R9+W2AaabJ+eHAVvhZa73k3vty+MZe4sdd1yvHgXApjTsgYTc4ZLOraA4kY64MOUFu+nBYq1URSFUJImbFMA8hjmsd6vDTicgRV4qZSFEnK8fGiNI5GP2HeosQHOcgUgX104cuBBfU9MQsreMVi2DVzEcHvPGPovjBKCzV1kW4YyZu+ize67HSMQC20tLyTVlAwC1o7ROhXmF+rlC/ZrAM5QkJHZ0r8DJq/CI9jtyFTMRwyVzmYpxarfc1X18DtdaO2ZorJGZ0c9f1dH721EAGnZHAxFLdYJPXG6wIYoqYPFVgzLAu1VF7npCWY5nuX/KFk8KbID+nE1M8Ekus=','e':'AQAB'}]}";
             var handler = new TestMessageHandler();

--- a/src/Security/test/Authentication.CloudFoundryBase.Test/TokenExchangerTest.cs
+++ b/src/Security/test/Authentication.CloudFoundryBase.Test/TokenExchangerTest.cs
@@ -10,6 +10,7 @@ using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Security.Claims;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Steeltoe.Security.Authentication.CloudFoundry.Test
@@ -84,7 +85,7 @@ namespace Steeltoe.Security.Authentication.CloudFoundry.Test
         }
 
         [Fact]
-        public async void ExchangeAuthCodeForClaimsIdentity_ExchangesCodeForIdentity()
+        public async Task ExchangeAuthCodeForClaimsIdentity_ExchangesCodeForIdentity()
         {
             // arrange
             var options = new AuthServerOptions()
@@ -101,7 +102,7 @@ namespace Steeltoe.Security.Authentication.CloudFoundry.Test
         }
 
         [Fact]
-        public async void ExchangeAuthCodeForClaimsIdentity_ReturnsNullOnFailure()
+        public async Task ExchangeAuthCodeForClaimsIdentity_ReturnsNullOnFailure()
         {
             // arrange
             var options = new AuthServerOptions()

--- a/src/Security/test/Authentication.CloudFoundryCore.Test/CloudFoundryContainerIdentityMtlsTest.cs
+++ b/src/Security/test/Authentication.CloudFoundryCore.Test/CloudFoundryContainerIdentityMtlsTest.cs
@@ -11,6 +11,7 @@ using System.IO;
 using System.Net;
 using System.Net.Http;
 using System.Security.Cryptography.X509Certificates;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Steeltoe.Security.Authentication.CloudFoundry.Test
@@ -25,7 +26,7 @@ namespace Steeltoe.Security.Authentication.CloudFoundry.Test
         }
 
         [Fact]
-        public async void CloudFoundryCertificateAuth_AcceptsSameSpace()
+        public async Task CloudFoundryCertificateAuth_AcceptsSameSpace()
         {
             // arrange
             var host = await GetHostBuilder().StartAsync();
@@ -38,7 +39,7 @@ namespace Steeltoe.Security.Authentication.CloudFoundry.Test
         }
 
         [Fact]
-        public async void CloudFoundryCertificateAuth_AcceptsSameOrg()
+        public async Task CloudFoundryCertificateAuth_AcceptsSameOrg()
         {
             // arrange
             var host = await GetHostBuilder().StartAsync();
@@ -51,7 +52,7 @@ namespace Steeltoe.Security.Authentication.CloudFoundry.Test
         }
 
         [Fact]
-        public async void CloudFoundryCertificateAuth_RejectsOrgMismatch()
+        public async Task CloudFoundryCertificateAuth_RejectsOrgMismatch()
         {
             // arrange
             var host = await GetHostBuilder().StartAsync();
@@ -64,7 +65,7 @@ namespace Steeltoe.Security.Authentication.CloudFoundry.Test
         }
 
         [Fact]
-        public async void CloudFoundryCertificateAuth_RejectsSpaceMismatch()
+        public async Task CloudFoundryCertificateAuth_RejectsSpaceMismatch()
         {
             // arrange
             var host = await GetHostBuilder().StartAsync();
@@ -77,7 +78,7 @@ namespace Steeltoe.Security.Authentication.CloudFoundry.Test
         }
 
         [Fact]
-        public async void AddCloudFoundryCertificateAuth_ForbiddenWithoutCert()
+        public async Task AddCloudFoundryCertificateAuth_ForbiddenWithoutCert()
         {
             // arrange
             var host = await GetHostBuilder().StartAsync();

--- a/src/Security/test/Authentication.CloudFoundryCore.Test/CloudFoundryExtensionsTest.cs
+++ b/src/Security/test/Authentication.CloudFoundryCore.Test/CloudFoundryExtensionsTest.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.TestHost;
 using Steeltoe.Extensions.Configuration.CloudFoundry;
 using System;
 using System.Net;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Steeltoe.Security.Authentication.CloudFoundry.Test
@@ -80,7 +81,7 @@ namespace Steeltoe.Security.Authentication.CloudFoundry.Test
             }";
 
         [Fact]
-        public async void AddCloudFoundryOAuthAuthentication_AddsIntoPipeline()
+        public async Task AddCloudFoundryOAuthAuthentication_AddsIntoPipeline()
         {
             var builder = GetHostBuilder<TestServerStartup>();
             using var server = new TestServer(builder);
@@ -92,7 +93,7 @@ namespace Steeltoe.Security.Authentication.CloudFoundry.Test
         }
 
         [Fact]
-        public async void AddCloudFoundryOAuthAuthentication_AddsIntoPipeline_UsesSSOInfo()
+        public async Task AddCloudFoundryOAuthAuthentication_AddsIntoPipeline_UsesSSOInfo()
         {
             Environment.SetEnvironmentVariable("VCAP_APPLICATION", vcap_application);
             Environment.SetEnvironmentVariable("VCAP_SERVICES", vcap_services);
@@ -112,7 +113,7 @@ namespace Steeltoe.Security.Authentication.CloudFoundry.Test
         }
 
         [Fact]
-        public async void AddCloudFoundryJwtBearerAuthentication_AddsIntoPipeline()
+        public async Task AddCloudFoundryJwtBearerAuthentication_AddsIntoPipeline()
         {
             var builder = GetHostBuilder<TestServerJwtStartup>();
             using var server = new TestServer(builder);
@@ -122,7 +123,7 @@ namespace Steeltoe.Security.Authentication.CloudFoundry.Test
         }
 
         [Fact]
-        public async void AddCloudFoundryOpenId_AddsIntoPipeline()
+        public async Task AddCloudFoundryOpenId_AddsIntoPipeline()
         {
             Environment.SetEnvironmentVariable("openIdConfigResponse", openIdConfigResponse);
             Environment.SetEnvironmentVariable("jwksResponse", jwksResponse);
@@ -138,7 +139,7 @@ namespace Steeltoe.Security.Authentication.CloudFoundry.Test
         }
 
         [Fact]
-        public async void AddCloudFoundryOpenId_AddsIntoPipeline_UsesSSOInfo()
+        public async Task AddCloudFoundryOpenId_AddsIntoPipeline_UsesSSOInfo()
         {
             Environment.SetEnvironmentVariable("VCAP_APPLICATION", vcap_application);
             Environment.SetEnvironmentVariable("VCAP_SERVICES", vcap_services);

--- a/src/Security/test/Authentication.CloudFoundryCore.Test/CloudFoundryOAuthHandlerTest.cs
+++ b/src/Security/test/Authentication.CloudFoundryCore.Test/CloudFoundryOAuthHandlerTest.cs
@@ -13,6 +13,7 @@ using System.Net.Http.Headers;
 using System.Security.Claims;
 using System.Text.Encodings.Web;
 using System.Text.Json;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Steeltoe.Security.Authentication.CloudFoundry.Test
@@ -20,7 +21,7 @@ namespace Steeltoe.Security.Authentication.CloudFoundry.Test
     public class CloudFoundryOAuthHandlerTest
     {
         [Fact]
-        public async void ExchangeCodeAsync_SendsTokenRequest_ReturnsValidTokenInfo()
+        public async Task ExchangeCodeAsync_SendsTokenRequest_ReturnsValidTokenInfo()
         {
             var handler = new TestMessageHandler();
             var response = new HttpResponseMessage(System.Net.HttpStatusCode.OK)
@@ -51,7 +52,7 @@ namespace Steeltoe.Security.Authentication.CloudFoundry.Test
         }
 
         [Fact]
-        public async void ExchangeCodeAsync_SendsTokenRequest_ReturnsErrorResponse()
+        public async Task ExchangeCodeAsync_SendsTokenRequest_ReturnsErrorResponse()
         {
             var handler = new TestMessageHandler();
             var response = new HttpResponseMessage(System.Net.HttpStatusCode.BadRequest)
@@ -143,7 +144,7 @@ namespace Steeltoe.Security.Authentication.CloudFoundry.Test
         }
 
         [Fact]
-        public async void CreateTicketAsync_SendsTokenInfoRequest_ReturnsValidTokenInfo()
+        public async Task CreateTicketAsync_SendsTokenInfoRequest_ReturnsValidTokenInfo()
         {
             var handler = new TestMessageHandler();
             var response = new HttpResponseMessage(System.Net.HttpStatusCode.OK)

--- a/src/Security/test/DataProtection.CredHubBase.Test/CredHubClientTests.cs
+++ b/src/Security/test/DataProtection.CredHubBase.Test/CredHubClientTests.cs
@@ -20,7 +20,7 @@ namespace Steeltoe.Security.DataProtection.CredHub.Test
         private readonly string credHubBase = "http://credhubServer/api/";
 
         [Fact]
-        public async void CreateAsync_RequestsToken_Once()
+        public async Task CreateAsync_RequestsToken_Once()
         {
             // arrange
             MockedRequest authRequest = null;
@@ -34,7 +34,7 @@ namespace Steeltoe.Security.DataProtection.CredHub.Test
         }
 
         [Fact]
-        public async void WriteAsync_Sets_Values()
+        public async Task WriteAsync_Sets_Values()
         {
             // arrange
             var mockHttpMessageHandler = InitializedHandlerWithLogin();
@@ -57,7 +57,7 @@ namespace Steeltoe.Security.DataProtection.CredHub.Test
         }
 
         [Fact]
-        public async void WriteAsync_Sets_Json()
+        public async Task WriteAsync_Sets_Json()
         {
             // arrange
             var jsonObject = JsonSerializer.Deserialize<JsonElement>(@"{""key"": 123,""key_list"": [""val1"",""val2""],""is_true"": true}");
@@ -81,7 +81,7 @@ namespace Steeltoe.Security.DataProtection.CredHub.Test
         }
 
         [Fact]
-        public async void WriteAsync_Sets_Password()
+        public async Task WriteAsync_Sets_Password()
         {
             // arrange
             var mockHttpMessageHandler = InitializedHandlerWithLogin();
@@ -104,7 +104,7 @@ namespace Steeltoe.Security.DataProtection.CredHub.Test
         }
 
         [Fact]
-        public async void WriteAsyncUserWithPermissions_Sets_UserWithPermissions()
+        public async Task WriteAsyncUserWithPermissions_Sets_UserWithPermissions()
         {
             // arrange
             var mockHttpMessageHandler = InitializedHandlerWithLogin();
@@ -131,7 +131,7 @@ namespace Steeltoe.Security.DataProtection.CredHub.Test
         }
 
         [Fact]
-        public async void WriteAsync_Sets_RootCertificate()
+        public async Task WriteAsync_Sets_RootCertificate()
         {
             // arrange
             var mockHttpMessageHandler = InitializedHandlerWithLogin();
@@ -158,7 +158,7 @@ namespace Steeltoe.Security.DataProtection.CredHub.Test
         }
 
         [Fact]
-        public async void WriteAsync_Sets_NonRootCertificate()
+        public async Task WriteAsync_Sets_NonRootCertificate()
         {
             // arrange
             var mockHttpMessageHandler = InitializedHandlerWithLogin();
@@ -186,7 +186,7 @@ namespace Steeltoe.Security.DataProtection.CredHub.Test
         }
 
         [Fact]
-        public async void WriteAsync_Sets_RSA()
+        public async Task WriteAsync_Sets_RSA()
         {
             // arrange
             var mockHttpMessageHandler = InitializedHandlerWithLogin();
@@ -212,7 +212,7 @@ namespace Steeltoe.Security.DataProtection.CredHub.Test
         }
 
         [Fact]
-        public async void WriteAsync_Sets_SSH()
+        public async Task WriteAsync_Sets_SSH()
         {
             // arrange
             var mockHttpMessageHandler = InitializedHandlerWithLogin();
@@ -238,7 +238,7 @@ namespace Steeltoe.Security.DataProtection.CredHub.Test
         }
 
         [Fact]
-        public async void GetByIdAsync_Gets()
+        public async Task GetByIdAsync_Gets()
         {
             // arrange
             var credId = Guid.Parse("f82cc4a6-4490-4ed7-92c9-5115006bd691");
@@ -263,7 +263,7 @@ namespace Steeltoe.Security.DataProtection.CredHub.Test
         }
 
         [Fact]
-        public async void GetByNameAsync_Gets()
+        public async Task GetByNameAsync_Gets()
         {
             // arrange
             var mockHttpMessageHandler = InitializedHandlerWithLogin();
@@ -292,7 +292,7 @@ namespace Steeltoe.Security.DataProtection.CredHub.Test
         }
 
         [Fact]
-        public async void GetByNameAsync_Throws_WithoutName()
+        public async Task GetByNameAsync_Throws_WithoutName()
         {
             // arrange
             var client = new CredHubClient();
@@ -302,7 +302,7 @@ namespace Steeltoe.Security.DataProtection.CredHub.Test
         }
 
         [Fact]
-        public async void GetByNameWithHistoryAsync_Gets()
+        public async Task GetByNameWithHistoryAsync_Gets()
         {
             // arrange
             var revisionCount = 3;
@@ -330,7 +330,7 @@ namespace Steeltoe.Security.DataProtection.CredHub.Test
         }
 
         [Fact]
-        public async void GenerateAsync_Creates_Password()
+        public async Task GenerateAsync_Creates_Password()
         {
             // arrange
             var mockHttpMessageHandler = InitializedHandlerWithLogin();
@@ -355,7 +355,7 @@ namespace Steeltoe.Security.DataProtection.CredHub.Test
         }
 
         [Fact]
-        public async void GenerateAsync_Creates_PasswordWithPermissions()
+        public async Task GenerateAsync_Creates_PasswordWithPermissions()
         {
             // arrange
             var mockHttpMessageHandler = InitializedHandlerWithLogin();
@@ -380,7 +380,7 @@ namespace Steeltoe.Security.DataProtection.CredHub.Test
         }
 
         [Fact]
-        public async void GenerateAsync_Creates_User()
+        public async Task GenerateAsync_Creates_User()
         {
             // arrange
             var mockHttpMessageHandler = InitializedHandlerWithLogin();
@@ -407,7 +407,7 @@ namespace Steeltoe.Security.DataProtection.CredHub.Test
         }
 
         [Fact]
-        public async void GenerateAsync_Creates_Certificate()
+        public async Task GenerateAsync_Creates_Certificate()
         {
             // arrange
             var mockHttpMessageHandler = InitializedHandlerWithLogin();
@@ -435,7 +435,7 @@ namespace Steeltoe.Security.DataProtection.CredHub.Test
         }
 
         [Fact]
-        public async void GenerateAsync_Creates_RSA()
+        public async Task GenerateAsync_Creates_RSA()
         {
             // arrange
             var mockHttpMessageHandler = InitializedHandlerWithLogin();
@@ -461,7 +461,7 @@ namespace Steeltoe.Security.DataProtection.CredHub.Test
         }
 
         [Fact]
-        public async void GenerateAsync_Creates_SSH()
+        public async Task GenerateAsync_Creates_SSH()
         {
             // arrange
             var mockHttpMessageHandler = InitializedHandlerWithLogin();
@@ -488,7 +488,7 @@ namespace Steeltoe.Security.DataProtection.CredHub.Test
         }
 
         [Fact]
-        public async void RegenerateAsync_Regenerates_Password()
+        public async Task RegenerateAsync_Regenerates_Password()
         {
             // arrange
             var mockHttpMessageHandler = InitializedHandlerWithLogin();
@@ -512,7 +512,7 @@ namespace Steeltoe.Security.DataProtection.CredHub.Test
         }
 
         [Fact]
-        public async void RegenerateAsync_Regenerates_RSA()
+        public async Task RegenerateAsync_Regenerates_RSA()
         {
             // arrange
             var mockHttpMessageHandler = InitializedHandlerWithLogin();
@@ -537,7 +537,7 @@ namespace Steeltoe.Security.DataProtection.CredHub.Test
         }
 
         [Fact]
-        public async void RegenerateAsync_Throws_WithoutName()
+        public async Task RegenerateAsync_Throws_WithoutName()
         {
             // arrange
             var client = new CredHubClient();
@@ -547,7 +547,7 @@ namespace Steeltoe.Security.DataProtection.CredHub.Test
         }
 
         [Fact]
-        public async void BulkRegenerateAsync_Regenerates_Certificates()
+        public async Task BulkRegenerateAsync_Regenerates_Certificates()
         {
             // arrange
             var mockHttpMessageHandler = InitializedHandlerWithLogin();
@@ -568,7 +568,7 @@ namespace Steeltoe.Security.DataProtection.CredHub.Test
         }
 
         [Fact]
-        public async void BulkRegenerateAsync_Throws_WithoutCA()
+        public async Task BulkRegenerateAsync_Throws_WithoutCA()
         {
             // arrange
             var client = new CredHubClient();
@@ -578,7 +578,7 @@ namespace Steeltoe.Security.DataProtection.CredHub.Test
         }
 
         [Fact]
-        public async void DeleteByNameAsync_ReturnsTrue_WhenCredDeleted()
+        public async Task DeleteByNameAsync_ReturnsTrue_WhenCredDeleted()
         {
             // arrange
             var mockHttpMessageHandler = InitializedHandlerWithLogin();
@@ -595,7 +595,7 @@ namespace Steeltoe.Security.DataProtection.CredHub.Test
         }
 
         [Fact]
-        public async void DeleteByNameAsync_ReturnsTrue_WhenCredNotFound()
+        public async Task DeleteByNameAsync_ReturnsTrue_WhenCredNotFound()
         {
             // arrange
             var mockHttpMessageHandler = InitializedHandlerWithLogin();
@@ -612,7 +612,7 @@ namespace Steeltoe.Security.DataProtection.CredHub.Test
         }
 
         [Fact]
-        public async void DeleteByNameAsync_Throws_WithoutName()
+        public async Task DeleteByNameAsync_Throws_WithoutName()
         {
             // arrange
             var client = new CredHubClient();
@@ -622,7 +622,7 @@ namespace Steeltoe.Security.DataProtection.CredHub.Test
         }
 
         [Fact]
-        public async void FindByNameAsync_Returns_Credentials_WithQuery()
+        public async Task FindByNameAsync_Returns_Credentials_WithQuery()
         {
             // arrange
             var mockHttpMessageHandler = InitializedHandlerWithLogin();
@@ -644,7 +644,7 @@ namespace Steeltoe.Security.DataProtection.CredHub.Test
         }
 
         [Fact]
-        public async void FindByNameAsync_Throws_WithoutQuery()
+        public async Task FindByNameAsync_Throws_WithoutQuery()
         {
             // arrange
             var client = new CredHubClient();
@@ -654,7 +654,7 @@ namespace Steeltoe.Security.DataProtection.CredHub.Test
         }
 
         [Fact]
-        public async void FindByPathAsync_Returns_Credentials_WithQuery()
+        public async Task FindByPathAsync_Returns_Credentials_WithQuery()
         {
             // arrange
             var mockHttpMessageHandler = InitializedHandlerWithLogin();
@@ -676,7 +676,7 @@ namespace Steeltoe.Security.DataProtection.CredHub.Test
         }
 
         [Fact]
-        public async void FindByPathAsync_Throws_WithoutQuery()
+        public async Task FindByPathAsync_Throws_WithoutQuery()
         {
             // arrange
             var client = new CredHubClient();
@@ -686,7 +686,7 @@ namespace Steeltoe.Security.DataProtection.CredHub.Test
         }
 
         [Fact]
-        public async void GetPermissionsAsync_Throws_WithoutName()
+        public async Task GetPermissionsAsync_Throws_WithoutName()
         {
             // arrange
             var client = new CredHubClient();
@@ -696,7 +696,7 @@ namespace Steeltoe.Security.DataProtection.CredHub.Test
         }
 
         [Fact]
-        public async void GetPermissionsAsync_ReturnsPermissionedActors()
+        public async Task GetPermissionsAsync_ReturnsPermissionedActors()
         {
             // arrange
             var mockHttpMessageHandler = InitializedHandlerWithLogin();
@@ -723,7 +723,7 @@ namespace Steeltoe.Security.DataProtection.CredHub.Test
         }
 
         [Fact]
-        public async void AddPermissionsAsync_Throws_WithoutName()
+        public async Task AddPermissionsAsync_Throws_WithoutName()
         {
             // arrange
             var client = new CredHubClient();
@@ -733,7 +733,7 @@ namespace Steeltoe.Security.DataProtection.CredHub.Test
         }
 
         [Fact]
-        public async void AddPermissionsAsync_Throws_WithNoPermissions()
+        public async Task AddPermissionsAsync_Throws_WithNoPermissions()
         {
             // arrange
             var client = new CredHubClient();
@@ -743,7 +743,7 @@ namespace Steeltoe.Security.DataProtection.CredHub.Test
         }
 
         [Fact]
-        public async void AddPermissionsAsync_Throws_WithNullPermissions()
+        public async Task AddPermissionsAsync_Throws_WithNullPermissions()
         {
             // arrange
             var client = new CredHubClient();
@@ -753,7 +753,7 @@ namespace Steeltoe.Security.DataProtection.CredHub.Test
         }
 
         [Fact]
-        public async void AddPermissionsAsync_AddsAndReturnsPermissions()
+        public async Task AddPermissionsAsync_AddsAndReturnsPermissions()
         {
             // arrange
             var credentialName = "/generated-password";
@@ -787,7 +787,7 @@ namespace Steeltoe.Security.DataProtection.CredHub.Test
         }
 
         [Fact]
-        public async void DeletePermissionAsync_Throws_WithoutActor()
+        public async Task DeletePermissionAsync_Throws_WithoutActor()
         {
             // arrange
             var client = new CredHubClient();
@@ -797,7 +797,7 @@ namespace Steeltoe.Security.DataProtection.CredHub.Test
         }
 
         [Fact]
-        public async void DeletePermissionAsync_Throws_WithoutPermissionToDelete()
+        public async Task DeletePermissionAsync_Throws_WithoutPermissionToDelete()
         {
             // arrange
             var client = new CredHubClient();
@@ -807,7 +807,7 @@ namespace Steeltoe.Security.DataProtection.CredHub.Test
         }
 
         [Fact]
-        public async void DeletePermissionAsync_ReturnsTrue_WhenDeleted()
+        public async Task DeletePermissionAsync_ReturnsTrue_WhenDeleted()
         {
             // arrange
             var mockHttpMessageHandler = InitializedHandlerWithLogin();
@@ -830,7 +830,7 @@ namespace Steeltoe.Security.DataProtection.CredHub.Test
         }
 
         [Fact]
-        public async void DeletePermissionAsync_ReturnsTrue_WhenNotFound()
+        public async Task DeletePermissionAsync_ReturnsTrue_WhenNotFound()
         {
             // arrange
             var mockHttpMessageHandler = InitializedHandlerWithLogin();
@@ -853,7 +853,7 @@ namespace Steeltoe.Security.DataProtection.CredHub.Test
         }
 
         [Fact]
-        public async void InterpolateServiceDataAsync_Throws_WithoutServiceData()
+        public async Task InterpolateServiceDataAsync_Throws_WithoutServiceData()
         {
             // arrange
             var client = new CredHubClient();
@@ -863,7 +863,7 @@ namespace Steeltoe.Security.DataProtection.CredHub.Test
         }
 
         [Fact]
-        public async void InterpolateServiceDataAsync_CallsEndpoint_ReturnsInterpolatedString()
+        public async Task InterpolateServiceDataAsync_CallsEndpoint_ReturnsInterpolatedString()
         {
             // arrange
             var mockHttpMessageHandler = InitializedHandlerWithLogin();


### PR DESCRIPTION
The primary purpose of this PR is to prevent async tests from operating as fire and forget (Identified by sonar update in previous PR) other issues addressed:
- remove a few instances of `[Trait("Category", "FlakyOnHostedAgents")]` which hasn't been used for a while
- skip some tests that appear to be causing testhost crashes due to underlying issue in the runtime in Mac + .NET 5