### PR TITLE
Make Steeltoe Metrics extensions play nice with Otel

### DIFF
--- a/src/Management/src/EndpointCore/Metrics/EndpointServiceCollectionExtensions.cs
+++ b/src/Management/src/EndpointCore/Metrics/EndpointServiceCollectionExtensions.cs
@@ -114,7 +114,7 @@ namespace Steeltoe.Management.Endpoint.Metrics
                 return new WavefrontMetricsExporter(new WavefrontExporterOptions(configuration), logger);
             });
 
-            services.AddOpenTelemetryMetricsForSteeltoe();
+          //  services.AddOpenTelemetryMetricsForSteeltoe();
 
             return services;
         }

--- a/src/Management/src/OpenTelemetryBase/Exporters/PullmetricsCollectionManager.cs
+++ b/src/Management/src/OpenTelemetryBase/Exporters/PullmetricsCollectionManager.cs
@@ -165,7 +165,7 @@ namespace Steeltoe.Management.OpenTelemetry.Exporters
             this.exporter.OnExport = this.onCollectRef;
             var result = this.exporter.Collect?.Invoke(Timeout.Infinite);
             this.exporter.OnExport = null;
-            return result.HasValue ? result.Value : false;
+            return result.GetValueOrDefault();
         }
 
         private ExportResult OnCollect(Batch<Metric> metrics)

--- a/src/Management/src/OpenTelemetryBase/Exporters/Wavefront/WavefrontExporterOptions.cs
+++ b/src/Management/src/OpenTelemetryBase/Exporters/Wavefront/WavefrontExporterOptions.cs
@@ -24,11 +24,11 @@ namespace Steeltoe.Management.OpenTelemetry.Exporters.Wavefront
 
         public string ApiToken { get; set; }
 
-        public int Step { get; set; } = 30000; // milliseconds
+        public int Step { get; set; } = 30_000; // milliseconds
 
-        public int BatchSize { get; set; } = 10000;
+        public int BatchSize { get; set; } = 10_000;
 
-        public int MaxQueueSize { get; set; } = 1000;
+        public int MaxQueueSize { get; set; } = 500_000;
 
         public WavefrontApplicationOptions ApplicationOptions { get; }
 


### PR DESCRIPTION
Working draft for a way to make Otel dependency more explicit:

Now to add steeltoe actuators, you would need

```csharp
builder.AddAllActuators();
builder.Services.AddOpenTelemetryMetricsForSteeltoe((provider, builder) => { builder.AddAspNetCoreInstrumentation() customize})
```
if you want just wavefront exporter
```csharp
builder.AddWavefrontMetrics();
builder.Services.AddOpenTelemetryMetricsForSteeltoe((provider, builder) => { builder.AddAspNetCoreInstrumentation() customize})
```
or Use otel extensions
```csharp

builder.Services.AddOpenTelemetryMetrics(b =>
   {
        b.ConfigureSteeltoeMetrics();

       b.Configure((provider, deferredBuilder) =>
       {
           deferredBuilder.AddMeter("Another Meter")
           .AddHttpClientInstrumentation()
           .AddConsoleExporter()
              .Build();
       });
   });
``` 