### PR TITLE
Pipeline updates, testing for .NET 6

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -94,6 +94,7 @@ jobs:
       arguments: '--blame-hang-timeout 3m -f net6.0 --no-build -c $(buildConfiguration) -maxcpucount:1 $(skipFilter) --collect "XPlat Code Coverage" --settings coverlet.runsettings --logger trx --results-directory $(Build.SourcesDirectory)'
       publishTestResults: false
   - task: DotNetCoreCLI@2
+    condition: succeededOrFailed()
     displayName: dotnet test 3.1
     inputs:
       command: test

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,32 +11,7 @@ pr:
 - main
 
 jobs:
-- job: Quick_Response
-  timeoutInMinutes: 20
-  pool:
-    vmImage: ubuntu-latest
-  steps:
-  - task: DotNetCoreCLI@2
-    displayName: dotnet restore
-    inputs:
-      command: restore
-      projects: src/Steeltoe.All.sln
-      feedsToUse: config
-      nugetConfigPath: nuget.config
-  - task: DotNetCoreCLI@2
-    displayName: dotnet build
-    inputs:
-      command: build
-      projects: src/Steeltoe.All.sln
-      arguments: '--no-restore -c $(buildConfiguration) -v n /p:TreatWarningsAsErrors=True'
-  - task: DotNetCoreCLI@2
-    displayName: dotnet test
-    inputs:
-      command: test
-      projects: src/Steeltoe.All.sln
-      arguments: '--blame-hang-timeout 3m --no-build -c $(buildConfiguration) -v n -f net5.0 --filter "Category!=SkipOnLinux&Category!=Integration&FullyQualifiedName!~CircuitBreaker"'
 - job: Steeltoe_CI
-  dependsOn: ['Quick_Response']
   timeoutInMinutes: 90
   variables:
     DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
@@ -73,6 +48,15 @@ jobs:
     env:
       PackageVersion: $(PackageVersion)
       PackageVersionOverride: $(PackageVersionOverride)
