### PR TITLE
Update KubernetesClient, minor related enhancements

### DIFF
--- a/src/Common/src/Common.Kubernetes/KubernetesClientHelpers.cs
+++ b/src/Common/src/Common.Kubernetes/KubernetesClientHelpers.cs
@@ -36,10 +36,12 @@ namespace Steeltoe.Common.Kubernetes
             catch (KubeConfigException e)
             {
                 // couldn't locate .kube\config or user-identified files. use an empty config object and fall back on user-defined Action to set the configuration
-                logger?.LogWarning(e, "Failed to build KubernetesClientConfiguration using files at configured or default location, creating an empty config...");
+                logger?.LogWarning(e, "Failed to build KubernetesClientConfiguration, creating an empty config...");
             }
 
-            kubernetesClientConfiguration?.Invoke(k8sConfig ?? new KubernetesClientConfiguration());
+            // BuildDefaultConfig() doesn't set a host if KubeConfigException is thrown
+            k8sConfig ??= new KubernetesClientConfiguration() { Host = "http://localhost:8080" };
+            kubernetesClientConfiguration?.Invoke(k8sConfig);
 
             return new k8s.Kubernetes(k8sConfig);
         }

--- a/src/Common/src/Common.Kubernetes/StandardPodUtilities.cs
+++ b/src/Common/src/Common.Kubernetes/StandardPodUtilities.cs
@@ -25,9 +25,14 @@ namespace Steeltoe.Extensions.Configuration.Kubernetes
                 throw new ArgumentNullException(nameof(kubernetesApplicationOptions));
             }
 
+            if (kubernetes is null)
+            {
+                throw new ArgumentNullException(nameof(kubernetes), "A Kubernetes client is required");
+            }
+
             _applicationOptions = kubernetesApplicationOptions;
             _logger = logger;
-            _kubernetes = kubernetes ?? KubernetesClientHelpers.GetKubernetesClient(_applicationOptions);
+            _kubernetes = kubernetes;
         }
 
         public async Task<V1Pod> GetCurrentPodAsync()

--- a/src/Common/src/Common.Kubernetes/Steeltoe.Common.Kubernetes.csproj
+++ b/src/Common/src/Common.Kubernetes/Steeltoe.Common.Kubernetes.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <Description>Steeltoe common library for Kubernetes</Description>
     <PackageTags>Kubernetes</PackageTags>
   </PropertyGroup>
@@ -8,7 +8,11 @@
   <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedproject.props" />
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="KubernetesClient" Version="2.0.16" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
     <PackageReference Include="KubernetesClient" Version="$(KubernetesClientVersion)" />
   </ItemGroup>
 

--- a/src/Common/test/Common.Kubernetes.Test/IServiceCollectionExtensionsTest.cs
+++ b/src/Common/test/Common.Kubernetes.Test/IServiceCollectionExtensionsTest.cs
@@ -27,7 +27,8 @@ namespace Steeltoe.Common.Kubernetes.Test
             // arrange
             var serviceCollection = new ServiceCollection();
             serviceCollection.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
-            Assert.NotNull(serviceCollection.GetApplicationInstanceInfo());
+            serviceCollection.RegisterDefaultApplicationInstanceInfo();
+            Assert.NotNull(serviceCollection.BuildServiceProvider().GetService<IApplicationInstanceInfo>());
 
             // act
             serviceCollection.AddKubernetesApplicationInstanceInfo();

--- a/src/Common/test/Common.Kubernetes.Test/IServiceCollectionExtensionsTest.cs
+++ b/src/Common/test/Common.Kubernetes.Test/IServiceCollectionExtensionsTest.cs
@@ -41,6 +41,7 @@ namespace Steeltoe.Common.Kubernetes.Test
         }
 
         [Fact]
+        [Obsolete]
         public void GetKubernetesApplicationOptions_ThrowsOnNull()
         {
             var ex = Assert.Throws<ArgumentNullException>(() => IServiceCollectionExtensions.GetKubernetesApplicationOptions(null));
@@ -48,6 +49,7 @@ namespace Steeltoe.Common.Kubernetes.Test
         }
 
         [Fact]
