### PR TITLE
Add ConfigMap appsettings file parsing

### DIFF
--- a/src/Configuration/src/KubernetesBase/Steeltoe.Extensions.Configuration.KubernetesBase.csproj
+++ b/src/Configuration/src/KubernetesBase/Steeltoe.Extensions.Configuration.KubernetesBase.csproj
@@ -16,6 +16,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="$(ExtensionsVersion)" />
   </ItemGroup>
 </Project>

--- a/src/Configuration/src/KubernetesBase/Steeltoe.Extensions.Configuration.KubernetesBase.csproj
+++ b/src/Configuration/src/KubernetesBase/Steeltoe.Extensions.Configuration.KubernetesBase.csproj
@@ -14,4 +14,8 @@
     <ProjectReference Include="..\..\..\Common\src\Common\Steeltoe.Common.csproj" />
     <ProjectReference Include="..\..\..\Common\src\Common.Kubernetes\Steeltoe.Common.Kubernetes.csproj" />
   </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.0" />
+  </ItemGroup>
 </Project>

--- a/src/Configuration/test/KubernetesBase.Test/KubernetesConfigMapProviderTest.cs
+++ b/src/Configuration/test/KubernetesBase.Test/KubernetesConfigMapProviderTest.cs
@@ -164,5 +164,58 @@ namespace Steeltoe.Extensions.Configuration.Kubernetes.Test
             Assert.False(provider.TryGet("TestKey", out _), "TryGet TestKey after update");
             Assert.False(provider.TryGet("TestKey2", out _), "TryGet TestKey2 after update");
         }
+
+        [Fact]
+        public void KubernetesConfigMapProvider_AddsJsonFileToDictionaryOnSuccess()
+        {
+            // arrange
+            var mockHttpMessageHandler = new MockHttpMessageHandler();
+            mockHttpMessageHandler
+                .Expect(HttpMethod.Get, "*")
+                .Respond(new StringContent("{\"kind\":\"ConfigMap\",\"apiVersion\":\"v1\",\"metadata\":{\"name\":\"testconfigmap\",\"namespace\":\"default\",\"selfLink\":\"/api/v1/namespaces/default/configmaps/testconfigmap\",\"uid\":\"8582b94c-f4fa-47fa-bacc-47019223775c\",\"resourceVersion\":\"1320622\",\"creationTimestamp\":\"2020-04-15T18:33:49Z\",\"annotations\":{\"kubectl.kubernetes.io/last-applied-configuration\":\"{\\\"apiVersion\\\":\\\"v1\\\",\\\"data\\\":{\\\"ConfigMapName\\\":\\\"testconfigmap\\\"},\\\"kind\\\":\\\"ConfigMap\\\",\\\"metadata\\\":{\\\"annotations\\\":{},\\\"name\\\":\\\"kubernetes1\\\",\\\"namespace\\\":\\\"default\\\"}}\\n\"}},\"data\":{" +
+                                           "\"appsettings.json\": \"{\n  \\\"Test0\\\": \\\"Value0\\\",\n  \\\"Test1\\\": [\n    {\n      \\\"Test2\\\": \\\"Value1\\\"\n    }\n  ]\n}\"" +
+                                           "}\n}\n"));
+
+            using var client = new k8s.Kubernetes(new KubernetesClientConfiguration { Host = "http://localhost" }, httpClient: mockHttpMessageHandler.ToHttpClient());
+            var settings = new KubernetesConfigSourceSettings("default", "testconfigmap", new ReloadSettings());
+            var provider = new KubernetesConfigMapProvider(client, settings);
+
+            // act
+            provider.Load();
+
+            // assert
+            Assert.True(provider.TryGet("Test0", out var testValue));
+            Assert.Equal("Value0", testValue);
+
+            Assert.True(provider.TryGet("Test1:0:Test2", out var testValue2));
+            Assert.Equal("Value1", testValue2);
+        }
+
+        [Fact]
+        public void KubernetesConfigMapProvider_AddsJsonFileToDictionaryWithConfigMapOverridesOnSuccess()
+        {
+            // arrange
+            var mockHttpMessageHandler = new MockHttpMessageHandler();
+            mockHttpMessageHandler
+                .Expect(HttpMethod.Get, "*")
+                .Respond(new StringContent("{\"kind\":\"ConfigMap\",\"apiVersion\":\"v1\",\"metadata\":{\"name\":\"testconfigmap\",\"namespace\":\"default\",\"selfLink\":\"/api/v1/namespaces/default/configmaps/testconfigmap\",\"uid\":\"8582b94c-f4fa-47fa-bacc-47019223775c\",\"resourceVersion\":\"1320622\",\"creationTimestamp\":\"2020-04-15T18:33:49Z\",\"annotations\":{\"kubectl.kubernetes.io/last-applied-configuration\":\"{\\\"apiVersion\\\":\\\"v1\\\",\\\"data\\\":{\\\"ConfigMapName\\\":\\\"testconfigmap\\\"},\\\"kind\\\":\\\"ConfigMap\\\",\\\"metadata\\\":{\\\"annotations\\\":{},\\\"name\\\":\\\"kubernetes1\\\",\\\"namespace\\\":\\\"default\\\"}}\\n\"}},\"data\":{" +
+                                           "\"Test0\": \"Value5\",\n" +
+                                           "\"appsettings.json\": \"{\n  \\\"Test0\\\": \\\"Value0\\\",\n  \\\"Test1\\\": [\n    {\n      \\\"Test2\\\": \\\"Value1\\\"\n    }\n  ]\n}\"" +
+                                           "}\n}\n"));
+
+            using var client = new k8s.Kubernetes(new KubernetesClientConfiguration { Host = "http://localhost" }, httpClient: mockHttpMessageHandler.ToHttpClient());
+            var settings = new KubernetesConfigSourceSettings("default", "testconfigmap", new ReloadSettings());
+            var provider = new KubernetesConfigMapProvider(client, settings);
+
+            // act
+            provider.Load();
+
+            // assert
+            Assert.True(provider.TryGet("Test0", out var testValue));
+            Assert.Equal("Value5", testValue);
+
+            Assert.True(provider.TryGet("Test1:0:Test2", out var testValue2));
+            Assert.Equal("Value1", testValue2);
+        }
     }
 }

