### PR TITLE
Allow configuration of JsonSerializerOptions for Actuators

### DIFF
--- a/src/Management/src/EndpointBase/Info/Contributor/GitInfoContributor.cs
+++ b/src/Management/src/EndpointBase/Info/Contributor/GitInfoContributor.cs
@@ -16,7 +16,6 @@ namespace Steeltoe.Management.Endpoint.Info.Contributor
     {
         private const string GITSETTINGS_PREFIX = "git";
         private const string GITPROPERTIES_FILE = "git.properties";
-        private const string DATETIME_OUTPUT_FORMAT = "yyyy-MM-ddTHH:mm:ssZ";
 
         private static readonly List<string> DATETIME_INPUT_KEYS = new List<string> { "time" };
         private readonly string _propFile;
@@ -84,12 +83,12 @@ namespace Steeltoe.Management.Endpoint.Info.Contributor
 
         protected override void AddKeyValue(Dictionary<string, object> dict, string key, string value)
         {
-            var valueToInsert = value;
+            object valueToInsert = value;
 
             if (DATETIME_INPUT_KEYS.Contains(key))
             {
                 // Normalize datetime values to ISO8601 format
-                valueToInsert = DateTime.Parse(value, CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal).ToString(DATETIME_OUTPUT_FORMAT);
+                valueToInsert = DateTime.Parse(value, CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal);
             }
 
             dict[key] = valueToInsert;

--- a/src/Management/src/EndpointBase/Info/EpochSecondsDateTimeConverter.cs
+++ b/src/Management/src/EndpointBase/Info/EpochSecondsDateTimeConverter.cs
@@ -1,0 +1,24 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Steeltoe.Management.Endpoint.Info
+{
+    public class EpochSecondsDateTimeConverter : JsonConverter<DateTime>
+    {
+        private static readonly DateTime _baseTime = new (1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+        public override DateTime Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) => DateTime.Parse(reader.GetString());
+
+        public override void Write(Utf8JsonWriter writer, DateTime value, JsonSerializerOptions options)
+        {
+            var utc = value.ToUniversalTime();
+            var valueToInsert = (utc.Ticks - _baseTime.Ticks) / 10000;
+            writer.WriteNumberValue(valueToInsert);
+        }
+    }
+}

--- a/src/Management/src/EndpointBase/ManagementEndpointOptions.cs
+++ b/src/Management/src/EndpointBase/ManagementEndpointOptions.cs
@@ -5,6 +5,9 @@
 using Microsoft.Extensions.Configuration;
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Steeltoe.Management.Endpoint
 {
@@ -31,6 +34,15 @@ namespace Steeltoe.Management.Endpoint
             if (section != null)
             {
                 section.Bind(this);
+                foreach (var converterTypeName in CustomJsonConverters ?? Array.Empty<string>())
+                {
+                    var converterType = Type.GetType(converterTypeName);
+                    if (converterType != null)
+                    {
+                        var converterInstance = (JsonConverter)Activator.CreateInstance(converterType);
+                        SerializerOptions.Converters.Add(converterInstance);
+                    }
+                }
             }
         }
 
@@ -43,5 +55,12 @@ namespace Steeltoe.Management.Endpoint
         public List<IEndpointOptions> EndpointOptions { get; set; }
 
         public bool UseStatusCodeFromResponse { get; set; } = true;
+
+        public JsonSerializerOptions SerializerOptions { get; set; } = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
+
+        /// <summary>
+        /// Gets or sets a list of <see href="https://docs.microsoft.com/dotnet/api/system.type.assemblyqualifiedname">assembly-qualified</see> custom JsonCoverters
+        /// </summary>
+        public string[] CustomJsonConverters { get; set; }
     }
 }

--- a/src/Management/src/EndpointBase/Middleware/EndpointMiddleware.cs
+++ b/src/Management/src/EndpointBase/Middleware/EndpointMiddleware.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.Logging;
 using Steeltoe.Management.Endpoint.Health;
 using Steeltoe.Management.Endpoint.Metrics;
 using System;
+using System.Linq;
 using System.Text.Json;
 
 namespace Steeltoe.Management.Endpoint.Middleware
@@ -20,26 +21,23 @@ namespace Steeltoe.Management.Endpoint.Middleware
         {
             _logger = logger;
             _mgmtOptions = mgmtOptions ?? throw new ArgumentNullException(nameof(mgmtOptions));
+            if (_mgmtOptions is ManagementEndpointOptions mgmt)
+            {
+                mgmt.SerializerOptions = GetSerializerOptions(mgmt.SerializerOptions);
+            }
         }
 
