### PR TITLE
Support .NET 6, update OTel

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -34,6 +34,18 @@ jobs:
     env:
       PackageVersion: $(PackageVersion)
       PackageVersionOverride: $(PackageVersionOverride)
+  - task: UseDotNet@2
+    displayName: Install .NET Core 3.1
+    inputs:
+      version: 3.1.x
+  - task: UseDotNet@2
+    displayName: Install .NET 5
+    inputs:
+      version: 5.0.x
+  - task: UseDotNet@2
+    displayName: Install .NET 6
+    inputs:
+      version: 6.0.x
   - task: DotNetCoreCLI@2
     displayName: dotnet restore
     inputs:
@@ -71,7 +83,7 @@ jobs:
     displayName: Publish build artifacts
     artifact: Packages
 - job: Steeltoe_CI
-  timeoutInMinutes: 60
+  timeoutInMinutes: 90
   variables:
     DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
     DOTNET_CLI_TELEMETRY_OPTOUT: 1
@@ -92,6 +104,18 @@ jobs:
   pool:
     vmImage: $(imageName)
   steps:
+  - task: UseDotNet@2
+    displayName: Install .NET Core 3.1
+    inputs:
+      version: 3.1.x
+  - task: UseDotNet@2
+    displayName: Install .NET 5
+    inputs:
+      version: 5.0.x
+  - task: UseDotNet@2
+    displayName: Install .NET 6
+    inputs:
+      version: 6.0.x
   - task: DotNetCoreCLI@2
     displayName: dotnet restore
     inputs:
@@ -122,6 +146,13 @@ jobs:
       docker run -d --name rabbitmq -p 5672:5672 -p 15672:15672 rabbitmq:3-management
     condition: eq(variables['integrationTests'], 'true')
     displayName: Start Docker services
+  - task: DotNetCoreCLI@2
+    displayName: dotnet test 6.0
+    inputs:
+      command: test
+      projects: '**/*.csproj'
+      arguments: '--blame-hang-timeout 3m -f net6.0 --no-build -c $(buildConfiguration) -maxcpucount:1 $(skipFilter) --collect "XPlat Code Coverage" --settings coverlet.runsettings --logger trx --results-directory $(Build.SourcesDirectory)'
+      publishTestResults: false
   - task: DotNetCoreCLI@2
     displayName: dotnet test 5.0
     inputs:

--- a/src/Bootstrap/src/Autoconfig/Steeltoe.Bootstrap.Autoconfig.csproj
+++ b/src/Bootstrap/src/Autoconfig/Steeltoe.Bootstrap.Autoconfig.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <RootNamespace>Steeltoe.Bootstrap.Autoconfig</RootNamespace>
     <Description>Package for automatically configuring Steeltoe packages that have separately been added to a project.</Description>
     <PackageTags>Autoconfiguration;automatic configuration;application bootstrapping</PackageTags>

--- a/src/Bootstrap/test/Autoconfig.Test/Steeltoe.Bootstrap.Autoconfig.Test.csproj
+++ b/src/Bootstrap/test/Autoconfig.Test/Steeltoe.Bootstrap.Autoconfig.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
   </PropertyGroup>
   
   <Import Project="..\..\..\..\versions.props" />

--- a/src/CircuitBreaker/src/Hystrix.MetricsEventsCore/Steeltoe.CircuitBreaker.Hystrix.MetricsEventsCore.csproj
+++ b/src/CircuitBreaker/src/Hystrix.MetricsEventsCore/Steeltoe.CircuitBreaker.Hystrix.MetricsEventsCore.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>Steeltoe Netflix Hystrix Metrics Event Stream ASP.NET Core</Description>
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <PackageTags>aspnetcore;Circuit Breaker;Spring;Spring Cloud;Spring Cloud Hystrix;Hystrix</PackageTags>
   </PropertyGroup>
 

--- a/src/CircuitBreaker/src/Hystrix.MetricsStreamCore/Steeltoe.CircuitBreaker.Hystrix.MetricsStreamCore.csproj
+++ b/src/CircuitBreaker/src/Hystrix.MetricsStreamCore/Steeltoe.CircuitBreaker.Hystrix.MetricsStreamCore.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <Description>Netflix Hystrix metrics event stream for ASP.NET Core over RabbitMQ</Description>
     <PackageTags>aspnetcore;Circuit Breaker;Spring;Spring Cloud;Spring Cloud Hystrix;Hystrix;turbine;cloudfoundry</PackageTags>
   </PropertyGroup>

--- a/src/CircuitBreaker/src/HystrixCore/Steeltoe.CircuitBreaker.HystrixCore.csproj
+++ b/src/CircuitBreaker/src/HystrixCore/Steeltoe.CircuitBreaker.HystrixCore.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <RootNamespace>Steeltoe.CircuitBreaker.Hystrix</RootNamespace>
     <Description>Package for adding Steeltoe Hystrix to ASP.NET Core applications</Description>
     <PackageTags>aspnetcore;Spring Cloud;Netflix;Hystrix Client;Circuit Breaker</PackageTags>

--- a/src/CircuitBreaker/test/Hystrix.MetricsEventsCore.Test/Steeltoe.CircuitBreaker.Hystrix.MetricsEventsCore.Test.csproj
+++ b/src/CircuitBreaker/test/Hystrix.MetricsEventsCore.Test/Steeltoe.CircuitBreaker.Hystrix.MetricsEventsCore.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
   </PropertyGroup>
   
   <Import Project="..\..\..\..\versions.props" />

--- a/src/CircuitBreaker/test/Hystrix.MetricsStreamCore.Test/Steeltoe.CircuitBreaker.Hystrix.MetricsStreamCore.Test.csproj
+++ b/src/CircuitBreaker/test/Hystrix.MetricsStreamCore.Test/Steeltoe.CircuitBreaker.Hystrix.MetricsStreamCore.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
   </PropertyGroup>
   
   <Import Project="..\..\..\..\versions.props" />

--- a/src/CircuitBreaker/test/HystrixCore.Test/Steeltoe.CircuitBreaker.HystrixCore.Test.csproj
+++ b/src/CircuitBreaker/test/HystrixCore.Test/Steeltoe.CircuitBreaker.HystrixCore.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
   </PropertyGroup>
   
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Common/src/Common.Hosting/Steeltoe.Common.Hosting.csproj
+++ b/src/Common/src/Common.Hosting/Steeltoe.Common.Hosting.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>Steeltoe library for common hosting-related utilities</Description>
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <AssemblyName>Steeltoe.Common.Hosting</AssemblyName>
     <PackageId>Steeltoe.Common.Hosting</PackageId>
     <PackageTags>NET Core;Cloud Hosting;</PackageTags>

--- a/src/Common/test/Common.Expression.Test/Steeltoe.Common.Expression.Test.csproj
+++ b/src/Common/test/Common.Expression.Test/Steeltoe.Common.Expression.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <RootNamespace>Steeltoe.Common.Expression</RootNamespace>
   </PropertyGroup>
 

--- a/src/Common/test/Common.Hosting.Test/HostBuilderExtensionsTest.cs
+++ b/src/Common/test/Common.Hosting.Test/HostBuilderExtensionsTest.cs
@@ -178,7 +178,7 @@ namespace Steeltoe.Common.Hosting.Test
         }
 
         [Fact]
-#if NET5_0
+#if NET5_0_OR_GREATER
         [Trait("Category", "SkipOnMacOS")] // for .NET 5, this test produces an admin prompt on OSX
 #endif
         public void UseCloudHosting_GenericHost_UsesLocalPortSettings()

--- a/src/Common/test/Common.Hosting.Test/Steeltoe.Common.Hosting.Test.csproj
+++ b/src/Common/test/Common.Hosting.Test/Steeltoe.Common.Hosting.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
   </PropertyGroup>
   
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Common/test/Common.Http.Test/Steeltoe.Common.Http.Test.csproj
+++ b/src/Common/test/Common.Http.Test/Steeltoe.Common.Http.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
   </PropertyGroup>
   
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Common/test/Common.Kubernetes.Test/Steeltoe.Common.Kubernetes.Test.csproj
+++ b/src/Common/test/Common.Kubernetes.Test/Steeltoe.Common.Kubernetes.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
   </PropertyGroup>
   
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Common/test/Common.Net.Test/Steeltoe.Common.Net.Test.csproj
+++ b/src/Common/test/Common.Net.Test/Steeltoe.Common.Net.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
   </PropertyGroup>
   
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Common/test/Common.RetryPolly.Test/Steeltoe.Common.RetryPolly.Test.csproj
+++ b/src/Common/test/Common.RetryPolly.Test/Steeltoe.Common.RetryPolly.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Common/test/Common.Security.Test/Steeltoe.Common.Security.Test.csproj
+++ b/src/Common/test/Common.Security.Test/Steeltoe.Common.Security.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Common/test/Common.Test/Steeltoe.Common.Test.csproj
+++ b/src/Common/test/Common.Test/Steeltoe.Common.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
   </PropertyGroup>
   
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Common/test/Common.TestResources/Steeltoe.Common.TestResources.csproj
+++ b/src/Common/test/Common.TestResources/Steeltoe.Common.TestResources.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <NoWarn>IDE0130</NoWarn>
   </PropertyGroup>