+  - task: UseDotNet@2
+    displayName: Install .NET Core 3.1
+    inputs:
+      version: 3.1.x
+  - task: UseDotNet@2
+    displayName: Install .NET 6
+    inputs:
+      version: 6.0.x
+      includePreviewVersions: true
   - task: DotNetCoreCLI@2
     displayName: dotnet restore
     inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,14 +8,7 @@ trigger:
     - build/*
     - project-docs/*
     - roadmaps/*
-pr:
-- main
-  paths:
-    exclude:
-    - README.md
-    - build/*
-    - project-docs/*
-    - roadmaps/*
+pr: none
 
 jobs:
 - job: Steeltoe_CI

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,7 +8,6 @@ trigger:
     - build/*
     - project-docs/*
     - roadmaps/*
-pr: none
 
 jobs:
 - job: Steeltoe_CI

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -87,11 +87,18 @@ jobs:
     condition: eq(variables['integrationTests'], 'true')
     displayName: Start Docker services
   - task: DotNetCoreCLI@2
-    displayName: dotnet test
+    displayName: dotnet test 6.0
     inputs:
       command: test
       projects: src/Steeltoe.All.sln
-      arguments: '--blame-hang-timeout 3m --no-build -c $(buildConfiguration) -maxcpucount:1 $(skipFilter) --collect "XPlat Code Coverage" --settings coverlet.runsettings --logger trx --results-directory $(Build.SourcesDirectory)'
+      arguments: '--blame-hang-timeout 3m -f net6.0 --no-build -c $(buildConfiguration) -maxcpucount:1 $(skipFilter) --collect "XPlat Code Coverage" --settings coverlet.runsettings --logger trx --results-directory $(Build.SourcesDirectory)'
+      publishTestResults: false
+  - task: DotNetCoreCLI@2
+    displayName: dotnet test 3.1
+    inputs:
+      command: test
+      projects: src/Steeltoe.All.sln
+      arguments: '--blame-hang-timeout 3m -f netcoreapp3.1 --no-build -c $(buildConfiguration) -maxcpucount:1 $(skipFilter) --collect "XPlat Code Coverage" --settings coverlet.runsettings --logger trx --results-directory $(Build.SourcesDirectory)'
       publishTestResults: false
   - script: |
       docker kill configserver

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,6 +10,12 @@ trigger:
     - roadmaps/*
 pr:
 - main
+  paths:
+    exclude:
+    - README.md
+    - build/*
+    - project-docs/*
+    - roadmaps/*
 
 jobs:
 - job: Steeltoe_CI

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,6 +5,7 @@ trigger:
   paths:
     exclude:
     - README.md
+    - build/*
     - project-docs/*
     - roadmaps/*
 pr:

--- a/build/circuitbreaker.yml
+++ b/build/circuitbreaker.yml
@@ -16,8 +16,3 @@ jobs:
   - template: templates/component-build.yaml
     parameters:
       component: CircuitBreaker
-      coverletInclude: "[Steeltoe.CircuitBreaker*]*"
-  - template: templates/consolidate-coverage.yaml
-    parameters:
-      JobNames:
-      - CircuitBreaker_ubuntu

--- a/build/circuitbreaker.yml
+++ b/build/circuitbreaker.yml
@@ -19,4 +19,4 @@ jobs:
   - template: templates/consolidate-coverage.yaml
     parameters:
       JobNames:
-      - CircuitBreaker_linux
+      - CircuitBreaker_ubuntu

--- a/build/circuitbreaker.yml
+++ b/build/circuitbreaker.yml
@@ -3,6 +3,8 @@ trigger:
     include:
     - main
   paths:
+    exclude:
+    - /*
     include:
     - build/templates/component-build.yml
     - build/circuitbreaker.yml

--- a/build/circuitbreaker.yml
+++ b/build/circuitbreaker.yml
@@ -16,3 +16,7 @@ jobs:
   - template: templates/component-build.yaml
     parameters:
       component: CircuitBreaker
+  - template: templates/consolidate-coverage.yaml
+    parameters:
+      JobNames:
+      - CircuitBreaker_linux

--- a/build/circuitbreaker.yml
+++ b/build/circuitbreaker.yml
@@ -4,7 +4,7 @@ trigger:
     - main
   paths:
     exclude:
-    - /*
+    - '*'
     include:
     - build/templates/component-build.yml
     - build/circuitbreaker.yml
@@ -16,6 +16,7 @@ jobs:
   - template: templates/component-build.yaml
     parameters:
       component: CircuitBreaker
+      coverletInclude: "[Steeltoe.CircuitBreaker*]*"
   - template: templates/consolidate-coverage.yaml
     parameters:
       JobNames:

--- a/build/circuitbreaker.yml
+++ b/build/circuitbreaker.yml
@@ -6,7 +6,7 @@ trigger:
     exclude:
     - '*'
     include:
-    - build/templates/component-build.yml
+    - build/templates/*
     - build/circuitbreaker.yml
     - src/CircuitBreaker/*
 pr:

--- a/build/circuitbreaker.yml
+++ b/build/circuitbreaker.yml
@@ -3,8 +3,6 @@ pr:
     include:
     - main
   paths:
-    exclude:
-    - '*'
     include:
     - build/templates/*
     - build/circuitbreaker.yml

--- a/build/circuitbreaker.yml
+++ b/build/circuitbreaker.yml
@@ -1,0 +1,16 @@
+trigger:
+  branches:
+    include:
+    - main
+  paths:
+    include:
+    - build/templates/component-build.yml
+    - build/circuitbreaker.yml
+    - src/CircuitBreaker/*
+pr:
+- main
+
+jobs:
+  - template: templates/component-build.yaml
+    parameters:
+      component: CircuitBreaker

--- a/build/common.yml
+++ b/build/common.yml
@@ -3,8 +3,6 @@ pr:
     include:
     - main
   paths:
-    exclude:
-    - '**/*'
     include:
     - build/templates/*
     - build/common.yml

--- a/build/common.yml
+++ b/build/common.yml
@@ -16,8 +16,3 @@ jobs:
   - template: templates/component-build.yaml
     parameters:
       component: Common
-      coverletInclude: "[Steeltoe.Common*]*"
-  - template: templates/consolidate-coverage.yaml
-    parameters:
-      JobNames:
-      - Common_ubuntu

--- a/build/common.yml
+++ b/build/common.yml
@@ -19,4 +19,4 @@ jobs:
   - template: templates/consolidate-coverage.yaml
     parameters:
       JobNames:
-      - Common_linux
+      - Common_ubuntu

--- a/build/common.yml
+++ b/build/common.yml
@@ -6,7 +6,7 @@ trigger:
     exclude:
     - '*'
     include:
-    - build/templates/component-build.yml
+    - build/templates/*
     - build/common.yml
     - src/Common/*
 pr:

--- a/build/common.yml
+++ b/build/common.yml
@@ -3,6 +3,8 @@ trigger:
     include:
     - main
   paths:
+    exclude:
+    - /*
     include:
     - build/templates/component-build.yml
     - build/common.yml

--- a/build/common.yml
+++ b/build/common.yml
@@ -4,7 +4,7 @@ pr:
     - main
   paths:
     exclude:
-    - '*'
+    - '**/*'
     include:
     - build/templates/*
     - build/common.yml

--- a/build/common.yml
+++ b/build/common.yml
@@ -1,0 +1,16 @@
+trigger:
+  branches:
+    include:
+    - main
+  paths:
+    include:
+    - build/templates/component-build.yml
+    - build/common.yml
+    - src/Common/*
+pr:
+- main
+
+jobs:
+  - template: templates/component-build.yaml
+    parameters:
+      component: Common

--- a/build/common.yml
+++ b/build/common.yml
@@ -1,4 +1,4 @@
-trigger:
+pr:
   branches:
     include:
     - main
@@ -9,8 +9,6 @@ trigger:
     - build/templates/*
     - build/common.yml
     - src/Common/*
-pr:
-- main
 
 jobs:
   - template: templates/component-build.yaml

--- a/build/common.yml
+++ b/build/common.yml
@@ -4,7 +4,7 @@ trigger:
     - main
   paths:
     exclude:
-    - /*
+    - '*'
     include:
     - build/templates/component-build.yml
     - build/common.yml
@@ -16,6 +16,7 @@ jobs:
   - template: templates/component-build.yaml
     parameters:
       component: Common
+      coverletInclude: "[Steeltoe.Common*]*"
   - template: templates/consolidate-coverage.yaml
     parameters:
       JobNames:

--- a/build/common.yml
+++ b/build/common.yml
@@ -16,3 +16,7 @@ jobs:
   - template: templates/component-build.yaml
     parameters:
       component: Common
+  - template: templates/consolidate-coverage.yaml
+    parameters:
+      JobNames:
+      - Common_linux

--- a/build/configuration.yml
+++ b/build/configuration.yml
@@ -1,4 +1,4 @@
-trigger:
+pr:
   branches:
     include:
     - main
@@ -9,8 +9,6 @@ trigger:
     - build/templates/*
     - build/configuration.yml
     - src/Configuration/*
-pr:
-- main
 
 jobs:
   - template: templates/component-build.yaml

--- a/build/configuration.yml
+++ b/build/configuration.yml
@@ -4,7 +4,7 @@ trigger:
     - main
   paths:
     exclude:
-    - /*
+    - '*'
     include:
     - build/templates/component-build.yml
     - build/configuration.yml
@@ -16,6 +16,7 @@ jobs:
   - template: templates/component-build.yaml
     parameters:
       component: Configuration
+      coverletInclude: "[Steeltoe.Extensions.Configuration*]*"
       runConfigServer: true
   - template: templates/consolidate-coverage.yaml
     parameters:

--- a/build/configuration.yml
+++ b/build/configuration.yml
@@ -6,7 +6,7 @@ trigger:
     exclude:
     - '*'
     include:
-    - build/templates/component-build.yml
+    - build/templates/*
     - build/configuration.yml
     - src/Configuration/*
 pr:

--- a/build/configuration.yml
+++ b/build/configuration.yml
@@ -1,0 +1,17 @@
+trigger:
+  branches:
+    include:
+    - main
+  paths:
+    include:
+    - build/templates/component-build.yml
+    - build/configuration.yml
+    - src/Configuration/*
+pr:
+- main
+
+jobs:
+  - template: templates/component-build.yaml
+    parameters:
+      component: Configuration
+      runConfigServer: true

--- a/build/configuration.yml
+++ b/build/configuration.yml
@@ -3,6 +3,8 @@ trigger:
     include:
     - main
   paths:
+    exclude:
+    - /*
     include:
     - build/templates/component-build.yml
     - build/configuration.yml

--- a/build/configuration.yml
+++ b/build/configuration.yml
@@ -3,8 +3,6 @@ pr:
     include:
     - main
   paths:
-    exclude:
-    - '*'
     include:
     - build/templates/*
     - build/configuration.yml

--- a/build/configuration.yml
+++ b/build/configuration.yml
@@ -20,4 +20,4 @@ jobs:
   - template: templates/consolidate-coverage.yaml
     parameters:
       JobNames:
-      - Configuration_linux
+      - Configuration_ubuntu

--- a/build/configuration.yml
+++ b/build/configuration.yml
@@ -16,9 +16,4 @@ jobs:
   - template: templates/component-build.yaml
     parameters:
       component: Configuration
-      coverletInclude: "[Steeltoe.Extensions.Configuration*]*"
       runConfigServer: true
-  - template: templates/consolidate-coverage.yaml
-    parameters:
-      JobNames:
-      - Configuration_ubuntu

--- a/build/configuration.yml
+++ b/build/configuration.yml
@@ -17,3 +17,7 @@ jobs:
     parameters:
       component: Configuration
       runConfigServer: true
+  - template: templates/consolidate-coverage.yaml
+    parameters:
+      JobNames:
+      - Configuration_linux

--- a/build/connectors.yml
+++ b/build/connectors.yml
@@ -1,4 +1,4 @@
-trigger:
+pr:
   branches:
     include:
     - main
@@ -9,8 +9,6 @@ trigger:
     - build/templates/*
     - build/connectors.yml
     - src/Connectors/*
-pr:
-- main
 
 jobs:
   - template: templates/component-build.yaml

--- a/build/connectors.yml
+++ b/build/connectors.yml
@@ -4,7 +4,7 @@ trigger:
     - main
   paths:
     exclude:
-    - /*
+    - '*'
     include:
     - build/templates/component-build.yml
     - build/connectors.yml
@@ -16,6 +16,7 @@ jobs:
   - template: templates/component-build.yaml
     parameters:
       component: Connectors
+      coverletInclude: "[*Connector*]*"
   - template: templates/consolidate-coverage.yaml
     parameters:
       JobNames:

--- a/build/connectors.yml
+++ b/build/connectors.yml
@@ -1,0 +1,16 @@
+trigger:
+  branches:
+    include:
+    - main
+  paths:
+    include:
+    - build/templates/component-build.yml
+    - build/connectors.yml
+    - src/Connectors/*
+pr:
+- main
+
+jobs:
+  - template: templates/component-build.yaml
+    parameters:
+      component: Connectors

--- a/build/connectors.yml
+++ b/build/connectors.yml
@@ -6,7 +6,7 @@ trigger:
     exclude:
     - '*'
     include:
-    - build/templates/component-build.yml
+    - build/templates/*
     - build/connectors.yml
     - src/Connectors/*
 pr:

--- a/build/connectors.yml
+++ b/build/connectors.yml
@@ -16,8 +16,3 @@ jobs:
   - template: templates/component-build.yaml
     parameters:
       component: Connectors
-      coverletInclude: "[*Connector*]*"
-  - template: templates/consolidate-coverage.yaml
-    parameters:
-      JobNames:
-      - Connectors_ubuntu

--- a/build/connectors.yml
+++ b/build/connectors.yml
@@ -19,4 +19,4 @@ jobs:
   - template: templates/consolidate-coverage.yaml
     parameters:
       JobNames:
-      - Connectors_linux
+      - Connectors_ubuntu

--- a/build/connectors.yml
+++ b/build/connectors.yml
@@ -3,8 +3,6 @@ pr:
     include:
     - main
   paths:
-    exclude:
-    - '*'
     include:
     - build/templates/*
     - build/connectors.yml

--- a/build/connectors.yml
+++ b/build/connectors.yml
@@ -3,6 +3,8 @@ trigger:
     include:
     - main
   paths:
+    exclude:
+    - /*
     include:
     - build/templates/component-build.yml
     - build/connectors.yml

--- a/build/connectors.yml
+++ b/build/connectors.yml
@@ -16,3 +16,7 @@ jobs:
   - template: templates/component-build.yaml
     parameters:
       component: Connectors
+  - template: templates/consolidate-coverage.yaml
+    parameters:
+      JobNames:
+      - Connectors_linux

--- a/build/discovery.yml
+++ b/build/discovery.yml
@@ -1,4 +1,4 @@
-trigger:
+pr:
   branches:
     include:
     - main
@@ -9,8 +9,6 @@ trigger:
     - build/templates/*
     - build/discovery.yml
     - src/Discovery/*
-pr:
-- main
 
 jobs:
   - template: templates/component-build.yaml

--- a/build/discovery.yml
+++ b/build/discovery.yml
@@ -4,7 +4,7 @@ trigger:
     - main
   paths:
     exclude:
-    - /*
+    - '*'
     include:
     - build/templates/component-build.yml
     - build/discovery.yml
@@ -16,6 +16,7 @@ jobs:
   - template: templates/component-build.yaml
     parameters:
       component: Discovery
+      coverletInclude: "[Steeltoe.Discovery*]*"
   - template: templates/consolidate-coverage.yaml
     parameters:
       JobNames:

--- a/build/discovery.yml
+++ b/build/discovery.yml
@@ -3,6 +3,8 @@ trigger:
     include:
     - main
   paths:
+    exclude:
+    - /*
     include:
     - build/templates/component-build.yml
     - build/discovery.yml

--- a/build/discovery.yml
+++ b/build/discovery.yml
@@ -1,0 +1,16 @@
+trigger:
+  branches:
+    include:
+    - main
+  paths:
+    include:
+    - build/templates/component-build.yml
+    - build/discovery.yml
+    - src/Discovery/*
+pr:
+- main
+
+jobs:
+  - template: templates/component-build.yaml
+    parameters:
+      component: Discovery

--- a/build/discovery.yml
+++ b/build/discovery.yml
@@ -19,4 +19,4 @@ jobs:
   - template: templates/consolidate-coverage.yaml
     parameters:
       JobNames:
-      - Discovery_linux
+      - Discovery_ubuntu

--- a/build/discovery.yml
+++ b/build/discovery.yml
@@ -16,3 +16,7 @@ jobs:
   - template: templates/component-build.yaml
     parameters:
       component: Discovery
+  - template: templates/consolidate-coverage.yaml
+    parameters:
+      JobNames:
+      - Discovery_linux

--- a/build/discovery.yml
+++ b/build/discovery.yml
@@ -6,7 +6,7 @@ trigger:
     exclude:
     - '*'
     include:
-    - build/templates/component-build.yml
+    - build/templates/*
     - build/discovery.yml
     - src/Discovery/*
 pr:

--- a/build/discovery.yml
+++ b/build/discovery.yml
@@ -16,8 +16,3 @@ jobs:
   - template: templates/component-build.yaml
     parameters:
       component: Discovery
-      coverletInclude: "[Steeltoe.Discovery*]*"
-  - template: templates/consolidate-coverage.yaml
-    parameters:
-      JobNames:
-      - Discovery_ubuntu

--- a/build/discovery.yml
+++ b/build/discovery.yml
@@ -3,8 +3,6 @@ pr:
     include:
     - main
   paths:
-    exclude:
-    - '*'
     include:
     - build/templates/*
     - build/discovery.yml

--- a/build/integration.yml
+++ b/build/integration.yml
@@ -6,7 +6,7 @@ trigger:
     exclude:
     - '*'
     include:
-    - build/templates/component-build.yml
+    - build/templates/*
     - build/integration.yml
     - src/Integration/*
 pr:

--- a/build/integration.yml
+++ b/build/integration.yml
@@ -16,8 +16,3 @@ jobs:
   - template: templates/component-build.yaml
     parameters:
       component: Integration
-      coverletInclude: "[Steeltoe.Integration*]*"
-  - template: templates/consolidate-coverage.yaml
-    parameters:
-      JobNames:
-      - Integration_ubuntu

--- a/build/integration.yml
+++ b/build/integration.yml
@@ -19,4 +19,4 @@ jobs:
   - template: templates/consolidate-coverage.yaml
     parameters:
       JobNames:
-      - Integration_linux
+      - Integration_ubuntu

--- a/build/integration.yml
+++ b/build/integration.yml
@@ -16,3 +16,7 @@ jobs:
   - template: templates/component-build.yaml
     parameters:
       component: Integration
+  - template: templates/consolidate-coverage.yaml
+    parameters:
+      JobNames:
+      - Integration_linux

--- a/build/integration.yml
+++ b/build/integration.yml
@@ -1,4 +1,4 @@
-trigger:
+pr:
   branches:
     include:
     - main
@@ -9,8 +9,6 @@ trigger:
     - build/templates/*
     - build/integration.yml
     - src/Integration/*
-pr:
-- main
 
 jobs:
   - template: templates/component-build.yaml

--- a/build/integration.yml
+++ b/build/integration.yml
@@ -3,6 +3,8 @@ trigger:
     include:
     - main
   paths:
+    exclude:
+    - /*
     include:
     - build/templates/component-build.yml
     - build/integration.yml

--- a/build/integration.yml
+++ b/build/integration.yml
@@ -1,0 +1,16 @@
+trigger:
+  branches:
+    include:
+    - main
+  paths:
+    include:
+    - build/templates/component-build.yml
+    - build/integration.yml
+    - src/Integration/*
+pr:
+- main
+
+jobs:
+  - template: templates/component-build.yaml
+    parameters:
+      component: Integration

--- a/build/integration.yml
+++ b/build/integration.yml
@@ -4,7 +4,7 @@ trigger:
     - main
   paths:
     exclude:
-    - /*
+    - '*'
     include:
     - build/templates/component-build.yml
     - build/integration.yml
@@ -16,6 +16,7 @@ jobs:
   - template: templates/component-build.yaml
     parameters:
       component: Integration
+      coverletInclude: "[Steeltoe.Integration*]*"
   - template: templates/consolidate-coverage.yaml
     parameters:
       JobNames:

--- a/build/integration.yml
+++ b/build/integration.yml
@@ -3,8 +3,6 @@ pr:
     include:
     - main
   paths:
-    exclude:
-    - '*'
     include:
     - build/templates/*
     - build/integration.yml

--- a/build/logging.yml
+++ b/build/logging.yml
@@ -6,7 +6,7 @@ trigger:
     exclude:
     - '*'
     include:
-    - build/templates/component-build.yml
+    - build/templates/*
     - build/logging.yml
     - src/Logging/*
 pr:

--- a/build/logging.yml
+++ b/build/logging.yml
@@ -3,6 +3,8 @@ trigger:
     include:
     - main
   paths:
+    exclude:
+    - /*
     include:
     - build/templates/component-build.yml
     - build/logging.yml

--- a/build/logging.yml
+++ b/build/logging.yml
@@ -4,7 +4,7 @@ trigger:
     - main
   paths:
     exclude:
-    - /*
+    - '*'
     include:
     - build/templates/component-build.yml
     - build/logging.yml
@@ -16,6 +16,7 @@ jobs:
   - template: templates/component-build.yaml
     parameters:
       component: Logging
+      coverletInclude: "[Steeltoe.Extensions.Logging*]*"
   - template: templates/consolidate-coverage.yaml
     parameters:
       JobNames:

--- a/build/logging.yml
+++ b/build/logging.yml
@@ -19,4 +19,4 @@ jobs:
   - template: templates/consolidate-coverage.yaml
     parameters:
       JobNames:
-      - Logging_linux
+      - Logging_ubuntu

--- a/build/logging.yml
+++ b/build/logging.yml
@@ -16,8 +16,3 @@ jobs:
   - template: templates/component-build.yaml
     parameters:
       component: Logging
-      coverletInclude: "[Steeltoe.Extensions.Logging*]*"
-  - template: templates/consolidate-coverage.yaml
-    parameters:
-      JobNames:
-      - Logging_ubuntu

--- a/build/logging.yml
+++ b/build/logging.yml
@@ -16,3 +16,7 @@ jobs:
   - template: templates/component-build.yaml
     parameters:
       component: Logging
+  - template: templates/consolidate-coverage.yaml
+    parameters:
+      JobNames:
+      - Logging_linux

--- a/build/logging.yml
+++ b/build/logging.yml
@@ -1,0 +1,16 @@
+trigger:
+  branches:
+    include:
+    - main
+  paths:
+    include:
+    - build/templates/component-build.yml
+    - build/logging.yml
+    - src/Logging/*
+pr:
+- main
+
+jobs:
+  - template: templates/component-build.yaml
+    parameters:
+      component: Logging

--- a/build/logging.yml
+++ b/build/logging.yml
@@ -1,4 +1,4 @@
-trigger:
+pr:
   branches:
     include:
     - main
@@ -9,8 +9,6 @@ trigger:
     - build/templates/*
     - build/logging.yml
     - src/Logging/*
-pr:
-- main
 
 jobs:
   - template: templates/component-build.yaml

--- a/build/logging.yml
+++ b/build/logging.yml
@@ -3,8 +3,6 @@ pr:
     include:
     - main
   paths:
-    exclude:
-    - '*'
     include:
     - build/templates/*
     - build/logging.yml

--- a/build/management.yml
+++ b/build/management.yml
@@ -1,4 +1,4 @@
-trigger:
+pr:
   branches:
     include:
     - main
@@ -9,8 +9,6 @@ trigger:
     - build/templates/*
     - build/management.yml
     - src/Management/*
-pr:
-- main
 
 jobs:
   - template: templates/component-build.yaml

--- a/build/management.yml
+++ b/build/management.yml
@@ -20,3 +20,8 @@ jobs:
     parameters:
       component: Management
       OS: windows
+  - template: templates/consolidate-coverage.yaml
+    parameters:
+      JobNames:
+      - Management_linux
+      - Management_windows

--- a/build/management.yml
+++ b/build/management.yml
@@ -23,5 +23,5 @@ jobs:
   - template: templates/consolidate-coverage.yaml
     parameters:
       JobNames:
-      - Management_linux
+      - Management_ubuntu
       - Management_windows

--- a/build/management.yml
+++ b/build/management.yml
@@ -1,0 +1,20 @@
+trigger:
+  branches:
+    include:
+    - main
+  paths:
+    include:
+    - build/templates/component-build.yml
+    - build/management.yml
+    - src/Management/*
+pr:
+- main
+
+jobs:
+  - template: templates/component-build.yaml
+    parameters:
+      component: Management
+  - template: templates/component-build.yaml
+    parameters:
+      component: Management
+      OS: windows

--- a/build/management.yml
+++ b/build/management.yml
@@ -3,6 +3,8 @@ trigger:
     include:
     - main
   paths:
+    exclude:
+    - /*
     include:
     - build/templates/component-build.yml
     - build/management.yml

--- a/build/management.yml
+++ b/build/management.yml
@@ -16,14 +16,7 @@ jobs:
   - template: templates/component-build.yaml
     parameters:
       component: Management
-      coverletInclude: "[Steeltoe.Management*]*"
   - template: templates/component-build.yaml
     parameters:
       component: Management
       OS: windows
-      coverletInclude: "[Steeltoe.Management*]*"
-  - template: templates/consolidate-coverage.yaml
-    parameters:
-      JobNames:
-      - Management_ubuntu
-      - Management_windows

--- a/build/management.yml
+++ b/build/management.yml
@@ -3,8 +3,6 @@ pr:
     include:
     - main
   paths:
-    exclude:
-    - '*'
     include:
     - build/templates/*
     - build/management.yml

--- a/build/management.yml
+++ b/build/management.yml
@@ -6,7 +6,7 @@ trigger:
     exclude:
     - '*'
     include:
-    - build/templates/component-build.yml
+    - build/templates/*
     - build/management.yml
     - src/Management/*
 pr:

--- a/build/management.yml
+++ b/build/management.yml
@@ -4,7 +4,7 @@ trigger:
     - main
   paths:
     exclude:
-    - /*
+    - '*'
     include:
     - build/templates/component-build.yml
     - build/management.yml
@@ -16,10 +16,12 @@ jobs:
   - template: templates/component-build.yaml
     parameters:
       component: Management
+      coverletInclude: "[Steeltoe.Management*]*"
   - template: templates/component-build.yaml
     parameters:
       component: Management
       OS: windows
+      coverletInclude: "[Steeltoe.Management*]*"
   - template: templates/consolidate-coverage.yaml
     parameters:
       JobNames:

--- a/build/messaging.yml
+++ b/build/messaging.yml
@@ -3,6 +3,8 @@ trigger:
     include:
     - main
   paths:
+    exclude:
+    - /*
     include:
     - build/templates/component-build.yml
     - build/messaging.yml

--- a/build/messaging.yml
+++ b/build/messaging.yml
@@ -4,7 +4,7 @@ trigger:
     - main
   paths:
     exclude:
-    - /*
+    - '*'
     include:
     - build/templates/component-build.yml
     - build/messaging.yml
@@ -17,6 +17,7 @@ jobs:
     parameters:
       component: Messaging
       runRabbitMQ: true
+      coverletInclude: "[Steeltoe.Messaging*]*"
   - template: templates/consolidate-coverage.yaml
     parameters:
       JobNames:

--- a/build/messaging.yml
+++ b/build/messaging.yml
@@ -6,7 +6,7 @@ trigger:
     exclude:
     - '*'
     include:
-    - build/templates/component-build.yml
+    - build/templates/*
     - build/messaging.yml
     - src/Messaging/*
 pr:

--- a/build/messaging.yml
+++ b/build/messaging.yml
@@ -1,0 +1,17 @@
+trigger:
+  branches:
+    include:
+    - main
+  paths:
+    include:
+    - build/templates/component-build.yml
+    - build/messaging.yml
+    - src/Messaging/*
+pr:
+- main
+
+jobs:
+  - template: templates/component-build.yaml
+    parameters:
+      component: Messaging
+      runRabbitMQ: true

--- a/build/messaging.yml
+++ b/build/messaging.yml
@@ -17,8 +17,3 @@ jobs:
     parameters:
       component: Messaging
       runRabbitMQ: true
-      coverletInclude: "[Steeltoe.Messaging*]*"
-  - template: templates/consolidate-coverage.yaml
-    parameters:
-      JobNames:
-      - Messaging_ubuntu

--- a/build/messaging.yml
+++ b/build/messaging.yml
@@ -3,8 +3,6 @@ pr:
     include:
     - main
   paths:
-    exclude:
-    - '*'
     include:
     - build/templates/*
     - build/messaging.yml

--- a/build/messaging.yml
+++ b/build/messaging.yml
@@ -20,4 +20,4 @@ jobs:
   - template: templates/consolidate-coverage.yaml
     parameters:
       JobNames:
-      - Messaging_linux
+      - Messaging_ubuntu

--- a/build/messaging.yml
+++ b/build/messaging.yml
@@ -17,3 +17,7 @@ jobs:
     parameters:
       component: Messaging
       runRabbitMQ: true
+  - template: templates/consolidate-coverage.yaml
+    parameters:
+      JobNames:
+      - Messaging_linux

--- a/build/messaging.yml
+++ b/build/messaging.yml
@@ -1,4 +1,4 @@
-trigger:
+pr:
   branches:
     include:
     - main
@@ -9,8 +9,6 @@ trigger:
     - build/templates/*
     - build/messaging.yml
     - src/Messaging/*
-pr:
-- main
 
 jobs:
   - template: templates/component-build.yaml

--- a/build/security.yml
+++ b/build/security.yml
@@ -16,9 +16,4 @@ jobs:
   - template: templates/component-build.yaml
     parameters:
       component: Security
-      coverletInclude: "[Steeltoe.Security*]*"
       skipFilter: --filter "Category!=SkipOnLinux"
-  - template: templates/consolidate-coverage.yaml
-    parameters:
-      JobNames:
-      - Security_ubuntu

--- a/build/security.yml
+++ b/build/security.yml
@@ -1,0 +1,17 @@
+trigger:
+  branches:
+    include:
+    - main
+  paths:
+    include:
+    - build/templates/component-build.yml
+    - build/security.yml
+    - src/Security/*
+pr:
+- main
+
+jobs:
+  - template: templates/component-build.yaml
+    parameters:
+      component: Security
+      skipFilter: --filter "Category!=SkipOnLinux"

--- a/build/security.yml
+++ b/build/security.yml
@@ -17,3 +17,7 @@ jobs:
     parameters:
       component: Security
       skipFilter: --filter "Category!=SkipOnLinux"
+  - template: templates/consolidate-coverage.yaml
+    parameters:
+      JobNames:
+      - Security_linux

--- a/build/security.yml
+++ b/build/security.yml
@@ -3,6 +3,8 @@ trigger:
     include:
     - main
   paths:
+    exclude:
+    - /*
     include:
     - build/templates/component-build.yml
     - build/security.yml

--- a/build/security.yml
+++ b/build/security.yml
@@ -6,7 +6,7 @@ trigger:
     exclude:
     - '*'
     include:
-    - build/templates/component-build.yml
+    - build/templates/*
     - build/security.yml
     - src/Security/*
 pr:

--- a/build/security.yml
+++ b/build/security.yml
@@ -20,4 +20,4 @@ jobs:
   - template: templates/consolidate-coverage.yaml
     parameters:
       JobNames:
-      - Security_linux
+      - Security_ubuntu

--- a/build/security.yml
+++ b/build/security.yml
@@ -1,4 +1,4 @@
-trigger:
+pr:
   branches:
     include:
     - main
@@ -9,8 +9,6 @@ trigger:
     - build/templates/*
     - build/security.yml
     - src/Security/*
-pr:
-- main
 
 jobs:
   - template: templates/component-build.yaml

--- a/build/security.yml
+++ b/build/security.yml
@@ -13,3 +13,7 @@ jobs:
     parameters:
       component: Security
       skipFilter: --filter "Category!=SkipOnLinux"
+  - template: templates/component-build.yaml
+    parameters:
+      component: Security
+      OS: windows

--- a/build/security.yml
+++ b/build/security.yml
@@ -3,8 +3,6 @@ pr:
     include:
     - main
   paths:
-    exclude:
-    - '*'
     include:
     - build/templates/*
     - build/security.yml

--- a/build/security.yml
+++ b/build/security.yml
@@ -4,7 +4,7 @@ trigger:
     - main
   paths:
     exclude:
-    - /*
+    - '*'
     include:
     - build/templates/component-build.yml
     - build/security.yml
@@ -16,6 +16,7 @@ jobs:
   - template: templates/component-build.yaml
     parameters:
       component: Security
+      coverletInclude: "[Steeltoe.Security*]*"
       skipFilter: --filter "Category!=SkipOnLinux"
   - template: templates/consolidate-coverage.yaml
     parameters:

--- a/build/stream.yml
+++ b/build/stream.yml
@@ -13,3 +13,4 @@ jobs:
     parameters:
       component: Stream
       runRabbitMQ: true
+      skipFilter: --filter "Category!=SkipOnLinux"

--- a/build/stream.yml
+++ b/build/stream.yml
@@ -7,10 +7,11 @@ pr:
     - '*'
     include:
     - build/templates/*
-    - build/circuitbreaker.yml
-    - src/CircuitBreaker/*
+    - build/stream.yml
+    - src/Stream/*
 
 jobs:
   - template: templates/component-build.yaml
     parameters:
-      component: CircuitBreaker
+      component: Stream
+      runRabbitMQ: true

--- a/build/stream.yml
+++ b/build/stream.yml
@@ -3,8 +3,6 @@ pr:
     include:
     - main
   paths:
-    exclude:
-    - '*'
     include:
     - build/templates/*
     - build/stream.yml

--- a/build/templates/component-build.yaml
+++ b/build/templates/component-build.yaml
@@ -4,6 +4,7 @@ parameters:
   runRabbitMQ: false
   skipFilter: ''
   OS: ubuntu
+  coverletInclude: "[*]*"
 
 jobs:
 - job: ${{parameters.component}}_${{parameters.OS}}
@@ -47,7 +48,8 @@ jobs:
     inputs:
       command: test
       projects: $(SolutionFile)
-      arguments: --no-build -c Release -maxcpucount:1 ${{parameters.skipFilter}} --collect "XPlat Code Coverage" --settings coverlet.runsettings
+      arguments: --no-build -c Release -maxcpucount:1 ${{parameters.skipFilter}} --collect "XPlat Code Coverage" /p:Include=${{parameters.coverletInclude}} /p:CoverletOutputFormat=opencover /p:DeterministicReport=true /p:UseSourceLink=true /p:ExcludeByAttribute="Obsolete,GeneratedCodeAttribute,CompilerGeneratedAttribute"
+
   - script: |
       docker kill rabbitmq
       docker rm rabbitmq

--- a/build/templates/component-build.yaml
+++ b/build/templates/component-build.yaml
@@ -48,7 +48,7 @@ jobs:
     inputs:
       command: test
       projects: $(SolutionFile)
-      arguments: '--no-build -c Release -maxcpucount:1 ${{parameters.skipFilter}} --collect "XPlat Code Coverage" /p:Include=\"${{parameters.coverletInclude}}\" /p:CoverletOutputFormat=opencover /p:DeterministicReport=true /p:UseSourceLink=true'
+      arguments: '--no-build -c Release -maxcpucount:1 ${{parameters.skipFilter}} --collect "XPlat Code Coverage" /p:Include=${{parameters.coverletInclude}} /p:CoverletOutputFormat=opencover /p:DeterministicReport=true /p:UseSourceLink=true'
 
   - script: |
       docker kill rabbitmq

--- a/build/templates/component-build.yaml
+++ b/build/templates/component-build.yaml
@@ -36,10 +36,10 @@ jobs:
       command: build
       projects: $(SolutionFile)
       arguments: --no-restore -c Release -v n /p:TreatWarningsAsErrors=True
-  - script: docker run -d --name rabbitmq -p 5672:5672 -p 15672:15672 rabbitmq:3-management
+  - script: docker run -d --name rabbitmq -p 5672:5672 -p 15672:15672 rabbitmq:3-management; sleep 10s
     condition: eq(${{parameters.runRabbitMQ}}, 'true')
     displayName: Start RabbitMQ
-  - script: docker run -d --name configserver -p 8888:8888 steeltoeoss/config-server --spring.cloud.config.server.git.default-label=main
+  - script: docker run -d --name configserver -p 8888:8888 steeltoeoss/config-server --spring.cloud.config.server.git.default-label=main; sleep 10s
     condition: eq(${{parameters.runConfigServer}}, 'true')
     displayName: Start Config Server
   - task: DotNetCoreCLI@2

--- a/build/templates/component-build.yaml
+++ b/build/templates/component-build.yaml
@@ -43,11 +43,17 @@ jobs:
     condition: eq(${{parameters.runConfigServer}}, 'true')
     displayName: Start Config Server
   - task: DotNetCoreCLI@2
-    displayName: dotnet test
+    displayName: dotnet test 3.1
     inputs:
       command: test
       projects: $(SolutionFile)
-      arguments: --no-build -c Release -maxcpucount:1 ${{parameters.skipFilter}}
+      arguments: --blame-hang-timeout 5m --no-build -c Release -f netcoreapp3.1 -maxcpucount:1 ${{parameters.skipFilter}}
+  - task: DotNetCoreCLI@2
+    displayName: dotnet test 6.0
+    inputs:
+      command: test
+      projects: $(SolutionFile)
+      arguments: --blame-hang-timeout 5m --no-build -c Release -f net6.0 -maxcpucount:1 ${{parameters.skipFilter}}
   - script: |
       docker kill rabbitmq
       docker rm rabbitmq

--- a/build/templates/component-build.yaml
+++ b/build/templates/component-build.yaml
@@ -43,17 +43,18 @@ jobs:
     condition: eq(${{parameters.runConfigServer}}, 'true')
     displayName: Start Config Server
   - task: DotNetCoreCLI@2
-    displayName: dotnet test 3.1
-    inputs:
-      command: test
-      projects: $(SolutionFile)
-      arguments: --blame-hang-timeout 5m --no-build -c Release -f netcoreapp3.1 -maxcpucount:1 ${{parameters.skipFilter}}
-  - task: DotNetCoreCLI@2
     displayName: dotnet test 6.0
     inputs:
       command: test
       projects: $(SolutionFile)
       arguments: --blame-hang-timeout 5m --no-build -c Release -f net6.0 -maxcpucount:1 ${{parameters.skipFilter}}
+  - task: DotNetCoreCLI@2
+    condition: succeededOrFailed()
+    displayName: dotnet test 3.1
+    inputs:
+      command: test
+      projects: $(SolutionFile)
+      arguments: --blame-hang-timeout 5m --no-build -c Release -f netcoreapp3.1 -maxcpucount:1 ${{parameters.skipFilter}}
   - script: |
       docker kill rabbitmq
       docker rm rabbitmq

--- a/build/templates/component-build.yaml
+++ b/build/templates/component-build.yaml
@@ -47,7 +47,7 @@ jobs:
     inputs:
       command: test
       projects: $(SolutionFile)
-      arguments: '--blame-hang-timeout 3m --no-build -c Release -maxcpucount:1 ${{parameters.skipFilter}} --collect "XPlat Code Coverage" --settings coverlet.runsettings --logger trx --results-directory $(Build.SourcesDirectory)'
+      arguments: '--blame-hang-timeout 3m --no-build -c Release -maxcpucount:1 ${{parameters.skipFilter}} --collect "XPlat Code Coverage" --settings coverlet.runsettings --logger trx --results-directory $(Agent.TempDirectory)'
   - task: PublishTestResults@2
     condition: succeededOrFailed()
     displayName: Publish test results
@@ -65,3 +65,15 @@ jobs:
       docker rm configserver
     condition: eq(${{parameters.runConfigServer}}, 'true')
     displayName: Stop Config Server
+  - task: Palmmedia.reportgenerator.reportgenerator-build-release-task.reportgenerator@4
+    condition: succeededOrFailed()
+    displayName: Consolidate coverage for this job
+    inputs:
+      reports: $(Agent.TempDirectory)/**/*opencover.xml
+      targetdir: $(Build.ArtifactStagingDirectory)/CodeCoverage
+      reporttypes: Cobertura
+  - task: PublishCodeCoverageResults@1
+    condition: succeededOrFailed()
+    inputs:
+      codeCoverageTool: Cobertura
+      summaryFileLocation: $(Build.ArtifactStagingDirectory)/CodeCoverage/cobertura.xml

