### PR TITLE
Get ConfigServer PollingInterval from Configuration object

### DIFF
--- a/src/Configuration/src/ConfigServerBase/ConfigurationSettingsHelper.cs
+++ b/src/Configuration/src/ConfigServerBase/ConfigurationSettingsHelper.cs
@@ -61,6 +61,7 @@ namespace Steeltoe.Extensions.Configuration.ConfigServer
             settings.DiscoveryServiceId = GetDiscoveryServiceId(clientConfigsection, settings.DiscoveryServiceId);
             settings.HealthEnabled = GetHealthEnabled(clientConfigsection, settings.HealthEnabled);
             settings.HealthTimeToLive = GetHealthTimeToLive(clientConfigsection, settings.HealthTimeToLive);
+            settings.PollingInterval = GetPollingInterval(clientConfigsection, settings.PollingInterval);
 
             // Override Config server URI
             settings.Uri = GetCloudFoundryUri(configPrefix, config, settings.Uri);
@@ -174,6 +175,11 @@ namespace Steeltoe.Extensions.Configuration.ConfigServer
         private static int GetTokenTtl(IConfigurationSection configServerSection)
         {
             return configServerSection.GetValue("tokenTtl", ConfigServerClientSettings.DEFAULT_VAULT_TOKEN_TTL);
+        }
+
+        private static TimeSpan GetPollingInterval(IConfigurationSection clientConfigsection, TimeSpan def)
+        {
+            return clientConfigsection.GetValue("pollingInterval", def);
         }
 
         private static string GetClientSecret(string configPrefix, IConfiguration config)

--- a/src/Configuration/test/ConfigServerBase.Test/ConfigServerConfigurationProviderTest.cs
+++ b/src/Configuration/test/ConfigServerBase.Test/ConfigServerConfigurationProviderTest.cs
@@ -390,13 +390,15 @@ namespace Steeltoe.Extensions.Configuration.ConfigServer.Test
             using var client = server.CreateClient();
             var provider = new ConfigServerConfigurationProvider(settings, client);
             var token = provider.GetReloadToken();
-
             await Task.Delay(2000);
             var postInitialLoadToken = provider.GetReloadToken();
-            await Task.Delay(500);
+
+            Assert.NotSame(token, postInitialLoadToken);
             Assert.NotNull(TestConfigServerStartup.LastRequest);
             Assert.True(TestConfigServerStartup.RequestCount > 1);
             Assert.True(token.HasChanged);
+
+            await Task.Delay(500);
             Assert.False(postInitialLoadToken.HasChanged);
         }
 


### PR DESCRIPTION
This PR update settings for PollingInterval from IConfiguration object allowing us configure it using appsettings instead of initialize it via default settings.