### PR TITLE
RabbitListenerErrorHandler Async Context

### DIFF
--- a/src/Messaging/test/RabbitMQ.Test/Attributes/AsyncListenerTest.cs
+++ b/src/Messaging/test/RabbitMQ.Test/Attributes/AsyncListenerTest.cs
@@ -6,7 +6,6 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
-using Steeltoe.Common.Services;
 using Steeltoe.Common.Util;
 using Steeltoe.Messaging.RabbitMQ.Config;
 using Steeltoe.Messaging.RabbitMQ.Connection;

--- a/src/Messaging/test/RabbitMQ.Test/Attributes/AsyncListenerTest.cs
+++ b/src/Messaging/test/RabbitMQ.Test/Attributes/AsyncListenerTest.cs
@@ -292,8 +292,6 @@ namespace Steeltoe.Messaging.RabbitMQ.Attributes
                 }
             }
 
-            // Error handler is connected when signature is "void", "Task", or "Task<T>"
-            // Error handler is disconnected (value not returned) whenever "async" is added
             [RabbitListener(Queue = "queueAsyncErrorHandler", Id = "asycErrorHandler", ErrorHandler = nameof(CustomListenerErrorHandler))]
             public async Task<string> HandleMessage(string msg)
             {


### PR DESCRIPTION
Resolves issue with RabbitListenerErrorHandler not being called when errors inside async methods.

Addresses #606 