### PR TITLE
RabbitHost CreateDefaultBuilder Command Line Args

### DIFF
--- a/src/Messaging/src/RabbitMQ/Host/RabbitHost.cs
+++ b/src/Messaging/src/RabbitMQ/Host/RabbitHost.cs
@@ -16,6 +16,9 @@ namespace Steeltoe.Messaging.RabbitMQ.Host
         public static IHostBuilder CreateDefaultBuilder() =>
             new RabbitHostBuilder(Microsoft.Extensions.Hosting.Host.CreateDefaultBuilder());
 
+        public static IHostBuilder CreateDefaultBuilder(string[] args) =>
+            new RabbitHostBuilder(Microsoft.Extensions.Hosting.Host.CreateDefaultBuilder(args));
+
         public IServiceProvider Services => _host.Services;
 
         private readonly IHost _host;

--- a/src/Messaging/test/RabbitMQ.Test/Host/RabbitHostTest.cs
+++ b/src/Messaging/test/RabbitMQ.Test/Host/RabbitHostTest.cs
@@ -79,5 +79,18 @@ namespace Steeltoe.Messaging.RabbitMQ.Host
                 Assert.Equal("TestPassword", rabbitOptions.Password);
             }
         }
+
+        [Fact]
+        public void HostShouldSendCommandLineArgs()
+        {
+            var hostBuilder = RabbitHost.CreateDefaultBuilder(new string[] { "RabbitHostCommandKey=RabbitHostCommandValue" });
+
+            using (var host = hostBuilder.Start())
+            {
+                var config = host.Services.GetService<IConfiguration>();
+
+                Assert.Equal("RabbitHostCommandValue", config["RabbitHostCommandKey"]);
+            }
+        }
     }
 }


### PR DESCRIPTION
Add command line args input to `RabbitHost.CreateDefaultBuilder` to allow use in generic host CreateDefaultBuilder method