### PR TITLE
Fixed a few tests that didn't assert on the outcome

### DIFF
--- a/src/Common/src/Common/Util/MimeType.cs
+++ b/src/Common/src/Common/Util/MimeType.cs
@@ -144,7 +144,7 @@ namespace Steeltoe.Common.Util
             if (PARAM_CHARSET.Equals(attribute))
             {
                 value = Unquote(value);
-                Encoding.GetEncoding(value);
+                _ = Encoding.GetEncoding(value);
             }
             else if (!IsQuotedstring(value))
             {

--- a/src/Management/src/EndpointBase/Metrics/Observer/HttpClientCoreObserver.cs
+++ b/src/Management/src/EndpointBase/Metrics/Observer/HttpClientCoreObserver.cs
@@ -121,14 +121,17 @@ namespace Steeltoe.Management.Endpoint.Metrics.Observer
 
         protected internal IEnumerable<KeyValuePair<string, object>> GetLabels(HttpRequestMessage request, HttpResponseMessage response, TaskStatus taskStatus)
         {
-            var uri = request.RequestUri.ToString();
+            var uri = request.RequestUri.GetComponents(UriComponents.PathAndQuery, UriFormat.SafeUnescaped);
             var statusCode = GetStatusCode(response, taskStatus);
-            var labels = new List<KeyValuePair<string, object>>();
-            labels.Add(KeyValuePair.Create(_uriTagKey, (object)uri));
-            labels.Add(KeyValuePair.Create(_statusTagKey, (object)statusCode));
-            labels.Add(KeyValuePair.Create(_clientTagKey, (object)request.RequestUri.Host));
-            labels.Add(KeyValuePair.Create(_methodTagKey, (object)request.Method.ToString()));
-            return labels;
+            var clientName = request.RequestUri.GetComponents(UriComponents.HostAndPort, UriFormat.UriEscaped);
+
+            return new Dictionary<string, object>
+            {
+                { _uriTagKey, uri },
+                { _statusTagKey, statusCode },
+                { _clientTagKey, clientName },
+                { _methodTagKey, request.Method.ToString() }
+            };
         }
 
         protected internal string GetStatusCode(HttpResponseMessage response, TaskStatus taskStatus)

--- a/src/Management/src/EndpointBase/Metrics/Observer/HttpClientDesktopObserver.cs
+++ b/src/Management/src/EndpointBase/Metrics/Observer/HttpClientDesktopObserver.cs
@@ -121,13 +121,17 @@ namespace Steeltoe.Management.Endpoint.Metrics.Observer
 
         protected internal IEnumerable<KeyValuePair<string, object>> GetLabels(HttpWebRequest request, HttpStatusCode statusCode)
         {
-            return new Dictionary<string, object>()
-                    {
-                        { _uriTagKey, request.RequestUri.ToString() },
-                        { _statusTagKey, statusCode.ToString() },
-                        { _clientTagKey, request.RequestUri.Host },
-                        { _methodTagKey, request.Method }
-                    }.ToList();
+            var uri = request.RequestUri.GetComponents(UriComponents.PathAndQuery, UriFormat.SafeUnescaped);
+            var status = ((int)statusCode).ToString();
+            var clientName = request.RequestUri.GetComponents(UriComponents.HostAndPort, UriFormat.UriEscaped);
+
+            return new Dictionary<string, object>
+            {
+                { _uriTagKey, uri },
+                { _statusTagKey, status },
+                { _clientTagKey, clientName },
+                { _methodTagKey, request.Method }
+            };
         }
     }
 }

--- a/src/Management/src/EndpointCore/Metrics/Observer/AspNetCoreHostingObserver.cs
+++ b/src/Management/src/EndpointCore/Metrics/Observer/AspNetCoreHostingObserver.cs
@@ -114,15 +114,13 @@ namespace Steeltoe.Management.Endpoint.Metrics.Observer
             var statusCode = arg.Response.StatusCode.ToString();
             var exception = GetException(arg);
 
-            var tagValues = new List<KeyValuePair<string, object>>
+            return new Dictionary<string, object>
             {
-                new KeyValuePair<string, object>(_uriTagKey, uri),
-                new KeyValuePair<string, object>(_statusTagKey, statusCode),
-                new KeyValuePair<string, object>(_exceptionTagKey, exception),
-                new KeyValuePair<string, object>(_methodTagKey, arg.Request.Method)
+                { _uriTagKey, uri },
+                { _statusTagKey, statusCode },
+                { _exceptionTagKey, exception },
+                { _methodTagKey, arg.Request.Method }
             };
-
-            return tagValues;
         }
 
         protected internal string GetException(HttpContext arg)