--- a/build/templates/component-build.yaml
+++ b/build/templates/component-build.yaml
@@ -35,7 +35,7 @@ jobs:
     inputs:
       command: build
       projects: $(SolutionFile)
-      arguments: '--no-restore -c Release -v n /p:TreatWarningsAsErrors=True'
+      arguments: --no-restore -c Release -v n /p:TreatWarningsAsErrors=True
   - script: docker run -d --name rabbitmq -p 5672:5672 -p 15672:15672 rabbitmq:3-management
     condition: eq(${{parameters.runRabbitMQ}}, 'true')
     displayName: Start RabbitMQ
@@ -47,14 +47,7 @@ jobs:
     inputs:
       command: test
       projects: $(SolutionFile)
-      arguments: '--blame-hang-timeout 3m --no-build -c Release -maxcpucount:1 ${{parameters.skipFilter}} --collect "XPlat Code Coverage" --settings coverlet.runsettings --logger trx --results-directory $(Agent.TempDirectory)'
-  - task: PublishTestResults@2
-    condition: succeededOrFailed()
-    displayName: Publish test results
-    inputs:
-      testResultsFormat: VSTest
-      testResultsFiles: '*.trx'
-      mergeTestResults: true
+      arguments: --no-build -c Release -maxcpucount:1 ${{parameters.skipFilter}} --collect "XPlat Code Coverage" --settings coverlet.runsettings
   - script: |
       docker kill rabbitmq
       docker rm rabbitmq
@@ -70,10 +63,9 @@ jobs:
     displayName: Consolidate coverage for this job
     inputs:
       reports: $(Agent.TempDirectory)/**/*opencover.xml
-      targetdir: $(Build.ArtifactStagingDirectory)/CodeCoverage
+      targetdir: $(Build.ArtifactStagingDirectory)/CodeCoverage/$(Agent.JobName)
       reporttypes: Cobertura
-  - task: PublishCodeCoverageResults@1
+  - publish: $(Build.ArtifactStagingDirectory)/CodeCoverage/$(Agent.JobName)
     condition: succeededOrFailed()
-    inputs:
-      codeCoverageTool: Cobertura
-      summaryFileLocation: $(Build.ArtifactStagingDirectory)/CodeCoverage/cobertura.xml
+    displayName: Publish code coverage artifacts
+    artifact: coverageResults-$(Agent.JobName)

--- a/build/templates/component-build.yaml
+++ b/build/templates/component-build.yaml
@@ -1,0 +1,67 @@
+parameters:
+  component: ''
+  runConfigServer: false
+  runRabbitMQ: false
+  skipFilter: ''
+  OS: ubuntu
+
+jobs:
+- job: ${{parameters.component}}_${{parameters.OS}}
+  variables:
+    DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+    DOTNET_CLI_TELEMETRY_OPTOUT: 1
+    SolutionFile: src/${{parameters.component}}/${{parameters.component}}.sln
+  pool:
+    vmImage: ${{parameters.OS}}-latest
+  steps:
+  - task: UseDotNet@2
+    displayName: Install .NET Core 3.1
+    inputs:
+      version: 3.1.x
+  - task: UseDotNet@2
+    displayName: Install .NET 6
+    inputs:
+      version: 6.0.x
+      includePreviewVersions: true
+  - task: DotNetCoreCLI@2
+    displayName: dotnet restore
+    inputs:
+      command: restore
+      projects: $(SolutionFile)
+      feedsToUse: config
+      nugetConfigPath: nuget.config
+  - task: DotNetCoreCLI@2
+    displayName: dotnet build
+    inputs:
+      command: build
+      projects: $(SolutionFile)
+      arguments: '--no-restore -c Release -v n /p:TreatWarningsAsErrors=True'
+  - script: docker run -d --name rabbitmq -p 5672:5672 -p 15672:15672 rabbitmq:3-management
+    condition: eq(${{parameters.runRabbitMQ}}, 'true')
+    displayName: Start RabbitMQ
+  - script: docker run -d --name configserver -p 8888:8888 steeltoeoss/config-server --spring.cloud.config.server.git.default-label=main
+    condition: eq(${{parameters.runConfigServer}}, 'true')
+    displayName: Start Config Server
+  - task: DotNetCoreCLI@2
+    displayName: dotnet test
+    inputs:
+      command: test
+      projects: $(SolutionFile)
+      arguments: '--blame-hang-timeout 3m --no-build -c Release -maxcpucount:1 ${{parameters.skipFilter}} --collect "XPlat Code Coverage" --settings coverlet.runsettings --logger trx --results-directory $(Build.SourcesDirectory)'
+  - task: PublishTestResults@2
+    condition: succeededOrFailed()
+    displayName: Publish test results
+    inputs:
+      testResultsFormat: VSTest
+      testResultsFiles: '*.trx'
+      mergeTestResults: true
+  - script: |
+      docker kill rabbitmq
+      docker rm rabbitmq
+    condition: eq(${{parameters.runRabbitMQ}}, 'true')
+    displayName: Stop RabbitMQ
+  - script: |
+      docker kill configserver
+      docker rm configserver
+    condition: eq(${{parameters.runConfigServer}}, 'true')
+    displayName: Stop Config Server

