### PR TITLE
Update RabbitListenerDeclareAtrributeProcessor.cs

### DIFF
--- a/src/Messaging/src/RabbitMQ/Config/RabbitListenerDeclareAtrributeProcessor.cs
+++ b/src/Messaging/src/RabbitMQ/Config/RabbitListenerDeclareAtrributeProcessor.cs
@@ -218,7 +218,7 @@ namespace Steeltoe.Messaging.RabbitMQ.Config
 
             if (type == ExchangeType.TOPIC)
             {
-                return new FanoutExchange(name);
+                return new TopicExchange(name);
             }
 
             if (type == ExchangeType.SYSTEM)

--- a/src/Messaging/test/RabbitMQ.Test/Attributes/RabbitListenerAttributeProcessorTest.cs
+++ b/src/Messaging/test/RabbitMQ.Test/Attributes/RabbitListenerAttributeProcessorTest.cs
@@ -198,7 +198,35 @@ namespace Steeltoe.Messaging.RabbitMQ.Attributes
             var queues = new List<IQueue>() { queue1, queue2 };
             var excep = await Assert.ThrowsAsync<ExpressionException>(() => Config.CreateAndStartServices(null, queues, typeof(InvalidValueInAnnotationTestBean)));
         }
+        
+        [Fact]
+        public void CreateExchangeReturnsCorrectType()
+        {
+            // Arrange
+            var services = new ServiceCollection();
 
+            // Act and assert
+            RabbitListenerDeclareAtrributeProcessor.ProcessDeclareAttributes(services, null, typeof(TestTarget));
+            var exchanges = services.BuildServiceProvider().GetServices<IExchange>();
+            Assert.Contains(exchanges, (ex) => ex.Type == ExchangeType.DIRECT);
+            Assert.Contains(exchanges, (ex) => ex.Type == ExchangeType.TOPIC);
+            Assert.Contains(exchanges, (ex) => ex.Type == ExchangeType.FANOUT);
+            Assert.Contains(exchanges, (ex) => ex.Type == ExchangeType.HEADERS);
+            Assert.Contains(exchanges, (ex) => ex.Type == ExchangeType.SYSTEM);
+        }
+
+        public class TestTarget
+        {
+            [DeclareExchange(Name ="test", Type = ExchangeType.DIRECT)]
+            [DeclareExchange(Name = "test", Type = ExchangeType.TOPIC)]
+            [DeclareExchange(Name = "test", Type = ExchangeType.FANOUT)]
+            [DeclareExchange(Name = "test", Type = ExchangeType.HEADERS)]
+            [DeclareExchange(Name = "test", Type = ExchangeType.SYSTEM)]
+            public void Method()
+            {
+            }
+        }
+        
         public class Config
         {
             public static async Task<ServiceProvider> CreateAndStartServices(IConfiguration configuration, List<IQueue> queues, params Type[] listeners)

--- a/src/Messaging/test/RabbitMQ.Test/Attributes/RabbitListenerAttributeProcessorTest.cs
+++ b/src/Messaging/test/RabbitMQ.Test/Attributes/RabbitListenerAttributeProcessorTest.cs
@@ -198,7 +198,7 @@ namespace Steeltoe.Messaging.RabbitMQ.Attributes
             var queues = new List<IQueue>() { queue1, queue2 };
             var excep = await Assert.ThrowsAsync<ExpressionException>(() => Config.CreateAndStartServices(null, queues, typeof(InvalidValueInAnnotationTestBean)));
         }
-        
+
         [Fact]
         public void CreateExchangeReturnsCorrectType()
         {
@@ -226,7 +226,7 @@ namespace Steeltoe.Messaging.RabbitMQ.Attributes
             {
             }
         }
-        
+
         public class Config
         {
             public static async Task<ServiceProvider> CreateAndStartServices(IConfiguration configuration, List<IQueue> queues, params Type[] listeners)


### PR DESCRIPTION
RabbitListenerDeclareAtrributeProcessor now creates a TopicExchange instead of a FanoutExchange when `type == ExchangeType.TOPIC`

Resolves https://github.com/SteeltoeOSS/Steeltoe/issues/696