--- a/src/Configuration/src/CloudFoundryCore/Steeltoe.Extensions.Configuration.CloudFoundryCore.csproj
+++ b/src/Configuration/src/CloudFoundryCore/Steeltoe.Extensions.Configuration.CloudFoundryCore.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <RootNamespace>Steeltoe.Extensions.Configuration.CloudFoundry</RootNamespace>
     <Description>Package for adding Cloud Foundry environment variable configuration provider to ASP.NET Core applications</Description>
     <PackageTags>aspnetcore;CloudFoundry;Spring;Spring Cloud;vcap</PackageTags>

--- a/src/Configuration/src/ConfigServerCore/Steeltoe.Extensions.Configuration.ConfigServerCore.csproj
+++ b/src/Configuration/src/ConfigServerCore/Steeltoe.Extensions.Configuration.ConfigServerCore.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <RootNamespace>Steeltoe.Extensions.Configuration.ConfigServer</RootNamespace>
     <Description>Package for adding Spring Cloud Config Server configuration provider to ASP.NET Core applications</Description>
     <PackageTags>aspnetcore;Spring Cloud;Spring Cloud Config Server</PackageTags>

--- a/src/Configuration/src/KubernetesCore/Steeltoe.Extensions.Configuration.KubernetesCore.csproj
+++ b/src/Configuration/src/KubernetesCore/Steeltoe.Extensions.Configuration.KubernetesCore.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <RootNamespace>Steeltoe.Extensions.Configuration.Kubernetes</RootNamespace>
     <Description>Package for adding Kubernetes environment variables, ConfigMaps and Secrets to .NET applications</Description>
     <PackageTags>Kubernetes;Spring;Spring Cloud;configuration;configmap</PackageTags>

--- a/src/Configuration/src/PlaceholderCore/Steeltoe.Extensions.Configuration.PlaceholderCore.csproj
+++ b/src/Configuration/src/PlaceholderCore/Steeltoe.Extensions.Configuration.PlaceholderCore.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <RootNamespace>Steeltoe.Extensions.Configuration.Placeholder</RootNamespace>
     <Description>Packing for adding property placeholder resolving config provider to ASP.NET Core applications</Description>
     <PackageTags>configuration;placeholders;aspnetcore;spring boot</PackageTags>

--- a/src/Configuration/src/SpringBootCore/Steeltoe.Extensions.Configuration.SpringBootCore.csproj
+++ b/src/Configuration/src/SpringBootCore/Steeltoe.Extensions.Configuration.SpringBootCore.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <RootNamespace>Steeltoe.Extensions.Configuration.SpringBoot</RootNamespace>
     <Description>Configuration provider for reading Spring Boot style configuration</Description>
     <PackageTags>configuration;springboot</PackageTags>

--- a/src/Configuration/test/CloudFoundryBase.Test/Steeltoe.Extensions.Configuration.CloudFoundryBase.Test.csproj
+++ b/src/Configuration/test/CloudFoundryBase.Test/Steeltoe.Extensions.Configuration.CloudFoundryBase.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
   </PropertyGroup>
   
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Configuration/test/CloudFoundryCore.Test/Steeltoe.Extensions.Configuration.CloudFoundryCore.Test.csproj
+++ b/src/Configuration/test/CloudFoundryCore.Test/Steeltoe.Extensions.Configuration.CloudFoundryCore.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
   </PropertyGroup>
   
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Configuration/test/ConfigServer.ITest/Steeltoe.Extensions.Configuration.ConfigServer.ITest.csproj
+++ b/src/Configuration/test/ConfigServer.ITest/Steeltoe.Extensions.Configuration.ConfigServer.ITest.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
   </PropertyGroup>
   
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Configuration/test/ConfigServerBase.Test/Steeltoe.Extensions.Configuration.ConfigServerBase.Test.csproj
+++ b/src/Configuration/test/ConfigServerBase.Test/Steeltoe.Extensions.Configuration.ConfigServerBase.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
   </PropertyGroup>
   
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Configuration/test/ConfigServerCore.Test/Steeltoe.Extensions.Configuration.ConfigServerCore.Test.csproj
+++ b/src/Configuration/test/ConfigServerCore.Test/Steeltoe.Extensions.Configuration.ConfigServerCore.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
   </PropertyGroup>
   
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Configuration/test/KubernetesBase.Test/Steeltoe.Extensions.Configuration.KubernetesBase.Test.csproj
+++ b/src/Configuration/test/KubernetesBase.Test/Steeltoe.Extensions.Configuration.KubernetesBase.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <RootNamespace>Steeltoe.Extensions.Configuration.Kubernetes.Test</RootNamespace>
   </PropertyGroup>
   

--- a/src/Configuration/test/KubernetesCore.Test/Steeltoe.Extensions.Configuration.KubernetesCore.Test.csproj
+++ b/src/Configuration/test/KubernetesCore.Test/Steeltoe.Extensions.Configuration.KubernetesCore.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <RootNamespace>Steeltoe.Extensions.Configuration.Kubernetes.Test</RootNamespace>
   </PropertyGroup>
   

--- a/src/Configuration/test/PlaceholderBase.Test/Steeltoe.Extensions.Configuration.PlaceholderBase.Test.csproj
+++ b/src/Configuration/test/PlaceholderBase.Test/Steeltoe.Extensions.Configuration.PlaceholderBase.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
   </PropertyGroup>
   
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Configuration/test/PlaceholderCore.Test/Steeltoe.Extensions.Configuration.PlaceholderCore.Test.csproj
+++ b/src/Configuration/test/PlaceholderCore.Test/Steeltoe.Extensions.Configuration.PlaceholderCore.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
   </PropertyGroup>
   
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Configuration/test/RandomValuesBase.Test/Steeltoe.Extensions.Configuration.RandomValueBase.Test.csproj
+++ b/src/Configuration/test/RandomValuesBase.Test/Steeltoe.Extensions.Configuration.RandomValueBase.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
   </PropertyGroup>
   
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Configuration/test/SpringBootBase.Test/Steeltoe.Extensions.Configuration.SpringBootBase.Test.csproj
+++ b/src/Configuration/test/SpringBootBase.Test/Steeltoe.Extensions.Configuration.SpringBootBase.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
   </PropertyGroup>
   
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Configuration/test/SpringBootCore.Test/Steeltoe.Extensions.Configuration.SpringBootCore.Test.csproj
+++ b/src/Configuration/test/SpringBootCore.Test/Steeltoe.Extensions.Configuration.SpringBootCore.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
   </PropertyGroup>
   
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Connectors/test/Connector.CloudFoundry.Test/Steeltoe.Connector.CloudFoundry.Test.csproj
+++ b/src/Connectors/test/Connector.CloudFoundry.Test/Steeltoe.Connector.CloudFoundry.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
   </PropertyGroup>
   
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Connectors/test/Connector.EF6Core.Test/Steeltoe.Connector.EF6Core.Test.csproj
+++ b/src/Connectors/test/Connector.EF6Core.Test/Steeltoe.Connector.EF6Core.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
   </PropertyGroup>
   
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Connectors/test/Connector.EFCore.Test/EntityFrameworkCoreTypeLocatorTest.cs
+++ b/src/Connectors/test/Connector.EFCore.Test/EntityFrameworkCoreTypeLocatorTest.cs
@@ -76,6 +76,7 @@ namespace Steeltoe.Connector.EFCore.Test
             Assert.NotNull(type);
         }
 
+#if !NET6_0 // TODO: remove when Oracle works with EF 6
         [Fact]
         public void Options_Found_In_OracleEF_Assembly()
         {
@@ -90,6 +91,7 @@ namespace Steeltoe.Connector.EFCore.Test
             Assert.NotNull(type);
             EntityFrameworkCoreTypeLocator.OracleEntityAssemblies = oracleAssemblies;
         }
+#endif
 
         [Fact(Skip = "Change NuGet reference to see this test pass")]
         public void Options_Found_In_Devart_Assembly()

--- a/src/Connectors/test/Connector.EFCore.Test/MySqlDbContextOptionsExtensionsTest.cs
+++ b/src/Connectors/test/Connector.EFCore.Test/MySqlDbContextOptionsExtensionsTest.cs
@@ -109,7 +109,7 @@ namespace Steeltoe.Connector.MySql.EFCore.Test
             Assert.True(con is MySqlConnection);
         }
 
