### PR TITLE
Fixed: Incorrect stack trace on thrown exception

### DIFF
--- a/src/Messaging/src/RabbitMQ/Support/RabbitExceptionTranslator.cs
+++ b/src/Messaging/src/RabbitMQ/Support/RabbitExceptionTranslator.cs
@@ -24,7 +24,7 @@ namespace Steeltoe.Messaging.RabbitMQ.Support
                     OperationInterruptedException => new RabbitIOException(exception),
                     IOException => new RabbitIOException(exception),
                     TimeoutException => new RabbitTimeoutException(exception),
-                    ConsumerCancelledException => throw exception,
+                    ConsumerCancelledException => exception,
                     _ => new RabbitUncategorizedException(exception)
                 };
     }


### PR DESCRIPTION
The conversion method should return the exception and let the caller throw, so the stack trace is preserved.