### PR TITLE
Let UseCloudHosting override LaunchSettings.json

### DIFF
--- a/src/Common/test/Common.Hosting.Test/HostBuilderExtensionsTest.cs
+++ b/src/Common/test/Common.Hosting.Test/HostBuilderExtensionsTest.cs
@@ -64,6 +64,7 @@ namespace Steeltoe.Common.Hosting.Test
         public void UseCloudHosting_ReadsTyePorts()
         {
             // Arrange
+            Environment.SetEnvironmentVariable("ASPNETCORE_URLS", null);
             Environment.SetEnvironmentVariable("PORT", "80;443");
             var hostBuilder = new WebHostBuilder()
                                 .UseStartup<TestServerStartup>()
@@ -193,7 +194,7 @@ namespace Steeltoe.Common.Hosting.Test
                 });
 
             // Act and Assert
-            hostBuilder.UseCloudHosting(5000, 5001);
+            hostBuilder.UseCloudHosting(5001, 5002);
             using var host = hostBuilder.Build();
             host.Start();
         }

--- a/src/Common/test/Common.Hosting.Test/TestServerStartupLocals.cs
+++ b/src/Common/test/Common.Hosting.Test/TestServerStartupLocals.cs
@@ -8,8 +8,8 @@ namespace Steeltoe.Common.Hosting.Test
     {
         public TestServerStartupLocals()
         {
-            ExpectedAddresses.Add("http://*:5000");
-            ExpectedAddresses.Add("https://*:5001");
+            ExpectedAddresses.Add("http://*:5001");
+            ExpectedAddresses.Add("https://*:5002");
         }
     }
 }


### PR DESCRIPTION
ApplicationUrl in LaunchSettings.json overrides `webHostBuilder.UseUrls`, so this change also sets ASPNETCORE_URLS when it is likely to be needed #747 

Also updates a test to not use the same default ports (5000, 5001) as ASP.NET