-#if NET5_0
+#if NET5_0_OR_GREATER
         // Run a MySQL server with Docker to match creds below with this command
         // docker run --name steeltoe-mysql -p 3306:3306 -e MYSQL_DATABASE=steeltoe -e MYSQL_ROOT_PASSWORD=steeltoe mysql
         [Fact(Skip = "Requires a running MySQL server to support AutoDetect")]

--- a/src/Connectors/test/Connector.EFCore.Test/Steeltoe.Connector.EFCore.Test.csproj
+++ b/src/Connectors/test/Connector.EFCore.Test/Steeltoe.Connector.EFCore.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
   </PropertyGroup>
   
   <Import Project="..\..\..\..\versions.props" />
@@ -21,7 +21,7 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'"><!--Oracle doesn't work with EF Core 5.0 yet-->
     <PackageReference Include="MySql.EntityFrameworkCore" Version="$(MySqlEFCoreVersion)" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net5.0' OR '$(TargetFramework)' == 'net6.0'">
     <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="$(PomeloEFCoreVersion)" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Connectors/test/Connector.EFCore.Test/Steeltoe.Connector.EFCore.Test.csproj
+++ b/src/Connectors/test/Connector.EFCore.Test/Steeltoe.Connector.EFCore.Test.csproj
@@ -15,14 +15,16 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="$(EFCoreTestVersion)" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="$(NpgsqlEFCoreVersion)" />
-    <PackageReference Include="Oracle.EntityFrameworkCore" Version="$(OracleEFCoreVersion)" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'"><!--Oracle doesn't work with EF Core 5.0 yet-->
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
     <PackageReference Include="MySql.EntityFrameworkCore" Version="$(MySqlEFCoreVersion)" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net5.0' OR '$(TargetFramework)' == 'net6.0'">
     <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="$(PomeloEFCoreVersion)" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' != 'net6.0'"><!--Oracle doesn't work with EF Core 6.0 yet-->
+    <PackageReference Include="Oracle.EntityFrameworkCore" Version="$(OracleEFCoreVersion)" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\CloudFoundry\Steeltoe.Connector.CloudFoundry.csproj" />

--- a/src/Connectors/test/ConnectorBase.Test/Steeltoe.Connector.ConnectorBase.Test.csproj
+++ b/src/Connectors/test/ConnectorBase.Test/Steeltoe.Connector.ConnectorBase.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <RootNamespace>Steeltoe.Connector.Test</RootNamespace>
   </PropertyGroup>
   
@@ -27,7 +27,6 @@
     <!--<PackageReference Include="MySql.Data" Version="$(MySqlV8)" />-->
     <PackageReference Include="Npgsql" Version="$(NpgsqlVersion)" />
     <PackageReference Include="RabbitMQ.Client" Version="$(RabbitClientVersion)" />
-    <PackageReference Include="StackExchange.Redis" Version="$(StackExchangeVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Connectors/test/ConnectorCore.Test/Steeltoe.Connector.ConnectorCore.Test.csproj
+++ b/src/Connectors/test/ConnectorCore.Test/Steeltoe.Connector.ConnectorCore.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
   </PropertyGroup>
   
   <Import Project="..\..\..\..\versions.props" />
@@ -29,7 +29,6 @@
     <PackageReference Include="Oracle.ManagedDataAccess.Core" Version="2.19.31" />
 
     <PackageReference Include="RabbitMQ.Client" Version="$(RabbitClientVersion)" />
-    <PackageReference Include="StackExchange.Redis" Version="$(StackExchangeVersion)" />
     <PackageReference Include="System.Data.SqlClient" Version="$(SqlClientVersion)" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(ExtensionsVersion)" />
   </ItemGroup>

--- a/src/Connectors/test/External.Connector.Test/External.Connector.Test.csproj
+++ b/src/Connectors/test/External.Connector.Test/External.Connector.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Discovery/src/ClientCore/Steeltoe.Discovery.ClientCore.csproj
+++ b/src/Discovery/src/ClientCore/Steeltoe.Discovery.ClientCore.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <Description>Package for using Steeltoe Service Discovery Client in ASP.NET Core applications</Description>
     <PackageTags>aspnetcore;service discovery;service registry;Spring Cloud;eureka;consul;kubernetes</PackageTags>
     <RootNamespace>Steeltoe.Discovery.Client</RootNamespace>

--- a/src/Discovery/test/ClientBase.Test/Steeltoe.Discovery.ClientBase.Test.csproj
+++ b/src/Discovery/test/ClientBase.Test/Steeltoe.Discovery.ClientBase.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
   </PropertyGroup>
   
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Discovery/test/ClientCore.Test/Steeltoe.Discovery.ClientCore.Test.csproj
+++ b/src/Discovery/test/ClientCore.Test/Steeltoe.Discovery.ClientCore.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
   </PropertyGroup>
   
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Discovery/test/Consul.Test/Steeltoe.Discovery.Consul.Test.csproj
+++ b/src/Discovery/test/Consul.Test/Steeltoe.Discovery.Consul.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
   </PropertyGroup>
   
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Discovery/test/Eureka.Test/Steeltoe.Discovery.Eureka.Test.csproj
+++ b/src/Discovery/test/Eureka.Test/Steeltoe.Discovery.Eureka.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
   </PropertyGroup>
   
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Discovery/test/Kubernetes.Test/Steeltoe.Discovery.Kubernetes.Test.csproj
+++ b/src/Discovery/test/Kubernetes.Test/Steeltoe.Discovery.Kubernetes.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <Nullable>enable</Nullable>
   </PropertyGroup>
   

--- a/src/Integration/src/Abstractions/Steeltoe.Integration.Abstractions.csproj
+++ b/src/Integration/src/Abstractions/Steeltoe.Integration.Abstractions.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <RootNamespace>Steeltoe.Integration</RootNamespace>
     <Description>
       Abstractions for use with Steeltoe Integration libraries

--- a/src/Integration/src/IntegrationBase/Steeltoe.Integration.IntegrationBase.csproj
+++ b/src/Integration/src/IntegrationBase/Steeltoe.Integration.IntegrationBase.csproj
@@ -5,7 +5,7 @@
       Steeltoe Integration Base
       **PLEASE NOTE** The public API of this package is subject to change and is not recommended for direct use outside of Steeltoe.
     </Description>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <RootNamespace>Steeltoe.Integration</RootNamespace>
     <PackageTags>Integration, NET Core, Spring, Spring Cloud</PackageTags>
   </PropertyGroup>

--- a/src/Integration/src/RabbitMQ/Steeltoe.Integration.RabbitMQ.csproj
+++ b/src/Integration/src/RabbitMQ/Steeltoe.Integration.RabbitMQ.csproj
@@ -5,7 +5,7 @@
       Steeltoe Integration RabbitMQ
       **PLEASE NOTE** The public API of this package is subject to change and is not recommended for direct use outside of Steeltoe.
     </Description>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <RootNamespace>Steeltoe.Integration.RabbitMQ</RootNamespace>
     <PackageTags>Integration, ASPNET Core, Spring, Spring Cloud, RabbitMQ</PackageTags>
   </PropertyGroup>

--- a/src/Integration/test/IntegrationBase.Test/Steeltoe.Integration.IntegrationBase.Test.csproj
+++ b/src/Integration/test/IntegrationBase.Test/Steeltoe.Integration.IntegrationBase.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <RootNamespace>Steeltoe.Integration</RootNamespace>
   </PropertyGroup>
 

--- a/src/Integration/test/RabbitMQ.Test/Steeltoe.Integration.RabbitMQ.Test.csproj
+++ b/src/Integration/test/RabbitMQ.Test/Steeltoe.Integration.RabbitMQ.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <RootNamespace>Steeltoe.Integration.RabbitMQ</RootNamespace>
   </PropertyGroup>
 