--- a/build/templates/component-build.yaml
+++ b/build/templates/component-build.yaml
@@ -48,7 +48,7 @@ jobs:
     inputs:
       command: test
       projects: $(SolutionFile)
-      arguments: --no-build -c Release -maxcpucount:1 ${{parameters.skipFilter}} --collect "XPlat Code Coverage" /p:Include=${{parameters.coverletInclude}} /p:CoverletOutputFormat=opencover /p:DeterministicReport=true /p:UseSourceLink=true /p:ExcludeByAttribute="Obsolete,GeneratedCodeAttribute,CompilerGeneratedAttribute"
+      arguments: '--no-build -c Release -maxcpucount:1 ${{parameters.skipFilter}} --collect "XPlat Code Coverage" /p:Include=${{parameters.coverletInclude}} /p:CoverletOutputFormat=opencover /p:DeterministicReport=true /p:UseSourceLink=true /p:ExcludeByAttribute="Obsolete,GeneratedCodeAttribute,CompilerGeneratedAttribute"'
 
   - script: |
       docker kill rabbitmq

--- a/build/templates/component-build.yaml
+++ b/build/templates/component-build.yaml
@@ -4,7 +4,6 @@ parameters:
   runRabbitMQ: false
   skipFilter: ''
   OS: ubuntu
-  coverletInclude: "[*]*"
 
 jobs:
 - job: ${{parameters.component}}_${{parameters.OS}}
@@ -48,8 +47,7 @@ jobs:
     inputs:
       command: test
       projects: $(SolutionFile)
-      arguments: '--no-build -c Release -maxcpucount:1 ${{parameters.skipFilter}} --collect "XPlat Code Coverage" /p:Include=${{parameters.coverletInclude}} /p:CoverletOutputFormat=opencover /p:DeterministicReport=true /p:UseSourceLink=true'
-
+      arguments: --no-build -c Release -maxcpucount:1 ${{parameters.skipFilter}}
   - script: |
       docker kill rabbitmq
       docker rm rabbitmq
@@ -60,14 +58,3 @@ jobs:
       docker rm configserver
     condition: eq(${{parameters.runConfigServer}}, 'true')
     displayName: Stop Config Server
-  - task: Palmmedia.reportgenerator.reportgenerator-build-release-task.reportgenerator@4
-    condition: succeededOrFailed()
-    displayName: Consolidate coverage for this job
-    inputs:
-      reports: $(Agent.TempDirectory)/**/*opencover.xml
-      targetdir: $(Build.ArtifactStagingDirectory)/CodeCoverage/$(Agent.JobName)
-      reporttypes: Cobertura
-  - publish: $(Build.ArtifactStagingDirectory)/CodeCoverage/$(Agent.JobName)
-    condition: succeededOrFailed()
-    displayName: Publish code coverage artifacts
-    artifact: coverageResults-$(Agent.JobName)

--- a/build/templates/component-build.yaml
+++ b/build/templates/component-build.yaml
@@ -48,7 +48,7 @@ jobs:
     inputs:
       command: test
       projects: $(SolutionFile)
-      arguments: '--no-build -c Release -maxcpucount:1 ${{parameters.skipFilter}} --collect "XPlat Code Coverage" /p:Include=${{parameters.coverletInclude}} /p:CoverletOutputFormat=opencover /p:DeterministicReport=true /p:UseSourceLink=true /p:ExcludeByAttribute="Obsolete,GeneratedCodeAttribute,CompilerGeneratedAttribute"'
+      arguments: '--no-build -c Release -maxcpucount:1 ${{parameters.skipFilter}} --collect "XPlat Code Coverage" /p:Include=\"${{parameters.coverletInclude}}\" /p:CoverletOutputFormat=opencover /p:DeterministicReport=true /p:UseSourceLink=true'
 
   - script: |
       docker kill rabbitmq

--- a/build/templates/consolidate-coverage.yaml
+++ b/build/templates/consolidate-coverage.yaml
@@ -1,0 +1,30 @@
+parameters:
+  - name: JobNames
+    type: object
+    default: {}
+jobs:
+- job: Consolidate_Coverage
+  dependsOn:
+  - ${{ each value in parameters.JobNames }}
+  pool:
+    vmImage: ubuntu-latest
+  steps:
+  - ${{ each value in parameters.JobNames }}:
+    - download: current
+      artifact: coverageResults-${{ value }}
+      condition: succeededOrFailed()
+      displayName: Download test coverage results from ${{ value }}
+      continueOnError: true
+  - task: Palmmedia.reportgenerator.reportgenerator-build-release-task.reportgenerator@4
+    condition: succeededOrFailed()
+    displayName: Consolidate code coverage results
+    inputs:
+      reports: $(Pipeline.Workspace)/**/Cobertura.xml
+      targetdir: $(Build.ArtifactStagingDirectory)/CodeCoverage
+      reporttypes: Cobertura
+  - task: PublishCodeCoverageResults@1
+    condition: succeededOrFailed()
+    displayName: Publish code coverage to Azure DevOps
+    inputs:
+      codeCoverageTool: Cobertura
+      summaryFileLocation: $(Build.ArtifactStagingDirectory)/CodeCoverage/Cobertura.xml

--- a/build/templates/consolidate-coverage.yaml
+++ b/build/templates/consolidate-coverage.yaml
@@ -5,7 +5,8 @@ parameters:
 jobs:
 - job: Consolidate_Coverage
   dependsOn:
-  - ${{ each value in parameters.JobNames }}
+  - ${{ each value in parameters.JobNames }}:
+    - ${{ value }}
   pool:
     vmImage: ubuntu-latest
   steps:

--- a/src/Bootstrap/src/Autoconfig/Steeltoe.Bootstrap.Autoconfig.csproj
+++ b/src/Bootstrap/src/Autoconfig/Steeltoe.Bootstrap.Autoconfig.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <RootNamespace>Steeltoe.Bootstrap.Autoconfig</RootNamespace>
     <Description>Package for automatically configuring Steeltoe packages that have separately been added to a project.</Description>
     <PackageTags>Autoconfiguration;automatic configuration;application bootstrapping</PackageTags>

--- a/src/Bootstrap/test/Autoconfig.Test/Steeltoe.Bootstrap.Autoconfig.Test.csproj
+++ b/src/Bootstrap/test/Autoconfig.Test/Steeltoe.Bootstrap.Autoconfig.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0;</TargetFrameworks>
   </PropertyGroup>
   
   <Import Project="..\..\..\..\versions.props" />

--- a/src/CircuitBreaker/src/Hystrix.MetricsEventsCore/Steeltoe.CircuitBreaker.Hystrix.MetricsEventsCore.csproj
+++ b/src/CircuitBreaker/src/Hystrix.MetricsEventsCore/Steeltoe.CircuitBreaker.Hystrix.MetricsEventsCore.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>Steeltoe Netflix Hystrix Metrics Event Stream ASP.NET Core</Description>
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <PackageTags>aspnetcore;Circuit Breaker;Spring;Spring Cloud;Spring Cloud Hystrix;Hystrix</PackageTags>
   </PropertyGroup>
 

--- a/src/CircuitBreaker/src/Hystrix.MetricsStreamCore/Steeltoe.CircuitBreaker.Hystrix.MetricsStreamCore.csproj
+++ b/src/CircuitBreaker/src/Hystrix.MetricsStreamCore/Steeltoe.CircuitBreaker.Hystrix.MetricsStreamCore.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <Description>Netflix Hystrix metrics event stream for ASP.NET Core over RabbitMQ</Description>
     <PackageTags>aspnetcore;Circuit Breaker;Spring;Spring Cloud;Spring Cloud Hystrix;Hystrix;turbine;cloudfoundry</PackageTags>
   </PropertyGroup>

--- a/src/CircuitBreaker/src/HystrixCore/Steeltoe.CircuitBreaker.HystrixCore.csproj
+++ b/src/CircuitBreaker/src/HystrixCore/Steeltoe.CircuitBreaker.HystrixCore.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <RootNamespace>Steeltoe.CircuitBreaker.Hystrix</RootNamespace>
     <Description>Package for adding Steeltoe Hystrix to ASP.NET Core applications</Description>
     <PackageTags>aspnetcore;Spring Cloud;Netflix;Hystrix Client;Circuit Breaker</PackageTags>

--- a/src/CircuitBreaker/test/Hystrix.MetricsEventsCore.Test/Steeltoe.CircuitBreaker.Hystrix.MetricsEventsCore.Test.csproj
+++ b/src/CircuitBreaker/test/Hystrix.MetricsEventsCore.Test/Steeltoe.CircuitBreaker.Hystrix.MetricsEventsCore.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0;</TargetFrameworks>
   </PropertyGroup>
   
   <Import Project="..\..\..\..\versions.props" />

--- a/src/CircuitBreaker/test/Hystrix.MetricsStreamCore.Test/Steeltoe.CircuitBreaker.Hystrix.MetricsStreamCore.Test.csproj
+++ b/src/CircuitBreaker/test/Hystrix.MetricsStreamCore.Test/Steeltoe.CircuitBreaker.Hystrix.MetricsStreamCore.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0;</TargetFrameworks>
   </PropertyGroup>
   
   <Import Project="..\..\..\..\versions.props" />

--- a/src/CircuitBreaker/test/HystrixCore.Test/Steeltoe.CircuitBreaker.HystrixCore.Test.csproj
+++ b/src/CircuitBreaker/test/HystrixCore.Test/Steeltoe.CircuitBreaker.HystrixCore.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0;</TargetFrameworks>
   </PropertyGroup>
   
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Common/src/Common.Hosting/Steeltoe.Common.Hosting.csproj
+++ b/src/Common/src/Common.Hosting/Steeltoe.Common.Hosting.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>Steeltoe library for common hosting-related utilities</Description>
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <AssemblyName>Steeltoe.Common.Hosting</AssemblyName>
     <PackageId>Steeltoe.Common.Hosting</PackageId>
     <PackageTags>NET Core;Cloud Hosting;</PackageTags>

--- a/src/Common/test/Common.Expression.Test/Steeltoe.Common.Expression.Test.csproj
+++ b/src/Common/test/Common.Expression.Test/Steeltoe.Common.Expression.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0;</TargetFrameworks>
     <RootNamespace>Steeltoe.Common.Expression</RootNamespace>
   </PropertyGroup>
 

--- a/src/Common/test/Common.Hosting.Test/HostBuilderExtensionsTest.cs
+++ b/src/Common/test/Common.Hosting.Test/HostBuilderExtensionsTest.cs
@@ -178,7 +178,7 @@ namespace Steeltoe.Common.Hosting.Test
         }
 
         [Fact]
-#if NET5_0
+#if NET6_0
         [Trait("Category", "SkipOnMacOS")] // for .NET 5, this test produces an admin prompt on OSX
 #endif
         public void UseCloudHosting_GenericHost_UsesLocalPortSettings()

--- a/src/Common/test/Common.Hosting.Test/Steeltoe.Common.Hosting.Test.csproj
+++ b/src/Common/test/Common.Hosting.Test/Steeltoe.Common.Hosting.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0;</TargetFrameworks>
   </PropertyGroup>
   
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Common/test/Common.Http.Test/Steeltoe.Common.Http.Test.csproj
+++ b/src/Common/test/Common.Http.Test/Steeltoe.Common.Http.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0;</TargetFrameworks>
   </PropertyGroup>
   
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Common/test/Common.Kubernetes.Test/Steeltoe.Common.Kubernetes.Test.csproj
+++ b/src/Common/test/Common.Kubernetes.Test/Steeltoe.Common.Kubernetes.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0;</TargetFrameworks>
   </PropertyGroup>
   
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Common/test/Common.Net.Test/Steeltoe.Common.Net.Test.csproj
+++ b/src/Common/test/Common.Net.Test/Steeltoe.Common.Net.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0;</TargetFrameworks>
   </PropertyGroup>
   
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Common/test/Common.RetryPolly.Test/Steeltoe.Common.RetryPolly.Test.csproj
+++ b/src/Common/test/Common.RetryPolly.Test/Steeltoe.Common.RetryPolly.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0;</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Common/test/Common.Security.Test/Steeltoe.Common.Security.Test.csproj
+++ b/src/Common/test/Common.Security.Test/Steeltoe.Common.Security.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0;</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Common/test/Common.Test/Steeltoe.Common.Test.csproj
+++ b/src/Common/test/Common.Test/Steeltoe.Common.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0;</TargetFrameworks>
   </PropertyGroup>
   
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Common/test/Common.TestResources/Steeltoe.Common.TestResources.csproj
+++ b/src/Common/test/Common.TestResources/Steeltoe.Common.TestResources.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <NoWarn>IDE0130</NoWarn>
   </PropertyGroup>

--- a/src/Common/test/Common.Utils.Test/Diagnostics/CommandExecutorTest.cs
+++ b/src/Common/test/Common.Utils.Test/Diagnostics/CommandExecutorTest.cs
@@ -7,6 +7,7 @@ using Steeltoe.Common.Utils.Diagnostics;
 using System;
 using System.Threading.Tasks;
 using Xunit;
+using Xunit.Sdk;
 
 namespace Steeltoe.Common.Utils.Test.Diagnostics
 {
@@ -37,7 +38,15 @@ namespace Steeltoe.Common.Utils.Test.Diagnostics
 
             // Assert
             result.ExitCode.Should().NotBe(0);
-            result.Error.Should().Contain("Unknown option: --no-such-option");
+            try
+            {
+                result.Error.Should().Contain("Unknown option: --no-such-option");
+            }
+            catch (XunitException)
+            {
+                // message changes if .NET 6 sdk is installed
+                result.Error.Should().Contain("--no-such-option does not exist");
+            }
         }
 
         [Fact]

--- a/src/Common/test/Common.Utils.Test/Steeltoe.Common.Utils.Test.csproj
+++ b/src/Common/test/Common.Utils.Test/Steeltoe.Common.Utils.Test.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0;</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Configuration/src/CloudFoundryCore/Steeltoe.Extensions.Configuration.CloudFoundryCore.csproj
+++ b/src/Configuration/src/CloudFoundryCore/Steeltoe.Extensions.Configuration.CloudFoundryCore.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <RootNamespace>Steeltoe.Extensions.Configuration.CloudFoundry</RootNamespace>
     <Description>Package for adding Cloud Foundry environment variable configuration provider to ASP.NET Core applications</Description>
     <PackageTags>aspnetcore;CloudFoundry;Spring;Spring Cloud;vcap</PackageTags>

--- a/src/Configuration/src/ConfigServerCore/Steeltoe.Extensions.Configuration.ConfigServerCore.csproj
+++ b/src/Configuration/src/ConfigServerCore/Steeltoe.Extensions.Configuration.ConfigServerCore.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <RootNamespace>Steeltoe.Extensions.Configuration.ConfigServer</RootNamespace>
     <Description>Package for adding Spring Cloud Config Server configuration provider to ASP.NET Core applications</Description>
     <PackageTags>aspnetcore;Spring Cloud;Spring Cloud Config Server</PackageTags>

--- a/src/Configuration/src/KubernetesCore/Steeltoe.Extensions.Configuration.KubernetesCore.csproj
+++ b/src/Configuration/src/KubernetesCore/Steeltoe.Extensions.Configuration.KubernetesCore.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <RootNamespace>Steeltoe.Extensions.Configuration.Kubernetes</RootNamespace>
     <Description>Package for adding Kubernetes environment variables, ConfigMaps and Secrets to .NET applications</Description>
     <PackageTags>Kubernetes;Spring;Spring Cloud;configuration;configmap</PackageTags>

