### PR TITLE
Add temp file/directory that can cleanup themselves

### DIFF
--- a/src/Common/Common.sln
+++ b/src/Common/Common.sln
@@ -72,6 +72,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Steeltoe.Common.Expression"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Steeltoe.Common.Expression.Test", "test\Common.Expression.Test\Steeltoe.Common.Expression.Test.csproj", "{C9006490-F0A8-4166-B003-DF4B73258154}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Steeltoe.Common.IO", "src\Common.IO\Steeltoe.Common.IO.csproj", "{E8EF5F9A-9126-4B73-AC6C-2795D2E618F4}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Steeltoe.Common.IO.Test", "test\Common.IO.Test\Steeltoe.Common.IO.Test.csproj", "{472ED9C1-80FA-4F87-9A5F-C135267FAC37}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -154,6 +158,14 @@ Global
 		{C9006490-F0A8-4166-B003-DF4B73258154}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C9006490-F0A8-4166-B003-DF4B73258154}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C9006490-F0A8-4166-B003-DF4B73258154}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E8EF5F9A-9126-4B73-AC6C-2795D2E618F4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E8EF5F9A-9126-4B73-AC6C-2795D2E618F4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E8EF5F9A-9126-4B73-AC6C-2795D2E618F4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E8EF5F9A-9126-4B73-AC6C-2795D2E618F4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{472ED9C1-80FA-4F87-9A5F-C135267FAC37}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{472ED9C1-80FA-4F87-9A5F-C135267FAC37}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{472ED9C1-80FA-4F87-9A5F-C135267FAC37}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{472ED9C1-80FA-4F87-9A5F-C135267FAC37}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -178,6 +190,8 @@ Global
 		{39CBC27D-108F-4BD9-A88E-5B1D3635CE30} = {CC77ED1F-BC03-4B9D-A07A-186C9A13042B}
 		{956FAAA7-AC7E-4AAA-B8F6-CBFDC776867F} = {D9798FDE-76F4-4848-8AE0-95249C0101F0}
 		{C9006490-F0A8-4166-B003-DF4B73258154} = {CC77ED1F-BC03-4B9D-A07A-186C9A13042B}
+		{E8EF5F9A-9126-4B73-AC6C-2795D2E618F4} = {D9798FDE-76F4-4848-8AE0-95249C0101F0}
+		{472ED9C1-80FA-4F87-9A5F-C135267FAC37} = {CC77ED1F-BC03-4B9D-A07A-186C9A13042B}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {4A85F9DA-2C2D-48E9-A28C-9B35C473C150}

--- a/src/Common/src/Common.IO/Steeltoe.Common.IO.csproj
+++ b/src/Common/src/Common.IO/Steeltoe.Common.IO.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/src/Common/src/Common.IO/TempDirectory.cs
+++ b/src/Common/src/Common.IO/TempDirectory.cs
@@ -1,0 +1,41 @@
+using System.IO;
+
+namespace Steeltoe.Common.IO
+{
+    public sealed class TempDirectory : TempPath
+    {
+        /// <inheritdoc/>
+        public TempDirectory()
+        {
+        }
+
+        /// <summary>
+        public TempDirectory(string name) : base(name)
+        {
+        }
+
+        protected override void Initialize()
+        {
+            base.Initialize();
+            Directory.CreateDirectory(FullPath);
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+            if (!(Directory.Exists(FullPath)))
+            {
+                return;
+            }
+
+            try
+            {
+                Directory.Delete(FullPath, true);
+            }
+            catch
+            {
+                // ignore
+            }
+        }
+    }
+}

--- a/src/Common/src/Common.IO/TempFile.cs
+++ b/src/Common/src/Common.IO/TempFile.cs
@@ -1,0 +1,46 @@
+using System.IO;
+
+namespace Steeltoe.Common.IO
+{
+    public sealed class TempFile : TempPath
+    {
+        /// <summary>
+        /// Creates a new instance of a TempFile.
+        /// </summary>
+        public TempFile()
+        {
+        }
+
+        /// <summary>
+        /// Creates a new instance of a TempFile with the specified name.
+        /// </summary>
+        public TempFile(string name) : base(name)
+        {
+        }
+
+        protected override void Initialize()
+        {
+            base.Initialize();
+            File.Create(FullPath).Dispose();
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+
+            if (!(File.Exists(FullPath)))
+            {
+                return;
+            }
+
+            try
+            {
+                File.Delete(FullPath);
+            }
+            catch
+            {
+                // ignore
+            }
+        }
+    }
+}