--- a/src/Logging/src/DynamicSerilogBase/SerilogOptions.cs
+++ b/src/Logging/src/DynamicSerilogBase/SerilogOptions.cs
@@ -28,7 +28,7 @@ namespace Steeltoe.Extensions.Logging.DynamicSerilog
         {
             var section = configuration.GetSection(ConfigPath);
             section.Bind(this);
-            if (MinimumLevel == null)
+            if (MinimumLevel == null || MinimumLevel.Default == (LogEventLevel)(-1))
             {
                 MinimumLevel = new MinimumLevel()
                 {
@@ -50,7 +50,7 @@ namespace Steeltoe.Extensions.Logging.DynamicSerilog
     public class MinimumLevel
 #pragma warning restore SA1402 // File may only contain a single class
     {
-        public LogEventLevel Default { get; set; }
+        public LogEventLevel Default { get; set; } = (LogEventLevel)(-1);
 
         public Dictionary<string, LogEventLevel> Override { get; set; }
     }

--- a/src/Logging/src/DynamicSerilogCore/Steeltoe.Extensions.Logging.DynamicSerilogCore.csproj
+++ b/src/Logging/src/DynamicSerilogCore/Steeltoe.Extensions.Logging.DynamicSerilogCore.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <Description>Steeltoe library for enabling dynamic management of Serilog in ASP.NET Core applications. Includes Console sink.</Description>
     <PackageTags>logging;dynamic logging;serilog;aspnetcore;management;monitoring;Spring Cloud;</PackageTags>
     <RootNamespace>Steeltoe.Extensions.Logging.DynamicSerilog</RootNamespace>

--- a/src/Logging/test/DynamicLogger.Test/DynamicLoggingBuilderTest.cs
+++ b/src/Logging/test/DynamicLogger.Test/DynamicLoggingBuilderTest.cs
@@ -183,7 +183,6 @@ namespace Steeltoe.Extensions.Logging.Test
         [Fact]
         public void DynamicLevelSetting_ParmLessAddDynamic_AddsConsoleOptions()
         {
-            // arrange
             var configuration = new ConfigurationBuilder().AddInMemoryCollection(Appsettings).Build();
             var services = new ServiceCollection()
                 .AddLogging(builder =>
@@ -193,13 +192,13 @@ namespace Steeltoe.Extensions.Logging.Test
                 })
                 .BuildServiceProvider();
 
-            // act
             var options = services.GetService<IOptionsMonitor<ConsoleLoggerOptions>>();
 
-            // assert
             Assert.NotNull(options);
             Assert.NotNull(options.CurrentValue);
+#pragma warning disable CS0618 // Type or member is obsolete
             Assert.True(options.CurrentValue.DisableColors);
+#pragma warning restore CS0618 // Type or member is obsolete
         }
 
         [Fact]
@@ -265,7 +264,9 @@ namespace Steeltoe.Extensions.Logging.Test
 
             // assert
             Assert.NotNull(options);
+#pragma warning disable CS0618 // Type or member is obsolete
             Assert.False(options.Value.DisableColors);
+#pragma warning restore CS0618 // Type or member is obsolete
         }
 
         [Fact]
@@ -286,7 +287,9 @@ namespace Steeltoe.Extensions.Logging.Test
 
             // assert
             Assert.NotNull(options);
+#pragma warning disable CS0618 // Type or member is obsolete
             Assert.True(options.Value.DisableColors);
+#pragma warning restore CS0618 // Type or member is obsolete
             Environment.SetEnvironmentVariable("VCAP_APPLICATION", string.Empty);
         }
     }

--- a/src/Logging/test/DynamicLogger.Test/Steeltoe.Extensions.Logging.DynamicLogger.Test.csproj
+++ b/src/Logging/test/DynamicLogger.Test/Steeltoe.Extensions.Logging.DynamicLogger.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
   </PropertyGroup>
   
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Logging/test/DynamicSerilogBase.Test/Steeltoe.Extensions.Logging.DynamicSerilogBase.Test.csproj
+++ b/src/Logging/test/DynamicSerilogBase.Test/Steeltoe.Extensions.Logging.DynamicSerilogBase.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <RootNamespace>Steeltoe.Extensions.Logging.DynamicSerilog.Test</RootNamespace>
   </PropertyGroup>
   

--- a/src/Logging/test/DynamicSerilogCore.Test/Steeltoe.Extensions.Logging.DynamicSerilogCore.Test.csproj
+++ b/src/Logging/test/DynamicSerilogCore.Test/Steeltoe.Extensions.Logging.DynamicSerilogCore.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <RootNamespace>Steeltoe.Extensions.Logging.DynamicSerilog.Test</RootNamespace>
   </PropertyGroup>
   

--- a/src/Management/src/CloudFoundryCore/CloudFoundryActuatorsStartupFilter.cs
+++ b/src/Management/src/CloudFoundryCore/CloudFoundryActuatorsStartupFilter.cs
@@ -32,7 +32,7 @@ namespace Steeltoe.Management.CloudFoundry
 
                 next(app);
 
-                app.UseEndpoints(endpoints => endpoints.MapAllActuators());
+                app.UseEndpoints(endpoints => endpoints.MapAllActuators(null));
                 app.ApplicationServices.InitializeAvailability();
             };
         }

--- a/src/Management/src/CloudFoundryCore/Steeltoe.Management.CloudFoundryCore.csproj
+++ b/src/Management/src/CloudFoundryCore/Steeltoe.Management.CloudFoundryCore.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <RootNamespace>Steeltoe.Management.CloudFoundry</RootNamespace>
     <Description>Package for using Steeltoe management endpoints with ASP.NET Core on Cloud Foundry.</Description>
     <PackageTags>actuator;management;monitoring;aspnetcore;CloudFoundry;Spring Cloud;</PackageTags>

--- a/src/Management/src/EndpointBase/Steeltoe.Management.EndpointBase.csproj
+++ b/src/Management/src/EndpointBase/Steeltoe.Management.EndpointBase.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Diagnostics.NETCore.Client" Version="0.2.221401" />
+    <PackageReference Include="Microsoft.Diagnostics.NETCore.Client" Version="0.2.251802" />
     <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="$(ExtensionsVersion)" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(ExtensionsVersion)" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="$(ExtensionsVersion)" />

--- a/src/Management/src/EndpointBase/Steeltoe.Management.EndpointBase.csproj
+++ b/src/Management/src/EndpointBase/Steeltoe.Management.EndpointBase.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="Microsoft.DiaSymReader" Version="$(SymReaderVersion)" />
     <PackageReference Include="Microsoft.DiaSymReader.PortablePdb" Version="$(SymReaderPortableVersion)" />
     <PackageReference Include="System.IO.FileSystem.DriveInfo" Version="$(DriveInfoVersion)" />
-    <PackageReference Include="System.Net.Http.Json" Version="3.2.1" />
+    <PackageReference Include="System.Net.Http.Json" Version="$(SystemNetHttpJsonVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Management/src/EndpointCore/ActuatorRouteBuilderExtensions.cs
+++ b/src/Management/src/EndpointCore/ActuatorRouteBuilderExtensions.cs
@@ -56,24 +56,39 @@ namespace Steeltoe.Management.Endpoint
         /// Generic routebuilder extension for Actuators.
         /// </summary>
         /// <param name="endpoints">IEndpointRouteBuilder to Map route.</param>
+        /// <param name="convention">A convention builder action that applies a convention to the whole collection. </param>
+        /// <typeparam name="TEndpoint">Middleware for which the route is mapped.</typeparam>
+        /// <exception cref="InvalidOperationException">When T is not found in service container</exception>
+        public static void Map<TEndpoint>(this IEndpointRouteBuilder endpoints, Action<IEndpointConventionBuilder> convention = null)
+        where TEndpoint : IEndpoint
+        {
+            MapActuatorEndpoint(endpoints, typeof(TEndpoint), convention);
+        }
+
+#if !NET6_0
+        /// <summary>
+        /// Generic routebuilder extension for Actuators.
+        /// </summary>
+        /// <param name="endpoints">IEndpointRouteBuilder to Map route.</param>
         /// <param name="conventionBuilder">A convention builder that applies a convention to the whole collection. </param>
         /// <typeparam name="TEndpoint">Middleware for which the route is mapped.</typeparam>
         /// <exception cref="InvalidOperationException">When T is not found in service container</exception>
-        public static IEndpointConventionBuilder Map<TEndpoint>(this IEndpointRouteBuilder endpoints, EndpointCollectionConventionBuilder conventionBuilder = null)
+        public static IEndpointConventionBuilder Map<TEndpoint>(this IEndpointRouteBuilder endpoints, EndpointCollectionConventionBuilder conventionBuilder)
         where TEndpoint : IEndpoint
         {
+#pragma warning disable CS0618 // Type or member is obsolete
             return MapActuatorEndpoint(endpoints, typeof(TEndpoint), conventionBuilder);
+#pragma warning restore CS0618 // Type or member is obsolete
         }
+#endif
 
         /// <summary>
         /// Maps all actuators that have been registered in <see cref="IServiceCollection"/>
         /// </summary>
         /// <param name="endpoints">The endpoint builder</param>
