### PR TITLE
Backport 766 to 3.1

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,14 +1,14 @@
 trigger:
   branches:
     include:
-    - main
+    - release/3.1
   paths:
     exclude:
     - README.md
     - project-docs/*
     - roadmaps/*
 pr:
-- main
+- release/3.1
 
 jobs:
 - job: Quick_Response
@@ -41,7 +41,7 @@ jobs:
   variables:
     DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
     DOTNET_CLI_TELEMETRY_OPTOUT: 1
-    PackageVersion: $[format('3.1.1-{0}', variables['Build.BuildId'])]
+    PackageVersion: $[format('3.1.2-{0}', variables['Build.BuildId'])]
   strategy:
     matrix:
       Linux:

--- a/src/Management/src/EndpointBase/DbMigrations/DbMigrationsEndpoint.cs
+++ b/src/Management/src/EndpointBase/DbMigrations/DbMigrationsEndpoint.cs
@@ -36,10 +36,10 @@ namespace Steeltoe.Management.Endpoint.DbMigrations
 
         internal static readonly Type _dbContextType = Type.GetType("Microsoft.EntityFrameworkCore.DbContext, Microsoft.EntityFrameworkCore");
         internal static readonly Type _migrationsExtensionsType = Type.GetType("Microsoft.EntityFrameworkCore.RelationalDatabaseFacadeExtensions,Microsoft.EntityFrameworkCore.Relational");
-        internal static readonly MethodInfo _getDatabase = _dbContextType.GetProperty("Database", BindingFlags.Public | BindingFlags.Instance).GetMethod;
-        internal static readonly MethodInfo _getPendingMigrations = _migrationsExtensionsType.GetMethod("GetPendingMigrations", BindingFlags.Static | BindingFlags.Public);
-        internal static readonly MethodInfo _getAppliedMigrations = _migrationsExtensionsType.GetMethod("GetAppliedMigrations", BindingFlags.Static | BindingFlags.Public);
-        internal static readonly MethodInfo _getMigrations = _migrationsExtensionsType.GetMethod("GetMigrations", BindingFlags.Static | BindingFlags.Public);
+        internal static readonly MethodInfo _getDatabase = _dbContextType?.GetProperty("Database", BindingFlags.Public | BindingFlags.Instance).GetMethod;
+        internal static readonly MethodInfo _getPendingMigrations = _migrationsExtensionsType?.GetMethod("GetPendingMigrations", BindingFlags.Static | BindingFlags.Public);
+        internal static readonly MethodInfo _getAppliedMigrations = _migrationsExtensionsType?.GetMethod("GetAppliedMigrations", BindingFlags.Static | BindingFlags.Public);
+        internal static readonly MethodInfo _getMigrations = _migrationsExtensionsType?.GetMethod("GetMigrations", BindingFlags.Static | BindingFlags.Public);
 
         private readonly IServiceProvider _container;
         private readonly DbMigrationsEndpointHelper _endpointHelper;
@@ -70,36 +70,43 @@ namespace Steeltoe.Management.Endpoint.DbMigrations
         private Dictionary<string, DbMigrationsDescriptor> DoInvoke()
         {
             var result = new Dictionary<string, DbMigrationsDescriptor>();
-            var knownEfContexts = _endpointHelper.ScanRootAssembly
-                    .GetReferencedAssemblies()
-                    .Select(Assembly.Load)
-                    .SelectMany(x => x.DefinedTypes)
-                    .Union(_endpointHelper.ScanRootAssembly.DefinedTypes)
-                    .Where(type => !type.IsAbstract && type.AsType() != _dbContextType && _dbContextType.GetTypeInfo().IsAssignableFrom(type.AsType()))
-                    .Select(typeInfo => typeInfo.AsType())
-                    .ToList();
-            var scope = _container.CreateScope().ServiceProvider;
-            foreach (var contextType in knownEfContexts)
+            if (_dbContextType is null)
             {
-                var dbContext = scope.GetService(contextType);
-                if (dbContext == null)
+                _logger?.LogCritical("DbMigrations endpoint invoked but no DbContext was found.");
+            }
+            else
+            {
+                var knownEfContexts = _endpointHelper.ScanRootAssembly
+                        .GetReferencedAssemblies()
+                        .Select(Assembly.Load)
+                        .SelectMany(x => x.DefinedTypes)
+                        .Union(_endpointHelper.ScanRootAssembly.DefinedTypes)
+                        .Where(type => !type.IsAbstract && type.AsType() != _dbContextType && _dbContextType.GetTypeInfo().IsAssignableFrom(type.AsType()))
+                        .Select(typeInfo => typeInfo.AsType())
+                        .ToList();
+                var scope = _container.CreateScope().ServiceProvider;
+                foreach (var contextType in knownEfContexts)
                 {
-                    continue;
-                }
+                    var dbContext = scope.GetService(contextType);
+                    if (dbContext == null)
+                    {
+                        continue;
+                    }
 
-                var descriptor = new DbMigrationsDescriptor();
-                var contextName = dbContext.GetType().Name;
-                result.Add(contextName, descriptor);
-                try
-                {
-                    descriptor.PendingMigrations = _endpointHelper.GetPendingMigrations(dbContext).ToList();
-                    descriptor.AppliedMigrations = _endpointHelper.GetAppliedMigrations(dbContext).ToList();
-                }
-                catch (DbException e) when (e.Message.Contains("exist"))
-                {
-                    // todo: maybe improve detection logic when database is new. hard to do generically across all providers
-                    _logger?.LogWarning("Encountered exception loading migrations: {exception}", e.Message);
-                    descriptor.PendingMigrations = _endpointHelper.GetMigrations(dbContext).ToList();
+                    var descriptor = new DbMigrationsDescriptor();
+                    var contextName = dbContext.GetType().Name;
+                    result.Add(contextName, descriptor);
+                    try
+                    {
+                        descriptor.PendingMigrations = _endpointHelper.GetPendingMigrations(dbContext).ToList();
+                        descriptor.AppliedMigrations = _endpointHelper.GetAppliedMigrations(dbContext).ToList();
+                    }
+                    catch (DbException e) when (e.Message.Contains("exist"))
+                    {
+                        // todo: maybe improve detection logic when database is new. hard to do generically across all providers
+                        _logger?.LogWarning("Encountered exception loading migrations: {exception}", e.Message);
+                        descriptor.PendingMigrations = _endpointHelper.GetMigrations(dbContext).ToList();
+                    }
                 }
             }
 

--- a/src/Management/src/EndpointCore/ActuatorRouteBuilderExtensions.cs
+++ b/src/Management/src/EndpointCore/ActuatorRouteBuilderExtensions.cs
@@ -127,7 +127,7 @@ namespace Steeltoe.Management.Endpoint
                 var pattern = RoutePatternFactory.Parse(fullPath);
 
                 // only add middleware if the route hasn't already been mapped
-                if (!endpoints.DataSources.Any(d => d.Endpoints.Any(ep => ((RouteEndpoint)ep).RoutePattern.RawText == pattern.RawText)))
+                if (!endpoints.DataSources.Any(d => d.Endpoints.Any(ep => ep is RouteEndpoint endpoint && endpoint.RoutePattern.RawText == pattern.RawText)))
                 {
                     var pipeline = endpoints.CreateApplicationBuilder()
                         .UseMiddleware(middleware, mgmtOptions)

--- a/src/Management/test/EndpointCore.Test/ActuatorRouteBuilderExtensionsTest.cs
+++ b/src/Management/test/EndpointCore.Test/ActuatorRouteBuilderExtensionsTest.cs
@@ -33,27 +33,25 @@ namespace Steeltoe.Management.Endpoint
         {
             get
             {
-                Func<Type, bool> query = t => t.GetInterfaces().Any(type => type.FullName == "Steeltoe.Management.IEndpoint");
-                var types = Assembly.Load("Steeltoe.Management.EndpointBase").GetTypes().Where(query).ToList();
-                types.AddRange(Assembly.Load("Steeltoe.Management.EndpointCore").GetTypes().Where(query));
+                static bool Query(Type t) => t.GetInterfaces().Any(type => type.FullName == "Steeltoe.Management.IEndpoint");
+                var types = Assembly.Load("Steeltoe.Management.EndpointBase").GetTypes().Where(Query).ToList();
+                types.AddRange(Assembly.Load("Steeltoe.Management.EndpointCore").GetTypes().Where(Query));
                 return types.Select(t => new object[] { t });
             }
         }
 
-        public static IEnumerable<object[]> IEndpointImplementationsWithAuth
+        public static IEnumerable<object[]> IEndpointImplementationsForCurrentPlatform
         {
             get
             {
-                Func<Type, bool> query = t => t.GetInterfaces().Any(type => type.FullName == "Steeltoe.Management.IEndpoint");
-                Func<Type, bool> supportedOnPlatform = t => !(t.Name.StartsWith("ThreadDump") || t.Name.StartsWith("HeapDump"))
+                static bool Query(Type t) => t.GetInterfaces().Any(type => type.FullName == "Steeltoe.Management.IEndpoint");
+                static bool SupportedOnPlatform(Type t) => !(t.Name.StartsWith("ThreadDump") || t.Name.StartsWith("HeapDump"))
                                                             || (t.Name.StartsWith("ThreadDump") && Platform.IsWindows)
                                                             || (t.Name.StartsWith("HeapDump") && EndpointServiceCollectionExtensions.IsHeapDumpSupported());
-                var types = Assembly.Load("Steeltoe.Management.EndpointBase").GetTypes().Where(query).Where(supportedOnPlatform).ToList();
-                types.AddRange(Assembly.Load("Steeltoe.Management.EndpointCore").GetTypes().Where(query).Where(supportedOnPlatform));
-                var auths = new bool[] { true, false };
-                return from t in types
-                       from a in auths
-                       select new object[] { t, a };
+                var types = Assembly.Load("Steeltoe.Management.EndpointBase").GetTypes()
+                                .Union(Assembly.Load("Steeltoe.Management.EndpointCore").GetTypes())
+                                .Where(Query).Where(SupportedOnPlatform).ToList();
+                return from t in types select new object[] { t };
             }
         }
 
@@ -67,50 +65,72 @@ namespace Steeltoe.Management.Endpoint
         }
 
         [Theory]
-        [MemberData(nameof(IEndpointImplementationsWithAuth))]
-        public async Task MapTestAuthSuccess(Type type, bool authSuccess)
+        [MemberData(nameof(IEndpointImplementationsForCurrentPlatform))]
+        public async Task MapTestAuthSuccess(Type type)
         {
             // Arrange
-            ServiceProvider provider = null;
-            Action<AuthorizationPolicyBuilder> policyAction = policy => policy.RequireClaim("scope", "invalidscope");
+            var hostBuilder = GetHostBuilder(type, policy => policy.RequireClaim("scope", "actuators.read"));
+            await ActAndAssert(type, hostBuilder, HttpStatusCode.OK);
+        }
 
-            if (authSuccess)
-            {
-                policyAction = policy => policy.RequireClaim("scope", "actuators.read"); // Set up for success
-            }
+        [Theory]
+        [MemberData(nameof(IEndpointImplementationsForCurrentPlatform))]
+        public async Task MapTestAuthFail(Type type)
+        {
+            // Arrange
+            var hostBuilder = GetHostBuilder(type, policy => policy.RequireClaim("scope", "invalidscope"));
+            await ActAndAssert(type, hostBuilder, HttpStatusCode.Unauthorized);
+        }
 
-            var hostBuilder = new HostBuilder().ConfigureWebHost(builder =>
-                    builder.UseTestServer()
-                    .ConfigureServices((context, s) =>
-                    {
-                        s.AddRouting();
-                        s.AddTraceActuator(context.Configuration, MediaTypeVersion.V1);
-                        s.AddThreadDumpActuator(context.Configuration, MediaTypeVersion.V1);
-                        s.AddCloudFoundryActuator(context.Configuration);
-                        s.AddAllActuators(context.Configuration); // Add all of them, but map one at a time
-                        s.AddAuthentication(TestAuthHandler.AuthenticationScheme)
+        private static IHostBuilder GetHostBuilder(Type type, Action<AuthorizationPolicyBuilder> policyAction)
+            => new HostBuilder()
+                .AddDynamicLogging()
+                .ConfigureServices((context, s) =>
+                {
+                    s.AddTraceActuator(context.Configuration, MediaTypeVersion.V1);
+                    s.AddThreadDumpActuator(context.Configuration, MediaTypeVersion.V1);
+                    s.AddCloudFoundryActuator(context.Configuration);
+                    s.AddAllActuators(context.Configuration); // Add all of them, but map one at a time
+                    s.AddRouting();
+                    s.AddAuthentication(TestAuthHandler.AuthenticationScheme)
                         .AddScheme<AuthenticationSchemeOptions, TestAuthHandler>(TestAuthHandler.AuthenticationScheme, options => { });
-                        s.AddAuthorization(options => options.AddPolicy("TestAuth", policyAction)); // setup Auth based on test Case
-                        provider = s.BuildServiceProvider();
-                    })
-                    .Configure(a => a.UseRouting().UseAuthentication().UseAuthorization().UseEndpoints(endpoints => endpoints.MapActuatorEndpoint(type).RequireAuthorization("TestAuth"))));
+                    s.AddAuthorization(options => options.AddPolicy("TestAuth", policyAction)); // setup Auth based on test Case
+                    s.AddServerSideBlazor();
+                })
+                .ConfigureWebHost(builder =>
+                {
+                    builder
+                        .Configure(app =>
+                            app
+                                .UseRouting()
+                                .UseAuthentication()
+                                .UseAuthorization()
+                                .UseEndpoints(endpoints =>
+                                {
+                                    endpoints.MapBlazorHub(); // https://github.com/SteeltoeOSS/Steeltoe/issues/729
+                                    endpoints.MapActuatorEndpoint(type).RequireAuthorization("TestAuth");
+                                }))
+                        .UseTestServer();
+                });
 
-            // Act
-            var host = await hostBuilder.AddDynamicLogging().StartAsync();
+        private static IManagementOptions GetManagementContext(Type type, IServiceProvider services)
+            => type.IsAssignableFrom(typeof(CloudFoundryEndpoint))
+                ? services.GetRequiredService<CloudFoundryManagementOptions>()
+                : services.GetRequiredService<ActuatorManagementOptions>();
+
+        private async Task ActAndAssert(Type type, IHostBuilder hostBuilder, HttpStatusCode expectedStatus)
+        {
+            var host = await hostBuilder.StartAsync();
+            var (middleware, optionsType) = ActuatorRouteBuilderExtensions.LookupMiddleware(type);
+            var options = host.Services.GetService(optionsType) as IEndpointOptions;
+            var path = options.GetContextPath(GetManagementContext(type, host.Services));
 
             // Assert
-            var (middleware, optionsType) = ActuatorRouteBuilderExtensions.LookupMiddleware(type);
-            var options = provider.GetService(optionsType) as IEndpointOptions;
-            var mgmtContext = type.IsAssignableFrom(typeof(CloudFoundryEndpoint))
-                ? (IManagementOptions)provider.GetRequiredService<CloudFoundryManagementOptions>()
-                : (IManagementOptions)provider.GetRequiredService<ActuatorManagementOptions>();
-            var path = options.GetContextPath(mgmtContext);
             Assert.NotNull(path);
 
             var response = host.GetTestServer().CreateClient().GetAsync(path);
-            var expected = authSuccess ? HttpStatusCode.OK : HttpStatusCode.Unauthorized;
 
-            Assert.True(expected == response.Result.StatusCode, $"Expected {expected}, but got {response.Result.StatusCode} for {path} and type {type}");
+            Assert.True(expectedStatus == response.Result.StatusCode, $"Expected {expectedStatus}, but got {response.Result.StatusCode} for {path} and type {type}");
         }
     }
 }

--- a/versions.props
+++ b/versions.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup Condition="'$(TF_BUILD)' != 'true'">
-    <VersionPrefix>3.1.0</VersionPrefix>
+    <VersionPrefix>3.1.2</VersionPrefix>
   </PropertyGroup>
   <PropertyGroup>
     <CoreFxVersion>4.4.0</CoreFxVersion>


### PR DESCRIPTION
* Gracefully handle missing EF Core ref in DbMigrations
* split pass/fail actuator auth scenarios into separate tests
* add fix for #729