--- a/src/Configuration/src/PlaceholderCore/Steeltoe.Extensions.Configuration.PlaceholderCore.csproj
+++ b/src/Configuration/src/PlaceholderCore/Steeltoe.Extensions.Configuration.PlaceholderCore.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <RootNamespace>Steeltoe.Extensions.Configuration.Placeholder</RootNamespace>
     <Description>Packing for adding property placeholder resolving config provider to ASP.NET Core applications</Description>
     <PackageTags>configuration;placeholders;aspnetcore;spring boot</PackageTags>

--- a/src/Configuration/src/SpringBootCore/Steeltoe.Extensions.Configuration.SpringBootCore.csproj
+++ b/src/Configuration/src/SpringBootCore/Steeltoe.Extensions.Configuration.SpringBootCore.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;</TargetFrameworks>
     <RootNamespace>Steeltoe.Extensions.Configuration.SpringBoot</RootNamespace>
     <Description>Configuration provider for reading Spring Boot style configuration</Description>
     <PackageTags>configuration;springboot</PackageTags>

--- a/src/Configuration/test/CloudFoundryBase.Test/Steeltoe.Extensions.Configuration.CloudFoundryBase.Test.csproj
+++ b/src/Configuration/test/CloudFoundryBase.Test/Steeltoe.Extensions.Configuration.CloudFoundryBase.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0;</TargetFrameworks>
   </PropertyGroup>
   
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Configuration/test/CloudFoundryCore.Test/Steeltoe.Extensions.Configuration.CloudFoundryCore.Test.csproj
+++ b/src/Configuration/test/CloudFoundryCore.Test/Steeltoe.Extensions.Configuration.CloudFoundryCore.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0;</TargetFrameworks>
   </PropertyGroup>
   
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Configuration/test/ConfigServer.ITest/Steeltoe.Extensions.Configuration.ConfigServer.ITest.csproj
+++ b/src/Configuration/test/ConfigServer.ITest/Steeltoe.Extensions.Configuration.ConfigServer.ITest.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0;</TargetFrameworks>
   </PropertyGroup>
   
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Configuration/test/ConfigServerBase.Test/Steeltoe.Extensions.Configuration.ConfigServerBase.Test.csproj
+++ b/src/Configuration/test/ConfigServerBase.Test/Steeltoe.Extensions.Configuration.ConfigServerBase.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0;</TargetFrameworks>
     <RootNamespace>Steeltoe.Extensions.Configuration.ConfigServer.Test</RootNamespace>
   </PropertyGroup>
   

--- a/src/Configuration/test/ConfigServerCore.Test/Steeltoe.Extensions.Configuration.ConfigServerCore.Test.csproj
+++ b/src/Configuration/test/ConfigServerCore.Test/Steeltoe.Extensions.Configuration.ConfigServerCore.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0;</TargetFrameworks>
   </PropertyGroup>
   
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Configuration/test/KubernetesBase.Test/Steeltoe.Extensions.Configuration.KubernetesBase.Test.csproj
+++ b/src/Configuration/test/KubernetesBase.Test/Steeltoe.Extensions.Configuration.KubernetesBase.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0;</TargetFrameworks>
     <RootNamespace>Steeltoe.Extensions.Configuration.Kubernetes.Test</RootNamespace>
   </PropertyGroup>
   

--- a/src/Configuration/test/KubernetesCore.Test/Steeltoe.Extensions.Configuration.KubernetesCore.Test.csproj
+++ b/src/Configuration/test/KubernetesCore.Test/Steeltoe.Extensions.Configuration.KubernetesCore.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0;</TargetFrameworks>
     <RootNamespace>Steeltoe.Extensions.Configuration.Kubernetes.Test</RootNamespace>
   </PropertyGroup>
   

--- a/src/Configuration/test/PlaceholderBase.Test/Steeltoe.Extensions.Configuration.PlaceholderBase.Test.csproj
+++ b/src/Configuration/test/PlaceholderBase.Test/Steeltoe.Extensions.Configuration.PlaceholderBase.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0;</TargetFrameworks>
   </PropertyGroup>
   
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Configuration/test/PlaceholderCore.Test/Steeltoe.Extensions.Configuration.PlaceholderCore.Test.csproj
+++ b/src/Configuration/test/PlaceholderCore.Test/Steeltoe.Extensions.Configuration.PlaceholderCore.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0;</TargetFrameworks>
   </PropertyGroup>
   
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Configuration/test/RandomValuesBase.Test/Steeltoe.Extensions.Configuration.RandomValueBase.Test.csproj
+++ b/src/Configuration/test/RandomValuesBase.Test/Steeltoe.Extensions.Configuration.RandomValueBase.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0;</TargetFrameworks>
   </PropertyGroup>
   
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Configuration/test/SpringBootBase.Test/Steeltoe.Extensions.Configuration.SpringBootBase.Test.csproj
+++ b/src/Configuration/test/SpringBootBase.Test/Steeltoe.Extensions.Configuration.SpringBootBase.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0;</TargetFrameworks>
   </PropertyGroup>
   
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Configuration/test/SpringBootCore.Test/Steeltoe.Extensions.Configuration.SpringBootCore.Test.csproj
+++ b/src/Configuration/test/SpringBootCore.Test/Steeltoe.Extensions.Configuration.SpringBootCore.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0;</TargetFrameworks>
   </PropertyGroup>
   
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Connectors/test/Connector.CloudFoundry.Test/Steeltoe.Connector.CloudFoundry.Test.csproj
+++ b/src/Connectors/test/Connector.CloudFoundry.Test/Steeltoe.Connector.CloudFoundry.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0;</TargetFrameworks>
   </PropertyGroup>
   
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Connectors/test/Connector.EF6Core.Test/Steeltoe.Connector.EF6Core.Test.csproj
+++ b/src/Connectors/test/Connector.EF6Core.Test/Steeltoe.Connector.EF6Core.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0;</TargetFrameworks>
   </PropertyGroup>
   
   <Import Project="..\..\..\..\versions.props" />
@@ -17,7 +17,7 @@
     <PackageReference Include="MySql.Data.EntityFramework" Version="$(MySqlV8)" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
-    <!-- with netcoreapp3.1/net5.0 returns "Warning NU1701 Package restored using '.NETFramework,Version=...' instead of the project target framework. This package may not be fully compatible with your project." -->
+    <!-- with netcoreapp3.1+ returns "Warning NU1701 Package restored using '.NETFramework,Version=...' instead of the project target framework. This package may not be fully compatible with your project." -->
     <PackageReference Include="Oracle.ManagedDataAccess.EntityFramework" Version="19.7.0" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Connectors/test/Connector.EFCore.Test/MySqlDbContextOptionsExtensionsTest.cs
+++ b/src/Connectors/test/Connector.EFCore.Test/MySqlDbContextOptionsExtensionsTest.cs
@@ -109,7 +109,7 @@ namespace Steeltoe.Connector.MySql.EFCore.Test
             Assert.True(con is MySqlConnection);
         }
 
-#if NET5_0
+#if NET6_0
         // Run a MySQL server with Docker to match creds below with this command
         // docker run --name steeltoe-mysql -p 3306:3306 -e MYSQL_DATABASE=steeltoe -e MYSQL_ROOT_PASSWORD=steeltoe mysql
         [Fact(Skip = "Requires a running MySQL server to support AutoDetect")]

--- a/src/Connectors/test/Connector.EFCore.Test/Steeltoe.Connector.EFCore.Test.csproj
+++ b/src/Connectors/test/Connector.EFCore.Test/Steeltoe.Connector.EFCore.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0;</TargetFrameworks>
   </PropertyGroup>
   
   <Import Project="..\..\..\..\versions.props" />
@@ -18,10 +18,10 @@
     <PackageReference Include="Oracle.EntityFrameworkCore" Version="$(OracleEFCoreVersion)" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'"><!--Oracle doesn't work with EF Core 5.0 yet-->
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'"><!--Oracle doesn't work with EF Core 5+ yet-->
     <PackageReference Include="MySql.EntityFrameworkCore" Version="$(MySqlEFCoreVersion)" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
     <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="$(PomeloEFCoreVersion)" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Connectors/test/ConnectorBase.Test/Steeltoe.Connector.ConnectorBase.Test.csproj
+++ b/src/Connectors/test/ConnectorBase.Test/Steeltoe.Connector.ConnectorBase.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0;</TargetFrameworks>
     <RootNamespace>Steeltoe.Connector.Test</RootNamespace>
   </PropertyGroup>
   
@@ -27,7 +27,6 @@
     <!--<PackageReference Include="MySql.Data" Version="$(MySqlV8)" />-->
     <PackageReference Include="Npgsql" Version="$(NpgsqlVersion)" />
     <PackageReference Include="RabbitMQ.Client" Version="$(RabbitClientVersion)" />
-    <PackageReference Include="StackExchange.Redis" Version="$(StackExchangeVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Connectors/test/ConnectorCore.Test/Steeltoe.Connector.ConnectorCore.Test.csproj
+++ b/src/Connectors/test/ConnectorCore.Test/Steeltoe.Connector.ConnectorCore.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0;</TargetFrameworks>
   </PropertyGroup>
   
   <Import Project="..\..\..\..\versions.props" />
@@ -29,7 +29,7 @@
     <PackageReference Include="Oracle.ManagedDataAccess.Core" Version="2.19.31" />
 
     <PackageReference Include="RabbitMQ.Client" Version="$(RabbitClientVersion)" />
-    <PackageReference Include="StackExchange.Redis" Version="$(StackExchangeVersion)" />
+    <!--<PackageReference Include="StackExchange.Redis" Version="$(StackExchangeVersion)" />-->
     <PackageReference Include="System.Data.SqlClient" Version="$(SqlClientVersion)" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(ExtensionsVersion)" />
   </ItemGroup>

--- a/src/Connectors/test/External.Connector.Test/External.Connector.Test.csproj
+++ b/src/Connectors/test/External.Connector.Test/External.Connector.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Discovery/src/ClientCore/Steeltoe.Discovery.ClientCore.csproj
+++ b/src/Discovery/src/ClientCore/Steeltoe.Discovery.ClientCore.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <Description>Package for using Steeltoe Service Discovery Client in ASP.NET Core applications</Description>
     <PackageTags>aspnetcore;service discovery;service registry;Spring Cloud;eureka;consul;kubernetes</PackageTags>
     <RootNamespace>Steeltoe.Discovery.Client</RootNamespace>

--- a/src/Discovery/src/Kubernetes/Steeltoe.Discovery.Kubernetes.csproj
+++ b/src/Discovery/src/Kubernetes/Steeltoe.Discovery.Kubernetes.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1</TargetFrameworks>
     <Description>Client for service discovery with Kubernetes native service discovery</Description>
     <PackageTags>aspnetcore;Kubernetes;Spring;Spring Cloud</PackageTags>
     <RootNamespace>Steeltoe.Discovery.Kubernetes</RootNamespace>

--- a/src/Discovery/test/ClientBase.Test/Steeltoe.Discovery.ClientBase.Test.csproj
+++ b/src/Discovery/test/ClientBase.Test/Steeltoe.Discovery.ClientBase.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0;</TargetFrameworks>
   </PropertyGroup>
   
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Discovery/test/ClientCore.Test/Steeltoe.Discovery.ClientCore.Test.csproj
+++ b/src/Discovery/test/ClientCore.Test/Steeltoe.Discovery.ClientCore.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0;</TargetFrameworks>
   </PropertyGroup>
   
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Discovery/test/Consul.Test/Steeltoe.Discovery.Consul.Test.csproj
+++ b/src/Discovery/test/Consul.Test/Steeltoe.Discovery.Consul.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0;</TargetFrameworks>
   </PropertyGroup>
   
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Discovery/test/Eureka.Test/Steeltoe.Discovery.Eureka.Test.csproj
+++ b/src/Discovery/test/Eureka.Test/Steeltoe.Discovery.Eureka.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0;</TargetFrameworks>
   </PropertyGroup>
   
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Discovery/test/Kubernetes.Test/Steeltoe.Discovery.Kubernetes.Test.csproj
+++ b/src/Discovery/test/Kubernetes.Test/Steeltoe.Discovery.Kubernetes.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0;</TargetFrameworks>
     <Nullable>enable</Nullable>
   </PropertyGroup>
   

--- a/src/Integration/src/Abstractions/Steeltoe.Integration.Abstractions.csproj
+++ b/src/Integration/src/Abstractions/Steeltoe.Integration.Abstractions.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
     <RootNamespace>Steeltoe.Integration</RootNamespace>
     <Description>
       Abstractions for use with Steeltoe Integration libraries

--- a/src/Integration/src/IntegrationBase/Steeltoe.Integration.IntegrationBase.csproj
+++ b/src/Integration/src/IntegrationBase/Steeltoe.Integration.IntegrationBase.csproj
@@ -5,7 +5,7 @@
       Steeltoe Integration Base
       **PLEASE NOTE** The public API of this package is subject to change and is not recommended for direct use outside of Steeltoe.
     </Description>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0;</TargetFrameworks>
     <RootNamespace>Steeltoe.Integration</RootNamespace>
     <PackageTags>Integration, NET Core, Spring, Spring Cloud</PackageTags>
   </PropertyGroup>

--- a/src/Integration/src/RabbitMQ/Steeltoe.Integration.RabbitMQ.csproj
+++ b/src/Integration/src/RabbitMQ/Steeltoe.Integration.RabbitMQ.csproj
@@ -5,7 +5,7 @@
       Steeltoe Integration RabbitMQ
       **PLEASE NOTE** The public API of this package is subject to change and is not recommended for direct use outside of Steeltoe.
     </Description>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0;</TargetFrameworks>
     <RootNamespace>Steeltoe.Integration.RabbitMQ</RootNamespace>
     <PackageTags>Integration, ASPNET Core, Spring, Spring Cloud, RabbitMQ</PackageTags>
   </PropertyGroup>

--- a/src/Integration/test/IntegrationBase.Test/Steeltoe.Integration.IntegrationBase.Test.csproj
+++ b/src/Integration/test/IntegrationBase.Test/Steeltoe.Integration.IntegrationBase.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0;</TargetFrameworks>
     <RootNamespace>Steeltoe.Integration</RootNamespace>
   </PropertyGroup>
 

--- a/src/Integration/test/RabbitMQ.Test/Steeltoe.Integration.RabbitMQ.Test.csproj
+++ b/src/Integration/test/RabbitMQ.Test/Steeltoe.Integration.RabbitMQ.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0;</TargetFrameworks>
     <RootNamespace>Steeltoe.Integration.RabbitMQ</RootNamespace>
   </PropertyGroup>
 

--- a/src/Logging/src/DynamicSerilogCore/Steeltoe.Extensions.Logging.DynamicSerilogCore.csproj
+++ b/src/Logging/src/DynamicSerilogCore/Steeltoe.Extensions.Logging.DynamicSerilogCore.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <Description>Steeltoe library for enabling dynamic management of Serilog in ASP.NET Core applications. Includes Console sink.</Description>
     <PackageTags>logging;dynamic logging;serilog;aspnetcore;management;monitoring;Spring Cloud;</PackageTags>
     <RootNamespace>Steeltoe.Extensions.Logging.DynamicSerilog</RootNamespace>

--- a/src/Logging/test/DynamicLogger.Test/Steeltoe.Extensions.Logging.DynamicLogger.Test.csproj
+++ b/src/Logging/test/DynamicLogger.Test/Steeltoe.Extensions.Logging.DynamicLogger.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0;</TargetFrameworks>
   </PropertyGroup>
   
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Logging/test/DynamicSerilogBase.Test/Steeltoe.Extensions.Logging.DynamicSerilogBase.Test.csproj
+++ b/src/Logging/test/DynamicSerilogBase.Test/Steeltoe.Extensions.Logging.DynamicSerilogBase.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0;</TargetFrameworks>
     <RootNamespace>Steeltoe.Extensions.Logging.DynamicSerilog.Test</RootNamespace>
   </PropertyGroup>
   