-        /// <returns>Endpoint convention builder</returns>
-        public static IEndpointConventionBuilder MapAllActuators(this IEndpointRouteBuilder endpoints)
+        /// <param name="convention">The convention action to apply</param>
+        public static void MapAllActuators(this IEndpointRouteBuilder endpoints, Action<IEndpointConventionBuilder> convention)
         {
-            var conventionBuilder = new EndpointCollectionConventionBuilder();
-
             foreach (var endpointEntry in endpoints.ServiceProvider.GetServices<EndpointMappingEntry>())
             {
                 // Some actuators only work on some platforms. i.e. Windows and Linux
@@ -84,22 +99,87 @@ namespace Steeltoe.Management.Endpoint
 
                 // This function just takes what has been registered, and sets up the endpoints
                 // This keeps this method flexible; new actuators that are added later should automatically become available
+                endpointEntry.SetupConvention(endpoints, convention);
+            }
+        }
+
+#if !NET6_0
+        /// <summary>
+        /// Maps all actuators that have been registered in <see cref="IServiceCollection"/>
+        /// </summary>
+        /// <param name="endpoints">The endpoint builder</param>
+        /// <returns>Endpoint convention builder</returns>
+        [Obsolete("Use MapAllActuators(this IEndpointRouteBuilder endpoints, Action<IEndpointConventionBuilder> convention) instead")]
+        public static IEndpointConventionBuilder MapAllActuators(this IEndpointRouteBuilder endpoints)
+        {
+            var conventionBuilder = new EndpointCollectionConventionBuilder();
+
+            foreach (var endpointEntry in endpoints.ServiceProvider.GetServices<EndpointMappingEntry>())
+            {
+                // Some actuators only work on some platforms. i.e. Windows and Linux
+                // Some actuators have different implemenation depending on the MediaTypeVersion
+                // Previously those checks where performed here and when adding things to the IServiceCollection
+                // Now all that logic is handled in the IServiceCollection setup; no need to keep code in two different places in sync
+
+                // This function just takes what has been registered, and sets up the endpoints
+                // This keeps this method flexible; new actuators that are added later should automatically become available
                 endpointEntry.Setup(endpoints, conventionBuilder);
             }
 
             return conventionBuilder;
         }
+#endif
 
         /// <summary>
         /// Maps all actuators that have been registered in <see cref="IServiceCollection"/>
         /// </summary>
         /// <param name="endpoints">The endpoint builder</param>
         /// <param name="version">Media Version</param>
-        /// <returns>Endpoint convention builder</returns>
         [Obsolete("MediaTypeVersion parameter is not used")]
-        public static IEndpointConventionBuilder MapAllActuators(this IEndpointRouteBuilder endpoints, MediaTypeVersion version)
-            => endpoints.MapAllActuators();
+        public static void MapAllActuators(this IEndpointRouteBuilder endpoints, MediaTypeVersion version)
+            => endpoints.MapAllActuators(null);
 
+        internal static void MapActuatorEndpoint(this IEndpointRouteBuilder endpoints, Type typeEndpoint, Action<IEndpointConventionBuilder> convention)
+        {
+            if (endpoints == null)
+            {
+                throw new ArgumentNullException(nameof(endpoints));
+            }
+
+            ConnectEndpointOptionsWithManagementOptions(endpoints);
+
+            var (middleware, optionsType) = LookupMiddleware(typeEndpoint);
+            var options = endpoints.ServiceProvider.GetService(optionsType) as IEndpointOptions;
+            var mgmtOptionsCollection = endpoints.ServiceProvider.GetServices<IManagementOptions>();
+
+            foreach (var mgmtOptions in mgmtOptionsCollection)
+            {
+                if ((mgmtOptions is CloudFoundryManagementOptions && options is IActuatorHypermediaOptions)
+                    || (mgmtOptions is ActuatorManagementOptions && options is ICloudFoundryOptions))
+                {
+                    continue;
+                }
+
+                var fullPath = options.GetContextPath(mgmtOptions);
+
+                var pattern = RoutePatternFactory.Parse(fullPath);
+
+                // only add middleware if the route hasn't already been mapped
+                if (!endpoints.DataSources.Any(d => d.Endpoints.Any(ep => ep is RouteEndpoint endpoint && endpoint.RoutePattern.RawText == pattern.RawText)))
+                {
+                    var pipeline = endpoints.CreateApplicationBuilder()
+                        .UseMiddleware(middleware, mgmtOptions)
+                        .Build();
+                    var allowedVerbs = options.AllowedVerbs ?? new List<string> { "Get" };
+                    var conventionBuilder = endpoints.MapMethods(fullPath, allowedVerbs, pipeline);
+                    convention?.Invoke(conventionBuilder);
+                }
+            }
+        }
+
+#if !NET6_0
+
+        [Obsolete("MediaTypeVersion parameter is not used")]
         internal static IEndpointConventionBuilder MapActuatorEndpoint(this IEndpointRouteBuilder endpoints, Type typeEndpoint, EndpointCollectionConventionBuilder conventionBuilder = null)
         {
             if (endpoints == null)
@@ -133,13 +213,14 @@ namespace Steeltoe.Management.Endpoint
                         .UseMiddleware(middleware, mgmtOptions)
                         .Build();
                     var allowedVerbs = options.AllowedVerbs ?? new List<string> { "Get" };
-
                     builder.AddConventionBuilder(endpoints.MapMethods(fullPath, allowedVerbs, pipeline));
                 }
             }
 
             return builder;
         }
+
+#endif
 
         private static void ConnectEndpointOptionsWithManagementOptions(IEndpointRouteBuilder endpoints)
         {

--- a/src/Management/src/EndpointCore/AllActuatorsStartupFilter.cs
+++ b/src/Management/src/EndpointCore/AllActuatorsStartupFilter.cs
@@ -40,8 +40,7 @@ namespace Steeltoe.Management.Endpoint
 
                 app.UseEndpoints(endpoints =>
                 {
-                    var builder = endpoints.MapAllActuators();
-                    _configureConventions?.Invoke(builder);
+                    endpoints.MapAllActuators(_configureConventions);
                 });
 
                 app.ApplicationServices.InitializeAvailability();

--- a/src/Management/src/EndpointCore/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Management/src/EndpointCore/Extensions/ServiceCollectionExtensions.cs
@@ -21,7 +21,14 @@ namespace Microsoft.Extensions.DependencyInjection
         {
             services.AddSingleton(new EndpointMappingEntry
             {
+                // new way compatible with .NET 6
+                SetupConvention = (endpoints, conventionBuilder) => endpoints.Map<TEndpoint>(conventionBuilder),
+#if !NET6_0
+                // old way for backwards compatibility, will be removed in the future
+#pragma warning disable CS0618 // Type or member is obsolete
                 Setup = (endpoints, convention) => endpoints.Map<TEndpoint>(convention)
+#pragma warning restore CS0618 // Type or member is obsolete
+#endif
             });
             return services;
         }

--- a/src/Management/src/EndpointCore/Hypermedia/ActuatorHypermediaEndpointMiddleware.cs
+++ b/src/Management/src/EndpointCore/Hypermedia/ActuatorHypermediaEndpointMiddleware.cs
@@ -74,7 +74,11 @@ namespace Steeltoe.Management.Endpoint.Hypermedia
                 var serializeOptions = new JsonSerializerOptions
                 {
                     PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-                    IgnoreNullValues = true,
+#if NET5_0_OR_GREATER
+                    DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull,
+#else
+                    IgnoreNullValues = true
+#endif
                 };
 
                 return JsonSerializer.Serialize(result, serializeOptions);

--- a/src/Management/src/EndpointCore/Internal/EndpointMappingEntry.cs
+++ b/src/Management/src/EndpointCore/Internal/EndpointMappingEntry.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Routing;
 using System;
 
@@ -9,6 +10,8 @@ namespace Steeltoe.Management.Endpoint.Internal
 {
     internal class EndpointMappingEntry
     {
+        public Action<IEndpointRouteBuilder, Action<IEndpointConventionBuilder>> SetupConvention { get; set; }
+
         public Action<IEndpointRouteBuilder, EndpointCollectionConventionBuilder> Setup { get; set; }
     }
 }

--- a/src/Management/src/EndpointCore/Steeltoe.Management.EndpointCore.csproj
+++ b/src/Management/src/EndpointCore/Steeltoe.Management.EndpointCore.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <RootNamespace>Steeltoe.Management.Endpoint</RootNamespace>
     <Description>Package for using Steeltoe management endpoints with ASP.NET Core.</Description>
     <PackageTags>Spring Cloud;Actuator;Management;Monitoring</PackageTags>
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="$(HealthChecksVersion)" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(ExtensionsVersion)" />
-    <PackageReference Include="System.Net.Http.Json" Version="3.2.1" />
+    <PackageReference Include="System.Net.Http.Json" Version="$(SystemNetHttpJsonVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Management/src/KubernetesCore/KubernetesActuatorsStartupFilter.cs
+++ b/src/Management/src/KubernetesCore/KubernetesActuatorsStartupFilter.cs
@@ -24,7 +24,7 @@ namespace Steeltoe.Management.Kubernetes
                 next(app);
                 app.UseEndpoints(endpoints =>
                 {
-                    endpoints.MapAllActuators();
+                    endpoints.MapAllActuators(null);
                 });
                 app.ApplicationServices.InitializeAvailability();
             };