--- a/src/Common/src/Common.IO/TempPath.cs
+++ b/src/Common/src/Common.IO/TempPath.cs
@@ -1,0 +1,60 @@
+using System;
+using System.IO;
+
+namespace Steeltoe.Common.IO
+{
+    public abstract class TempPath : IDisposable
+    {
+        /// <summary>
+        /// Gets the absolute path of the TempPath.
+        /// </summary>
+        public string FullPath { get; }
+
+        /// <summary>
+        /// Gets the name of the TempPath.
+        /// </summary>
+        public string Name { get; }
+
+        /// <summary>
+        /// Creates a new instance of a TempPath with a GUID as its name.
+        /// </summary>
+        public TempPath() : this(Guid.NewGuid().ToString())
+        {
+        }
+
+        /// <summary>
+        /// Creates a new instance of a TempPath with the specified name.
+        /// The full path to the file will be rooted in at <code>Path.GetTempPath()</code>.
+        /// </summary>
+        /// <param name="name">Name of temporary path</param>
+        public TempPath(string name)
+        {
+            Name = name;
+            FullPath = $"{Path.GetTempPath()}{Path.DirectorySeparatorChar}{Name}";
+            Initialize();
+        }
+
+        protected virtual void Initialize()
+        {
+            
+        }
+        
+        ~TempPath()
+        {
+            Dispose(false);
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                GC.SuppressFinalize(this);
+            }
+        }
+    }
+}

--- a/src/Common/test/Common.IO.Test/Steeltoe.Common.IO.Test.csproj
+++ b/src/Common/test/Common.IO.Test/Steeltoe.Common.IO.Test.csproj
@@ -1,0 +1,18 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+  </PropertyGroup>
+
+  <Import Project="..\..\..\..\versions.props" />
+  <Import Project="..\..\..\..\sharedtest.props" />
+
+  <ItemGroup>
+    <None Update="xunit.runner.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Common.IO\Steeltoe.Common.IO.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Common/test/Common.IO.Test/TempDirectoryTest.cs
+++ b/src/Common/test/Common.IO.Test/TempDirectoryTest.cs
@@ -1,0 +1,29 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+using System.IO;
+using Xunit;
+
+namespace Steeltoe.Common.IO.Test
+{
+    public class TempDirectoryTest
+    {
+        [Fact]
+        public void TempDirectoryRemovesItself()
+        {
+            var tempDir = new TempDirectory();
+            Assert.True(Directory.Exists(tempDir.FullPath));
+            File.Create(Path.Join(tempDir.FullPath, "foo")).Dispose();
+            tempDir.Dispose();
+            Assert.False(Directory.Exists(tempDir.FullPath));
+        }
+
+        [Fact]
+        public void TempDirectoryCanBeNamed()
+        {
+            using var tempDir = new TempDirectory("Jill");
+            Assert.Equal("Jill", tempDir.Name);
+        }
+    }
+}

--- a/src/Common/test/Common.IO.Test/TempFileTest.cs
+++ b/src/Common/test/Common.IO.Test/TempFileTest.cs
@@ -1,0 +1,28 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+using System.IO;
+using Xunit;
+
+namespace Steeltoe.Common.IO.Test
+{
+    public class TempFileTest
+    {
+        [Fact]
+        public void TempFileRemovesItself()
+        {
+            var tempFile = new TempFile();
+            Assert.True(File.Exists(tempFile.FullPath));
+            tempFile.Dispose();
+            Assert.False(File.Exists(tempFile.FullPath));
+        }
+
+        [Fact]
+        public void TempFileCanBeNamed()
+        {
+            using var tempFile = new TempFile("Jack");
+            Assert.Equal("Jack", tempFile.Name);
+        }
+    }
+}


### PR DESCRIPTION
Couple of utility classes that can cleanup after themselves, thus simplifying temp file usage.

Sample:
```
    using var tempFile = new TempFile();
```
A temp file is created during construction and subsequently deleted when the var goes out of scope.

Similar behavior for `TempDirectory`.