+        [Obsolete]
         public void GetKubernetesApplicationOptions_ReturnsAndAddsOptions()
         {
             // arrange
@@ -61,7 +63,6 @@ namespace Steeltoe.Common.Kubernetes.Test
             // assert
             Assert.NotNull(options);
             Assert.Single(appInfos);
-            Assert.Equal(options, appInfos.FirstOrDefault());
             Assert.IsType<KubernetesApplicationOptions>(options);
             Assert.Equal(Assembly.GetEntryAssembly().GetName().Name, options.ApplicationName);
         }
@@ -82,8 +83,9 @@ namespace Steeltoe.Common.Kubernetes.Test
 
             // act
             serviceCollection.AddKubernetesClient();
-            var client = serviceCollection.BuildServiceProvider().GetService<IKubernetes>();
-            var appInfos = serviceCollection.BuildServiceProvider().GetServices<IApplicationInstanceInfo>();
+            var serviceProvider = serviceCollection.BuildServiceProvider();
+            var client = serviceProvider.GetService<IKubernetes>();
+            var appInfos = serviceProvider.GetServices<IApplicationInstanceInfo>();
 
             // assert
             Assert.NotNull(client);

--- a/src/Configuration/src/KubernetesBase/Steeltoe.Extensions.Configuration.KubernetesBase.csproj
+++ b/src/Configuration/src/KubernetesBase/Steeltoe.Extensions.Configuration.KubernetesBase.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <RootNamespace>Steeltoe.Extensions.Configuration.Kubernetes</RootNamespace>
     <Description>Configuration Provider for reading Cloud Foundry Environment Variables</Description>
     <PackageTags>configuration;Kubernetes</PackageTags>

--- a/src/Discovery/src/Kubernetes/Discovery/KubernetesDiscoveryClient.cs
+++ b/src/Discovery/src/Kubernetes/Discovery/KubernetesDiscoveryClient.cs
@@ -198,6 +198,7 @@ namespace Steeltoe.Discovery.Kubernetes.Discovery
             return serviceMetadata;
         }
 
+#if NETSTANDARD2_0
         private V1EndpointPort FindEndpointPort(V1EndpointSubset subset)
         {
             var ports = subset.Ports;
@@ -216,6 +217,28 @@ namespace Steeltoe.Discovery.Kubernetes.Discovery
 
             return endpointPort;
         }