--- a/src/Configuration/test/KubernetesBase.Test/KubernetesConfigMapProviderTest.cs
+++ b/src/Configuration/test/KubernetesBase.Test/KubernetesConfigMapProviderTest.cs
@@ -192,15 +192,14 @@ namespace Steeltoe.Extensions.Configuration.Kubernetes.Test
         }
 
         [Fact]
-        public void KubernetesConfigMapProvider_AddsJsonFileToDictionaryWithConfigMapOverridesOnSuccess()
+        public void KubernetesConfigMapProvider_AddsEnvSpecificJsonFileToDictionaryOnSuccess()
         {
             // arrange
             var mockHttpMessageHandler = new MockHttpMessageHandler();
             mockHttpMessageHandler
                 .Expect(HttpMethod.Get, "*")
                 .Respond(new StringContent("{\"kind\":\"ConfigMap\",\"apiVersion\":\"v1\",\"metadata\":{\"name\":\"testconfigmap\",\"namespace\":\"default\",\"selfLink\":\"/api/v1/namespaces/default/configmaps/testconfigmap\",\"uid\":\"8582b94c-f4fa-47fa-bacc-47019223775c\",\"resourceVersion\":\"1320622\",\"creationTimestamp\":\"2020-04-15T18:33:49Z\",\"annotations\":{\"kubectl.kubernetes.io/last-applied-configuration\":\"{\\\"apiVersion\\\":\\\"v1\\\",\\\"data\\\":{\\\"ConfigMapName\\\":\\\"testconfigmap\\\"},\\\"kind\\\":\\\"ConfigMap\\\",\\\"metadata\\\":{\\\"annotations\\\":{},\\\"name\\\":\\\"kubernetes1\\\",\\\"namespace\\\":\\\"default\\\"}}\\n\"}},\"data\":{" +
-                                           "\"Test0\": \"Value5\",\n" +
-                                           "\"appsettings.json\": \"{\n  \\\"Test0\\\": \\\"Value0\\\",\n  \\\"Test1\\\": [\n    {\n      \\\"Test2\\\": \\\"Value1\\\"\n    }\n  ]\n}\"" +
+                                           "\"appsettings.demo.json\": \"{\n  \\\"Test0\\\": \\\"Value0\\\",\n  \\\"Test1\\\": [\n    {\n      \\\"Test2\\\": \\\"Value1\\\"\n    }\n  ]\n}\"" +
                                            "}\n}\n"));
 
             using var client = new k8s.Kubernetes(new KubernetesClientConfiguration { Host = "http://localhost" }, httpClient: mockHttpMessageHandler.ToHttpClient());
@@ -212,7 +211,7 @@ namespace Steeltoe.Extensions.Configuration.Kubernetes.Test
 
             // assert
             Assert.True(provider.TryGet("Test0", out var testValue));
-            Assert.Equal("Value5", testValue);
+            Assert.Equal("Value0", testValue);
 
             Assert.True(provider.TryGet("Test1:0:Test2", out var testValue2));
             Assert.Equal("Value1", testValue2);


### PR DESCRIPTION
- Add support for ConfigMap entry with key `appsettings.json` being parsed using the JsonConfigurationProvider
- ConfigMap entries with keys duplicated in the `appsettings.json`'s value will use the values specified in the ConfigMap
#639 