### PR TITLE
Rename RabbitHost -> RabbitMQHost

### DIFF
--- a/src/Messaging/src/RabbitMQ/Host/RabbitMQHost.cs
+++ b/src/Messaging/src/RabbitMQ/Host/RabbitMQHost.cs
@@ -11,19 +11,19 @@ using System.Threading.Tasks;
 
 namespace Steeltoe.Messaging.RabbitMQ.Host
 {
-    public sealed class RabbitHost : IHost
+    public sealed class RabbitMQHost : IHost
     {
         public static IHostBuilder CreateDefaultBuilder() =>
-            new RabbitHostBuilder(Microsoft.Extensions.Hosting.Host.CreateDefaultBuilder());
+            new RabbitMQHostBuilder(Microsoft.Extensions.Hosting.Host.CreateDefaultBuilder());
 
         public static IHostBuilder CreateDefaultBuilder(string[] args) =>
-            new RabbitHostBuilder(Microsoft.Extensions.Hosting.Host.CreateDefaultBuilder(args));
+            new RabbitMQHostBuilder(Microsoft.Extensions.Hosting.Host.CreateDefaultBuilder(args));
 
         public IServiceProvider Services => _host.Services;
 
         private readonly IHost _host;
 
-        public RabbitHost(IHost host)
+        public RabbitMQHost(IHost host)
         {
             _host = host;
         }

--- a/src/Messaging/src/RabbitMQ/Host/RabbitMQHostBuilder.cs
+++ b/src/Messaging/src/RabbitMQ/Host/RabbitMQHostBuilder.cs
@@ -13,13 +13,13 @@ using System.Collections.Generic;
 
 namespace Steeltoe.Messaging.RabbitMQ.Host
 {
-    public class RabbitHostBuilder : IHostBuilder
+    public class RabbitMQHostBuilder : IHostBuilder
     {
         public IDictionary<object, object> Properties => _hostbuilder.Properties;
 
         private readonly IHostBuilder _hostbuilder;
 
-        public RabbitHostBuilder(IHostBuilder hostbuilder)
+        public RabbitMQHostBuilder(IHostBuilder hostbuilder)
         {
             _hostbuilder = hostbuilder;
 
@@ -43,7 +43,7 @@ namespace Steeltoe.Messaging.RabbitMQ.Host
         {
             var host = _hostbuilder.Build();
 
-            return new RabbitHost(host);
+            return new RabbitMQHost(host);
         }
 
         public IHostBuilder ConfigureAppConfiguration(Action<HostBuilderContext, IConfigurationBuilder> configureDelegate)

--- a/src/Messaging/test/RabbitMQ.Test/Host/RabbitMQHostTest.cs
+++ b/src/Messaging/test/RabbitMQ.Test/Host/RabbitMQHostTest.cs
@@ -13,14 +13,14 @@ using Xunit;
 
 namespace Steeltoe.Messaging.RabbitMQ.Host
 {
-    public class RabbitHostTest
+    public class RabbitMQHostTest
     {
         [Fact]
         public void HostCanBeStarted()
         {
             MockRabbitHostedService hostedService;
 
-            using (var host = RabbitHost.CreateDefaultBuilder()
+            using (var host = RabbitMQHost.CreateDefaultBuilder()
                                 .ConfigureServices(svc => svc.AddSingleton<IHostedService, MockRabbitHostedService>())
                                 .Start())
             {
@@ -40,7 +40,7 @@ namespace Steeltoe.Messaging.RabbitMQ.Host
         [Fact]
         public void HostShouldInitializeServices()
         {
-            using (var host = RabbitHost.CreateDefaultBuilder().Start())
+            using (var host = RabbitMQHost.CreateDefaultBuilder().Start())
             {
                 var lifecycleProcessor = host.Services.GetRequiredService<ILifecycleProcessor>();
                 var rabbitHostService = (RabbitHostService)host.Services.GetRequiredService<IHostedService>();
@@ -53,7 +53,7 @@ namespace Steeltoe.Messaging.RabbitMQ.Host
         [Fact]
         public void HostShouldAddRabbitOptionsConfiguration()
         {
-            var hostBuilder = RabbitHost.CreateDefaultBuilder();
+            var hostBuilder = RabbitMQHost.CreateDefaultBuilder();
 
             var appSettings = new Dictionary<string, string>()
             {
@@ -83,7 +83,7 @@ namespace Steeltoe.Messaging.RabbitMQ.Host
         [Fact]
         public void HostShouldSendCommandLineArgs()
         {
-            var hostBuilder = RabbitHost.CreateDefaultBuilder(new string[] { "RabbitHostCommandKey=RabbitHostCommandValue" });
+            var hostBuilder = RabbitMQHost.CreateDefaultBuilder(new string[] { "RabbitHostCommandKey=RabbitHostCommandValue" });
 
             using (var host = hostBuilder.Start())
             {


### PR DESCRIPTION
Changing naming convention to include "RabbitMQ" in class names