-        public EndpointMiddleware(IEndpoint<TResult> endpoint, IManagementOptions mgmtOptions,  ILogger logger = null)
+        public EndpointMiddleware(IEndpoint<TResult> endpoint, IManagementOptions mgmtOptions, ILogger logger = null)
+            : this(mgmtOptions, logger)
         {
-            _logger = logger;
             _endpoint = endpoint ?? throw new ArgumentNullException(nameof(endpoint));
-            _mgmtOptions = mgmtOptions ?? throw new ArgumentNullException(nameof(mgmtOptions));
         }
 
         public IEndpoint<TResult> Endpoint
         {
-            get
-            {
-                return _endpoint;
-            }
+            get => _endpoint;
 
-            set
-            {
-                _endpoint = value;
-            }
+            set => _endpoint = value;
         }
 
         public virtual string HandleRequest()
@@ -52,13 +50,15 @@ namespace Steeltoe.Management.Endpoint.Middleware
         {
             try
             {
-                var options = new JsonSerializerOptions()
+                JsonSerializerOptions options;
+                if (_mgmtOptions is ManagementEndpointOptions mgmt)
                 {
-                    IgnoreNullValues = true,
-                    PropertyNamingPolicy = JsonNamingPolicy.CamelCase
-                };
-                options.Converters.Add(new HealthConverter());
-                options.Converters.Add(new MetricsResponseConverter());
+                    options = mgmt.SerializerOptions;
+                }
+                else
+                {
+                    options = GetSerializerOptions(null);
+                }
 
                 return JsonSerializer.Serialize(result, options);
             }
@@ -69,24 +69,30 @@ namespace Steeltoe.Management.Endpoint.Middleware
 
             return string.Empty;
         }
+
+        internal JsonSerializerOptions GetSerializerOptions(JsonSerializerOptions serializerOptions)
+        {
+            serializerOptions ??= new JsonSerializerOptions() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
+            serializerOptions.IgnoreNullValues = true;
+            if (serializerOptions.Converters?.Any(c => c is HealthConverter) != true)
+            {
+                serializerOptions.Converters.Add(new HealthConverter());
+                serializerOptions.Converters.Add(new MetricsResponseConverter());
+            }
+
+            return serializerOptions;
+        }
     }
 
-#pragma warning disable SA1402 // File may only contain a single class
     public class EndpointMiddleware<TResult, TRequest> : EndpointMiddleware<TResult>
     {
         protected new IEndpoint<TResult, TRequest> _endpoint;
 
         internal new IEndpoint<TResult, TRequest> Endpoint
         {
-            get
-            {
-                return _endpoint;
-            }
+            get => _endpoint;
 
-            set
-            {
-                _endpoint = value;
-            }
+            set => _endpoint = value;
         }
 
         public EndpointMiddleware(IEndpoint<TResult, TRequest> endpoint, IManagementOptions mgmtOptions, ILogger logger = null)
@@ -106,5 +112,4 @@ namespace Steeltoe.Management.Endpoint.Middleware
             return Serialize(result);
         }
     }
-#pragma warning restore SA1402 // File may only contain a single class
 }

--- a/src/Management/test/EndpointBase.Test/Info/Contributor/GitInfoContributorTest.cs
+++ b/src/Management/test/EndpointBase.Test/Info/Contributor/GitInfoContributorTest.cs
@@ -2,11 +2,11 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-using Steeltoe.Management.Endpoint.Info.Contributor;
 using Steeltoe.Management.Endpoint.Test;
 using Steeltoe.Management.Info;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using Xunit;
 
@@ -87,7 +87,7 @@ namespace Steeltoe.Management.Endpoint.Info.Contributor.Test
 
             // Verify that datetime values are normalized correctly
             var gitBuildTime = gitBuildDict["time"];
-            Assert.Equal("2017-07-12T18:40:39Z", gitBuildTime);
+            Assert.Equal(DateTime.Parse("2017-07-12T18:40:39Z", CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal), gitBuildTime);
 
             var gitCommitDict = gitDict["commit"] as Dictionary<string, object>;
             Assert.NotNull(gitCommitDict);
@@ -95,7 +95,7 @@ namespace Steeltoe.Management.Endpoint.Info.Contributor.Test
 
             // Verify that datetime values are normalized correctly
             var gitCommitTime = gitCommitDict["time"];
-            Assert.Equal("2017-06-08T12:47:02Z", gitCommitTime);
+            Assert.Equal(DateTime.Parse("2017-06-08T12:47:02Z", CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal), gitCommitTime);
         }
     }
 }


### PR DESCRIPTION
Allow configuring the `JsonSerializerOptions` used for Actuators #725
Add a `JsonConverter` that can bring back Epoch time for gitinfo from #724 