--- a/src/Management/src/KubernetesCore/Steeltoe.Management.KubernetesCore.csproj
+++ b/src/Management/src/KubernetesCore/Steeltoe.Management.KubernetesCore.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <Description>Package for using Steeltoe management endpoints with ASP.NET Core on Kubernetes.</Description>
     <PackageTags>actuator;management;monitoring;aspnetcore;Kubernetes;Spring Cloud;k8s</PackageTags>
   </PropertyGroup>

--- a/src/Management/src/OpenTelemetryBase/Steeltoe.Management.OpenTelemetryBase.csproj
+++ b/src/Management/src/OpenTelemetryBase/Steeltoe.Management.OpenTelemetryBase.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>Steeltoe Management OpenTelemetry</Description>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <AssemblyName>Steeltoe.Management.OpenTelemetryBase</AssemblyName>
     <PackageId>Steeltoe.Management.OpenTelemetryBase</PackageId>
     <PackageTags>Tracing;OpenTelemetry;Management;Monitoring</PackageTags>
@@ -13,7 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="OpenTelemetry" Version="$(OpenTelemetryVersion)" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="5.0.0" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="$(UnsafeCompilerServicesVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Management/src/TaskCore/Steeltoe.Management.TaskCore.csproj
+++ b/src/Management/src/TaskCore/Steeltoe.Management.TaskCore.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <Description>Extensions for running tasks embedded in your ASP.NET Core application. Ideal for cf run-task in Cloud Foundry.</Description>
     <PackageTags>tasks;management;monitoring;aspnetcore;Spring Cloud;cf run-task</PackageTags>
   </PropertyGroup>

--- a/src/Management/src/TracingCore/Steeltoe.Management.TracingCore.csproj
+++ b/src/Management/src/TracingCore/Steeltoe.Management.TracingCore.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <RootNamespace>Steeltoe.Management.Tracing</RootNamespace>
     <Description>Add distributed tracing to ASP.NET Core applications</Description>
     <PackageTags>aspnetcore;management;monitoring;metrics;Distributed Trace</PackageTags>

--- a/src/Management/test/CloudFoundryCore.Test/Steeltoe.Management.CloudFoundryCore.Test.csproj
+++ b/src/Management/test/CloudFoundryCore.Test/Steeltoe.Management.CloudFoundryCore.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
   </PropertyGroup>
   
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Management/test/EndpointBase.Test/BaseTest.cs
+++ b/src/Management/test/EndpointBase.Test/BaseTest.cs
@@ -36,7 +36,11 @@ namespace Steeltoe.Management.Endpoint.Test
             var options = new JsonSerializerOptions()
             {
                 PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+#if NET5_0_OR_GREATER
+                DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull,
+#else
                 IgnoreNullValues = true
+#endif
             };
             options.Converters.Add(new HealthConverter());
             options.Converters.Add(new MetricsResponseConverter());

--- a/src/Management/test/EndpointBase.Test/Health/HealthTest.cs
+++ b/src/Management/test/EndpointBase.Test/Health/HealthTest.cs
@@ -56,8 +56,12 @@ namespace Steeltoe.Management.Endpoint.Health.Test
             {
                 var options = new JsonSerializerOptions()
                 {
-                    IgnoreNullValues = true,
                     PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+#if NET5_0_OR_GREATER
+                    DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull
+#else
+                    IgnoreNullValues = true
+#endif
                 };
                 options.Converters.Add(new HealthConverter());
 

--- a/src/Management/test/EndpointBase.Test/Steeltoe.Management.EndpointBase.Test.csproj
+++ b/src/Management/test/EndpointBase.Test/Steeltoe.Management.EndpointBase.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <RootNamespace>Steeltoe.Management.Endpoint.Test</RootNamespace>
   </PropertyGroup>
   

--- a/src/Management/test/EndpointCore.Test/ActuatorRouteBuilderExtensionsTest.cs
+++ b/src/Management/test/EndpointCore.Test/ActuatorRouteBuilderExtensionsTest.cs
@@ -19,7 +19,6 @@ using Steeltoe.Management.Endpoint.Trace;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net;
 using System.Reflection;
 using System.Threading.Tasks;
 using Xunit;
@@ -68,18 +67,16 @@ namespace Steeltoe.Management.Endpoint
         [MemberData(nameof(IEndpointImplementationsForCurrentPlatform))]
         public async Task MapTestAuthSuccess(Type type)
         {
-            // Arrange
             var hostBuilder = GetHostBuilder(type, policy => policy.RequireClaim("scope", "actuators.read"));
-            await ActAndAssert(type, hostBuilder, HttpStatusCode.OK);
+            await ActAndAssert(type, hostBuilder, true);
         }
 
         [Theory]
         [MemberData(nameof(IEndpointImplementationsForCurrentPlatform))]
         public async Task MapTestAuthFail(Type type)
         {
-            // Arrange
             var hostBuilder = GetHostBuilder(type, policy => policy.RequireClaim("scope", "invalidscope"));
-            await ActAndAssert(type, hostBuilder, HttpStatusCode.Unauthorized);
+            await ActAndAssert(type, hostBuilder, false);
         }
 
         private static IHostBuilder GetHostBuilder(Type type, Action<AuthorizationPolicyBuilder> policyAction)
@@ -108,7 +105,14 @@ namespace Steeltoe.Management.Endpoint
                                 .UseEndpoints(endpoints =>
                                 {
                                     endpoints.MapBlazorHub(); // https://github.com/SteeltoeOSS/Steeltoe/issues/729
+#if NET6_0
+                                    endpoints.MapActuatorEndpoint(type, convention => convention.RequireAuthorization("TestAuth"));
+#else
+#pragma warning disable CS0618 // Type or member is obsolete
                                     endpoints.MapActuatorEndpoint(type).RequireAuthorization("TestAuth");
+#pragma warning restore CS0618 // Type or member is obsolete
+#endif
+
                                 }))
                         .UseTestServer();
                 });
@@ -118,19 +122,19 @@ namespace Steeltoe.Management.Endpoint
                 ? services.GetRequiredService<CloudFoundryManagementOptions>()
                 : services.GetRequiredService<ActuatorManagementOptions>();
 
-        private async Task ActAndAssert(Type type, IHostBuilder hostBuilder, HttpStatusCode expectedStatus)
+        private async Task ActAndAssert(Type type, IHostBuilder hostBuilder, bool expectedSuccess)
         {
             var host = await hostBuilder.StartAsync();
             var (middleware, optionsType) = ActuatorRouteBuilderExtensions.LookupMiddleware(type);
             var options = host.Services.GetService(optionsType) as IEndpointOptions;
             var path = options.GetContextPath(GetManagementContext(type, host.Services));
 
-            // Assert
             Assert.NotNull(path);
 
-            var response = host.GetTestServer().CreateClient().GetAsync(path);
+            using var server = host.GetTestServer();
+            var response = await server.CreateClient().GetAsync(path);
 
-            Assert.True(expectedStatus == response.Result.StatusCode, $"Expected {expectedStatus}, but got {response.Result.StatusCode} for {path} and type {type}");
+            Assert.True(expectedSuccess == response.IsSuccessStatusCode, $"Expected {(expectedSuccess ? "success" : "failure")}, but got {response.StatusCode} for {path} and type {type}");
         }
     }
 }

--- a/src/Management/test/EndpointCore.Test/Steeltoe.Management.EndpointCore.Test.csproj
+++ b/src/Management/test/EndpointCore.Test/Steeltoe.Management.EndpointCore.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <AssemblyName>Steeltoe.Management.EndpointCore.Test</AssemblyName>
     <RootNamespace>Steeltoe.Management.Endpoint.Test</RootNamespace>
   </PropertyGroup>

--- a/src/Management/test/KubernetesCore.Test/Steeltoe.Management.KubernetesCore.Test.csproj
+++ b/src/Management/test/KubernetesCore.Test/Steeltoe.Management.KubernetesCore.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   