--- a/src/Management/test/EndpointBase.Test/Metrics/Observer/HttpClientCoreObserverTest.cs
+++ b/src/Management/test/EndpointBase.Test/Metrics/Observer/HttpClientCoreObserverTest.cs
@@ -96,10 +96,11 @@ namespace Steeltoe.Management.Endpoint.Metrics.Observer.Test
             var resp = GetHttpResponseMessage(HttpStatusCode.InternalServerError);
             var tagContext = obs.GetLabels(req, resp, TaskStatus.RanToCompletion);
             var tagValues = tagContext.ToList();
-            tagValues.Contains(KeyValuePair.Create("clientName", (object)"localhost:5555"));
-            tagValues.Contains(KeyValuePair.Create("uri", (object)"/foo/bar"));
-            tagValues.Contains(KeyValuePair.Create("status", (object)"500"));
-            tagValues.Contains(KeyValuePair.Create("method", (object)"GET"));
+
+            Assert.Contains(KeyValuePair.Create("clientName", (object)"localhost:5555"), tagValues);
+            Assert.Contains(KeyValuePair.Create("uri", (object)"/foo/bar"), tagValues);
+            Assert.Contains(KeyValuePair.Create("status", (object)"500"), tagValues);
+            Assert.Contains(KeyValuePair.Create("method", (object)"GET"), tagValues);
         }
 
         [Fact]

--- a/src/Management/test/EndpointBase.Test/Metrics/Observer/HttpClientDesktopObserverTest.cs
+++ b/src/Management/test/EndpointBase.Test/Metrics/Observer/HttpClientDesktopObserverTest.cs
@@ -74,10 +74,11 @@ namespace Steeltoe.Management.Endpoint.Metrics.Observer.Test
 
             var req = GetHttpRequestMessage();
             var labels = observer.GetLabels(req, HttpStatusCode.InternalServerError).ToList();
-            labels.Contains(KeyValuePair.Create("clientName", (object)"localhost:5555"));
-            labels.Contains(KeyValuePair.Create("uri", (object)"/foo/bar"));
-            labels.Contains(KeyValuePair.Create("status", (object)"500"));
-            labels.Contains(KeyValuePair.Create("method", (object)"GET"));
+
+            Assert.Contains(KeyValuePair.Create("clientName", (object)"localhost:5555"), labels);
+            Assert.Contains(KeyValuePair.Create("uri", (object)"/foo/bar"), labels);
+            Assert.Contains(KeyValuePair.Create("status", (object)"500"), labels);
+            Assert.Contains(KeyValuePair.Create("method", (object)"GET"), labels);
         }
 
         [Fact]

--- a/src/Management/test/EndpointCore.Test/Metrics/Observer/AspNetCoreHostingObserverTest.cs
+++ b/src/Management/test/EndpointCore.Test/Metrics/Observer/AspNetCoreHostingObserverTest.cs
@@ -105,11 +105,12 @@ namespace Steeltoe.Management.Endpoint.Metrics.Observer.Test
             context.Features.Set<IExceptionHandlerFeature>(exceptionHandlerFeature);
             context.Response.StatusCode = 404;
 
-            var tagContext = observer.GetLabelSets(context);
-            tagContext.Contains(KeyValuePair.Create("exception", (object)"ArgumentNullException"));
-            tagContext.Contains(KeyValuePair.Create("uri", (object)"/foobar"));
-            tagContext.Contains(KeyValuePair.Create("status", (object)"404"));
-            tagContext.Contains(KeyValuePair.Create("method", (object)"GET"));
+            var tagContext = observer.GetLabelSets(context).ToList();
+
+            Assert.Contains(KeyValuePair.Create("exception", (object)"ArgumentNullException"), tagContext);
+            Assert.Contains(KeyValuePair.Create("uri", (object)"/foobar"), tagContext);
+            Assert.Contains(KeyValuePair.Create("status", (object)"404"), tagContext);
+            Assert.Contains(KeyValuePair.Create("method", (object)"GET"), tagContext);
         }
 
         [Fact]

--- a/src/Security/test/Authentication.CloudFoundryCore.Test/CloudFoundryOAuthHandlerTest.cs
+++ b/src/Security/test/Authentication.CloudFoundryCore.Test/CloudFoundryOAuthHandlerTest.cs
@@ -140,7 +140,7 @@ namespace Steeltoe.Security.Authentication.CloudFoundry.Test
             Assert.NotNull(content);
             Assert.Equal(HttpMethod.Post, message.Method);
 
-            message.Headers.Accept.Contains(new MediaTypeWithQualityHeaderValue("application/json"));
+            Assert.Contains(new MediaTypeWithQualityHeaderValue("application/json"), message.Headers.Accept);
         }
 
         [Fact]


### PR DESCRIPTION
While looking at warnings from Resharper, I found some tests that didn't assert on the outcome.

After correcting these tests, some of them failed. I've adapted the target logic accordingly to make the tests succeed without changing their assumptions.

Note this is a breaking change. If taking a breaking change is not an option, we should adapt the tests instead to match the current behavior.