### PR TITLE
drop .NET Core 2.1 from tests

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -68,6 +68,15 @@ jobs:
     inputs:
       filePath: src/Connectors/EnableGemFire.ps1
       arguments: $(PivNetAPIToken)
+  - task: UseDotNet@2
+    displayName: Install .NET Core 3.1
+    inputs:
+      version: 3.1.x
+  - task: UseDotNet@2
+    displayName: Install .NET 6
+    inputs:
+      version: 6.0.x
+      includePreviewVersions: true
   - task: DotNetCoreCLI@2
     displayName: dotnet restore
     inputs:

--- a/src/CircuitBreaker/test/Hystrix.MetricsEventsCore.Test/Startup.cs
+++ b/src/CircuitBreaker/test/Hystrix.MetricsEventsCore.Test/Startup.cs
@@ -35,15 +35,11 @@ namespace Steeltoe.CircuitBreaker.Hystrix.MetricsEvents.Test
         public void Configure(IApplicationBuilder app)
         {
             app.UseHystrixRequestContext();
-#if NETCOREAPP3_1 || NET5_0
             app.UseRouting();
             app.UseEndpoints(endpoints =>
             {
                 endpoints.MapControllerRoute("default", "{controller=Home}/{action=Index}/{id?}");
             });
-#else
-            app.UseMvc();
-#endif
         }
     }
 }

--- a/src/CircuitBreaker/test/Hystrix.MetricsEventsCore.Test/Steeltoe.CircuitBreaker.Hystrix.MetricsEventsCore.Test.csproj
+++ b/src/CircuitBreaker/test/Hystrix.MetricsEventsCore.Test/Steeltoe.CircuitBreaker.Hystrix.MetricsEventsCore.Test.csproj
@@ -1,9 +1,9 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />
@@ -16,10 +16,10 @@
     </None>
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+  <ItemGroup Condition="'$(TargetFramework)' != 'net461'">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net461' OR '$(TargetFramework)' == 'netcoreapp2.1'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="$(AspNetCoreVersion)" />
   </ItemGroup>
 

--- a/src/CircuitBreaker/test/Hystrix.MetricsEventsCore.Test/Steeltoe.CircuitBreaker.Hystrix.MetricsEventsCore.Test.csproj
+++ b/src/CircuitBreaker/test/Hystrix.MetricsEventsCore.Test/Steeltoe.CircuitBreaker.Hystrix.MetricsEventsCore.Test.csproj
@@ -1,14 +1,10 @@
-<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
-  </PropertyGroup>
-  <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp3.1;net5.0</TargetFrameworks>
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedtest.props" />
-  <Import Project="..\..\..\..\targetframework.props" />
 
   <ItemGroup>
     <None Update="xunit.runner.json">
@@ -16,11 +12,8 @@
     </None>
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' != 'net461'">
+  <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="$(AspNetCoreVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CircuitBreaker/test/Hystrix.MetricsStreamCore.Test/Steeltoe.CircuitBreaker.Hystrix.MetricsStreamCore.Test.csproj
+++ b/src/CircuitBreaker/test/Hystrix.MetricsStreamCore.Test/Steeltoe.CircuitBreaker.Hystrix.MetricsStreamCore.Test.csproj
@@ -1,14 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
-  </PropertyGroup>
-  <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp3.1;net5.0</TargetFrameworks>
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedtest.props" />
-  <Import Project="..\..\..\..\targetframework.props" />
 
   <ItemGroup>
     <None Update="xunit.runner.json">
@@ -16,9 +12,6 @@
     </None>
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
-    <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="$(AspNetCoreVersion)" />
-  </ItemGroup>
   <ItemGroup>
     <PackageReference Include="RabbitMQ.Client" Version="$(RabbitClientVersion)" />
     <PackageReference Include="System.Reactive" Version="$(ReactiveVersion)" />

--- a/src/CircuitBreaker/test/Hystrix.MetricsStreamCore.Test/Steeltoe.CircuitBreaker.Hystrix.MetricsStreamCore.Test.csproj
+++ b/src/CircuitBreaker/test/Hystrix.MetricsStreamCore.Test/Steeltoe.CircuitBreaker.Hystrix.MetricsStreamCore.Test.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />
@@ -16,7 +16,7 @@
     </None>
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net461' OR '$(TargetFramework)' == 'netcoreapp2.1'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
     <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="$(AspNetCoreVersion)" />
   </ItemGroup>
   <ItemGroup>

--- a/src/CircuitBreaker/test/HystrixBase.Test/Steeltoe.CircuitBreaker.HystrixBase.Test.csproj
+++ b/src/CircuitBreaker/test/HystrixBase.Test/Steeltoe.CircuitBreaker.HystrixBase.Test.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp2.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net461;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />

--- a/src/CircuitBreaker/test/HystrixBase.Test/Steeltoe.CircuitBreaker.HystrixBase.Test.csproj
+++ b/src/CircuitBreaker/test/HystrixBase.Test/Steeltoe.CircuitBreaker.HystrixBase.Test.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;net5.0</TargetFrameworks>
+    <TargetFrameworks>net461;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />

--- a/src/CircuitBreaker/test/HystrixCore.Test/Steeltoe.CircuitBreaker.HystrixCore.Test.csproj
+++ b/src/CircuitBreaker/test/HystrixCore.Test/Steeltoe.CircuitBreaker.HystrixCore.Test.csproj
@@ -1,19 +1,19 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedtest.props" />
   <Import Project="..\..\..\..\targetframework.props" />
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net461' OR '$(TargetFramework)' == 'netcoreapp2.1'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
     <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="$(AspNetCoreVersion)" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+  <ItemGroup Condition="'$(TargetFramework)' != 'net461'">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 

--- a/src/CircuitBreaker/test/HystrixCore.Test/Steeltoe.CircuitBreaker.HystrixCore.Test.csproj
+++ b/src/CircuitBreaker/test/HystrixCore.Test/Steeltoe.CircuitBreaker.HystrixCore.Test.csproj
@@ -1,24 +1,13 @@
-<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
-  </PropertyGroup>
-  <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp3.1;net5.0</TargetFrameworks>
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedtest.props" />
-  <Import Project="..\..\..\..\targetframework.props" />
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
-    <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="$(AspNetCoreVersion)" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' != 'net461'">
-    <FrameworkReference Include="Microsoft.AspNetCore.App" />
-  </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(ExtensionsVersion)" />
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
   
   <ItemGroup>

--- a/src/Common/test/Common.Autofac.Test/Steeltoe.Common.Autofac.Test.csproj
+++ b/src/Common/test/Common.Autofac.Test/Steeltoe.Common.Autofac.Test.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;net461</TargetFrameworks>
+    <TargetFrameworks>net461</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Common/test/Common.Hosting.Test/Steeltoe.Common.Hosting.Test.csproj
+++ b/src/Common/test/Common.Hosting.Test/Steeltoe.Common.Hosting.Test.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp3.1;net461;netcoreapp2.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net461;net5.0;</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />
@@ -24,7 +24,7 @@
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="$(AspNetCoreVersion)" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net461' OR '$(TargetFramework)' == 'netcoreapp2.1'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
     <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="$(AspNetCoreVersion)" />
   </ItemGroup>

--- a/src/Common/test/Common.Hosting.Test/Steeltoe.Common.Hosting.Test.csproj
+++ b/src/Common/test/Common.Hosting.Test/Steeltoe.Common.Hosting.Test.csproj
@@ -1,14 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
-  </PropertyGroup>
-  <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp3.1;net461;net5.0;</TargetFrameworks>
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp3.1;net6.0;</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedtest.props" />
-  <Import Project="..\..\..\..\targetframework.props" />
 
   <ItemGroup>
     <None Update="xunit.runner.json">
@@ -22,10 +18,5 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="$(AspNetCoreVersion)" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
-    <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="$(AspNetCoreVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="$(AspNetCoreVersion)" />
   </ItemGroup>
 </Project>

--- a/src/Common/test/Common.Http.Test/Steeltoe.Common.Http.Test.csproj
+++ b/src/Common/test/Common.Http.Test/Steeltoe.Common.Http.Test.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp3.1;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Common/test/Common.Http.Test/Steeltoe.Common.Http.Test.csproj
+++ b/src/Common/test/Common.Http.Test/Steeltoe.Common.Http.Test.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Common/test/Common.Net.Test/Steeltoe.Common.Net.Test.csproj
+++ b/src/Common/test/Common.Net.Test/Steeltoe.Common.Net.Test.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp3.1;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Common/test/Common.Net.Test/Steeltoe.Common.Net.Test.csproj
+++ b/src/Common/test/Common.Net.Test/Steeltoe.Common.Net.Test.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Common/test/Common.Security.Test/Steeltoe.Common.Security.Test.csproj
+++ b/src/Common/test/Common.Security.Test/Steeltoe.Common.Security.Test.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp3.1;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Common/test/Common.Security.Test/Steeltoe.Common.Security.Test.csproj
+++ b/src/Common/test/Common.Security.Test/Steeltoe.Common.Security.Test.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Common/test/Common.Test/Steeltoe.Common.Test.csproj
+++ b/src/Common/test/Common.Test/Steeltoe.Common.Test.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Common/test/Common.Test/Steeltoe.Common.Test.csproj
+++ b/src/Common/test/Common.Test/Steeltoe.Common.Test.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp3.1;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />
@@ -22,7 +22,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="$(ExtensionsVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="$(AspNetCoreVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="$(ExtensionsVersion)" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(ExtensionsVersion)" />
   </ItemGroup>
   

--- a/src/Configuration/src/CloudFoundryCore/CloudFoundryHostBuilderExtensions.cs
+++ b/src/Configuration/src/CloudFoundryCore/CloudFoundryHostBuilderExtensions.cs
@@ -49,7 +49,7 @@ namespace Steeltoe.Extensions.Configuration.CloudFoundry
             return webHostBuilder;
         }
 
-#if NETCOREAPP3_1 || NET5_0
+#if NETCOREAPP3_1
         /// <summary>
         /// Enable the application to listen on port(s) provided by the environment at runtime
         /// </summary>

--- a/src/Configuration/test/CloudFoundryAutofac.Test/Steeltoe.Extensions.Configuration.CloudFoundryAutofac.Test.csproj
+++ b/src/Configuration/test/CloudFoundryAutofac.Test/Steeltoe.Extensions.Configuration.CloudFoundryAutofac.Test.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;net461</TargetFrameworks>
+    <TargetFrameworks>net461</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Configuration/test/CloudFoundryBase.Test/Steeltoe.Extensions.Configuration.CloudFoundryBase.Test.csproj
+++ b/src/Configuration/test/CloudFoundryBase.Test/Steeltoe.Extensions.Configuration.CloudFoundryBase.Test.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp3.1;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Configuration/test/CloudFoundryBase.Test/Steeltoe.Extensions.Configuration.CloudFoundryBase.Test.csproj
+++ b/src/Configuration/test/CloudFoundryBase.Test/Steeltoe.Extensions.Configuration.CloudFoundryBase.Test.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Configuration/test/CloudFoundryCore.Test/Steeltoe.Extensions.Configuration.CloudFoundryCore.Test.csproj
+++ b/src/Configuration/test/CloudFoundryCore.Test/Steeltoe.Extensions.Configuration.CloudFoundryCore.Test.csproj
@@ -1,14 +1,10 @@
-<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
-  </PropertyGroup>
-  <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp3.1;net5.0</TargetFrameworks>
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedtest.props" />
-  <Import Project="..\..\..\..\targetframework.props" />
 
   <ItemGroup>
     <None Update="xunit.runner.json">
@@ -20,9 +16,5 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="$(AspNetCoreVersion)" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="$(AspNetCoreVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="$(AspNetCoreVersion)" />
   </ItemGroup>
 </Project>

--- a/src/Configuration/test/CloudFoundryCore.Test/Steeltoe.Extensions.Configuration.CloudFoundryCore.Test.csproj
+++ b/src/Configuration/test/CloudFoundryCore.Test/Steeltoe.Extensions.Configuration.CloudFoundryCore.Test.csproj
@@ -1,9 +1,9 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />
@@ -21,7 +21,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="$(AspNetCoreVersion)" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net461' OR '$(TargetFramework)' == 'netcoreapp2.1'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="$(AspNetCoreVersion)" />
   </ItemGroup>

--- a/src/Configuration/test/CloudFoundryCore.Test/TestServerStartup.cs
+++ b/src/Configuration/test/CloudFoundryCore.Test/TestServerStartup.cs
@@ -16,11 +16,7 @@ namespace Steeltoe.Extensions.Configuration.CloudFoundry.Test
 
         public void Configure(IApplicationBuilder app)
         {
-#if NETCOREAPP3_1 || NET5_0
             app.UseRouting();
-#else
-            app.UseMvc();
-#endif
         }
     }
 }

--- a/src/Configuration/test/ConfigServer.ITest/ConfigServerConfigurationExtensionsIntegrationTest.cs
+++ b/src/Configuration/test/ConfigServer.ITest/ConfigServerConfigurationExtensionsIntegrationTest.cs
@@ -105,7 +105,7 @@ namespace Steeltoe.Extensions.Configuration.ConfigServer.ITest
 
             // Act and Assert (TestServer expects Spring Cloud Config server to be running)
             using var server = new TestServer(builder);