+#endif
+
+#if NETSTANDARD2_1
+        private Corev1EndpointPort FindEndpointPort(V1EndpointSubset subset)
+        {
+            var ports = subset.Ports;
+            Corev1EndpointPort endpointPort;
+            if (ports.Count == 1)
+            {
+                endpointPort = ports[0];
+            }
+            else
+            {
+                endpointPort = ports
+                    .FirstOrDefault(port =>
+                        string.IsNullOrEmpty(_discoveryOptions.CurrentValue.PrimaryPortName) ||
+                        _discoveryOptions.CurrentValue.PrimaryPortName.ToUpper().Equals(port.Name.ToUpper()));
+            }
+
+            return endpointPort;
+        }
+#endif
 
         private EndpointSubsetNs GetSubsetsFromEndpoints(V1Endpoints endpoints)
         {

--- a/src/Discovery/src/Kubernetes/Discovery/KubernetesServiceInstance.cs
+++ b/src/Discovery/src/Kubernetes/Discovery/KubernetesServiceInstance.cs
@@ -17,7 +17,14 @@ namespace Steeltoe.Discovery.Kubernetes.Discovery
         private const string Coln = ":";
 
         private V1EndpointAddress _endpointAddress;
+
+#if NETSTANDARD2_0
         private V1EndpointPort _endpointPort;
+#endif
+
+#if NETSTANDARD2_1
+        private Corev1EndpointPort _endpointPort;
+#endif
 
         public string InstanceId { get; }
 
@@ -33,6 +40,7 @@ namespace Steeltoe.Discovery.Kubernetes.Discovery
 
         public IDictionary<string, string> Metadata { get; }
 
+#if NETSTANDARD2_0
         public KubernetesServiceInstance(
             string instanceId,
             string serviceId,
@@ -48,6 +56,25 @@ namespace Steeltoe.Discovery.Kubernetes.Discovery
             IsSecure = isSecure;
             Metadata = metadata;
         }
+#endif
+
+#if NETSTANDARD2_1
+        public KubernetesServiceInstance(
+            string instanceId,
+            string serviceId,
+            V1EndpointAddress endpointAddress,
+            Corev1EndpointPort endpointPort,
+            IDictionary<string, string> metadata,
+            bool isSecure)
+        {
+            InstanceId = instanceId;
+            ServiceId = serviceId;
+            _endpointAddress = endpointAddress;
+            _endpointPort = endpointPort;
+            IsSecure = isSecure;
+            Metadata = metadata;
+        }
+#endif
 
         public string GetScheme()
         {

--- a/src/Discovery/src/Kubernetes/KubernetesDiscoveryClientExtension.cs
+++ b/src/Discovery/src/Kubernetes/KubernetesDiscoveryClientExtension.cs
@@ -45,9 +45,8 @@ namespace Steeltoe.Discovery.Kubernetes
         private static void AddKubernetesServices(IServiceCollection services)
         {
             services.AddKubernetesClient();
-            services.PostConfigure<KubernetesDiscoveryOptions>(options =>
+            services.AddOptions<KubernetesDiscoveryOptions>().PostConfigure<KubernetesApplicationOptions>((options, appOptions) =>
             {
-                var appOptions = services.GetKubernetesApplicationOptions() as KubernetesApplicationOptions;
                 options.ServiceName = appOptions.ApplicationNameInContext(SteeltoeComponent.Kubernetes, appOptions.KubernetesRoot + ":discovery:servicename");
                 if (options.Namespace == "default" && appOptions.NameSpace != "default")
                 {

--- a/src/Discovery/src/Kubernetes/KubernetesDiscoveryClientExtension.cs
+++ b/src/Discovery/src/Kubernetes/KubernetesDiscoveryClientExtension.cs
@@ -22,10 +22,7 @@ namespace Steeltoe.Discovery.Kubernetes
     {
         public void ApplyServices(IServiceCollection services)
         {
-            var serviceProvider = services.BuildServiceProvider();
-            var config = serviceProvider.GetRequiredService<IConfiguration>();
-            ConfigureKubernetesServices(services, config);
-            AddKubernetesServices(services);
+            ConfigureKubernetesServices(services);
         }
 
         public bool IsConfigured(IConfiguration configuration, IServiceInfo serviceInfo = null)
@@ -36,23 +33,20 @@ namespace Steeltoe.Discovery.Kubernetes
                 .Any();
         }
 
-        private static void ConfigureKubernetesServices(IServiceCollection services, IConfiguration config)
-        {
-            var kubernetesSection = config.GetSection(KubernetesDiscoveryOptions.KUBERNETES_DISCOVERY_CONFIGURATION_PREFIX);
-            services.Configure<KubernetesDiscoveryOptions>(kubernetesSection);
-        }
-
-        private static void AddKubernetesServices(IServiceCollection services)
+        private static void ConfigureKubernetesServices(IServiceCollection services)
         {
             services.AddKubernetesClient();
-            services.AddOptions<KubernetesDiscoveryOptions>().PostConfigure<KubernetesApplicationOptions>((options, appOptions) =>
-            {
-                options.ServiceName = appOptions.ApplicationNameInContext(SteeltoeComponent.Kubernetes, appOptions.KubernetesRoot + ":discovery:servicename");
-                if (options.Namespace == "default" && appOptions.NameSpace != "default")
+            services
+                .AddOptions<KubernetesDiscoveryOptions>()
+                .Configure<IConfiguration>((options, config) => config.GetSection(KubernetesDiscoveryOptions.KUBERNETES_DISCOVERY_CONFIGURATION_PREFIX).Bind(options))
+                .PostConfigure<KubernetesApplicationOptions>((options, appOptions) =>
                 {
-                    options.Namespace = appOptions.NameSpace;
-                }
-            });
+                    options.ServiceName = appOptions.ApplicationNameInContext(SteeltoeComponent.Kubernetes, appOptions.KubernetesRoot + ":discovery:servicename");
+                    if (options.Namespace == "default" && appOptions.NameSpace != "default")
+                    {
+                        options.Namespace = appOptions.NameSpace;
+                    }
+                });
             services.AddSingleton((p) =>
             {
                 var kubernetesOptions = p.GetRequiredService<IOptionsMonitor<KubernetesDiscoveryOptions>>();

--- a/src/Discovery/src/Kubernetes/Steeltoe.Discovery.Kubernetes.csproj
+++ b/src/Discovery/src/Kubernetes/Steeltoe.Discovery.Kubernetes.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <Description>Client for service discovery with Kubernetes native service discovery</Description>
     <PackageTags>aspnetcore;Kubernetes;Spring;Spring Cloud</PackageTags>
     <RootNamespace>Steeltoe.Discovery.Kubernetes</RootNamespace>
@@ -11,7 +11,6 @@
   <Import Project="..\..\..\..\sharedproject.props" />
 
   <ItemGroup>
-    <PackageReference Include="KubernetesClient" Version="$(KubernetesClientVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(ExtensionsVersion)" />
   </ItemGroup>
 

--- a/src/Discovery/test/Kubernetes.Test/Discovery/KubernetesServiceInstanceTest.cs
+++ b/src/Discovery/test/Kubernetes.Test/Discovery/KubernetesServiceInstanceTest.cs
@@ -26,7 +26,7 @@ namespace Steeltoe.Discovery.Kubernetes.Test.Discovery
         private KubernetesServiceInstance AssertServiceInstance(bool secure)
         {
             var address = new V1EndpointAddress { Ip = "1.2.3.4" };
-            var port = new V1EndpointPort { Port = 8080 };
+            var port = new Corev1EndpointPort { Port = 8080 };
             var instance = new KubernetesServiceInstance("123", "myString", address, port, new Dictionary<string, string>(), secure);
             Assert.Equal(expected: "123", actual: instance.InstanceId);
             Assert.Equal(expected: "myString", actual: instance.ServiceId);

--- a/src/Management/src/KubernetesCore/ServiceCollectionExtensions.cs
+++ b/src/Management/src/KubernetesCore/ServiceCollectionExtensions.cs
@@ -31,7 +31,7 @@ namespace Steeltoe.Management.Kubernetes
             {
                 if (podUtilities == null)
                 {
-                    services.AddKubernetesApplicationInstanceInfo();
+                    services.AddKubernetesClient();
                     services.AddSingleton<IPodUtilities, StandardPodUtilities>();
                 }
                 else

--- a/versions.props
+++ b/versions.props
@@ -18,7 +18,7 @@
     <SystemReflectionVersion>4.6.0</SystemReflectionVersion>
     <TelemetryCorrelationVersion>1.0.0</TelemetryCorrelationVersion>
     <WebInfrastructureVersion>1.0.0</WebInfrastructureVersion>
-    <KubernetesClientVersion>2.0.16</KubernetesClientVersion>
+    <KubernetesClientVersion>5.0.13</KubernetesClientVersion>
     <MongoDbClientVersion>2.5.0</MongoDbClientVersion>
 
     <MySqlCoreVersion>8.0.9-dmr</MySqlCoreVersion>


### PR DESCRIPTION
- Update kubernetesclient #723
   - Only applies to (new) netstandard2.1 target
- reduce usage of temporary serviceproviders