### PR TITLE
Reduce possibility of duplicate keys for health checkers

### DIFF
--- a/src/Management/src/EndpointBase/Health/DefaultHealthAggregator.cs
+++ b/src/Management/src/EndpointBase/Health/DefaultHealthAggregator.cs
@@ -26,7 +26,7 @@ namespace Steeltoe.Management.Endpoint.Health
             var keyList = new ConcurrentBag<string>();
             Parallel.ForEach(contributors, contributor =>
             {
-                var contributorId = GetKey(ref keyList, contributor.Id);
+                var contributorId = GetKey(keyList, contributor.Id);
                 HealthCheckResult healthCheckResult = null;
                 try
                 {
@@ -43,14 +43,14 @@ namespace Steeltoe.Management.Endpoint.Health
             return AddChecksSetStatus(aggregatorResult, healthChecks);
         }
 
-        protected static string GetKey(ref ConcurrentBag<string> keys, string key)
+        protected static string GetKey(ConcurrentBag<string> keys, string key)
         {
             lock (keys)
             {
                 // add the contributor with a -n appended to the id
                 if (keys.Any(k => k.Equals(key)))
                 {
-                    var newKey = string.Concat(key, "-", keys.Count(k => k == key));
+                    var newKey = string.Concat(key, "-", keys.Count(k => k.StartsWith(key)));
                     keys.Add(newKey);
                     return newKey;
                 }

--- a/src/Management/src/EndpointBase/Health/DefaultHealthAggregator.cs
+++ b/src/Management/src/EndpointBase/Health/DefaultHealthAggregator.cs
@@ -26,7 +26,7 @@ namespace Steeltoe.Management.Endpoint.Health
             var keyList = new ConcurrentBag<string>();
             Parallel.ForEach(contributors, contributor =>
             {
-                var contributorId = GetKey(keyList, contributor.Id);
+                var contributorId = GetKey(ref keyList, contributor.Id);
                 HealthCheckResult healthCheckResult = null;
                 try
                 {
@@ -43,19 +43,22 @@ namespace Steeltoe.Management.Endpoint.Health
             return AddChecksSetStatus(aggregatorResult, healthChecks);
         }
 
-        protected static string GetKey(ConcurrentBag<string> keys, string key)
+        protected static string GetKey(ref ConcurrentBag<string> keys, string key)
         {
-            // add the contributor with a -n appended to the id
-            if (keys.Any(k => k.Equals(key)))
+            lock (keys)
             {
-                var newKey = string.Concat(key, "-", keys.Count(k => k == key));
-                keys.Add(newKey);
-                return newKey;
-            }
-            else
-            {
-                keys.Add(key);
-                return key;
+                // add the contributor with a -n appended to the id
+                if (keys.Any(k => k.Equals(key)))
+                {
+                    var newKey = string.Concat(key, "-", keys.Count(k => k == key));
+                    keys.Add(newKey);
+                    return newKey;
+                }
+                else
+                {
+                    keys.Add(key);
+                    return key;
+                }
             }
         }
 

--- a/src/Management/src/EndpointCore/Health/HealthRegistrationsAggregator.cs
+++ b/src/Management/src/EndpointCore/Health/HealthRegistrationsAggregator.cs
@@ -33,7 +33,7 @@ namespace Steeltoe.Management.Endpoint.Health
             // run all HealthCheckRegistration checks in parallel
             Parallel.ForEach(healthCheckRegistrations, registration =>
             {
-                var contributorName = GetKey(keyList, registration.Name);
+                var contributorName = GetKey(ref keyList, registration.Name);
                 HealthCheckResult healthCheckResult = null;
                 try
                 {

--- a/src/Management/src/EndpointCore/Health/HealthRegistrationsAggregator.cs
+++ b/src/Management/src/EndpointCore/Health/HealthRegistrationsAggregator.cs
@@ -33,7 +33,7 @@ namespace Steeltoe.Management.Endpoint.Health
             // run all HealthCheckRegistration checks in parallel
             Parallel.ForEach(healthCheckRegistrations, registration =>
             {
-                var contributorName = GetKey(ref keyList, registration.Name);
+                var contributorName = GetKey(keyList, registration.Name);
                 HealthCheckResult healthCheckResult = null;
                 try
                 {

--- a/src/Management/test/EndpointBase.Test/Health/DefaultHealthAggregatorTest.cs
+++ b/src/Management/test/EndpointBase.Test/Health/DefaultHealthAggregatorTest.cs
@@ -56,16 +56,17 @@ namespace Steeltoe.Management.Endpoint.Health.Test
         [Fact]
         public void Aggregate_DuplicateContributor_ReturnsExpectedHealth()
         {
-            var contribs = new List<IHealthContributor>()
+            var contribs = new List<IHealthContributor>();
+            for (var i = 0; i < 10; i++)
             {
-                new UpContributor(),
-                new UpContributor()
-            };
+                contribs.Add(new UpContributor());
+            }
+
             var agg = new DefaultHealthAggregator();
             var result = agg.Aggregate(contribs);
             Assert.NotNull(result);
             Assert.Equal(HealthStatus.UP, result.Status);
-            Assert.Contains("Up-1", result.Details.Keys);
+            Assert.Contains("Up-9", result.Details.Keys);
         }
 
         [Fact]


### PR DESCRIPTION
Health checkers are supposed to be given a unique Id during aggregation by the default aggregator, but that isn't always happening - see intermittent test failures of this test for proof:
`Steeltoe.Management.Endpoint.Health.Test.DefaultHealthAggregatorTest.Aggregate_DuplicateContributor_ReturnsExpectedHealth`

fixes #681 