--- a/src/Management/test/OpenTelemetry.Test/Steeltoe.OpenTelemetry.Test.csproj
+++ b/src/Management/test/OpenTelemetry.Test/Steeltoe.OpenTelemetry.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>Unit test project for OpenTelemetry</Description>
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/src/Management/test/TaskCore.Test/Steeltoe.Management.TaskCore.Test.csproj
+++ b/src/Management/test/TaskCore.Test/Steeltoe.Management.TaskCore.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Management/test/TracingBase.Test/Steeltoe.Management.TracingBase.Test.csproj
+++ b/src/Management/test/TracingBase.Test/Steeltoe.Management.TracingBase.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Management/test/TracingCore.Test/Steeltoe.Management.TracingCore.Test.csproj
+++ b/src/Management/test/TracingCore.Test/Steeltoe.Management.TracingCore.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Messaging/src/MessagingBase/Steeltoe.Messaging.MessagingBase.csproj
+++ b/src/Messaging/src/MessagingBase/Steeltoe.Messaging.MessagingBase.csproj
@@ -2,7 +2,7 @@
   
   <PropertyGroup>
     <Description>Steeltoe Messaging Base</Description>
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <RootNamespace>Steeltoe.Messaging</RootNamespace>
     <AssemblyName>Steeltoe.Messaging.MessagingBase</AssemblyName>
     <PackageId>Steeltoe.Messaging.MessagingBase</PackageId>

--- a/src/Messaging/src/RabbitMQ/Retry/RepublishMessageRecoverer.cs
+++ b/src/Messaging/src/RabbitMQ/Retry/RepublishMessageRecoverer.cs
@@ -101,7 +101,7 @@ namespace Steeltoe.Messaging.RabbitMQ.Retry
                 var routingKey = ErrorRoutingKey != null ? ErrorRoutingKey : PrefixedOriginalRoutingKey(message);
                 ErrorTemplate.Send(ErrorExchangeName, routingKey, message);
 
