### PR TITLE
Improve Pipeline Reliability

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -162,7 +162,7 @@ jobs:
       SignClientSecret: $(SignClientSecret)
       ArtifactDirectory: $(Build.ArtifactStagingDirectory)/packages
   - publish: $(Build.ArtifactStagingDirectory)/packages
-    condition: eq(variables['package'], 'true')
+    condition: and(succeeded(), eq(variables['package'], 'true'))
     displayName: Publish build artifacts
     artifact: Packages
   - bash: bash <(curl -s https://codecov.io/bash)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -167,7 +167,7 @@ jobs:
     artifact: Packages
   - bash: bash <(curl -s https://codecov.io/bash)
     displayName: Upload to codecov.io
-    condition: succeededOrFailed()
+    condition: and(succeeded(), or(eq(variables['Agent.OS'], 'Windows_NT'), eq(variables['integrationTests'], 'true')))
 - job: Wrap_up
   dependsOn:
   - Steeltoe_CI

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -132,7 +132,7 @@ jobs:
       targetdir: $(Build.ArtifactStagingDirectory)/CodeCoverage/$(Agent.JobName)
       reporttypes: Cobertura
   - publish: $(Build.ArtifactStagingDirectory)/CodeCoverage/$(Agent.JobName)
-    condition: and(succeededOrFailed(), or(eq(variables['Agent.OS'], 'Windows_NT'), eq(variables['integrationTests'], 'true')))
+    condition: and(succeeded(), or(eq(variables['Agent.OS'], 'Windows_NT'), eq(variables['integrationTests'], 'true')))
     displayName: Publish code coverage artifacts
     artifact: coverageResults-$(Agent.JobName)
   - task: SonarCloudAnalyze@1

--- a/src/Common/test/Common.Security.Test/ConfigurationExtensionsTest.cs
+++ b/src/Common/test/Common.Security.Test/ConfigurationExtensionsTest.cs
@@ -32,6 +32,7 @@ namespace Steeltoe.Common.Security.Test
         }
 
         [Fact]
+        [Trait("Category", "SkipOnMacOS")]
         public async Task AddPemFiles_ReloadsOnChange()
         {
             var tempFile1 = await CreateTempFileAsync("cert");

--- a/src/Messaging/test/RabbitMQ.Test/Connection/RoutingConnectionFactoryTest.cs
+++ b/src/Messaging/test/RabbitMQ.Test/Connection/RoutingConnectionFactoryTest.cs
@@ -103,6 +103,7 @@ namespace Steeltoe.Messaging.RabbitMQ.Connection
         }
 
         [Fact]
+        [Trait("Category", "SkipOnMacOS")]
         public async Task TestAbstractRoutingConnectionFactoryWithListenerContainer()
         {
             var connectionFactory1 = new Mock<IConnectionFactory>();


### PR DESCRIPTION
- Only publish code coverage results to the pipeline on success
- Skip a couple tests on MacOS that are flaky on that OS
#635