--- a/src/Logging/test/DynamicSerilogCore.Test/Steeltoe.Extensions.Logging.DynamicSerilogCore.Test.csproj
+++ b/src/Logging/test/DynamicSerilogCore.Test/Steeltoe.Extensions.Logging.DynamicSerilogCore.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0;</TargetFrameworks>
     <RootNamespace>Steeltoe.Extensions.Logging.DynamicSerilog.Test</RootNamespace>
   </PropertyGroup>
   

--- a/src/Management/src/CloudFoundryCore/Steeltoe.Management.CloudFoundryCore.csproj
+++ b/src/Management/src/CloudFoundryCore/Steeltoe.Management.CloudFoundryCore.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <RootNamespace>Steeltoe.Management.CloudFoundry</RootNamespace>
     <Description>Package for using Steeltoe management endpoints with ASP.NET Core on Cloud Foundry.</Description>
     <PackageTags>actuator;management;monitoring;aspnetcore;CloudFoundry;Spring Cloud;</PackageTags>

--- a/src/Management/src/EndpointBase/Steeltoe.Management.EndpointBase.csproj
+++ b/src/Management/src/EndpointBase/Steeltoe.Management.EndpointBase.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Diagnostics.NETCore.Client" Version="0.2.221401" />
+    <PackageReference Include="Microsoft.Diagnostics.NETCore.Client" Version="0.2.236902" />
     <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="$(ExtensionsVersion)" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(ExtensionsVersion)" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="$(ExtensionsVersion)" />