-                _logger?.LogWarning("Republishing failed message to exchange '(exchange}' with routing key '{routingKey}'", ErrorExchangeName, routingKey);
+                _logger?.LogWarning("Republishing failed message to exchange '{exchange}' with routing key '{routingKey}'", ErrorExchangeName, routingKey);
             }
             else
             {

--- a/src/Messaging/src/RabbitMQ/Steeltoe.Messaging.RabbitMQ.csproj
+++ b/src/Messaging/src/RabbitMQ/Steeltoe.Messaging.RabbitMQ.csproj
@@ -2,7 +2,7 @@
   
   <PropertyGroup>
     <Description>Steeltoe Messaging RabbitMQ</Description>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <RootNamespace>Steeltoe.Messaging.RabbitMQ</RootNamespace>
     <AssemblyName>Steeltoe.Messaging.RabbitMQ</AssemblyName>
     <PackageId>Steeltoe.Messaging.RabbitMQ</PackageId>

--- a/src/Messaging/test/MessagingBase.Test/Steeltoe.Messaging.MessagingBase.Test.csproj
+++ b/src/Messaging/test/MessagingBase.Test/Steeltoe.Messaging.MessagingBase.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <RootNamespace>Steeltoe.Messaging</RootNamespace>
   </PropertyGroup>
   

--- a/src/Messaging/test/RabbitMQ.Test/Steeltoe.Messaging.RabbitMQ.Test.csproj
+++ b/src/Messaging/test/RabbitMQ.Test/Steeltoe.Messaging.RabbitMQ.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <RootNamespace>Steeltoe.Messaging.RabbitMQ</RootNamespace>
   </PropertyGroup>
   

--- a/src/Security/src/Authentication.CloudFoundryCore/Steeltoe.Security.Authentication.CloudFoundryCore.csproj
+++ b/src/Security/src/Authentication.CloudFoundryCore/Steeltoe.Security.Authentication.CloudFoundryCore.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <RootNamespace>Steeltoe.Security.Authentication.CloudFoundry</RootNamespace>
     <Description>ASP.NET Core External Security Provider for CloudFoundry</Description>
     <PackageTags>CloudFoundry;ASPNET Core;Security;OAuth2;SSO;OpenIDConnect</PackageTags>

--- a/src/Security/src/Authentication.MtlsCore/Steeltoe.Security.Authentication.MtlsCore.csproj
+++ b/src/Security/src/Authentication.MtlsCore/Steeltoe.Security.Authentication.MtlsCore.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <RootNamespace>Steeltoe.Security.Authentication.Mtls</RootNamespace>
     <Description>ASP.NET Core middleware that enables an application to support certificate authentication.</Description>
     <PackageTags>aspnetcore;authentication;security;x509;certificate;mtls</PackageTags>

--- a/src/Security/src/DataProtection.CredHubCore/Steeltoe.Security.DataProtection.CredHubCore.csproj
+++ b/src/Security/src/DataProtection.CredHubCore/Steeltoe.Security.DataProtection.CredHubCore.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <RootNamespace>Steeltoe.Security.DataProtection.CredHub</RootNamespace>
     <Description>ASP.NET Core Extensions for CredHub Client</Description>
     <PackageTags>CloudFoundry;aspnetcore;Security;DataProtection;CredHub</PackageTags>

--- a/src/Security/test/Authentication.CloudFoundryBase.Test/Steeltoe.Security.Authentication.CloudFoundryBase.Test.csproj
+++ b/src/Security/test/Authentication.CloudFoundryBase.Test/Steeltoe.Security.Authentication.CloudFoundryBase.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Security/test/Authentication.CloudFoundryCore.Test/Steeltoe.Security.Authentication.CloudFoundryCore.Test.csproj
+++ b/src/Security/test/Authentication.CloudFoundryCore.Test/Steeltoe.Security.Authentication.CloudFoundryCore.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <RootNamespace>Steeltoe.Security.Authentication.CloudFoundry.Test</RootNamespace>
   </PropertyGroup>
 

--- a/src/Security/test/Authentication.CloudFoundryCore.Test/TestServerCertificateStartup.cs
+++ b/src/Security/test/Authentication.CloudFoundryCore.Test/TestServerCertificateStartup.cs
@@ -30,7 +30,7 @@ namespace Steeltoe.Security.Authentication.CloudFoundry.Test
         {
             app.UseCloudFoundryCertificateAuth();
 
-            app.Use(async (context, next) =>
+            app.Run(async (context) =>
             {
                 var authorizationResult = await authorizationService.AuthorizeAsync(context.User, null, context.Request.Path.Value.Replace("/", string.Empty));
 

--- a/src/Security/test/Authentication.MtlsCore.Test/ClientCertificateAuthenticationTests.cs
+++ b/src/Security/test/Authentication.MtlsCore.Test/ClientCertificateAuthenticationTests.cs
@@ -546,7 +546,7 @@ namespace Steeltoe.Security.Authentication.MtlsCore.Test
 
                     app.UseAuthentication();
 
-                    app.Use(async (context, next) =>
+                    app.Run(async (context) =>
                     {
                         var request = context.Request;
                         var response = context.Response;

--- a/src/Security/test/Authentication.MtlsCore.Test/Steeltoe.Security.Authentication.MtlsCore.Test.csproj
+++ b/src/Security/test/Authentication.MtlsCore.Test/Steeltoe.Security.Authentication.MtlsCore.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
   </PropertyGroup>
   
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Security/test/DataProtection.CredHubBase.Test/Steeltoe.Security.DataProtection.CredHubBase.Test.csproj
+++ b/src/Security/test/DataProtection.CredHubBase.Test/Steeltoe.Security.DataProtection.CredHubBase.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Security/test/DataProtection.CredHubCore.Test/Steeltoe.Security.DataProtection.CredHubCore.Test.csproj
+++ b/src/Security/test/DataProtection.CredHubCore.Test/Steeltoe.Security.DataProtection.CredHubCore.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Security/test/DataProtection.RedisCore.Test/Steeltoe.Security.DataProtection.RedisCore.Test.csproj
+++ b/src/Security/test/DataProtection.RedisCore.Test/Steeltoe.Security.DataProtection.RedisCore.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
   </PropertyGroup>
   
   <Import Project="..\..\..\..\versions.props" />

--- a/src/Stream/src/Abstractions/Steeltoe.Stream.Abstractions.csproj
+++ b/src/Stream/src/Abstractions/Steeltoe.Stream.Abstractions.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <RootNamespace>Steeltoe.Stream</RootNamespace>
     <Description>Abstractions for use with Steeltoe Stream</Description>
     <PackageTags></PackageTags>

--- a/src/Stream/src/BinderRabbitMQ/Steeltoe.Stream.Binder.RabbitMQ.csproj
+++ b/src/Stream/src/BinderRabbitMQ/Steeltoe.Stream.Binder.RabbitMQ.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>Steeltoe Stream RabbitMQ Binder</Description>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <RootNamespace>Steeltoe.Stream.Binder.RabbitMQ</RootNamespace>
     <PackageTags>Streams, ASPNET Core, Spring, Spring Cloud, RabbitMQ, Binder</PackageTags>
   </PropertyGroup>

--- a/src/Stream/src/StreamBase/Steeltoe.Stream.StreamBase.csproj
+++ b/src/Stream/src/StreamBase/Steeltoe.Stream.StreamBase.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <RootNamespace>Steeltoe.Stream</RootNamespace>
     <Description>Steeltoe Stream Base</Description>
     <PackageTags>Streams, NET Core, Spring, Spring Cloud</PackageTags>

--- a/src/Stream/test/BinderRabbitMQ.Test/Steeltoe.Stream.Binder.RabbitMQ.Test.csproj
+++ b/src/Stream/test/BinderRabbitMQ.Test/Steeltoe.Stream.Binder.RabbitMQ.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <RootNamespace>Steeltoe.Stream.Binder.Rabbit</RootNamespace>
     <OutputType>Exe</OutputType>
   </PropertyGroup>

--- a/src/Stream/test/BinderTests/Steeltoe.Stream.BinderTests.csproj
+++ b/src/Stream/test/BinderTests/Steeltoe.Stream.BinderTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <RootNamespace>Steeltoe.Stream.Binder</RootNamespace>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netcoreapp3.1|AnyCPU'">

--- a/src/Stream/test/MockBinder/Steeltoe.Stream.MockBinder.csproj
+++ b/src/Stream/test/MockBinder/Steeltoe.Stream.MockBinder.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <IsPackable>False</IsPackable>
   </PropertyGroup>
   

--- a/src/Stream/test/StreamBase.Test/Steeltoe.Stream.StreamBase.Test.csproj
+++ b/src/Stream/test/StreamBase.Test/Steeltoe.Stream.StreamBase.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <RootNamespace>Steeltoe.Stream</RootNamespace>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netcoreapp3.1|AnyCPU'">

--- a/src/Stream/test/StubBinder1/Steeltoe.Stream.StubBinder1.csproj
+++ b/src/Stream/test/StubBinder1/Steeltoe.Stream.StubBinder1.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <IsPackable>False</IsPackable>
   </PropertyGroup>
   

--- a/src/Stream/test/StubBinder2/Steeltoe.Stream.StubBinder2.csproj
+++ b/src/Stream/test/StubBinder2/Steeltoe.Stream.StubBinder2.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <IsPackable>False</IsPackable>
   </PropertyGroup>
   

--- a/src/Stream/test/TestBinder/Steeltoe.Stream.TestBinder.csproj
+++ b/src/Stream/test/TestBinder/Steeltoe.Stream.TestBinder.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <IsPackable>False</IsPackable>
   </PropertyGroup>
   

--- a/versions.props
+++ b/versions.props
@@ -91,7 +91,7 @@
     <MySqlEFCoreVersion>5.0.0</MySqlEFCoreVersion>
     <NpgsqlEFCoreVersion>5.0.0</NpgsqlEFCoreVersion>
     <OracleEFCoreVersion>5.21.1</OracleEFCoreVersion>
-    <PomeloEFCoreVersion>5.0.0-alpha.2</PomeloEFCoreVersion>
+    <PomeloEFCoreVersion>5.0.0</PomeloEFCoreVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'net6.0'">
     <AspNetCoreVersion>6.0.0</AspNetCoreVersion>

--- a/versions.props
+++ b/versions.props
@@ -105,7 +105,7 @@
     <MicrosoftExtensionsRedisVersion>6.0.0</MicrosoftExtensionsRedisVersion>
     <SystemJsonVersion>6.0.0</SystemJsonVersion>
     <SystemNetHttpJsonVersion>6.0.0</SystemNetHttpJsonVersion>
-    <OpenTelemetryVersion>1.2.0-beta2.1</OpenTelemetryVersion>
+    <OpenTelemetryVersion>1.2.0-rc1</OpenTelemetryVersion>
     <UnsafeCompilerServicesVersion>6.0.0</UnsafeCompilerServicesVersion>
   </PropertyGroup>
 </Project>

--- a/versions.props
+++ b/versions.props
@@ -94,14 +94,14 @@
     <PomeloEFCoreVersion>5.0.0-alpha.2</PomeloEFCoreVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'net6.0'">
-    <AspNetCoreVersion>6.0.0-rc.2.*</AspNetCoreVersion>
-    <EFCoreTestVersion>6.0.0-rc.1.21452.10</EFCoreTestVersion>
-    <MySqlEFCoreVersion>6.0.0-preview3</MySqlEFCoreVersion>
-    <NpgsqlEFCoreVersion>6.0.0-rc.1</NpgsqlEFCoreVersion>
+    <AspNetCoreVersion>6.0.0</AspNetCoreVersion>
+    <EFCoreTestVersion>6.0.0</EFCoreTestVersion>
+    <MySqlEFCoreVersion>6.0.0</MySqlEFCoreVersion>
+    <NpgsqlEFCoreVersion>6.0.0</NpgsqlEFCoreVersion>
     <OracleEFCoreVersion>5.21.1</OracleEFCoreVersion>
-    <PomeloEFCoreVersion>6.0.0-rc.1</PomeloEFCoreVersion>
+    <PomeloEFCoreVersion>6.0.0</PomeloEFCoreVersion>
     <EF6Version>6.4.0</EF6Version>
-    <ExtensionsVersion>6.0.0-rc.2.*</ExtensionsVersion>
+    <ExtensionsVersion>6.0.0</ExtensionsVersion>
     <MicrosoftExtensionsRedisVersion>6.0.0</MicrosoftExtensionsRedisVersion>
     <SystemJsonVersion>6.0.0</SystemJsonVersion>
     <SystemNetHttpJsonVersion>6.0.0</SystemNetHttpJsonVersion>

--- a/versions.props
+++ b/versions.props
@@ -15,6 +15,7 @@
     <SymReaderPortableVersion>1.4.0</SymReaderPortableVersion>
     <SystemDiagnosticsVersion>5.0.1</SystemDiagnosticsVersion>
     <SystemJsonVersion>4.6.0</SystemJsonVersion>
+    <SystemNetHttpJsonVersion>3.2.1</SystemNetHttpJsonVersion>
     <SystemReflectionVersion>4.6.0</SystemReflectionVersion>
     <TelemetryCorrelationVersion>1.0.0</TelemetryCorrelationVersion>
     <WebInfrastructureVersion>1.0.0</WebInfrastructureVersion>
@@ -41,7 +42,7 @@
     <MoqVersion>4.13.1</MoqVersion>
     
     <OpenTelemetryVersion>1.1.0</OpenTelemetryVersion>
-    <OpenTelemetryInstrumentationVersion>1.0.0-rc7</OpenTelemetryInstrumentationVersion>
+    <OpenTelemetryInstrumentationVersion>1.0.0-rc8</OpenTelemetryInstrumentationVersion>
     
     <RabbitClientVersion>5.0.1</RabbitClientVersion>
     <ReactiveVersion>4.1.5</ReactiveVersion>
@@ -72,6 +73,7 @@
     <HealthChecksVersion>3.1.0</HealthChecksVersion>
     <LoggingVersion>3.1.0</LoggingVersion>
     <LightweightEmitVersion>4.7.0</LightweightEmitVersion>
+    <UnsafeCompilerServicesVersion>5.0.0</UnsafeCompilerServicesVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
     <AspNetCoreVersion>3.1.0</AspNetCoreVersion>
@@ -90,5 +92,20 @@
     <NpgsqlEFCoreVersion>5.0.0</NpgsqlEFCoreVersion>
     <OracleEFCoreVersion>5.21.1</OracleEFCoreVersion>
     <PomeloEFCoreVersion>5.0.0-alpha.2</PomeloEFCoreVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net6.0'">
+    <AspNetCoreVersion>6.0.0-rc.2.*</AspNetCoreVersion>
+    <EFCoreTestVersion>6.0.0-rc.1.21452.10</EFCoreTestVersion>
+    <MySqlEFCoreVersion>6.0.0-preview3</MySqlEFCoreVersion>
+    <NpgsqlEFCoreVersion>6.0.0-rc.1</NpgsqlEFCoreVersion>
+    <OracleEFCoreVersion>5.21.1</OracleEFCoreVersion>
+    <PomeloEFCoreVersion>6.0.0-rc.1</PomeloEFCoreVersion>
+    <EF6Version>6.4.0</EF6Version>
+    <ExtensionsVersion>6.0.0-rc.2.*</ExtensionsVersion>
+    <MicrosoftExtensionsRedisVersion>6.0.0</MicrosoftExtensionsRedisVersion>
+    <SystemJsonVersion>6.0.0</SystemJsonVersion>
+    <SystemNetHttpJsonVersion>6.0.0</SystemNetHttpJsonVersion>
+    <OpenTelemetryVersion>1.2.0-beta2.1</OpenTelemetryVersion>
+    <UnsafeCompilerServicesVersion>6.0.0</UnsafeCompilerServicesVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
* Update projects and pipeline to build or test .NET 6 as necessary
* Include .NET 6 fixes already in `main`
* Upgrade OTel to 1.2 beta to get around restriction of < 6.0.0 for Microsoft.Extensions.Logging