-            var client = server.CreateClient();
+            using var client = server.CreateClient();
             var result = await client.GetStringAsync("http://localhost/Home/VerifyAsInjectedOptions");
 
             Assert.Equal(
@@ -194,7 +194,7 @@ namespace Steeltoe.Extensions.Configuration.ConfigServer.ITest
             {
                 // Act and Assert (TestServer expects Spring Cloud Config server to be running @ localhost:8888)
                 using var server = new TestServer(builder);
-                var client = server.CreateClient();
+                using var client = server.CreateClient();
                 var result = await client.GetStringAsync("http://localhost/Home/VerifyAsInjectedOptions");
 
                 Assert.Equal(
@@ -289,7 +289,7 @@ namespace Steeltoe.Extensions.Configuration.ConfigServer.ITest
             {
                 // Act and Assert (TestServer expects Spring Cloud Config server to be running)
                 using var server = new TestServer(builder);
-                var client = server.CreateClient();
+                using var client = server.CreateClient();
                 var result = await client.GetStringAsync("http://localhost/Home/VerifyAsInjectedOptions");
 
                 Assert.Equal(
@@ -437,7 +437,7 @@ namespace Steeltoe.Extensions.Configuration.ConfigServer.ITest
 
             // Act and Assert (TestServer expects Spring Cloud Config server to be running)
             using var server = new TestServer(builder);
-            var client = server.CreateClient();
+            using var client = server.CreateClient();
             var result = await client.GetStringAsync("http://localhost/Home/Health");
 
             // after switching to newer config server image, the health response has changed to

--- a/src/Configuration/test/ConfigServer.ITest/Steeltoe.Extensions.Configuration.ConfigServer.ITest.csproj
+++ b/src/Configuration/test/ConfigServer.ITest/Steeltoe.Extensions.Configuration.ConfigServer.ITest.csproj
@@ -1,9 +1,9 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />
@@ -20,11 +20,11 @@
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="$(ExtensionsVersion)" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net461' OR '$(TargetFramework)' == 'netcoreapp2.1'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="$(AspNetCoreVersion)" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+  <ItemGroup Condition="'$(TargetFramework)' != 'net461'">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 

--- a/src/Configuration/test/ConfigServer.ITest/Steeltoe.Extensions.Configuration.ConfigServer.ITest.csproj
+++ b/src/Configuration/test/ConfigServer.ITest/Steeltoe.Extensions.Configuration.ConfigServer.ITest.csproj
@@ -1,14 +1,10 @@
-<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
-  </PropertyGroup>
-  <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp3.1;net5.0</TargetFrameworks>
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedtest.props" />
-  <Import Project="..\..\..\..\targetframework.props" />
 
   <ItemGroup>
     <None Update="xunit.runner.json">
@@ -20,11 +16,8 @@
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="$(ExtensionsVersion)" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="$(AspNetCoreVersion)" />
-  </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' != 'net461'">
+  <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 

--- a/src/Configuration/test/ConfigServer.ITest/TestServerStartup.cs
+++ b/src/Configuration/test/ConfigServer.ITest/TestServerStartup.cs
@@ -28,23 +28,11 @@ namespace Steeltoe.Extensions.Configuration.ConfigServer.ITest
         public void Configure(IApplicationBuilder app)
         {
             var config = app.ApplicationServices.GetServices<IConfiguration>();
-#if NETCOREAPP3_1 || NET5_0
             app.UseRouting();
             app.UseEndpoints(endpoints =>
             {
                 endpoints.MapControllerRoute("default", "{controller=Home}/{action=Index}/{id?}");
             });
-#else
-            app.UseMvc(routes =>
-                {
-                    routes.MapRoute(
-                        name: "VerifyAsInjectedOptions",
-                        template: "{controller=Home}/{action=VerifyAsInjectedOptions}");
-                    routes.MapRoute(
-                        name: "Health",
-                        template: "{controller=Home}/{action=Health}");
-                });
-#endif
         }
     }
 }

--- a/src/Configuration/test/ConfigServerAutofac.Test/Steeltoe.Extensions.Configuration.ConfigServerAutofac.Test.csproj
+++ b/src/Configuration/test/ConfigServerAutofac.Test/Steeltoe.Extensions.Configuration.ConfigServerAutofac.Test.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;net461</TargetFrameworks>
+    <TargetFrameworks>net461</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Configuration/test/ConfigServerBase.Test/ConfigServerConfigurationProviderTest.cs
+++ b/src/Configuration/test/ConfigServerBase.Test/ConfigServerConfigurationProviderTest.cs
@@ -22,6 +22,8 @@ namespace Steeltoe.Extensions.Configuration.ConfigServer.Test
 {
     public class ConfigServerConfigurationProviderTest
     {
+        private readonly ConfigServerClientSettings _commonSettings = new () { Name = "myName" };
+
         [Fact]
         public void SettingsConstructor__ThrowsIfSettingsNull()
         {
@@ -399,14 +401,10 @@ namespace Steeltoe.Extensions.Configuration.ConfigServer.Test
             TestConfigServerStartup.Reset();
             TestConfigServerStartup.ReturnStatus = new int[] { 500 };
             var builder = new WebHostBuilder().UseStartup<TestConfigServerStartup>().UseEnvironment("testing");
-            using var server = new TestServer(builder);
-            var settings = new ConfigServerClientSettings
-            {
-                Uri = "http://localhost:8888",
-                Name = "myName"
-            };
-            server.BaseAddress = new Uri(settings.Uri);
-            var provider = new ConfigServerConfigurationProvider(settings, server.CreateClient());
+            using var server = new TestServer(builder) { BaseAddress = new Uri(ConfigServerClientSettings.DEFAULT_URI) };
+            var settings = _commonSettings;
+            using var client = server.CreateClient();
+            var provider = new ConfigServerConfigurationProvider(settings, client);
 
             // Act and Assert
             var ex = await Assert.ThrowsAsync<HttpRequestException>(() => provider.RemoteLoadAsync(settings.GetUris(), null));
@@ -423,15 +421,10 @@ namespace Steeltoe.Extensions.Configuration.ConfigServer.Test
             TestConfigServerStartup.Reset();
             TestConfigServerStartup.ReturnStatus = new int[] { 204 };
             var builder = new WebHostBuilder().UseStartup<TestConfigServerStartup>().UseEnvironment(envir.EnvironmentName);
-            var server = new TestServer(builder);
-
-            var settings = new ConfigServerClientSettings
-            {
-                Uri = "http://localhost:8888",
-                Name = "myName"
-            };
-            server.BaseAddress = new Uri(settings.Uri);
-            var provider = new ConfigServerConfigurationProvider(settings, server.CreateClient());
+            using var server = new TestServer(builder) { BaseAddress = new Uri(ConfigServerClientSettings.DEFAULT_URI) };
+            var settings = _commonSettings;
+            using var client = server.CreateClient();
+            var provider = new ConfigServerConfigurationProvider(settings, client);
 
             // Act and Assert
             var result = await provider.RemoteLoadAsync(settings.GetRawUris(), null);
@@ -467,16 +460,11 @@ namespace Steeltoe.Extensions.Configuration.ConfigServer.Test
             TestConfigServerStartup.ReturnStatus = new int[] { 404, 200 };
             TestConfigServerStartup.Label = "testlabel";
             var builder = new WebHostBuilder().UseStartup<TestConfigServerStartup>().UseEnvironment(envir.EnvironmentName);
-            var server = new TestServer(builder);
-
-            var settings = new ConfigServerClientSettings
-            {
-                Uri = "http://localhost:8888",
-                Name = "myName",
-                Label = "label,testlabel"
-            };
-            server.BaseAddress = new Uri(settings.Uri);
-            var provider = new ConfigServerConfigurationProvider(settings, server.CreateClient());
+            using var server = new TestServer(builder) { BaseAddress = new Uri(ConfigServerClientSettings.DEFAULT_URI) };
+            var settings = _commonSettings;
+            settings.Label = "label,testlabel";
+            using var client = server.CreateClient();
+            var provider = new ConfigServerConfigurationProvider(settings, client);
 
             // Act and Assert
             provider.DoLoad();
@@ -510,15 +498,10 @@ namespace Steeltoe.Extensions.Configuration.ConfigServer.Test
             TestConfigServerStartup.Reset();
             TestConfigServerStartup.Response = environment;
             var builder = new WebHostBuilder().UseStartup<TestConfigServerStartup>().UseEnvironment(envir.EnvironmentName);
-            var server = new TestServer(builder);
-
-            var settings = new ConfigServerClientSettings
-            {
-                Uri = "http://localhost:8888",
-                Name = "myName"
-            };
-            server.BaseAddress = new Uri(settings.Uri);
-            var provider = new ConfigServerConfigurationProvider(settings, server.CreateClient());
+            using var server = new TestServer(builder) { BaseAddress = new Uri(ConfigServerClientSettings.DEFAULT_URI) };
+            var settings = _commonSettings;
+            using var client = server.CreateClient();
+            var provider = new ConfigServerConfigurationProvider(settings, client);
 
             // Act and Assert
             var env = await provider.RemoteLoadAsync(settings.GetUris(), null);
@@ -547,15 +530,11 @@ namespace Steeltoe.Extensions.Configuration.ConfigServer.Test
             TestConfigServerStartup.Reset();
             TestConfigServerStartup.ReturnStatus = new int[] { 500, 200 };
             var builder = new WebHostBuilder().UseStartup<TestConfigServerStartup>().UseEnvironment(envir.EnvironmentName);
-            var server = new TestServer(builder);
-
-            var settings = new ConfigServerClientSettings
-            {
-                Uri = "http://localhost:8888, http://localhost:8888",
-                Name = "myName"
-            };
-            server.BaseAddress = new Uri("http://localhost:8888");
-            var provider = new ConfigServerConfigurationProvider(settings, server.CreateClient());
+            using var server = new TestServer(builder) { BaseAddress = new Uri(ConfigServerClientSettings.DEFAULT_URI) };
+            var settings = _commonSettings;
+            settings.Uri = "http://localhost:8888, http://localhost:8888";
+            using var client = server.CreateClient();
+            var provider = new ConfigServerConfigurationProvider(settings, client);
 
             // Act and Assert
             provider.LoadInternal();
@@ -572,15 +551,11 @@ namespace Steeltoe.Extensions.Configuration.ConfigServer.Test
             TestConfigServerStartup.Reset();
             TestConfigServerStartup.ReturnStatus = new int[] { 404, 200 };
             var builder = new WebHostBuilder().UseStartup<TestConfigServerStartup>().UseEnvironment(envir.EnvironmentName);
-            var server = new TestServer(builder);
-
-            var settings = new ConfigServerClientSettings
-            {
-                Uri = "http://localhost:8888, http://localhost:8888",
-                Name = "myName"
-            };
-            server.BaseAddress = new Uri("http://localhost:8888");
-            var provider = new ConfigServerConfigurationProvider(settings, server.CreateClient());
+            using var server = new TestServer(builder) { BaseAddress = new Uri(ConfigServerClientSettings.DEFAULT_URI) };
+            var settings = _commonSettings;
+            settings.Uri = "http://localhost:8888, http://localhost:8888";
+            using var client = server.CreateClient();
+            var provider = new ConfigServerConfigurationProvider(settings, client);
 
             // Act and Assert
             provider.LoadInternal();
@@ -597,15 +572,10 @@ namespace Steeltoe.Extensions.Configuration.ConfigServer.Test
             TestConfigServerStartup.Reset();
             TestConfigServerStartup.ReturnStatus = new int[] { 404 };
             var builder = new WebHostBuilder().UseStartup<TestConfigServerStartup>().UseEnvironment(envir.EnvironmentName);
-            var server = new TestServer(builder);
-
-            var settings = new ConfigServerClientSettings
-            {
-                Uri = "http://localhost:8888",
-                Name = "myName"
-            };
-            server.BaseAddress = new Uri(settings.Uri);
-            var provider = new ConfigServerConfigurationProvider(settings, server.CreateClient());
+            using var server = new TestServer(builder) { BaseAddress = new Uri(ConfigServerClientSettings.DEFAULT_URI) };
+            var settings = _commonSettings;
+            using var client = server.CreateClient();
+            var provider = new ConfigServerConfigurationProvider(settings, client);
 
             // Act and Assert
             provider.LoadInternal();
@@ -622,16 +592,11 @@ namespace Steeltoe.Extensions.Configuration.ConfigServer.Test
             TestConfigServerStartup.Reset();
             TestConfigServerStartup.ReturnStatus = new int[] { 404 };
             var builder = new WebHostBuilder().UseStartup<TestConfigServerStartup>().UseEnvironment(envir.EnvironmentName);
-            var server = new TestServer(builder);
-
-            var settings = new ConfigServerClientSettings
-            {
-                Uri = "http://localhost:8888",
-                Name = "myName",
-                FailFast = true
-            };
-            server.BaseAddress = new Uri(settings.Uri);
-            var provider = new ConfigServerConfigurationProvider(settings, server.CreateClient());
+            using var server = new TestServer(builder) { BaseAddress = new Uri(ConfigServerClientSettings.DEFAULT_URI) };
+            var settings = _commonSettings;
+            settings.FailFast = true;
+            using var client = server.CreateClient();
+            var provider = new ConfigServerConfigurationProvider(settings, client);
 
             // Act and Assert
             var ex = Assert.Throws<ConfigServerException>(() => provider.LoadInternal());
@@ -641,20 +606,16 @@ namespace Steeltoe.Extensions.Configuration.ConfigServer.Test
         public void Load_MultipleConfigServers_ReturnsNotFoundStatus__DoesNotContinueChecking_FailFastEnabled()
         {
             // Arrange
+            var settings = _commonSettings;
+            settings.FailFast = true;
+            settings.Uri = "http://localhost:8888,http://localhost:8888";
             var envir = HostingHelpers.GetHostingEnvironment();
+            var builder = new WebHostBuilder().UseStartup<TestConfigServerStartup>().UseEnvironment(envir.EnvironmentName);
+            using var server = new TestServer(builder) { BaseAddress = new Uri(ConfigServerClientSettings.DEFAULT_URI) };
+            using var client = server.CreateClient();
+            var provider = new ConfigServerConfigurationProvider(settings, client);
             TestConfigServerStartup.Reset();
             TestConfigServerStartup.ReturnStatus = new int[] { 404, 200 };
-            var builder = new WebHostBuilder().UseStartup<TestConfigServerStartup>().UseEnvironment(envir.EnvironmentName);
-            var server = new TestServer(builder);
-
-            var settings = new ConfigServerClientSettings
-            {
-                Uri = "http://localhost:8888, http://localhost:8888 ",
-                Name = "myName",
-                FailFast = true
-            };
-            server.BaseAddress = new Uri("http://localhost:8888");
-            var provider = new ConfigServerConfigurationProvider(settings, server.CreateClient());
 
             // Act and Assert
             var ex = Assert.Throws<ConfigServerException>(() => provider.LoadInternal());
@@ -669,16 +630,11 @@ namespace Steeltoe.Extensions.Configuration.ConfigServer.Test
             TestConfigServerStartup.Reset();
             TestConfigServerStartup.ReturnStatus = new int[] { 500 };
             var builder = new WebHostBuilder().UseStartup<TestConfigServerStartup>().UseEnvironment(envir.EnvironmentName);
-            var server = new TestServer(builder);
-
-            var settings = new ConfigServerClientSettings
-            {
-                Uri = "http://localhost:8888",
-                Name = "myName",
-                FailFast = true
-            };
-            server.BaseAddress = new Uri(settings.Uri);
-            var provider = new ConfigServerConfigurationProvider(settings, server.CreateClient());
+            using var server = new TestServer(builder) { BaseAddress = new Uri(ConfigServerClientSettings.DEFAULT_URI) };
+            var settings = _commonSettings;
+            settings.FailFast = true;
+            using var client = server.CreateClient();
+            var provider = new ConfigServerConfigurationProvider(settings, client);
 
             // Act and Assert
             var ex = Assert.Throws<ConfigServerException>(() => provider.LoadInternal());
@@ -692,16 +648,12 @@ namespace Steeltoe.Extensions.Configuration.ConfigServer.Test
             TestConfigServerStartup.Reset();
             TestConfigServerStartup.ReturnStatus = new int[] { 500, 500, 500 };
             var builder = new WebHostBuilder().UseStartup<TestConfigServerStartup>().UseEnvironment(envir.EnvironmentName);
-            var server = new TestServer(builder);
-
-            var settings = new ConfigServerClientSettings
-            {
-                Uri = "http://localhost:8888, http://localhost:8888, http://localhost:8888",
-                Name = "myName",
-                FailFast = true
-            };
-            server.BaseAddress = new Uri("http://localhost:8888");
-            var provider = new ConfigServerConfigurationProvider(settings, server.CreateClient());
+            using var server = new TestServer(builder) { BaseAddress = new Uri(ConfigServerClientSettings.DEFAULT_URI) };
+            var settings = _commonSettings;
+            settings.FailFast = true;
+            settings.Uri = "http://localhost:8888, http://localhost:8888, http://localhost:8888";
+            using var client = server.CreateClient();
+            var provider = new ConfigServerConfigurationProvider(settings, client);
 
             // Act and Assert
             var ex = Assert.Throws<ConfigServerException>(() => provider.LoadInternal());
@@ -716,17 +668,16 @@ namespace Steeltoe.Extensions.Configuration.ConfigServer.Test
             TestConfigServerStartup.Reset();
             TestConfigServerStartup.ReturnStatus = new int[] { 500, 500, 500, 500, 500, 500 };
             var builder = new WebHostBuilder().UseStartup<TestConfigServerStartup>().UseEnvironment(envir.EnvironmentName);
-            var server = new TestServer(builder);
+            using var server = new TestServer(builder) { BaseAddress = new Uri(ConfigServerClientSettings.DEFAULT_URI) };
 
             var settings = new ConfigServerClientSettings
             {
-                Uri = "http://localhost:8888",
                 Name = "myName",
                 FailFast = true,
                 RetryEnabled = true
             };
-            server.BaseAddress = new Uri(settings.Uri);
-            var provider = new ConfigServerConfigurationProvider(settings, server.CreateClient());
+            using var client = server.CreateClient();
+            var provider = new ConfigServerConfigurationProvider(settings, client);
 
             // Act and Assert
             var ex = Assert.Throws<ConfigServerException>(() => provider.LoadInternal());
@@ -757,15 +708,10 @@ namespace Steeltoe.Extensions.Configuration.ConfigServer.Test
             TestConfigServerStartup.Reset();
             TestConfigServerStartup.Response = environment;
             var builder = new WebHostBuilder().UseStartup<TestConfigServerStartup>().UseEnvironment(envir.EnvironmentName);
-            var server = new TestServer(builder);
-
-            var settings = new ConfigServerClientSettings
-            {
-                Uri = "http://localhost:8888",
-                Name = "myName"
-            };
-            server.BaseAddress = new Uri(settings.Uri);
-            var provider = new ConfigServerConfigurationProvider(settings, server.CreateClient());
+            using var server = new TestServer(builder) { BaseAddress = new Uri(ConfigServerClientSettings.DEFAULT_URI) };
+            var settings = _commonSettings;
+            using var client = server.CreateClient();
+            var provider = new ConfigServerConfigurationProvider(settings, client);
 
             // Act and Assert
             provider.LoadInternal();
@@ -805,15 +751,10 @@ namespace Steeltoe.Extensions.Configuration.ConfigServer.Test
             TestConfigServerStartup.Reset();
             TestConfigServerStartup.Response = environment;
             var builder = new WebHostBuilder().UseStartup<TestConfigServerStartup>().UseEnvironment(envir.EnvironmentName);
-            var server = new TestServer(builder);
-
-            var settings = new ConfigServerClientSettings
-            {
-                Uri = "http://localhost:8888",
-                Name = "myName"
-            };
-            server.BaseAddress = new Uri(settings.Uri);
-            var provider = new ConfigServerConfigurationProvider(settings, server.CreateClient());
+            using var server = new TestServer(builder) { BaseAddress = new Uri(ConfigServerClientSettings.DEFAULT_URI) };
+            var settings = _commonSettings;
+            using var client = server.CreateClient();
+            var provider = new ConfigServerConfigurationProvider(settings, client);
 
             // Act and Assert
             provider.Load();
@@ -1040,7 +981,6 @@ namespace Steeltoe.Extensions.Configuration.ConfigServer.Test
         {
             var settings = new ConfigServerClientSettings
             {
-                Uri = "http://localhost:8888/",
                 Name = "foo",
                 Environment = "development",
                 Token = "MyVaultToken"
@@ -1062,7 +1002,6 @@ namespace Steeltoe.Extensions.Configuration.ConfigServer.Test
         {
             var settings = new ConfigServerClientSettings
             {
-                Uri = "http://localhost:8888/",
                 Name = "foo",
                 Environment = "development",
                 DiscoveryEnabled = true
@@ -1082,7 +1021,6 @@ namespace Steeltoe.Extensions.Configuration.ConfigServer.Test
 
             settings = new ConfigServerClientSettings
             {
-                Uri = "http://localhost:8888/",
                 Name = "foo",
                 Environment = "development"
             };
@@ -1158,7 +1096,6 @@ namespace Steeltoe.Extensions.Configuration.ConfigServer.Test
 
             var settings = new ConfigServerClientSettings
             {
-                Uri = "http://localhost:8888/",
                 Name = "foo",
                 Environment = "development"
             };
@@ -1217,18 +1154,10 @@ namespace Steeltoe.Extensions.Configuration.ConfigServer.Test
                 .UseStartup<TestConfigServerStartup>()
                 .UseEnvironment(hostingEnvironment.EnvironmentName);
 
-            var settings = new ConfigServerClientSettings
-            {
-                Uri = "http://localhost:8888",
-                Name = "myName"
-            };
-
-            var server = new TestServer(hostBuilder)
-            {
-                BaseAddress = new Uri(settings.Uri)
-            };
-
-            var provider = new ConfigServerConfigurationProvider(settings, server.CreateClient());
+            var settings = _commonSettings;
+            using var server = new TestServer(hostBuilder) { BaseAddress = new Uri(settings.Uri) };
+            using var client = server.CreateClient();
+            var provider = new ConfigServerConfigurationProvider(settings, client);
 
             var configurationBuilder = new ConfigurationBuilder();
 

--- a/src/Configuration/test/ConfigServerBase.Test/Steeltoe.Extensions.Configuration.ConfigServerBase.Test.csproj
+++ b/src/Configuration/test/ConfigServerBase.Test/Steeltoe.Extensions.Configuration.ConfigServerBase.Test.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp3.1;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Configuration/test/ConfigServerBase.Test/Steeltoe.Extensions.Configuration.ConfigServerBase.Test.csproj
+++ b/src/Configuration/test/ConfigServerBase.Test/Steeltoe.Extensions.Configuration.ConfigServerBase.Test.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Configuration/test/ConfigServerCore.Test/ConfigServerConfigurationBuilderExtensionsCoreTest.cs
+++ b/src/Configuration/test/ConfigServerCore.Test/ConfigServerConfigurationBuilderExtensionsCoreTest.cs
@@ -33,11 +33,7 @@ namespace Steeltoe.Extensions.Configuration.ConfigServerCore.Test
         {
             // Arrange
             IConfigurationBuilder configurationBuilder = new ConfigurationBuilder();
-#if NETCOREAPP3_1 || NET5_0
             IHostEnvironment env = null;
-#else
-            IHostingEnvironment env = null;
-#endif
 
             // Act and Assert
             var ex = Assert.Throws<ArgumentNullException>(() => configurationBuilder.AddConfigServer(env));

--- a/src/Configuration/test/ConfigServerCore.Test/Steeltoe.Extensions.Configuration.ConfigServerCore.Test.csproj
+++ b/src/Configuration/test/ConfigServerCore.Test/Steeltoe.Extensions.Configuration.ConfigServerCore.Test.csproj
@@ -1,14 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
-  </PropertyGroup>
-  <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp3.1;net5.0</TargetFrameworks>
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedtest.props" />
-  <Import Project="..\..\..\..\targetframework.props" />
 
   <ItemGroup>
     <None Update="xunit.runner.json">
@@ -19,10 +15,6 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\ConfigServerCore\Steeltoe.Extensions.Configuration.ConfigServerCore.csproj" />
     <ProjectReference Include="..\ConfigServerBase.Test\Steeltoe.Extensions.Configuration.ConfigServerBase.Test.csproj" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
-    <PackageReference Include="Microsoft.AspNetCore" Version="$(AspNetCoreVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Configuration/test/ConfigServerCore.Test/Steeltoe.Extensions.Configuration.ConfigServerCore.Test.csproj
+++ b/src/Configuration/test/ConfigServerCore.Test/Steeltoe.Extensions.Configuration.ConfigServerCore.Test.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />
@@ -21,7 +21,7 @@
     <ProjectReference Include="..\ConfigServerBase.Test\Steeltoe.Extensions.Configuration.ConfigServerBase.Test.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net461' OR '$(TargetFramework)' == 'netcoreapp2.1'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
     <PackageReference Include="Microsoft.AspNetCore" Version="$(AspNetCoreVersion)" />
   </ItemGroup>
 

--- a/src/Configuration/test/PlaceholderBase.Test/Steeltoe.Extensions.Configuration.PlaceholderBase.Test.csproj
+++ b/src/Configuration/test/PlaceholderBase.Test/Steeltoe.Extensions.Configuration.PlaceholderBase.Test.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp3.1;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Configuration/test/PlaceholderBase.Test/Steeltoe.Extensions.Configuration.PlaceholderBase.Test.csproj
+++ b/src/Configuration/test/PlaceholderBase.Test/Steeltoe.Extensions.Configuration.PlaceholderBase.Test.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Configuration/test/PlaceholderCore.Test/Steeltoe.Extensions.Configuration.PlaceholderCore.Test.csproj
+++ b/src/Configuration/test/PlaceholderCore.Test/Steeltoe.Extensions.Configuration.PlaceholderCore.Test.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Configuration/test/PlaceholderCore.Test/Steeltoe.Extensions.Configuration.PlaceholderCore.Test.csproj
+++ b/src/Configuration/test/PlaceholderCore.Test/Steeltoe.Extensions.Configuration.PlaceholderCore.Test.csproj
@@ -1,14 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
-  </PropertyGroup>
-  <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp3.1;net5.0</TargetFrameworks>
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedtest.props" />
-  <Import Project="..\..\..\..\targetframework.props" />
 
   <ItemGroup>
     <None Update="xunit.runner.json">

--- a/src/Configuration/test/RandomValuesBase.Test/Steeltoe.Extensions.Configuration.RandomValueBase.Test.csproj
+++ b/src/Configuration/test/RandomValuesBase.Test/Steeltoe.Extensions.Configuration.RandomValueBase.Test.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp3.1;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Configuration/test/RandomValuesBase.Test/Steeltoe.Extensions.Configuration.RandomValueBase.Test.csproj
+++ b/src/Configuration/test/RandomValuesBase.Test/Steeltoe.Extensions.Configuration.RandomValueBase.Test.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Connectors/test/Connector.EF6Autofac.Net4Test/Steeltoe.CloudFoundry.Connector.EF6Autofac.Test.csproj
+++ b/src/Connectors/test/Connector.EF6Autofac.Net4Test/Steeltoe.CloudFoundry.Connector.EF6Autofac.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net461;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp3.1;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Connectors/test/Connector.EF6Core.Test/Steeltoe.CloudFoundry.Connector.EF6Core.Test.csproj
+++ b/src/Connectors/test/Connector.EF6Core.Test/Steeltoe.CloudFoundry.Connector.EF6Core.Test.csproj
@@ -1,14 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
-  </PropertyGroup>
-  <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp3.1;net5.0</TargetFrameworks>
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedtest.props" />
-  <Import Project="..\..\..\..\targetframework.props" />
 
   <ItemGroup>
     <None Update="xunit.runner.json">
@@ -21,7 +17,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="MySql.Data.EntityFramework" Version="$(MySqlV8)" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net461'">

--- a/src/Connectors/test/Connector.EFCore.Test/MySqlDbContextOptionsExtensionsTest.cs
+++ b/src/Connectors/test/Connector.EFCore.Test/MySqlDbContextOptionsExtensionsTest.cs
@@ -6,7 +6,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-#if NET5_0
+#if NET6_0
 using MySqlConnector;
 #else
 using MySql.Data.MySqlClient;
@@ -97,7 +97,7 @@ namespace Steeltoe.CloudFoundry.Connector.MySql.EFCore.Test
             var config = new ConfigurationBuilder().Build();
 
             // Act and Assert
-#if NET5_0
+#if NET6_0
             services.AddDbContext<GoodDbContext>(options => options.UseMySql(config, serverVersion: MySqlServerVersion.LatestSupportedServerVersion));
 #else
             services.AddDbContext<GoodDbContext>(options => options.UseMySql(config));
@@ -110,7 +110,7 @@ namespace Steeltoe.CloudFoundry.Connector.MySql.EFCore.Test
             Assert.NotNull(con as MySqlConnection);
         }
 
-#if NET5_0
+#if NET6_0
         // Run a MySQL server with Docker to match creds below with this command
         // docker run --name steeltoe-mysql -p 3306:3306 -e MYSQL_DATABASE=steeltoe -e MYSQL_ROOT_PASSWORD=steeltoe mysql
         [Fact(Skip = "Requires a running MySQL server to support AutoDetect")]
@@ -181,7 +181,7 @@ namespace Steeltoe.CloudFoundry.Connector.MySql.EFCore.Test
             var config = builder.Build();
 
             // Act
-#if NET5_0
+#if NET6_0
             services.AddDbContext<GoodDbContext>(options => options.UseMySql(config, "spring-cloud-broker-db2", serverVersion: MySqlServerVersion.LatestSupportedServerVersion));
 #else
             services.AddDbContext<GoodDbContext>(options => options.UseMySql(config, "spring-cloud-broker-db2"));
@@ -218,7 +218,7 @@ namespace Steeltoe.CloudFoundry.Connector.MySql.EFCore.Test
             var config = builder.Build();
 
             // Act and Assert
-#if NET5_0
+#if NET6_0
             services.AddDbContext<GoodDbContext>(options => options.UseMySql(config, serverVersion: MySqlServerVersion.LatestSupportedServerVersion));
 #else
             services.AddDbContext<GoodDbContext>(options => options.UseMySql(config));

--- a/src/Connectors/test/Connector.EFCore.Test/Steeltoe.CloudFoundry.Connector.EFCore.Test.csproj
+++ b/src/Connectors/test/Connector.EFCore.Test/Steeltoe.CloudFoundry.Connector.EFCore.Test.csproj
@@ -1,14 +1,10 @@
-<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
-  </PropertyGroup>
-  <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp3.1;net5.0</TargetFrameworks>
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedtest.props" />
-  <Import Project="..\..\..\..\targetframework.props" />
 
   <ItemGroup>
     <None Update="xunit.runner.json">
@@ -25,13 +21,10 @@
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="$(NpgsqlEFCoreVersion)" />
     <PackageReference Include="Oracle.EntityFrameworkCore" Version="$(OracleEFCoreVersion)" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
-    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="$(PomeloEFCoreVersion)" />
-  </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
     <PackageReference Include="MySql.EntityFrameworkCore" Version="$(MySqlEFCoreVersion)" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
     <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="$(PomeloEFCoreVersion)" />
   </ItemGroup>
 </Project>

--- a/src/Connectors/test/Connector.EFCore.Test/Steeltoe.CloudFoundry.Connector.EFCore.Test.csproj
+++ b/src/Connectors/test/Connector.EFCore.Test/Steeltoe.CloudFoundry.Connector.EFCore.Test.csproj
@@ -1,9 +1,9 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />
@@ -25,7 +25,7 @@
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="$(NpgsqlEFCoreVersion)" />
     <PackageReference Include="Oracle.EntityFrameworkCore" Version="$(OracleEFCoreVersion)" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net461' OR '$(TargetFramework)' == 'netcoreapp2.1'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
     <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="$(PomeloEFCoreVersion)" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">

--- a/src/Connectors/test/ConnectorAutofac.Test/Steeltoe.CloudFoundry.ConnectorAutofac.Test.csproj
+++ b/src/Connectors/test/ConnectorAutofac.Test/Steeltoe.CloudFoundry.ConnectorAutofac.Test.csproj
@@ -19,7 +19,6 @@
     <PackageReference Include="Oracle.ManagedDataAccess.Core" Version="2.19.31" />
     <!--<PackageReference Include="MySql.Data" Version="$(MySqlV6)" />-->
     <PackageReference Include="RabbitMQ.Client" Version="$(RabbitClientVersion)" />
-    <PackageReference Include="StackExchange.Redis" Version="$(StackExchangeVersion)" />
     <PackageReference Include="System.Data.SqlClient" Version="$(SqlClientVersion)" />
   </ItemGroup>
 

--- a/src/Connectors/test/ConnectorAutofac.Test/Steeltoe.CloudFoundry.ConnectorAutofac.Test.csproj
+++ b/src/Connectors/test/ConnectorAutofac.Test/Steeltoe.CloudFoundry.ConnectorAutofac.Test.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>net461</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Connectors/test/ConnectorBase.Test/Steeltoe.CloudFoundry.ConnectorBase.Test.csproj
+++ b/src/Connectors/test/ConnectorBase.Test/Steeltoe.CloudFoundry.ConnectorBase.Test.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Connectors/test/ConnectorBase.Test/Steeltoe.CloudFoundry.ConnectorBase.Test.csproj
+++ b/src/Connectors/test/ConnectorBase.Test/Steeltoe.CloudFoundry.ConnectorBase.Test.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp3.1;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />
@@ -34,6 +34,5 @@
     <!--<PackageReference Include="MySql.Data" Version="$(MySqlV8)" />-->
     <PackageReference Include="Npgsql" Version="$(NpgsqlVersion)" />
     <PackageReference Include="RabbitMQ.Client" Version="$(RabbitClientVersion)" />
-    <PackageReference Include="StackExchange.Redis" Version="$(StackExchangeVersion)" />
   </ItemGroup>
 </Project>

--- a/src/Connectors/test/ConnectorCore.Test/Steeltoe.CloudFoundry.ConnectorCore.Test.csproj
+++ b/src/Connectors/test/ConnectorCore.Test/Steeltoe.CloudFoundry.ConnectorCore.Test.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Connectors/test/ConnectorCore.Test/Steeltoe.CloudFoundry.ConnectorCore.Test.csproj
+++ b/src/Connectors/test/ConnectorCore.Test/Steeltoe.CloudFoundry.ConnectorCore.Test.csproj
@@ -1,14 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
-  </PropertyGroup>
-  <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp3.1;net5.0</TargetFrameworks>
+
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedtest.props" />
-  <Import Project="..\..\..\..\targetframework.props" />
 
   <ItemGroup>
     <None Update="xunit.runner.json">
@@ -37,7 +34,6 @@
     <PackageReference Include="Oracle.ManagedDataAccess.Core" Version="2.19.31" />
 
     <PackageReference Include="RabbitMQ.Client" Version="$(RabbitClientVersion)" />
-    <PackageReference Include="StackExchange.Redis" Version="$(StackExchangeVersion)" />
     <PackageReference Include="System.Data.SqlClient" Version="$(SqlClientVersion)" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(ExtensionsVersion)" />
   </ItemGroup>

--- a/src/Discovery/test/ClientAutofac.Test/DiscoveryContainerBuilderExtensionsTest.cs
+++ b/src/Discovery/test/ClientAutofac.Test/DiscoveryContainerBuilderExtensionsTest.cs
@@ -128,9 +128,9 @@ namespace Steeltoe.Discovery.Client.Test
             // Arrange
             var appsettings = @"
 {
-    'spring': {
-        'application': {
-            'name': 'myName'
+    ""spring"": {
+        ""application"": {
+            ""name"": ""myName""
         },
     }
 }";

--- a/src/Discovery/test/ClientAutofac.Test/DiscoveryContainerBuilderExtensionsTest.cs
+++ b/src/Discovery/test/ClientAutofac.Test/DiscoveryContainerBuilderExtensionsTest.cs
@@ -91,16 +91,16 @@ namespace Steeltoe.Discovery.Client.Test
             // Arrange
             var appsettings = @"
 {
-    'spring': {
-        'application': {
-            'name': 'myName'
+    ""spring"": {
+        ""application"": {
+            ""name"": ""myName""
         },
     },
-    'eureka': {
-        'client': {
-            'shouldFetchRegistry': false,
-            'shouldRegisterWithEureka': false,
-            'serviceUrl': 'http://localhost:8761/eureka/'
+    ""eureka"": {
+        ""client"": {
+            ""shouldFetchRegistry"": false,
+            ""shouldRegisterWithEureka"": false,
+            ""serviceUrl"": ""http://localhost:8761/eureka/""
         }
     }
 }";

--- a/src/Discovery/test/ClientAutofac.Test/Steeltoe.Discovery.ClientAutofac.Test.csproj
+++ b/src/Discovery/test/ClientAutofac.Test/Steeltoe.Discovery.ClientAutofac.Test.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;net461</TargetFrameworks>
+    <TargetFrameworks>net461</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Discovery/test/ClientCore.Test/DiscoveryHostBuilderExtensionsTest.cs
+++ b/src/Discovery/test/ClientCore.Test/DiscoveryHostBuilderExtensionsTest.cs
@@ -68,7 +68,6 @@ namespace Steeltoe.Discovery.Client.Test
             Assert.IsType<DiscoveryClientStartupFilter>(filter);
         }
 
-#if NETCOREAPP3_1 || NET5_0
         [Fact]
         public async Task AddServiceDiscovery_IHostBuilder_IStartupFilterFires()
         {
@@ -85,7 +84,6 @@ namespace Steeltoe.Discovery.Client.Test
             //   but debug through and you'll see it. Also the code coverage report should provide validation
             Assert.True(true);
         }
-#endif
 
         [Fact]
         public void AddServiceDiscovery_IHostBuilder_AddsServiceDiscovery_Consul()

--- a/src/Discovery/test/ClientCore.Test/DiscoveryServiceCollectionExtensionsTest.cs
+++ b/src/Discovery/test/ClientCore.Test/DiscoveryServiceCollectionExtensionsTest.cs
@@ -3,12 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 using Consul;
-using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-#if NETCOREAPP3_1 || NET5_0
 using Microsoft.Extensions.Hosting;
-#endif
 using Steeltoe.CloudFoundry.Connector;
 using Steeltoe.Common;
 using Steeltoe.Common.Discovery;
@@ -124,11 +121,7 @@ namespace Steeltoe.Discovery.Client.Test
 
             var services = new ServiceCollection();
             services.AddOptions();
-#if NETCOREAPP3_1 || NET5_0
             services.AddSingleton<IHostApplicationLifetime>(new TestApplicationLifetime());
-#else
-            services.AddSingleton<IApplicationLifetime>(new TestApplicationLifetime());
-#endif
             services.AddDiscoveryClient(config);
 
             var service = services.BuildServiceProvider().GetService<IDiscoveryClient>();
@@ -153,11 +146,7 @@ namespace Steeltoe.Discovery.Client.Test
             var config = new ConfigurationBuilder().AddInMemoryCollection(appsettings).Build();
             var services = new ServiceCollection();
             services.AddOptions();
-#if NETCOREAPP3_1 || NET5_0
             services.AddSingleton<IHostApplicationLifetime>(new TestApplicationLifetime());
-#else
-            services.AddSingleton<IApplicationLifetime>(new TestApplicationLifetime());
-#endif
             services.AddDiscoveryClient(config);
 
             var service = services.BuildServiceProvider().GetService<IDiscoveryClient>();
@@ -206,11 +195,7 @@ namespace Steeltoe.Discovery.Client.Test
             };
 
             var services = new ServiceCollection();
-#if NETCOREAPP3_1 || NET5_0
             services.AddSingleton<IHostApplicationLifetime>(new TestApplicationLifetime());
-#else
-            services.AddSingleton<IApplicationLifetime>(new TestApplicationLifetime());
-#endif
             services.AddDiscoveryClient(options);
 
             var service = services.BuildServiceProvider().GetService<IDiscoveryClient>();
@@ -232,11 +217,7 @@ namespace Steeltoe.Discovery.Client.Test
             };
 
             var services = new ServiceCollection();
-#if NETCOREAPP3_1 || NET5_0
             services.AddSingleton<IHostApplicationLifetime>(new TestApplicationLifetime());
-#else
-            services.AddSingleton<IApplicationLifetime>(new TestApplicationLifetime());
-#endif
             services.AddDiscoveryClient(options);
 
             var built = services.BuildServiceProvider();
@@ -261,11 +242,7 @@ namespace Steeltoe.Discovery.Client.Test
             };
 
             var services = new ServiceCollection();
-#if NETCOREAPP3_1 || NET5_0
             services.AddSingleton<IHostApplicationLifetime>(new TestApplicationLifetime());
-#else
-            services.AddSingleton<IApplicationLifetime>(new TestApplicationLifetime());
-#endif
             services.AddDiscoveryClient(options);
             services.AddSingleton<IHealthCheckHandler, ScopedEurekaHealthCheckHandler>();
 
@@ -290,11 +267,7 @@ namespace Steeltoe.Discovery.Client.Test
             };
 
             var services = new ServiceCollection();
-#if NETCOREAPP3_1 || NET5_0
             services.AddSingleton<IHostApplicationLifetime>(new TestApplicationLifetime());
-#else
-            services.AddSingleton<IApplicationLifetime>(new TestApplicationLifetime());
-#endif
             Assert.Throws<ArgumentException>(() => services.AddDiscoveryClient(options));
         }
 
@@ -303,11 +276,7 @@ namespace Steeltoe.Discovery.Client.Test
         {
             // Arrange
             var services = new ServiceCollection();
-#if NETCOREAPP3_1 || NET5_0
             services.AddSingleton<IHostApplicationLifetime>(new TestApplicationLifetime());
-#else
-            services.AddSingleton<IApplicationLifetime>(new TestApplicationLifetime());
-#endif
             services.AddDiscoveryClient((options) =>
            {
                options.ClientType = DiscoveryClientType.EUREKA;
@@ -343,11 +312,7 @@ namespace Steeltoe.Discovery.Client.Test
             var hprovider = new TestClientHandlerProvider();
             services.AddSingleton<IEurekaDiscoveryClientHandlerProvider>(hprovider);
 
-#if NETCOREAPP3_1 || NET5_0
             services.AddSingleton<IHostApplicationLifetime>(new TestApplicationLifetime());
-#else
-            services.AddSingleton<IApplicationLifetime>(new TestApplicationLifetime());
-#endif
             services.AddDiscoveryClient(options);
 
             var service = services.BuildServiceProvider().GetService<IDiscoveryClient>();

--- a/src/Discovery/test/ClientCore.Test/Steeltoe.Discovery.ClientCore.Test.csproj
+++ b/src/Discovery/test/ClientCore.Test/Steeltoe.Discovery.ClientCore.Test.csproj
@@ -1,14 +1,10 @@
-<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
-  </PropertyGroup>
-  <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp3.1;net5.0</TargetFrameworks>
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedtest.props" />
-  <Import Project="..\..\..\..\targetframework.props" />
 
   <ItemGroup>
     <None Update="xunit.runner.json">
@@ -18,11 +14,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\ClientCore\Steeltoe.Discovery.ClientCore.csproj" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
-    <PackageReference Include="Microsoft.AspNetCore" Version="$(AspNetCoreVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="$(LoggingVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Discovery/test/ClientCore.Test/Steeltoe.Discovery.ClientCore.Test.csproj
+++ b/src/Discovery/test/ClientCore.Test/Steeltoe.Discovery.ClientCore.Test.csproj
@@ -1,9 +1,9 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />
@@ -20,7 +20,7 @@
     <ProjectReference Include="..\..\src\ClientCore\Steeltoe.Discovery.ClientCore.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net461' OR '$(TargetFramework)' == 'netcoreapp2.1'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
     <PackageReference Include="Microsoft.AspNetCore" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="$(LoggingVersion)" />
   </ItemGroup>

--- a/src/Discovery/test/ClientCore.Test/TestApplicationLifetime.cs
+++ b/src/Discovery/test/ClientCore.Test/TestApplicationLifetime.cs
@@ -2,17 +2,12 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-#if NETCOREAPP3_1 || NET5_0
 using Microsoft.Extensions.Hosting;
-#else
-using Microsoft.AspNetCore.Hosting;
-#endif
 using System;
 using System.Threading;
 
 namespace Steeltoe.Discovery.Client.Test
 {
-#if NETCOREAPP3_1 || NET5_0
     public class TestApplicationLifetime : IHostApplicationLifetime
     {
         public CancellationToken ApplicationStarted => throw new NotImplementedException();
@@ -26,19 +21,4 @@ namespace Steeltoe.Discovery.Client.Test
             throw new NotImplementedException();
         }
     }
-#else
-    public class TestApplicationLifetime : IApplicationLifetime
-    {
-        public CancellationToken ApplicationStarted => throw new NotImplementedException();
-
-        public CancellationToken ApplicationStopping => new CancellationTokenSource().Token;
-
-        public CancellationToken ApplicationStopped => throw new NotImplementedException();
-
-        public void StopApplication()
-        {
-            throw new NotImplementedException();
-        }
-    }
-#endif
 }

--- a/src/Discovery/test/ConsulBase.Test/Steeltoe.Discovery.ConsulBase.Test.csproj
+++ b/src/Discovery/test/ConsulBase.Test/Steeltoe.Discovery.ConsulBase.Test.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp3.1;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Discovery/test/ConsulBase.Test/Steeltoe.Discovery.ConsulBase.Test.csproj
+++ b/src/Discovery/test/ConsulBase.Test/Steeltoe.Discovery.ConsulBase.Test.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Discovery/test/EurekaBase.Test/Steeltoe.Discovery.EurekaBase.Test.csproj
+++ b/src/Discovery/test/EurekaBase.Test/Steeltoe.Discovery.EurekaBase.Test.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp3.1;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Discovery/test/EurekaBase.Test/Steeltoe.Discovery.EurekaBase.Test.csproj
+++ b/src/Discovery/test/EurekaBase.Test/Steeltoe.Discovery.EurekaBase.Test.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Logging/test/DynamicLogger.Test/Steeltoe.Extensions.Logging.DynamicLogger.Test.csproj
+++ b/src/Logging/test/DynamicLogger.Test/Steeltoe.Extensions.Logging.DynamicLogger.Test.csproj
@@ -1,24 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
-  </PropertyGroup>
-  <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp3.1;net5.0</TargetFrameworks>
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedtest.props" />
-  <Import Project="..\..\..\..\targetframework.props" />
 
   <ItemGroup>
     <None Update="xunit.runner.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
-    <PackageReference Include="Microsoft.AspNetCore" Version="$(AspNetCoreVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="$(LoggingVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Logging/test/DynamicLogger.Test/Steeltoe.Extensions.Logging.DynamicLogger.Test.csproj
+++ b/src/Logging/test/DynamicLogger.Test/Steeltoe.Extensions.Logging.DynamicLogger.Test.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />
@@ -16,7 +16,7 @@
     </None>
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net461' OR '$(TargetFramework)' == 'netcoreapp2.1'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
     <PackageReference Include="Microsoft.AspNetCore" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="$(LoggingVersion)" />
   </ItemGroup>

--- a/src/Logging/test/SerilogDynamicLoggerCore.Test/Steeltoe.Extensions.Logging.SerilogDynamicLoggerCore.Test.csproj
+++ b/src/Logging/test/SerilogDynamicLoggerCore.Test/Steeltoe.Extensions.Logging.SerilogDynamicLoggerCore.Test.csproj
@@ -1,14 +1,10 @@
-<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
-  </PropertyGroup>
-  <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp3.1;net5.0</TargetFrameworks>
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedtest.props" />
-  <Import Project="..\..\..\..\targetframework.props" />
 
   <ItemGroup>
     <None Update="serilogSettings.json">
@@ -23,9 +19,6 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="$(ExtensionsVersion)" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
     <PackageReference Include="Serilog.Exceptions" Version="5.0.0" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="$(AspNetCoreVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Logging/test/SerilogDynamicLoggerCore.Test/Steeltoe.Extensions.Logging.SerilogDynamicLoggerCore.Test.csproj
+++ b/src/Logging/test/SerilogDynamicLoggerCore.Test/Steeltoe.Extensions.Logging.SerilogDynamicLoggerCore.Test.csproj
@@ -1,9 +1,9 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />
@@ -24,10 +24,8 @@
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
     <PackageReference Include="Serilog.Exceptions" Version="5.0.0" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.1' AND '$(TargetFramework)' != 'net5.0'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="$(AspNetCoreVersion)" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Management/test/CloudFoundryCore.Test/CloudFoundryServiceCollectionExtensionsTest.cs
+++ b/src/Management/test/CloudFoundryCore.Test/CloudFoundryServiceCollectionExtensionsTest.cs
@@ -3,9 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.AspNetCore.Builder;
-#if !NETCOREAPP3_1 && !NET5_0
-using Microsoft.AspNetCore.Builder.Internal;
-#endif
 using Microsoft.AspNetCore.Cors.Infrastructure;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;

--- a/src/Management/test/CloudFoundryCore.Test/Steeltoe.Management.CloudFoundryCore.Test.csproj
+++ b/src/Management/test/CloudFoundryCore.Test/Steeltoe.Management.CloudFoundryCore.Test.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />
@@ -15,7 +15,7 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net461' OR '$(TargetFramework)' == 'netcoreapp2.1'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
     <PackageReference Include="Microsoft.AspNetCore" Version="$(AspNetCoreVersion)" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Management/test/CloudFoundryCore.Test/Steeltoe.Management.CloudFoundryCore.Test.csproj
+++ b/src/Management/test/CloudFoundryCore.Test/Steeltoe.Management.CloudFoundryCore.Test.csproj
@@ -1,22 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
-  </PropertyGroup>
-  <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp3.1;net5.0</TargetFrameworks>
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedtest.props" />
-  <Import Project="..\..\..\..\targetframework.props" />
 
   <ItemGroup>
     <None Update="xunit.runner.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
-    <PackageReference Include="Microsoft.AspNetCore" Version="$(AspNetCoreVersion)" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="$(AspNetCoreVersion)" />

--- a/src/Management/test/EndpointBase.Test/Env/EnvEndpointTest.cs
+++ b/src/Management/test/EndpointBase.Test/Env/EnvEndpointTest.cs
@@ -21,7 +21,7 @@ namespace Steeltoe.Management.Endpoint.Env.Test
         {
             IEnvOptions options = null;
             IConfiguration configuration = null;
-#if NETCOREAPP3_1 || NET5_0
+#if NETCOREAPP3_1 || NET6_0
             IHostEnvironment env = null;
 #else
             IHostingEnvironment env = null;

--- a/src/Management/test/EndpointBase.Test/Metrics/Observer/HttpClientDesktopObserverTest.cs
+++ b/src/Management/test/EndpointBase.Test/Metrics/Observer/HttpClientDesktopObserverTest.cs
@@ -114,7 +114,9 @@ namespace Steeltoe.Management.Endpoint.Metrics.Observer.Test
 
         private HttpWebRequest GetHttpRequestMessage()
         {
+#pragma warning disable SYSLIB0014 // Type or member is obsolete
             var m = WebRequest.CreateHttp("http://localhost:5555/foo/bar");
+#pragma warning restore SYSLIB0014 // Type or member is obsolete
             m.Method = HttpMethod.Get.Method;
             return m;
         }

--- a/src/Management/test/EndpointBase.Test/Steeltoe.Management.EndpointBase.Test.csproj
+++ b/src/Management/test/EndpointBase.Test/Steeltoe.Management.EndpointBase.Test.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp3.1;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Management/test/EndpointBase.Test/Steeltoe.Management.EndpointBase.Test.csproj
+++ b/src/Management/test/EndpointBase.Test/Steeltoe.Management.EndpointBase.Test.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Management/test/EndpointCore.Test/Env/EndpointMiddlewareTest.cs
+++ b/src/Management/test/EndpointCore.Test/Env/EndpointMiddlewareTest.cs
@@ -33,11 +33,7 @@ namespace Steeltoe.Management.Endpoint.Env.Test
             ["management:endpoints:path"] = "/cloudfoundryapplication"
         };
 
-#if NETCOREAPP3_1 || NET5_0
         private readonly IHostEnvironment host = HostingHelpers.GetHostingEnvironment();
-#else
-        private readonly Microsoft.Extensions.Hosting.IHostingEnvironment host = (Microsoft.Extensions.Hosting.IHostingEnvironment)HostingHelpers.GetHostingEnvironment();
-#endif
 
         [Fact]
         public async void HandleEnvRequestAsync_ReturnsExpected()

--- a/src/Management/test/EndpointCore.Test/Env/EndpointServiceCollectionTest.cs
+++ b/src/Management/test/EndpointCore.Test/Env/EndpointServiceCollectionTest.cs
@@ -34,13 +34,8 @@ namespace Steeltoe.Management.Endpoint.Env.Test
         public void AddEnvActuator_AddsCorrectServices()
         {
             var services = new ServiceCollection();
-#if NETCOREAPP3_1 || NET5_0
             var host = HostingHelpers.GetHostingEnvironment();
             services.AddSingleton<IHostEnvironment>(host);
-#else
-            var host = (IHostingEnvironment)HostingHelpers.GetHostingEnvironment();
-            services.AddSingleton<IHostingEnvironment>(host);
-#endif
 
             var appSettings = new Dictionary<string, string>()
             {

--- a/src/Management/test/EndpointCore.Test/Mappings/Startup.cs
+++ b/src/Management/test/EndpointCore.Test/Mappings/Startup.cs
@@ -28,15 +28,11 @@ namespace Steeltoe.Management.Endpoint.Mappings.Test
         {
             app.UseMappingsActuator();
 
-#if NETCOREAPP3_1 || NET5_0
             app.UseRouting();
             app.UseEndpoints(endpoints =>
             {
                 endpoints.MapControllerRoute("default", "{controller=Home}/{action=Index}/{id?}");
             });
-#else
-            app.UseMvc();
-#endif
         }
     }
 }

--- a/src/Management/test/EndpointCore.Test/SpringBootAdminClient/SpringBootAdminClientExtensionTests.cs
+++ b/src/Management/test/EndpointCore.Test/SpringBootAdminClient/SpringBootAdminClientExtensionTests.cs
@@ -59,22 +59,11 @@ namespace Steeltoe.Management.EndpointCore.Test.SpringBootAdminClient
         private MyAppLifeTime AddApplicationLifetime(ServiceCollection services)
         {
             var appLifeTime = new MyAppLifeTime();
-#if NETCOREAPP3_1 || NET5_0
             services.TryAddSingleton<IHostApplicationLifetime>(appLifeTime);
-#else
-            services.TryAddSingleton<IApplicationLifetime>(appLifeTime);
-#endif
             return appLifeTime;
         }
 
-        private class MyAppLifeTime :
-#if NETCOREAPP3_1 || NET5_0
-            IHostApplicationLifetime
-#else
-#pragma warning disable CS0618 // Needed for 2.x
-            IApplicationLifetime
-#pragma warning restore CS0618
-#endif
+        private class MyAppLifeTime : IHostApplicationLifetime
         {
             public CancellationTokenSource AppStartTokenSource = new CancellationTokenSource();
             public CancellationTokenSource AppStopTokenSource = new CancellationTokenSource();

--- a/src/Management/test/EndpointCore.Test/Steeltoe.Management.EndpointCore.Test.csproj
+++ b/src/Management/test/EndpointCore.Test/Steeltoe.Management.EndpointCore.Test.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />
@@ -46,7 +46,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="$(ExtensionsVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="$(ExtensionsVersion)" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net461' OR '$(TargetFramework)' == 'netcoreapp2.1'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
     <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="$(AspNetCoreVersion)" />
   </ItemGroup>

--- a/src/Management/test/EndpointCore.Test/Steeltoe.Management.EndpointCore.Test.csproj
+++ b/src/Management/test/EndpointCore.Test/Steeltoe.Management.EndpointCore.Test.csproj
@@ -1,14 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
-  </PropertyGroup>
-  <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp3.1;net5.0</TargetFrameworks>
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedtest.props" />
-  <Import Project="..\..\..\..\targetframework.props" />
   
   <ItemGroup>
     <None Update="empty.git.properties">
@@ -45,9 +41,5 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="$(ExtensionsVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="$(ExtensionsVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="$(ExtensionsVersion)" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
-    <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="$(AspNetCoreVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="$(AspNetCoreVersion)" />
   </ItemGroup>
 </Project>

--- a/src/Management/test/EndpointWeb.Net4Test/Handler/ActuatorHypermediaHandlerTest.cs
+++ b/src/Management/test/EndpointWeb.Net4Test/Handler/ActuatorHypermediaHandlerTest.cs
@@ -57,6 +57,5 @@ namespace Steeltoe.Management.EndpointWeb.Handler.Test
             // assert
             Assert.Equal(expectedResult, result);
         }
-
     }
 }

--- a/src/Management/test/ExporterBase.Test/Steeltoe.Management.ExporterBase.Test.csproj
+++ b/src/Management/test/ExporterBase.Test/Steeltoe.Management.ExporterBase.Test.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp3.1;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />
@@ -14,11 +14,4 @@
     <ProjectReference Include="..\..\src\ExporterBase\Steeltoe.Management.ExporterBase.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="$(AspNetCoreVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="$(ExtensionsVersion)" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="$(AspNetCoreVersion)" />
-  </ItemGroup>
 </Project>

--- a/src/Management/test/ExporterBase.Test/Steeltoe.Management.ExporterBase.Test.csproj
+++ b/src/Management/test/ExporterBase.Test/Steeltoe.Management.ExporterBase.Test.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />
@@ -18,7 +18,7 @@
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="$(ExtensionsVersion)" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net461' OR '$(TargetFramework)' == 'netcoreapp2.1'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="$(AspNetCoreVersion)" />
   </ItemGroup>
 </Project>

--- a/src/Management/test/ExporterCore.Test/Steeltoe.Management.ExporterCore.Test.csproj
+++ b/src/Management/test/ExporterCore.Test/Steeltoe.Management.ExporterCore.Test.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />
@@ -18,7 +18,7 @@
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="$(ExtensionsVersion)" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net461' OR '$(TargetFramework)' == 'netcoreapp2.1'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="$(AspNetCoreVersion)" />
   </ItemGroup>
 </Project>

--- a/src/Management/test/ExporterCore.Test/Steeltoe.Management.ExporterCore.Test.csproj
+++ b/src/Management/test/ExporterCore.Test/Steeltoe.Management.ExporterCore.Test.csproj
@@ -1,14 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
-  </PropertyGroup>
-  <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp3.1;net5.0</TargetFrameworks>
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedtest.props" />
-  <Import Project="..\..\..\..\targetframework.props" />
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\ExporterCore\Steeltoe.Management.ExporterCore.csproj" />
@@ -17,8 +13,5 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="$(ExtensionsVersion)" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="$(AspNetCoreVersion)" />
   </ItemGroup>
 </Project>

--- a/src/Management/test/OpenCensus.Test/Steeltoe.Management.OpenCensus.Test.csproj
+++ b/src/Management/test/OpenCensus.Test/Steeltoe.Management.OpenCensus.Test.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Description>Unit test project for OpenCensus</Description>
     <TargetFrameworks>net462;net6.0</TargetFrameworks>
-    <TargetFrameworks Condition="$(OS) != 'Windows_NT'">netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks Condition="$(OS) != 'Windows_NT'">netcoreapp3.1;net6.0</TargetFrameworks>
     <AssemblyName>OpenCensus.Tests</AssemblyName>
     <PackageId>OpenCensus.Tests</PackageId>
     <PackageTags>OpenCensus;Tracing;Management;Monitoring</PackageTags>

--- a/src/Management/test/OpenCensus.Test/Steeltoe.Management.OpenCensus.Test.csproj
+++ b/src/Management/test/OpenCensus.Test/Steeltoe.Management.OpenCensus.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>Unit test project for OpenCensus</Description>
-    <TargetFrameworks>net462;net5.0</TargetFrameworks>
+    <TargetFrameworks>net462;net6.0</TargetFrameworks>
     <TargetFrameworks Condition="$(OS) != 'Windows_NT'">netcoreapp3.1;net5.0</TargetFrameworks>
     <AssemblyName>OpenCensus.Tests</AssemblyName>
     <PackageId>OpenCensus.Tests</PackageId>

--- a/src/Management/test/OpenCensus.Test/Steeltoe.Management.OpenCensus.Test.csproj
+++ b/src/Management/test/OpenCensus.Test/Steeltoe.Management.OpenCensus.Test.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>Unit test project for OpenCensus</Description>
-    <TargetFrameworks>net46;netcoreapp2.1;net5.0</TargetFrameworks>
-    <TargetFrameworks Condition="$(OS) != 'Windows_NT'">netcoreapp2.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net462;net5.0</TargetFrameworks>
+    <TargetFrameworks Condition="$(OS) != 'Windows_NT'">netcoreapp3.1;net5.0</TargetFrameworks>
     <AssemblyName>OpenCensus.Tests</AssemblyName>
     <PackageId>OpenCensus.Tests</PackageId>
     <PackageTags>OpenCensus;Tracing;Management;Monitoring</PackageTags>

--- a/src/Management/test/TaskCore.Test/Steeltoe.Management.TaskCore.Test.csproj
+++ b/src/Management/test/TaskCore.Test/Steeltoe.Management.TaskCore.Test.csproj
@@ -1,18 +1,11 @@
-<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
-  </PropertyGroup>
-  <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp3.1;net5.0</TargetFrameworks>
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedtest.props" />
-  <Import Project="..\..\..\..\targetframework.props" />
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
-    <PackageReference Include="Microsoft.AspNetCore" Version="$(AspNetCoreVersion)" />
-  </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\TaskCore\Steeltoe.Management.TaskCore.csproj" />
   </ItemGroup>

--- a/src/Management/test/TaskCore.Test/Steeltoe.Management.TaskCore.Test.csproj
+++ b/src/Management/test/TaskCore.Test/Steeltoe.Management.TaskCore.Test.csproj
@@ -1,16 +1,16 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedtest.props" />
   <Import Project="..\..\..\..\targetframework.props" />
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net461' OR '$(TargetFramework)' == 'netcoreapp2.1'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
     <PackageReference Include="Microsoft.AspNetCore" Version="$(AspNetCoreVersion)" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Management/test/TracingBase.Test/Observer/HttpClientCoreObserverTest.cs
+++ b/src/Management/test/TracingBase.Test/Observer/HttpClientCoreObserverTest.cs
@@ -69,7 +69,7 @@ namespace Steeltoe.Management.Tracing.Observer.Test
             obs.ProcessEvent(HttpClientCoreObserver.STOP_EVENT, new { Request = request });
             var span = GetCurrentSpan(tracing.Tracer);
             Assert.Null(span);
-#if NET5_0
+#if NET6_0
             Assert.DoesNotContain(request.Options, o => o.Key == HttpClientCoreObserver.SPANCONTEXT_KEY);
 #else
             Assert.False(request.Properties.TryGetValue(HttpClientCoreObserver.SPANCONTEXT_KEY, out var context));
@@ -88,7 +88,7 @@ namespace Steeltoe.Management.Tracing.Observer.Test
             obs.ProcessEvent(HttpClientCoreObserver.EXCEPTION_EVENT, new { Request = request });
             var span = GetCurrentSpan(tracing.Tracer);
             Assert.Null(span);
-#if NET5_0
+#if NET6_0
             Assert.DoesNotContain(request.Options, o => o.Key == HttpClientCoreObserver.SPANCONTEXT_KEY);
 #else
             Assert.False(request.Properties.TryGetValue(HttpClientCoreObserver.SPANCONTEXT_KEY, out var context));
@@ -97,7 +97,7 @@ namespace Steeltoe.Management.Tracing.Observer.Test
             obs.ProcessEvent(HttpClientCoreObserver.EXCEPTION_EVENT, new { Request = request, Exception = new Exception() });
             span = GetCurrentSpan(tracing.Tracer);
             Assert.Null(span);
-#if NET5_0
+#if NET6_0
             Assert.DoesNotContain(request.Options, o => o.Key == HttpClientCoreObserver.SPANCONTEXT_KEY);
 #else
             Assert.False(request.Properties.TryGetValue(HttpClientCoreObserver.SPANCONTEXT_KEY, out context));
@@ -115,7 +115,7 @@ namespace Steeltoe.Management.Tracing.Observer.Test
 
             var span = GetCurrentSpan(tracing.Tracer);
             Assert.NotNull(span);
-#if NET5_0
+#if NET6_0
             var context = request.Options.First(o => o.Key == HttpClientCoreObserver.SPANCONTEXT_KEY).Value;
 #else
             Assert.True(request.Properties.TryGetValue(HttpClientCoreObserver.SPANCONTEXT_KEY, out object context));
@@ -132,7 +132,7 @@ namespace Steeltoe.Management.Tracing.Observer.Test
             var response = GetHttpResponseMessage(HttpStatusCode.InternalServerError);
             obs.ProcessEvent(HttpClientCoreObserver.STOP_EVENT, new { Request = request, Response = response, RequestTaskStatus = TaskStatus.RanToCompletion });
             Assert.True(span.HasEnded);
-#if NET5_0
+#if NET6_0
             Assert.DoesNotContain(request.Options, o => o.Key == HttpClientCoreObserver.SPANCONTEXT_KEY);
 #else
             Assert.False(request.Properties.TryGetValue(HttpClientCoreObserver.SPANCONTEXT_KEY, out var ctx));
@@ -163,7 +163,7 @@ namespace Steeltoe.Management.Tracing.Observer.Test
 
             var span = GetCurrentSpan(tracing.Tracer);
             Assert.NotNull(span);
-#if NET5_0
+#if NET6_0
             var context = request.Options.FirstOrDefault(o => o.Key == HttpClientCoreObserver.SPANCONTEXT_KEY).Value;
 #else
             Assert.True(request.Properties.TryGetValue(HttpClientCoreObserver.SPANCONTEXT_KEY, out var context));
@@ -177,7 +177,7 @@ namespace Steeltoe.Management.Tracing.Observer.Test
             var response = GetHttpResponseMessage(HttpStatusCode.OK);
             obs.ProcessEvent(HttpClientCoreObserver.STOP_EVENT, new { Request = request, Response = response, RequestTaskStatus = TaskStatus.RanToCompletion });
             Assert.True(span.HasEnded);
-#if NET5_0
+#if NET6_0
             Assert.DoesNotContain(request.Options, o => o.Key == HttpClientCoreObserver.SPANCONTEXT_KEY);
 #else
             Assert.False(request.Properties.TryGetValue(HttpClientCoreObserver.SPANCONTEXT_KEY, out var ctx));
@@ -206,7 +206,7 @@ namespace Steeltoe.Management.Tracing.Observer.Test
 
             var span = GetCurrentSpan(tracing.Tracer);
             Assert.NotNull(span);
-#if NET5_0
+#if NET6_0
             var context = request.Options.FirstOrDefault(o => o.Key == HttpClientCoreObserver.SPANCONTEXT_KEY).Value;
 #else
             Assert.True(request.Properties.TryGetValue(HttpClientCoreObserver.SPANCONTEXT_KEY, out var context));

--- a/src/Management/test/TracingBase.Test/Observer/HttpClientDesktopObserverTest.cs
+++ b/src/Management/test/TracingBase.Test/Observer/HttpClientDesktopObserverTest.cs
@@ -196,7 +196,9 @@ namespace Steeltoe.Management.Tracing.Observer.Test
 
         private HttpWebRequest GetHttpRequestMessage()
         {
+#pragma warning disable SYSLIB0014 // Type or member is obsolete
             var m = WebRequest.CreateHttp("http://localhost:5555/");
+#pragma warning restore SYSLIB0014 // Type or member is obsolete
             m.Method = HttpMethod.Get.Method;
             m.Headers.Add("TEST", "Header");
             return m;

--- a/src/Management/test/TracingBase.Test/Steeltoe.Management.TracingBase.Test.csproj
+++ b/src/Management/test/TracingBase.Test/Steeltoe.Management.TracingBase.Test.csproj
@@ -1,9 +1,9 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />
@@ -18,7 +18,7 @@
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="$(ExtensionsVersion)" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net461' OR '$(TargetFramework)' == 'netcoreapp2.1'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="$(AspNetCoreVersion)" />
   </ItemGroup>
 </Project>

--- a/src/Management/test/TracingBase.Test/Steeltoe.Management.TracingBase.Test.csproj
+++ b/src/Management/test/TracingBase.Test/Steeltoe.Management.TracingBase.Test.csproj
@@ -1,9 +1,9 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp3.1;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />
@@ -14,11 +14,4 @@
     <ProjectReference Include="..\..\src\TracingBase\Steeltoe.Management.TracingBase.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="$(AspNetCoreVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="$(ExtensionsVersion)" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="$(AspNetCoreVersion)" />
-  </ItemGroup>
 </Project>

--- a/src/Management/test/TracingCore.Test/Steeltoe.Management.TracingCore.Test.csproj
+++ b/src/Management/test/TracingCore.Test/Steeltoe.Management.TracingCore.Test.csproj
@@ -1,9 +1,9 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />
@@ -18,7 +18,7 @@
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="$(ExtensionsVersion)" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net461' OR '$(TargetFramework)' == 'netcoreapp2.1'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="$(AspNetCoreVersion)" />
   </ItemGroup>
 </Project>

--- a/src/Management/test/TracingCore.Test/Steeltoe.Management.TracingCore.Test.csproj
+++ b/src/Management/test/TracingCore.Test/Steeltoe.Management.TracingCore.Test.csproj
@@ -1,14 +1,10 @@
-<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
-  </PropertyGroup>
-  <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp3.1;net5.0</TargetFrameworks>
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedtest.props" />
-  <Import Project="..\..\..\..\targetframework.props" />
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\TracingCore\Steeltoe.Management.TracingCore.csproj" />
@@ -17,8 +13,5 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="$(ExtensionsVersion)" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="$(AspNetCoreVersion)" />
   </ItemGroup>
 </Project>

--- a/src/Security/test/Authentication.CloudFoundryBase.Test/CloudFoundryHelperTest.cs
+++ b/src/Security/test/Authentication.CloudFoundryBase.Test/CloudFoundryHelperTest.cs
@@ -6,7 +6,7 @@
 using Newtonsoft.Json.Linq;
 #endif
 using System;
-#if NETCOREAPP3_1 || NET5_0
+#if NETCOREAPP3_1 || NET6_0
 using System.Text.Json;
 #endif
 using Xunit;
@@ -40,7 +40,7 @@ namespace Steeltoe.Security.Authentication.CloudFoundry.Test
         public void GetExpTime_FindsTime()
         {
             var info = TestHelpers.GetValidTokenInfoRequestResponse();
-#if NETCOREAPP3_1 || NET5_0
+#if NETCOREAPP3_1 || NET6_0
             var payload = JsonDocument.Parse(info).RootElement;
 #else
             var payload = JObject.Parse(info);
@@ -53,7 +53,7 @@ namespace Steeltoe.Security.Authentication.CloudFoundry.Test
         public void GetIssueTime_FindsTime()
         {
             var info = TestHelpers.GetValidTokenInfoRequestResponse();
-#if NETCOREAPP3_1 || NET5_0
+#if NETCOREAPP3_1 || NET6_0
             var payload = JsonDocument.Parse(info).RootElement;
 #else
             var payload = JObject.Parse(info);
@@ -66,7 +66,7 @@ namespace Steeltoe.Security.Authentication.CloudFoundry.Test
         public void GetScopes_FindsScopes()
         {
             var info = TestHelpers.GetValidTokenInfoRequestResponse();
-#if NETCOREAPP3_1 || NET5_0
+#if NETCOREAPP3_1 || NET6_0
             var payload = JsonDocument.Parse(info).RootElement;
 #else
             var payload = JObject.Parse(info);

--- a/src/Security/test/Authentication.CloudFoundryBase.Test/Steeltoe.Security.Authentication.CloudFoundryBase.Test.csproj
+++ b/src/Security/test/Authentication.CloudFoundryBase.Test/Steeltoe.Security.Authentication.CloudFoundryBase.Test.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp3.1;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Security/test/Authentication.CloudFoundryBase.Test/Steeltoe.Security.Authentication.CloudFoundryBase.Test.csproj
+++ b/src/Security/test/Authentication.CloudFoundryBase.Test/Steeltoe.Security.Authentication.CloudFoundryBase.Test.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Security/test/Authentication.CloudFoundryCore.Test/CloudFoundryOAuthBuilderTest.cs
+++ b/src/Security/test/Authentication.CloudFoundryCore.Test/CloudFoundryOAuthBuilderTest.cs
@@ -4,9 +4,7 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Net;
-using System.Text;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -14,16 +12,16 @@ namespace Steeltoe.Security.Authentication.CloudFoundry.Test
 {
     public class CloudFoundryOAuthBuilderTest
     {
+#if NET6_0
+        [Fact(Skip = "Un-skip in 6.0 RC1 - https://github.com/dotnet/aspnetcore/issues/34354")]
+#else
         [Fact]
+#endif
         public async Task ShouldKeepDefaultServiceUrlsIfAuthDomainNotPresent()
         {
             var expectedAuthoricationUrl = $"http://{CloudFoundryDefaults.OAuthServiceUrl}/oauth/authorize";
             var webApplicationFactory = new TestApplicationFactory<TestServerStartup>();
-#if NETCOREAPP3_1 || NET5_0
             var client = webApplicationFactory.CreateDefaultClient();
-#else
-            var client = webApplicationFactory.GetTestServer().CreateClient();
-#endif
             var result = await client.GetAsync("http://localhost/");
             var location = result.Headers.Location.ToString();
 
@@ -31,7 +29,11 @@ namespace Steeltoe.Security.Authentication.CloudFoundry.Test
             Assert.StartsWith(expectedAuthoricationUrl, location, StringComparison.OrdinalIgnoreCase);
         }
 
+#if NET6_0
+        [Fact(Skip = "Un-skip in 6.0 RC1 - https://github.com/dotnet/aspnetcore/issues/34354")]
+#else
         [Fact]
+#endif
         public async Task ShouldAddAuthDomainToServiceUrlsIfPresent()
         {
             var authDomain = "http://this-config-server-url";
@@ -47,11 +49,7 @@ namespace Steeltoe.Security.Authentication.CloudFoundry.Test
 
             var webApplicationFactory = new TestApplicationFactory<TestServerStartup>(configuration);
 
-#if NETCOREAPP3_1 || NET5_0
             var client = webApplicationFactory.CreateDefaultClient();
-#else
-            var client = webApplicationFactory.GetTestServer().CreateClient();
-#endif
             var result = await client.GetAsync("http://localhost/");
 
             var location = result.Headers.Location.ToString();

--- a/src/Security/test/Authentication.CloudFoundryCore.Test/CloudFoundryOAuthHandlerTest.cs
+++ b/src/Security/test/Authentication.CloudFoundryCore.Test/CloudFoundryOAuthHandlerTest.cs
@@ -7,17 +7,12 @@ using Microsoft.AspNetCore.Authentication.OAuth;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-#if !NETCOREAPP3_1 && !NET5_0
-using Newtonsoft.Json.Linq;
-#endif
 using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Security.Claims;
 using System.Text.Encodings.Web;
-#if NETCOREAPP3_1 || NET5_0
 using System.Text.Json;
-#endif
 using Xunit;
 
 namespace Steeltoe.Security.Authentication.CloudFoundry.Test
@@ -117,13 +112,8 @@ namespace Steeltoe.Security.Authentication.CloudFoundry.Test
 
             var testHandler = GetTestHandler(opts);
 
-#if NETCOREAPP3_1 || NET5_0
             var payload = JsonDocument.Parse(TestHelpers.GetValidTokenInfoRequestResponse());
             var tokens = OAuthTokenResponse.Success(payload);
-#else
-            var payload = JObject.Parse(TestHelpers.GetValidTokenInfoRequestResponse());
-            var tokens = OAuthTokenResponse.Success(payload);
-#endif
             var parameters = testHandler.GetTokenInfoRequestParameters(tokens);
             Assert.NotNull(parameters);
 
@@ -140,13 +130,8 @@ namespace Steeltoe.Security.Authentication.CloudFoundry.Test
             };
             var testHandler = GetTestHandler(opts);
 
-#if NETCOREAPP3_1 || NET5_0
             var payload = JsonDocument.Parse(TestHelpers.GetValidTokenInfoRequestResponse());
             var tokens = OAuthTokenResponse.Success(payload);
-#else
-            var payload = JObject.Parse(TestHelpers.GetValidTokenInfoRequestResponse());
-            var tokens = OAuthTokenResponse.Success(payload);
-#endif
 
             var message = testHandler.GetTokenInfoRequestMessage(tokens);
             Assert.NotNull(message);
@@ -176,13 +161,8 @@ namespace Steeltoe.Security.Authentication.CloudFoundry.Test
 
             var identity = new ClaimsIdentity();
 
-#if NETCOREAPP3_1 || NET5_0
             var payload = JsonDocument.Parse(TestHelpers.GetValidTokenInfoRequestResponse());
             var tokens = OAuthTokenResponse.Success(payload);
-#else
-            var payload = JObject.Parse(TestHelpers.GetValidTokenInfoRequestResponse());
-            var tokens = OAuthTokenResponse.Success(payload);
-#endif
             var resp = await testHandler.TestCreateTicketAsync(identity, new AuthenticationProperties(), tokens);
 
             Assert.NotNull(handler.LastRequest);

--- a/src/Security/test/Authentication.CloudFoundryCore.Test/CloudFoundryOpenIdConnectConfigurerTest.cs
+++ b/src/Security/test/Authentication.CloudFoundryCore.Test/CloudFoundryOpenIdConnectConfigurerTest.cs
@@ -27,16 +27,10 @@ namespace Steeltoe.Security.Authentication.CloudFoundry.Test
             Assert.Equal(CloudFoundryDefaults.ClientId, oidcOptions.ClientId);
             Assert.Equal(CloudFoundryDefaults.ClientSecret, oidcOptions.ClientSecret);
             Assert.Equal(new PathString(CloudFoundryDefaults.CallbackPath), oidcOptions.CallbackPath);
-#if NETCOREAPP3_1 || NET5_0
             Assert.Equal(19, oidcOptions.ClaimActions.Count());
-#else
-            Assert.Equal(21, oidcOptions.ClaimActions.Count());
-#endif
             Assert.Equal(CookieAuthenticationDefaults.AuthenticationScheme, oidcOptions.SignInScheme);
             Assert.False(oidcOptions.SaveTokens);
-#if !NET461
             Assert.NotNull(oidcOptions.BackchannelHttpHandler);
-#endif
         }
 
         [Fact]
@@ -57,11 +51,7 @@ namespace Steeltoe.Security.Authentication.CloudFoundry.Test
             Assert.Equal("secret", oidcOptions.ClientSecret);
             Assert.Equal(new PathString(CloudFoundryDefaults.CallbackPath), oidcOptions.CallbackPath);
             Assert.Null(oidcOptions.BackchannelHttpHandler);
-#if NETCOREAPP3_1 || NET5_0
             Assert.Equal(19, oidcOptions.ClaimActions.Count());
-#else
-            Assert.Equal(21, oidcOptions.ClaimActions.Count());
-#endif
             Assert.Equal(CookieAuthenticationDefaults.AuthenticationScheme, oidcOptions.SignInScheme);
             Assert.False(oidcOptions.SaveTokens);
             Assert.Null(oidcOptions.BackchannelHttpHandler);

--- a/src/Security/test/Authentication.CloudFoundryCore.Test/CloudFoundryOpenIdConnectOptionsTest.cs
+++ b/src/Security/test/Authentication.CloudFoundryCore.Test/CloudFoundryOpenIdConnectOptionsTest.cs
@@ -22,11 +22,7 @@ namespace Steeltoe.Security.Authentication.CloudFoundry.Test
             Assert.Equal(CloudFoundryDefaults.ClientSecret, opts.ClientSecret);
             Assert.Equal(new PathString("/signin-cloudfoundry"), opts.CallbackPath);
             Assert.True(opts.ValidateCertificates);
-#if NETCOREAPP3_1 || NET5_0
             Assert.Equal(19, opts.ClaimActions.Count());
-#else
-            Assert.Equal(21, opts.ClaimActions.Count());
-#endif
             Assert.Equal(CookieAuthenticationDefaults.AuthenticationScheme, opts.SignInScheme);
             Assert.False(opts.SaveTokens);
         }

--- a/src/Security/test/Authentication.CloudFoundryCore.Test/CloudFoundryScopeClaimActionTest.cs
+++ b/src/Security/test/Authentication.CloudFoundryCore.Test/CloudFoundryScopeClaimActionTest.cs
@@ -2,13 +2,8 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-#if !NETCOREAPP3_1 && !NET5_0
-using Newtonsoft.Json.Linq;
-#endif
 using System.Security.Claims;
-#if NETCOREAPP3_1 || NET5_0
 using System.Text.Json;
-#endif
 using Xunit;
 
 namespace Steeltoe.Security.Authentication.CloudFoundry.Test
@@ -19,11 +14,7 @@ namespace Steeltoe.Security.Authentication.CloudFoundry.Test
         public void Run_AddsClaims()
         {
             var resp = TestHelpers.GetValidTokenInfoRequestResponse();
-#if NETCOREAPP3_1 || NET5_0
             var payload = JsonDocument.Parse(resp).RootElement;
-#else
-            var payload = JObject.Parse(resp);
-#endif
             var action = new CloudFoundryScopeClaimAction("scope", ClaimValueTypes.String);
             var ident = new ClaimsIdentity();
             action.Run(payload, ident, "Issuer");

--- a/src/Security/test/Authentication.CloudFoundryCore.Test/MyTestCloudFoundryHandler.cs
+++ b/src/Security/test/Authentication.CloudFoundryCore.Test/MyTestCloudFoundryHandler.cs
@@ -30,11 +30,7 @@ namespace Steeltoe.Security.Authentication.CloudFoundry.Test
 
         public async Task<OAuthTokenResponse> TestExchangeCodeAsync(string code, string redirectUri)
         {
-#if NETCOREAPP3_1 || NET5_0
             return await ExchangeCodeAsync(new OAuthCodeExchangeContext(new AuthenticationProperties(), code, redirectUri));
-#else
-            return await ExchangeCodeAsync(code, redirectUri);
-#endif
         }
 
         public string TestBuildChallengeUrl(AuthenticationProperties properties, string redirectUri)

--- a/src/Security/test/Authentication.CloudFoundryCore.Test/Steeltoe.Security.Authentication.CloudFoundryCore.Test.csproj
+++ b/src/Security/test/Authentication.CloudFoundryCore.Test/Steeltoe.Security.Authentication.CloudFoundryCore.Test.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Security/test/Authentication.CloudFoundryCore.Test/Steeltoe.Security.Authentication.CloudFoundryCore.Test.csproj
+++ b/src/Security/test/Authentication.CloudFoundryCore.Test/Steeltoe.Security.Authentication.CloudFoundryCore.Test.csproj
@@ -1,14 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
-  </PropertyGroup>
-  <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp3.1;net5.0</TargetFrameworks>
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
+    <DisableImplicitNamespaceImports>true</DisableImplicitNamespaceImports>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedtest.props" />
-  <Import Project="..\..\..\..\targetframework.props" />
 
   <ItemGroup>
     <None Update="xunit.runner.json">

--- a/src/Security/test/Authentication.CloudFoundryCore.Test/TestApplicationFactory.cs
+++ b/src/Security/test/Authentication.CloudFoundryCore.Test/TestApplicationFactory.cs
@@ -23,7 +23,6 @@ namespace Steeltoe.Security.Authentication.CloudFoundry.Test
             this.configuration = configuration ?? ImmutableDictionary<string, string>.Empty;
         }
 
-#if NETCOREAPP3_1 || NET5_0
         protected override IHost CreateHost(IHostBuilder builder)
         {
             builder.UseContentRoot(Directory.GetCurrentDirectory());
@@ -45,19 +44,5 @@ namespace Steeltoe.Security.Authentication.CloudFoundry.Test
 
             return builder;
         }
-#else
-        public TestServer GetTestServer()
-        {
-            var webHostBuilder = new WebHostBuilder()
-                .ConfigureAppConfiguration(configurationBuilder =>
-                {
-                    configurationBuilder.AddInMemoryCollection(configuration);
-                })
-                .UseContentRoot(Directory.GetCurrentDirectory())
-                .UseStartup<TStartup>();
-
-            return new TestServer(webHostBuilder);
-        }
-#endif
     }
 }

--- a/src/Security/test/DataProtection.CredHubBase.Test/Steeltoe.Security.DataProtection.CredHubBase.Test.csproj
+++ b/src/Security/test/DataProtection.CredHubBase.Test/Steeltoe.Security.DataProtection.CredHubBase.Test.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp3.1;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Security/test/DataProtection.CredHubBase.Test/Steeltoe.Security.DataProtection.CredHubBase.Test.csproj
+++ b/src/Security/test/DataProtection.CredHubBase.Test/Steeltoe.Security.DataProtection.CredHubBase.Test.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Security/test/DataProtection.CredHubCore.Test/Steeltoe.Security.DataProtection.CredHubCore.Test.csproj
+++ b/src/Security/test/DataProtection.CredHubCore.Test/Steeltoe.Security.DataProtection.CredHubCore.Test.csproj
@@ -1,16 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedtest.props" />
   <Import Project="..\..\..\..\targetframework.props" />
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net461' OR '$(TargetFramework)' == 'netcoreapp2.1'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="$(AspNetCoreVersion)" />
   </ItemGroup>
 

--- a/src/Security/test/DataProtection.CredHubCore.Test/Steeltoe.Security.DataProtection.CredHubCore.Test.csproj
+++ b/src/Security/test/DataProtection.CredHubCore.Test/Steeltoe.Security.DataProtection.CredHubCore.Test.csproj
@@ -1,18 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
-  </PropertyGroup>
-  <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp3.1;net5.0</TargetFrameworks>
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedtest.props" />
-  <Import Project="..\..\..\..\targetframework.props" />
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="$(AspNetCoreVersion)" />
-  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\DataProtection.CredHubCore\Steeltoe.Security.DataProtection.CredHubCore.csproj" />

--- a/src/Security/test/DataProtection.RedisCore.Test/Steeltoe.Security.DataProtection.RedisCore.Test.csproj
+++ b/src/Security/test/DataProtection.RedisCore.Test/Steeltoe.Security.DataProtection.RedisCore.Test.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Security/test/DataProtection.RedisCore.Test/Steeltoe.Security.DataProtection.RedisCore.Test.csproj
+++ b/src/Security/test/DataProtection.RedisCore.Test/Steeltoe.Security.DataProtection.RedisCore.Test.csproj
@@ -1,14 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup Condition="! $(OS.Contains('Win'))">
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
-  </PropertyGroup>
-  <PropertyGroup Condition="$(OS.Contains('Win'))">
-    <TargetFrameworks>net461;netcoreapp3.1;net5.0</TargetFrameworks>
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedtest.props" />
-  <Import Project="..\..\..\..\targetframework.props" />
 
   <ItemGroup>
     <None Update="xunit.runner.json">

--- a/versions.props
+++ b/versions.props
@@ -57,7 +57,7 @@
     <StyleCopVersion>1.1.118</StyleCopVersion>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'net461' OR '$(TargetFramework)' == 'netcoreapp2.1'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'net461'">
     <AspNetVersion>5.2.4</AspNetVersion>
     <OwinVersion>4.0.0</OwinVersion>
     <OwinOAuthVersion>4.0.0</OwinOAuthVersion>

--- a/versions.props
+++ b/versions.props
@@ -24,7 +24,6 @@
     <MySqlV8>8.0.23</MySqlV8>
     <NpgsqlVersion>4.0.0</NpgsqlVersion>
     <SqlClientVersion>4.5.0</SqlClientVersion>
-    <MicrosoftExtensionsRedisVersion>2.2.0</MicrosoftExtensionsRedisVersion>
     <StackExchangeVersion>2.0.513</StackExchangeVersion>
 
     <AutofacVersion>4.6.1</AutofacVersion>
@@ -70,6 +69,7 @@
     <ExtensionsVersion>2.2.0</ExtensionsVersion>
     <HealthChecksVersion>2.2.0</HealthChecksVersion>
     <LoggingVersion>2.2.0</LoggingVersion>
+    <MicrosoftExtensionsRedisVersion>2.2.0</MicrosoftExtensionsRedisVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1' OR '$(TargetFramework)' == 'netstandard2.1'">
     <AspNetCoreVersion>3.1.0</AspNetCoreVersion>
@@ -82,15 +82,17 @@
     <ExtensionsVersion>3.1.0</ExtensionsVersion>
     <HealthChecksVersion>3.1.0</HealthChecksVersion>
     <LoggingVersion>3.1.0</LoggingVersion>
+    <MicrosoftExtensionsRedisVersion>3.1.0</MicrosoftExtensionsRedisVersion>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net5.0'">
-    <AspNetCoreVersion>5.0.0</AspNetCoreVersion>
-    <EFCoreTestVersion>5.0.0</EFCoreTestVersion>
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net6.0'">
+    <AspNetCoreVersion>6.0.0-preview.7.21378.6</AspNetCoreVersion>
+    <EFCoreTestVersion>6.0.0-preview.7.21378.4</EFCoreTestVersion>
     <EF6Version>6.4.0</EF6Version>
-    <MySqlEFCoreVersion>5.0.0</MySqlEFCoreVersion>
-    <NpgsqlEFCoreVersion>5.0.0</NpgsqlEFCoreVersion>
+    <MySqlEFCoreVersion>6.0.0-preview3</MySqlEFCoreVersion>
+    <NpgsqlEFCoreVersion>6.0.0-preview7</NpgsqlEFCoreVersion>
     <OracleEFCoreVersion>5.21.1</OracleEFCoreVersion>
-    <PomeloEFCoreVersion>5.0.0-alpha.2</PomeloEFCoreVersion>
-    <ExtensionsVersion>5.0.0</ExtensionsVersion>
+    <PomeloEFCoreVersion>6.0.0-preview.5</PomeloEFCoreVersion>
+    <ExtensionsVersion>6.0.0-preview.7.21377.19</ExtensionsVersion>
+    <MicrosoftExtensionsRedisVersion>6.0.0-preview.7.21378.6</MicrosoftExtensionsRedisVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Drop netcoreapp2.1 from all tests, net461 from tests that require ASP.NET Core 2.1 #759 
Also swaps out .NET 5 in favor of .NET 6 (preview)