--- a/src/Management/src/EndpointCore/Env/EndpointServiceCollectionExtensions.cs
+++ b/src/Management/src/EndpointCore/Env/EndpointServiceCollectionExtensions.cs
@@ -1,7 +1,8 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -33,7 +34,7 @@ namespace Steeltoe.Management.Endpoint.Env
 
             services.TryAddSingleton<IHostEnvironment>((provider) =>
             {
-                var service = provider.GetRequiredService<IHostEnvironment>();
+                var service = provider.GetRequiredService<IWebHostEnvironment>();
                 return new GenericHostingEnvironment()
                 {
                     EnvironmentName = service.EnvironmentName,

--- a/src/Management/src/EndpointCore/Steeltoe.Management.EndpointCore.csproj
+++ b/src/Management/src/EndpointCore/Steeltoe.Management.EndpointCore.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <RootNamespace>Steeltoe.Management.Endpoint</RootNamespace>
     <Description>Package for using Steeltoe management endpoints with ASP.NET Core.</Description>
     <PackageTags>Spring Cloud;Actuator;Management;Monitoring</PackageTags>

--- a/src/Management/src/KubernetesCore/Steeltoe.Management.KubernetesCore.csproj
+++ b/src/Management/src/KubernetesCore/Steeltoe.Management.KubernetesCore.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <Description>Package for using Steeltoe management endpoints with ASP.NET Core on Kubernetes.</Description>
     <PackageTags>actuator;management;monitoring;aspnetcore;Kubernetes;Spring Cloud;k8s</PackageTags>
   </PropertyGroup>

--- a/src/Management/src/TaskCore/Steeltoe.Management.TaskCore.csproj
+++ b/src/Management/src/TaskCore/Steeltoe.Management.TaskCore.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <Description>Extensions for running tasks embedded in your ASP.NET Core application. Ideal for cf run-task in Cloud Foundry.</Description>
     <PackageTags>tasks;management;monitoring;aspnetcore;Spring Cloud;cf run-task</PackageTags>
   </PropertyGroup>

--- a/src/Management/src/TracingCore/Steeltoe.Management.TracingCore.csproj
+++ b/src/Management/src/TracingCore/Steeltoe.Management.TracingCore.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <RootNamespace>Steeltoe.Management.Tracing</RootNamespace>
     <Description>Add distributed tracing to ASP.NET Core applications</Description>
     <PackageTags>aspnetcore;management;monitoring;metrics;Distributed Trace</PackageTags>

--- a/src/Management/test/CloudFoundryCore.Test/Steeltoe.Management.CloudFoundryCore.Test.csproj
+++ b/src/Management/test/CloudFoundryCore.Test/Steeltoe.Management.CloudFoundryCore.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0;</TargetFrameworks>
   </PropertyGroup>
   
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Management/test/EndpointBase.Test/BaseTest.cs
+++ b/src/Management/test/EndpointBase.Test/BaseTest.cs
@@ -8,6 +8,7 @@ using Steeltoe.Management.Endpoint.Health;
 using Steeltoe.Management.Endpoint.Metrics;
 using System;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Steeltoe.Management.Endpoint.Test
 {
@@ -16,6 +17,7 @@ namespace Steeltoe.Management.Endpoint.Test
         public virtual void Dispose()
         {
             DiagnosticsManager.Instance.Dispose();
+            GC.SuppressFinalize(this);
         }
 
         public ILogger<T> GetLogger<T>()
@@ -36,7 +38,7 @@ namespace Steeltoe.Management.Endpoint.Test
             var options = new JsonSerializerOptions()
             {
                 PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-                IgnoreNullValues = true
+                DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
             };
             options.Converters.Add(new HealthConverter());
             options.Converters.Add(new MetricsResponseConverter());

--- a/src/Management/test/EndpointBase.Test/Health/HealthTest.cs
+++ b/src/Management/test/EndpointBase.Test/Health/HealthTest.cs
@@ -7,6 +7,7 @@ using Steeltoe.Management.Endpoint.Test;
 using System;
 using System.Collections.Generic;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using Xunit;
 
 namespace Steeltoe.Management.Endpoint.Health.Test
@@ -56,7 +57,7 @@ namespace Steeltoe.Management.Endpoint.Health.Test
             {
                 var options = new JsonSerializerOptions()
                 {
-                    IgnoreNullValues = true,
+                    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
                     PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
                 };
                 options.Converters.Add(new HealthConverter());

--- a/src/Management/test/EndpointBase.Test/Steeltoe.Management.EndpointBase.Test.csproj
+++ b/src/Management/test/EndpointBase.Test/Steeltoe.Management.EndpointBase.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0;</TargetFrameworks>
     <RootNamespace>Steeltoe.Management.Endpoint.Test</RootNamespace>
   </PropertyGroup>
   
@@ -37,13 +37,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="5.7.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="$(EFCoreVersion)" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="$(EFCoreVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="$(ExtensionsVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="$(ExtensionsVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="$(ExtensionsVersion)" />
+    <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVersion)" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="$(EFCoreTestVersion)" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="$(EFCoreTestVersion)" />
     <PackageReference Include="NSubstitute" Version="4.2.0" />
     <PackageReference Include="RichardSzalay.MockHttp" Version="$(MockHttpVersion)" />
+    <PackageReference Include="System.Net.Http.Json" Version="$(SystemJsonVersion)" />
   </ItemGroup>
 </Project>

--- a/src/Management/test/EndpointBase.Test/Steeltoe.Management.EndpointBase.Test.csproj
+++ b/src/Management/test/EndpointBase.Test/Steeltoe.Management.EndpointBase.Test.csproj
@@ -42,6 +42,5 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="$(EFCoreTestVersion)" />
     <PackageReference Include="NSubstitute" Version="4.2.0" />
     <PackageReference Include="RichardSzalay.MockHttp" Version="$(MockHttpVersion)" />
-    <PackageReference Include="System.Net.Http.Json" Version="$(SystemJsonVersion)" />
   </ItemGroup>
 </Project>

--- a/src/Management/test/EndpointCore.Test/Steeltoe.Management.EndpointCore.Test.csproj
+++ b/src/Management/test/EndpointCore.Test/Steeltoe.Management.EndpointCore.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0;</TargetFrameworks>
     <AssemblyName>Steeltoe.Management.EndpointCore.Test</AssemblyName>
     <RootNamespace>Steeltoe.Management.Endpoint.Test</RootNamespace>
   </PropertyGroup>
@@ -43,10 +43,7 @@
 
   <ItemGroup>
     <PackageReference Include="AspNetCore.HealthChecks.System" Version="3.1.2" />
-    <PackageReference Include="FluentAssertions.Json" Version="5.0.0" />
+    <PackageReference Include="FluentAssertions.Json" Version="5.5.0" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="$(AspNetCoreVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="$(ExtensionsVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="$(ExtensionsVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="$(ExtensionsVersion)" />
   </ItemGroup>
 </Project>

--- a/src/Management/test/KubernetesCore.Test/Steeltoe.Management.KubernetesCore.Test.csproj
+++ b/src/Management/test/KubernetesCore.Test/Steeltoe.Management.KubernetesCore.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0;</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   

--- a/src/Management/test/OpenTelemetry.Test/Steeltoe.OpenTelemetry.Test.csproj
+++ b/src/Management/test/OpenTelemetry.Test/Steeltoe.OpenTelemetry.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>Unit test project for OpenTelemetry</Description>
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/src/Management/test/TaskCore.Test/Steeltoe.Management.TaskCore.Test.csproj
+++ b/src/Management/test/TaskCore.Test/Steeltoe.Management.TaskCore.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0;</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Management/test/TracingBase.Test/Steeltoe.Management.TracingBase.Test.csproj
+++ b/src/Management/test/TracingBase.Test/Steeltoe.Management.TracingBase.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0;</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />
@@ -13,7 +13,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="$(AspNetCoreVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="$(ExtensionsVersion)" />
     <PackageReference Include="OpenTelemetry.Exporter.Zipkin" Version="$(OpenTelemetryVersion)" PrivateAssets="all" />
     <PackageReference Include="OpenTelemetry.Exporter.Jaeger" Version="$(OpenTelemetryVersion)" PrivateAssets="all" />
   </ItemGroup>

--- a/src/Management/test/TracingCore.Test/Steeltoe.Management.TracingCore.Test.csproj
+++ b/src/Management/test/TracingCore.Test/Steeltoe.Management.TracingCore.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0;</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />
@@ -13,7 +13,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="$(AspNetCoreVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="$(ExtensionsVersion)" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="$(OpenTelemetryVersion)" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/src/Messaging/src/MessagingBase/Steeltoe.Messaging.MessagingBase.csproj
+++ b/src/Messaging/src/MessagingBase/Steeltoe.Messaging.MessagingBase.csproj
@@ -2,7 +2,7 @@
   
   <PropertyGroup>
     <Description>Steeltoe Messaging Base</Description>
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <RootNamespace>Steeltoe.Messaging</RootNamespace>
     <AssemblyName>Steeltoe.Messaging.MessagingBase</AssemblyName>
     <PackageId>Steeltoe.Messaging.MessagingBase</PackageId>

--- a/src/Messaging/src/RabbitMQ/Retry/RepublishMessageRecoverer.cs
+++ b/src/Messaging/src/RabbitMQ/Retry/RepublishMessageRecoverer.cs
@@ -101,7 +101,7 @@ namespace Steeltoe.Messaging.RabbitMQ.Retry
                 var routingKey = ErrorRoutingKey != null ? ErrorRoutingKey : PrefixedOriginalRoutingKey(message);
                 ErrorTemplate.Send(ErrorExchangeName, routingKey, message);
 
-                _logger?.LogWarning("Republishing failed message to exchange '(exchange}' with routing key '{routingKey}'", ErrorExchangeName, routingKey);
+                _logger?.LogWarning("Republishing failed message to exchange '{exchange}' with routing key '{routingKey}'", ErrorExchangeName, routingKey);
             }
             else
             {

--- a/src/Messaging/src/RabbitMQ/Steeltoe.Messaging.RabbitMQ.csproj
+++ b/src/Messaging/src/RabbitMQ/Steeltoe.Messaging.RabbitMQ.csproj
@@ -2,7 +2,7 @@
   
   <PropertyGroup>
     <Description>Steeltoe Messaging RabbitMQ</Description>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <RootNamespace>Steeltoe.Messaging.RabbitMQ</RootNamespace>
     <AssemblyName>Steeltoe.Messaging.RabbitMQ</AssemblyName>
     <PackageId>Steeltoe.Messaging.RabbitMQ</PackageId>

--- a/src/Messaging/test/MessagingBase.Test/Steeltoe.Messaging.MessagingBase.Test.csproj
+++ b/src/Messaging/test/MessagingBase.Test/Steeltoe.Messaging.MessagingBase.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0;</TargetFrameworks>
     <RootNamespace>Steeltoe.Messaging</RootNamespace>
   </PropertyGroup>
   

--- a/src/Messaging/test/RabbitMQ.Test/Steeltoe.Messaging.RabbitMQ.Test.csproj
+++ b/src/Messaging/test/RabbitMQ.Test/Steeltoe.Messaging.RabbitMQ.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0;</TargetFrameworks>
     <RootNamespace>Steeltoe.Messaging.RabbitMQ</RootNamespace>
   </PropertyGroup>
   

--- a/src/Security/src/Authentication.CloudFoundryCore/Steeltoe.Security.Authentication.CloudFoundryCore.csproj
+++ b/src/Security/src/Authentication.CloudFoundryCore/Steeltoe.Security.Authentication.CloudFoundryCore.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <RootNamespace>Steeltoe.Security.Authentication.CloudFoundry</RootNamespace>
     <Description>ASP.NET Core External Security Provider for CloudFoundry</Description>
     <PackageTags>CloudFoundry;ASPNET Core;Security;OAuth2;SSO;OpenIDConnect</PackageTags>

--- a/src/Security/src/Authentication.MtlsCore/Steeltoe.Security.Authentication.MtlsCore.csproj
+++ b/src/Security/src/Authentication.MtlsCore/Steeltoe.Security.Authentication.MtlsCore.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0;</TargetFrameworks>
     <RootNamespace>Steeltoe.Security.Authentication.Mtls</RootNamespace>
     <Description>ASP.NET Core middleware that enables an application to support certificate authentication.</Description>
     <PackageTags>aspnetcore;authentication;security;x509;certificate;mtls</PackageTags>

--- a/src/Security/src/DataProtection.CredHubCore/Steeltoe.Security.DataProtection.CredHubCore.csproj
+++ b/src/Security/src/DataProtection.CredHubCore/Steeltoe.Security.DataProtection.CredHubCore.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0;</TargetFrameworks>
     <RootNamespace>Steeltoe.Security.DataProtection.CredHub</RootNamespace>
     <Description>ASP.NET Core Extensions for CredHub Client</Description>
     <PackageTags>CloudFoundry;aspnetcore;Security;DataProtection;CredHub</PackageTags>

--- a/src/Security/test/Authentication.CloudFoundryBase.Test/Steeltoe.Security.Authentication.CloudFoundryBase.Test.csproj
+++ b/src/Security/test/Authentication.CloudFoundryBase.Test/Steeltoe.Security.Authentication.CloudFoundryBase.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0;</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Security/test/Authentication.CloudFoundryCore.Test/Steeltoe.Security.Authentication.CloudFoundryCore.Test.csproj
+++ b/src/Security/test/Authentication.CloudFoundryCore.Test/Steeltoe.Security.Authentication.CloudFoundryCore.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0;</TargetFrameworks>
     <RootNamespace>Steeltoe.Security.Authentication.CloudFoundry.Test</RootNamespace>
   </PropertyGroup>
 

--- a/src/Security/test/Authentication.CloudFoundryCore.Test/TestServerCertificateStartup.cs
+++ b/src/Security/test/Authentication.CloudFoundryCore.Test/TestServerCertificateStartup.cs
@@ -30,7 +30,7 @@ namespace Steeltoe.Security.Authentication.CloudFoundry.Test
         {
             app.UseCloudFoundryCertificateAuth();
 
-            app.Use(async (context, next) =>
+            app.Run(async (context) =>
             {
                 var authorizationResult = await authorizationService.AuthorizeAsync(context.User, null, context.Request.Path.Value.Replace("/", string.Empty));
 

--- a/src/Security/test/Authentication.MtlsCore.Test/ClientCertificateAuthenticationTests.cs
+++ b/src/Security/test/Authentication.MtlsCore.Test/ClientCertificateAuthenticationTests.cs
@@ -404,7 +404,7 @@ namespace Steeltoe.Security.Authentication.MtlsCore.Test
             if (!string.IsNullOrEmpty(Certificates.SelfSignedValidWithNoEku.SubjectName.Name))
             {
                 actual = responseAsXml.Elements("claim").Where(claim => claim.Attribute("Type").Value == ClaimTypes.X500DistinguishedName);
-                if (actual.Count() > 0)
+                if (actual.Any())
                 {
                     Assert.Single(actual);
                     Assert.Equal(Certificates.SelfSignedValidWithNoEku.SubjectName.Name, actual.First().Value);
@@ -414,7 +414,7 @@ namespace Steeltoe.Security.Authentication.MtlsCore.Test
             if (!string.IsNullOrEmpty(Certificates.SelfSignedValidWithNoEku.SerialNumber))
             {
                 actual = responseAsXml.Elements("claim").Where(claim => claim.Attribute("Type").Value == ClaimTypes.SerialNumber);
-                if (actual.Count() > 0)
+                if (actual.Any())
                 {
                     Assert.Single(actual);
                     Assert.Equal(Certificates.SelfSignedValidWithNoEku.SerialNumber, actual.First().Value);
@@ -424,7 +424,7 @@ namespace Steeltoe.Security.Authentication.MtlsCore.Test
             if (!string.IsNullOrEmpty(Certificates.SelfSignedValidWithNoEku.GetNameInfo(X509NameType.DnsName, false)))
             {
                 actual = responseAsXml.Elements("claim").Where(claim => claim.Attribute("Type").Value == ClaimTypes.Dns);
-                if (actual.Count() > 0)
+                if (actual.Any())
                 {
                     Assert.Single(actual);
                     Assert.Equal(Certificates.SelfSignedValidWithNoEku.GetNameInfo(X509NameType.DnsName, false), actual.First().Value);
@@ -434,7 +434,7 @@ namespace Steeltoe.Security.Authentication.MtlsCore.Test
             if (!string.IsNullOrEmpty(Certificates.SelfSignedValidWithNoEku.GetNameInfo(X509NameType.EmailName, false)))
             {
                 actual = responseAsXml.Elements("claim").Where(claim => claim.Attribute("Type").Value == ClaimTypes.Email);
-                if (actual.Count() > 0)
+                if (actual.Any())
                 {
                     Assert.Single(actual);
                     Assert.Equal(Certificates.SelfSignedValidWithNoEku.GetNameInfo(X509NameType.EmailName, false), actual.First().Value);
@@ -444,7 +444,7 @@ namespace Steeltoe.Security.Authentication.MtlsCore.Test
             if (!string.IsNullOrEmpty(Certificates.SelfSignedValidWithNoEku.GetNameInfo(X509NameType.SimpleName, false)))
             {
                 actual = responseAsXml.Elements("claim").Where(claim => claim.Attribute("Type").Value == ClaimTypes.Name);
-                if (actual.Count() > 0)
+                if (actual.Any())
                 {
                     Assert.Single(actual);
                     Assert.Equal(Certificates.SelfSignedValidWithNoEku.GetNameInfo(X509NameType.SimpleName, false), actual.First().Value);
@@ -454,7 +454,7 @@ namespace Steeltoe.Security.Authentication.MtlsCore.Test
             if (!string.IsNullOrEmpty(Certificates.SelfSignedValidWithNoEku.GetNameInfo(X509NameType.UpnName, false)))
             {
                 actual = responseAsXml.Elements("claim").Where(claim => claim.Attribute("Type").Value == ClaimTypes.Upn);
-                if (actual.Count() > 0)
+                if (actual.Any())
                 {
                     Assert.Single(actual);
                     Assert.Equal(Certificates.SelfSignedValidWithNoEku.GetNameInfo(X509NameType.UpnName, false), actual.First().Value);
@@ -464,7 +464,7 @@ namespace Steeltoe.Security.Authentication.MtlsCore.Test
             if (!string.IsNullOrEmpty(Certificates.SelfSignedValidWithNoEku.GetNameInfo(X509NameType.UrlName, false)))
             {
                 actual = responseAsXml.Elements("claim").Where(claim => claim.Attribute("Type").Value == ClaimTypes.Uri);
-                if (actual.Count() > 0)
+                if (actual.Any())
                 {
                     Assert.Single(actual);
                     Assert.Equal(Certificates.SelfSignedValidWithNoEku.GetNameInfo(X509NameType.UrlName, false), actual.First().Value);
@@ -546,7 +546,7 @@ namespace Steeltoe.Security.Authentication.MtlsCore.Test
 
                     app.UseAuthentication();
 
-                    app.Use(async (context, next) =>
+                    app.Run(async (context) =>
                     {
                         var request = context.Request;
                         var response = context.Response;

--- a/src/Security/test/Authentication.MtlsCore.Test/Steeltoe.Security.Authentication.MtlsCore.Test.csproj
+++ b/src/Security/test/Authentication.MtlsCore.Test/Steeltoe.Security.Authentication.MtlsCore.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0;</TargetFrameworks>
   </PropertyGroup>
   
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Security/test/DataProtection.CredHubBase.Test/Steeltoe.Security.DataProtection.CredHubBase.Test.csproj
+++ b/src/Security/test/DataProtection.CredHubBase.Test/Steeltoe.Security.DataProtection.CredHubBase.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0;</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Security/test/DataProtection.CredHubCore.Test/Steeltoe.Security.DataProtection.CredHubCore.Test.csproj
+++ b/src/Security/test/DataProtection.CredHubCore.Test/Steeltoe.Security.DataProtection.CredHubCore.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Security/test/DataProtection.RedisCore.Test/Steeltoe.Security.DataProtection.RedisCore.Test.csproj
+++ b/src/Security/test/DataProtection.RedisCore.Test/Steeltoe.Security.DataProtection.RedisCore.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0;</TargetFrameworks>
   </PropertyGroup>
   
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Steeltoe.All.sln
+++ b/src/Steeltoe.All.sln
@@ -351,6 +351,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "_build", "_build", "{656A78
 		..\build\management.yml = ..\build\management.yml
 		..\build\messaging.yml = ..\build\messaging.yml
 		..\build\security.yml = ..\build\security.yml
+		..\build\stream.yml = ..\build\stream.yml
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "templates", "templates", "{FC49CC5C-EFB6-4B08-AE63-05364EB27021}"

--- a/src/Steeltoe.All.sln
+++ b/src/Steeltoe.All.sln
@@ -1,14 +1,14 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.28803.452
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31710.8
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Steeltoe.Common", "Common\src\Common\Steeltoe.Common.csproj", "{61812938-5132-4AB6-B48D-2DF4189B3E37}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Steeltoe.Common.Test", "Common\test\Common.Test\Steeltoe.Common.Test.csproj", "{12BB796A-63C5-40D0-A2DE-80D9996DE571}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Steeltoe.Common.Utils", "Common\src\Common.Utils\Steeltoe.Common.Utils.csproj", "{EA3A9883-47B4-4386-8E2E-7D8714346DF8}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Steeltoe.Common.Utils", "Common\src\Common.Utils\Steeltoe.Common.Utils.csproj", "{EA3A9883-47B4-4386-8E2E-7D8714346DF8}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Steeltoe.Common.Utils.Test", "Common\test\Common.Utils.Test\Steeltoe.Common.Utils.Test.csproj", "{D449D5D8-AD62-4E10-AF46-A1DF99B35035}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Steeltoe.Common.Utils.Test", "Common\test\Common.Utils.Test\Steeltoe.Common.Utils.Test.csproj", "{D449D5D8-AD62-4E10-AF46-A1DF99B35035}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Steeltoe.Common.Http", "Common\src\Common.Http\Steeltoe.Common.Http.csproj", "{E58EB8CA-2389-4A28-B0EF-34C2B57BB270}"
 EndProject
@@ -52,9 +52,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "_shared", "_shared", "{DC1B
 	ProjectSection(SolutionItems) = preProject
 		..\.editorconfig = ..\.editorconfig
 		..\.gitignore = ..\.gitignore
-		..\azure-pipelines.yml = ..\azure-pipelines.yml
-		..\codecov.yml = ..\codecov.yml
-		..\coverlet.runsettings = ..\coverlet.runsettings
 		..\nuget.config = ..\nuget.config
 		..\sharedproject.props = ..\sharedproject.props
 		..\sharedtest.props = ..\sharedtest.props
@@ -339,6 +336,28 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Steeltoe.Extensions.Configu
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Steeltoe.OpenTelemetry.Test", "Management\test\OpenTelemetry.Test\Steeltoe.OpenTelemetry.Test.csproj", "{9F40820C-82C9-4AC2-999F-87D3F48E6636}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "_build", "_build", "{656A7881-FE4F-4EE0-81C8-DA1DE6CDF29E}"
+	ProjectSection(SolutionItems) = preProject
+		..\azure-pipelines.yml = ..\azure-pipelines.yml
+		..\codecov.yml = ..\codecov.yml
+		..\coverlet.runsettings = ..\coverlet.runsettings
+		..\build\circuitbreaker.yml = ..\build\circuitbreaker.yml
+		..\build\common.yml = ..\build\common.yml
+		..\build\configuration.yml = ..\build\configuration.yml
+		..\build\connectors.yml = ..\build\connectors.yml
+		..\build\discovery.yml = ..\build\discovery.yml
+		..\build\integration.yml = ..\build\integration.yml
+		..\build\logging.yml = ..\build\logging.yml
+		..\build\management.yml = ..\build\management.yml
+		..\build\messaging.yml = ..\build\messaging.yml
+		..\build\security.yml = ..\build\security.yml
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "templates", "templates", "{FC49CC5C-EFB6-4B08-AE63-05364EB27021}"
+	ProjectSection(SolutionItems) = preProject
+		..\build\templates\component-build.yaml = ..\build\templates\component-build.yaml
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -349,6 +368,18 @@ Global
 		{61812938-5132-4AB6-B48D-2DF4189B3E37}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{61812938-5132-4AB6-B48D-2DF4189B3E37}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{61812938-5132-4AB6-B48D-2DF4189B3E37}.Release|Any CPU.Build.0 = Release|Any CPU
+		{12BB796A-63C5-40D0-A2DE-80D9996DE571}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{12BB796A-63C5-40D0-A2DE-80D9996DE571}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{12BB796A-63C5-40D0-A2DE-80D9996DE571}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{12BB796A-63C5-40D0-A2DE-80D9996DE571}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EA3A9883-47B4-4386-8E2E-7D8714346DF8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EA3A9883-47B4-4386-8E2E-7D8714346DF8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EA3A9883-47B4-4386-8E2E-7D8714346DF8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EA3A9883-47B4-4386-8E2E-7D8714346DF8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D449D5D8-AD62-4E10-AF46-A1DF99B35035}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D449D5D8-AD62-4E10-AF46-A1DF99B35035}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D449D5D8-AD62-4E10-AF46-A1DF99B35035}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D449D5D8-AD62-4E10-AF46-A1DF99B35035}.Release|Any CPU.Build.0 = Release|Any CPU
 		{E58EB8CA-2389-4A28-B0EF-34C2B57BB270}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{E58EB8CA-2389-4A28-B0EF-34C2B57BB270}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E58EB8CA-2389-4A28-B0EF-34C2B57BB270}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -365,10 +396,6 @@ Global
 		{C67D2028-D637-4D81-84A2-5D64F2E389DA}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C67D2028-D637-4D81-84A2-5D64F2E389DA}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C67D2028-D637-4D81-84A2-5D64F2E389DA}.Release|Any CPU.Build.0 = Release|Any CPU
-		{12BB796A-63C5-40D0-A2DE-80D9996DE571}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{12BB796A-63C5-40D0-A2DE-80D9996DE571}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{12BB796A-63C5-40D0-A2DE-80D9996DE571}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{12BB796A-63C5-40D0-A2DE-80D9996DE571}.Release|Any CPU.Build.0 = Release|Any CPU
 		{1ACC6991-7D4C-48B2-A41C-4B179B19A85C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{1ACC6991-7D4C-48B2-A41C-4B179B19A85C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{1ACC6991-7D4C-48B2-A41C-4B179B19A85C}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -885,25 +912,19 @@ Global
 		{9F40820C-82C9-4AC2-999F-87D3F48E6636}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{9F40820C-82C9-4AC2-999F-87D3F48E6636}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{9F40820C-82C9-4AC2-999F-87D3F48E6636}.Release|Any CPU.Build.0 = Release|Any CPU
-		{EA3A9883-47B4-4386-8E2E-7D8714346DF8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{EA3A9883-47B4-4386-8E2E-7D8714346DF8}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{EA3A9883-47B4-4386-8E2E-7D8714346DF8}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{EA3A9883-47B4-4386-8E2E-7D8714346DF8}.Release|Any CPU.Build.0 = Release|Any CPU
-		{D449D5D8-AD62-4E10-AF46-A1DF99B35035}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{D449D5D8-AD62-4E10-AF46-A1DF99B35035}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{D449D5D8-AD62-4E10-AF46-A1DF99B35035}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{D449D5D8-AD62-4E10-AF46-A1DF99B35035}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{61812938-5132-4AB6-B48D-2DF4189B3E37} = {59874241-E276-4035-B31D-14924889A1C9}
+		{12BB796A-63C5-40D0-A2DE-80D9996DE571} = {59874241-E276-4035-B31D-14924889A1C9}
+		{EA3A9883-47B4-4386-8E2E-7D8714346DF8} = {59874241-E276-4035-B31D-14924889A1C9}
+		{D449D5D8-AD62-4E10-AF46-A1DF99B35035} = {59874241-E276-4035-B31D-14924889A1C9}
 		{E58EB8CA-2389-4A28-B0EF-34C2B57BB270} = {59874241-E276-4035-B31D-14924889A1C9}
 		{8F27A2D4-FEF2-4783-99C4-6B2ABA3D9431} = {59874241-E276-4035-B31D-14924889A1C9}
 		{DFE642E6-1CD0-4485-AC86-43CEBC451484} = {59874241-E276-4035-B31D-14924889A1C9}
 		{C67D2028-D637-4D81-84A2-5D64F2E389DA} = {59874241-E276-4035-B31D-14924889A1C9}
-		{12BB796A-63C5-40D0-A2DE-80D9996DE571} = {59874241-E276-4035-B31D-14924889A1C9}
 		{1ACC6991-7D4C-48B2-A41C-4B179B19A85C} = {59874241-E276-4035-B31D-14924889A1C9}
 		{880208DF-05C6-4763-A447-744D6C8DBDEA} = {59874241-E276-4035-B31D-14924889A1C9}
 		{137F6F0A-04A4-402D-A452-4634DEBC6B7C} = {43870F18-E788-433B-A41D-7C98174BA402}
@@ -1034,8 +1055,7 @@ Global
 		{B748B8B7-D6B8-40AC-AD19-73B6213CA363} = {4AB95F47-0C93-4C88-B87F-231262CD0E89}
 		{5D86C95F-A0C3-417E-A9E3-4426927E2897} = {4AB95F47-0C93-4C88-B87F-231262CD0E89}
 		{9F40820C-82C9-4AC2-999F-87D3F48E6636} = {8BD7D5E5-D887-4BD7-9F42-725A8714F7BC}
-		{EA3A9883-47B4-4386-8E2E-7D8714346DF8} = {59874241-E276-4035-B31D-14924889A1C9}
-		{D449D5D8-AD62-4E10-AF46-A1DF99B35035} = {59874241-E276-4035-B31D-14924889A1C9}
+		{FC49CC5C-EFB6-4B08-AE63-05364EB27021} = {656A7881-FE4F-4EE0-81C8-DA1DE6CDF29E}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {AB0245B9-2464-47F8-BE15-D80A7A2FA965}

--- a/src/Steeltoe.All.sln
+++ b/src/Steeltoe.All.sln
@@ -339,12 +339,12 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "_build", "_build", "{656A7881-FE4F-4EE0-81C8-DA1DE6CDF29E}"
 	ProjectSection(SolutionItems) = preProject
 		..\azure-pipelines.yml = ..\azure-pipelines.yml
-		..\codecov.yml = ..\codecov.yml
-		..\coverlet.runsettings = ..\coverlet.runsettings
 		..\build\circuitbreaker.yml = ..\build\circuitbreaker.yml
+		..\codecov.yml = ..\codecov.yml
 		..\build\common.yml = ..\build\common.yml
 		..\build\configuration.yml = ..\build\configuration.yml
 		..\build\connectors.yml = ..\build\connectors.yml
+		..\coverlet.runsettings = ..\coverlet.runsettings
 		..\build\discovery.yml = ..\build\discovery.yml
 		..\build\integration.yml = ..\build\integration.yml
 		..\build\logging.yml = ..\build\logging.yml
@@ -356,6 +356,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "templates", "templates", "{FC49CC5C-EFB6-4B08-AE63-05364EB27021}"
 	ProjectSection(SolutionItems) = preProject
 		..\build\templates\component-build.yaml = ..\build\templates\component-build.yaml
+		..\build\templates\consolidate-coverage.yaml = ..\build\templates\consolidate-coverage.yaml
 	EndProjectSection
 EndProject
 Global

--- a/src/Stream/src/Abstractions/Steeltoe.Stream.Abstractions.csproj
+++ b/src/Stream/src/Abstractions/Steeltoe.Stream.Abstractions.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <RootNamespace>Steeltoe.Stream</RootNamespace>
     <Description>Abstractions for use with Steeltoe Stream</Description>
     <PackageTags></PackageTags>

--- a/src/Stream/src/BinderRabbitMQ/Steeltoe.Stream.Binder.RabbitMQ.csproj
+++ b/src/Stream/src/BinderRabbitMQ/Steeltoe.Stream.Binder.RabbitMQ.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>Steeltoe Stream RabbitMQ Binder</Description>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <RootNamespace>Steeltoe.Stream.Binder.RabbitMQ</RootNamespace>
     <PackageTags>Streams, ASPNET Core, Spring, Spring Cloud, RabbitMQ, Binder</PackageTags>
   </PropertyGroup>
@@ -10,7 +10,6 @@
   <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedproject.props" />
   <ItemGroup>
-    <ProjectReference Include="..\..\..\Common\src\Abstractions\Steeltoe.Common.Abstractions.csproj" />
     <ProjectReference Include="..\..\..\Integration\src\RabbitMQ\Steeltoe.Integration.RabbitMQ.csproj" />
     <ProjectReference Include="..\..\..\Messaging\src\RabbitMQ\Steeltoe.Messaging.RabbitMQ.csproj" />
     <ProjectReference Include="..\StreamBase\Steeltoe.Stream.StreamBase.csproj" />

--- a/src/Stream/src/StreamBase/Steeltoe.Stream.StreamBase.csproj
+++ b/src/Stream/src/StreamBase/Steeltoe.Stream.StreamBase.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <RootNamespace>Steeltoe.Stream</RootNamespace>
     <Description>Steeltoe Stream Base</Description>
     <PackageTags>Streams, NET Core, Spring, Spring Cloud</PackageTags>
@@ -10,23 +10,16 @@
   <Import Project="..\..\..\..\sharedproject.props" />
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\Configuration\src\SpringBootBase\Steeltoe.Extensions.Configuration.SpringBootBase.csproj" />
+    <ProjectReference Include="..\Abstractions\Steeltoe.Stream.Abstractions.csproj" />
+    <ProjectReference Include="..\..\..\Common\src\Common.RetryPolly\Steeltoe.Common.RetryPolly.csproj" />
     <ProjectReference Include="..\..\..\Configuration\src\SpringBootCore\Steeltoe.Extensions.Configuration.SpringBootCore.csproj" />
     <ProjectReference Include="..\..\..\Connectors\src\ConnectorCore\Steeltoe.Connector.ConnectorCore.csproj" />
-    <ProjectReference Include="..\..\..\Messaging\src\RabbitMQ\Steeltoe.Messaging.RabbitMQ.csproj" />
-    <ProjectReference Include="..\Abstractions\Steeltoe.Stream.Abstractions.csproj" />
-    <ProjectReference Include="..\..\..\Messaging\src\MessagingBase\Steeltoe.Messaging.MessagingBase.csproj" />
     <ProjectReference Include="..\..\..\Integration\src\IntegrationBase\Steeltoe.Integration.IntegrationBase.csproj" />
-    <ProjectReference Include="..\..\..\Common\src\Common.RetryPolly\Steeltoe.Common.RetryPolly.csproj" />
+    <ProjectReference Include="..\..\..\Messaging\src\RabbitMQ\Steeltoe.Messaging.RabbitMQ.csproj" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Castle.Core" Version="$(CastleCoreVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="$(ExtensionsVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="$(ExtensionsVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="$(ExtensionsVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="$(ExtensionsVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="$(ExtensionsVersion)" />
     <PackageReference Include="System.Runtime.Loader" Version="$(RuntimeLoaderVersion)" />
   </ItemGroup>
 

--- a/src/Stream/test/BinderRabbitMQ.Test/Steeltoe.Stream.Binder.RabbitMQ.Test.csproj
+++ b/src/Stream/test/BinderRabbitMQ.Test/Steeltoe.Stream.Binder.RabbitMQ.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0;</TargetFrameworks>
     <RootNamespace>Steeltoe.Stream.Binder.Rabbit</RootNamespace>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
@@ -19,16 +19,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\Integration\src\IntegrationBase\Steeltoe.Integration.IntegrationBase.csproj" />
-    <ProjectReference Include="..\..\..\Messaging\src\RabbitMQ\Steeltoe.Messaging.RabbitMQ.csproj" />
-    <ProjectReference Include="..\..\src\BinderRabbitMQ\Steeltoe.Stream.Binder.RabbitMQ.csproj" />
     <ProjectReference Include="..\BinderTests\Steeltoe.Stream.BinderTests.csproj" />
     <PackageReference Include="EasyNetQ.Management.Client" Version="1.3.0" />
     <PackageReference Include="Moq" Version="$(MoqVersion)" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(ExtensionsVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="$(ExtensionsVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="$(ExtensionsVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="$(ExtensionsVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/Stream/test/BinderTests/Steeltoe.Stream.BinderTests.csproj
+++ b/src/Stream/test/BinderTests/Steeltoe.Stream.BinderTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0;</TargetFrameworks>
     <RootNamespace>Steeltoe.Stream.Binder</RootNamespace>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netcoreapp3.1|AnyCPU'">
@@ -18,14 +18,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\Integration\src\RabbitMQ\Steeltoe.Integration.RabbitMQ.csproj" />
     <ProjectReference Include="..\..\src\BinderRabbitMQ\Steeltoe.Stream.Binder.RabbitMQ.csproj" />
-    <ProjectReference Include="..\..\src\StreamBase\Steeltoe.Stream.StreamBase.csproj" />
     <PackageReference Include="Moq" Version="$(MoqVersion)" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(ExtensionsVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="$(ExtensionsVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="$(ExtensionsVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="$(ExtensionsVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/Stream/test/MockBinder/Steeltoe.Stream.MockBinder.csproj
+++ b/src/Stream/test/MockBinder/Steeltoe.Stream.MockBinder.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0;</TargetFrameworks>
     <IsPackable>False</IsPackable>
   </PropertyGroup>
   

--- a/src/Stream/test/StreamBase.Test/Steeltoe.Stream.StreamBase.Test.csproj
+++ b/src/Stream/test/StreamBase.Test/Steeltoe.Stream.StreamBase.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0;</TargetFrameworks>
     <RootNamespace>Steeltoe.Stream</RootNamespace>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netcoreapp3.1|AnyCPU'">
@@ -26,10 +26,6 @@
     <ProjectReference Include="..\..\..\Connectors\src\ConnectorCore\Steeltoe.Connector.ConnectorCore.csproj" />
     <ProjectReference Include="..\..\src\StreamBase\Steeltoe.Stream.StreamBase.csproj" />
     <PackageReference Include="Moq" Version="$(MoqVersion)" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(ExtensionsVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="$(ExtensionsVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="$(ExtensionsVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="$(ExtensionsVersion)" />
     <ProjectReference Include="..\TestBinder\Steeltoe.Stream.TestBinder.csproj"/>
 
   </ItemGroup>

--- a/src/Stream/test/StubBinder1/Steeltoe.Stream.StubBinder1.csproj
+++ b/src/Stream/test/StubBinder1/Steeltoe.Stream.StubBinder1.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0;</TargetFrameworks>
     <IsPackable>False</IsPackable>
   </PropertyGroup>
   

--- a/src/Stream/test/StubBinder2/Steeltoe.Stream.StubBinder2.csproj
+++ b/src/Stream/test/StubBinder2/Steeltoe.Stream.StubBinder2.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0;</TargetFrameworks>
     <IsPackable>False</IsPackable>
   </PropertyGroup>
   

--- a/src/Stream/test/TestBinder/Steeltoe.Stream.TestBinder.csproj
+++ b/src/Stream/test/TestBinder/Steeltoe.Stream.TestBinder.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0;</TargetFrameworks>
     <IsPackable>False</IsPackable>
   </PropertyGroup>
   

--- a/versions.props
+++ b/versions.props
@@ -6,7 +6,6 @@
     <CoreFxVersion>4.4.0</CoreFxVersion>
     <CSharpVersion>4.5.0</CSharpVersion>
     <DriveInfoVersion>4.3.1</DriveInfoVersion>
-    <EFCoreVersion>2.0.0</EFCoreVersion>
     <HttpVersion>4.3.4</HttpVersion>
     <WinHttpHandlerVersion>4.7.0</WinHttpHandlerVersion>
     <HttpClientVersion>4.3.4</HttpClientVersion>
@@ -14,7 +13,7 @@
     <SymReaderVersion>1.2.0</SymReaderVersion>
     <SymReaderPortableVersion>1.4.0</SymReaderPortableVersion>
     <SystemDiagnosticsVersion>5.0.1</SystemDiagnosticsVersion>
-    <SystemJsonVersion>4.6.0</SystemJsonVersion>
+    <SystemJsonVersion>5.0.2</SystemJsonVersion>
     <SystemReflectionVersion>4.6.0</SystemReflectionVersion>
     <TelemetryCorrelationVersion>1.0.0</TelemetryCorrelationVersion>
     <WebInfrastructureVersion>1.0.0</WebInfrastructureVersion>
@@ -30,10 +29,10 @@
 
     <AutofacVersion>4.6.1</AutofacVersion>
     <BouncyCastleVersion>1.8.4</BouncyCastleVersion>
-    <ConsulVersion>0.7.2.6</ConsulVersion>
-    <CoverletVersion>3.0.3</CoverletVersion>
+    <ConsulVersion>1.6.10.3</ConsulVersion>
+    <CoverletVersion>3.1.0</CoverletVersion>
     <HdrHistogramVersion>2.0.0</HdrHistogramVersion>
-    <HttpExtensionsVersion>2.1.0</HttpExtensionsVersion>
+    <HttpExtensionsVersion>3.1.0</HttpExtensionsVersion>
     <DiagnosticsExtensionsVersion>2.2.5</DiagnosticsExtensionsVersion>
     <FluentAssertionsVersion>5.10.*</FluentAssertionsVersion>
     <JsonNetVersion>11.0.2</JsonNetVersion>
@@ -45,7 +44,7 @@
     
     <RabbitClientVersion>5.0.1</RabbitClientVersion>
     <ReactiveVersion>4.1.5</ReactiveVersion>
-    <TestSdkVersion>16.9.1</TestSdkVersion>
+    <TestSdkVersion>16.11.0</TestSdkVersion>
     <XunitAnalyzersVersion>0.9.0</XunitAnalyzersVersion>
     <XunitVersion>2.4.1</XunitVersion>
     <XunitStudioVersion>2.4.3</XunitStudioVersion>
@@ -57,7 +56,7 @@
     <HealthChecksRedisVersion>2.2.3</HealthChecksRedisVersion>
     <HealthChecksSqlServerVersion>2.2.0</HealthChecksSqlServerVersion>
 
-    <SonarAnalyzerVersion>8.22.0.31243</SonarAnalyzerVersion>
+    <SonarAnalyzerVersion>8.29.0.36737</SonarAnalyzerVersion>
     <SourceLinkGitHubVersion>1.0.0</SourceLinkGitHubVersion>
     <StyleCopVersion>1.1.118</StyleCopVersion>
 
@@ -69,6 +68,7 @@
     <RuntimeLoaderVersion>4.3.0</RuntimeLoaderVersion>
 
     <ExtensionsVersion>3.1.0</ExtensionsVersion>
+    <EFCoreVersion>3.1.0</EFCoreVersion>
     <HealthChecksVersion>3.1.0</HealthChecksVersion>
     <LoggingVersion>3.1.0</LoggingVersion>
     <LightweightEmitVersion>4.7.0</LightweightEmitVersion>
@@ -77,20 +77,23 @@
     <AspNetCoreVersion>3.1.0</AspNetCoreVersion>
     <EFCoreTestVersion>3.1.6</EFCoreTestVersion>
     <EF6Version>6.3.0</EF6Version>
+    <ExtensionsVersion>3.1.0</ExtensionsVersion>
     <MySqlEFCoreVersion>3.1.10</MySqlEFCoreVersion>
     <NpgsqlEFCoreVersion>3.1.0</NpgsqlEFCoreVersion>
     <PomeloEFCoreVersion>3.1.0</PomeloEFCoreVersion>
     <OracleEFCoreVersion>3.19.80</OracleEFCoreVersion>
     <MicrosoftExtensionsRedisVersion>3.1.19</MicrosoftExtensionsRedisVersion>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net5.0'">
-    <AspNetCoreVersion>5.0.0</AspNetCoreVersion>
-    <EFCoreTestVersion>5.0.0</EFCoreTestVersion>
-    <EF6Version>6.4.0</EF6Version>
-    <MySqlEFCoreVersion>5.0.0</MySqlEFCoreVersion>
-    <NpgsqlEFCoreVersion>5.0.0</NpgsqlEFCoreVersion>
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net6.0'">
+    <AspNetCoreVersion>6.0.0-rc.*</AspNetCoreVersion>
+    <EFCoreTestVersion>6.0.0-preview.*</EFCoreTestVersion>
+    <MySqlEFCoreVersion>6.0.0-preview3</MySqlEFCoreVersion>
+    <NpgsqlEFCoreVersion>6.0.0-preview7</NpgsqlEFCoreVersion>
     <OracleEFCoreVersion>5.21.1</OracleEFCoreVersion>
-    <PomeloEFCoreVersion>5.0.0</PomeloEFCoreVersion>
-    <MicrosoftExtensionsRedisVersion>5.0.1</MicrosoftExtensionsRedisVersion>
+    <PomeloEFCoreVersion>6.0.0-preview.5</PomeloEFCoreVersion>
+    <EF6Version>6.4.0</EF6Version>
+    <ExtensionsVersion>6.0.0-rc.*</ExtensionsVersion>
+    <MicrosoftExtensionsRedisVersion>6.0.0-rc.*</MicrosoftExtensionsRedisVersion>
+    <SystemJsonVersion>6.0.0-rc.*</SystemJsonVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
- Update tests to run .NET 6 instead of 5 #764 
- Drop .NET 5 from packages that don't do anything different between netcoreapp3.1/net5
- New builds by component/feature with path triggers for faster responses (related to #756, but still in devops)
- #787