### PR TITLE
RabbitMQ Test Fixes

### DIFF
--- a/src/Messaging/src/RabbitMQ/Util/ActiveObjectCounter.cs
+++ b/src/Messaging/src/RabbitMQ/Util/ActiveObjectCounter.cs
@@ -47,6 +47,10 @@ namespace Steeltoe.Messaging.RabbitMQ.Util
                     }
 
                     t0 = DateTimeOffset.Now.Ticks;
+                    if (t0 >= t1)
+                    {
+                        break;
+                    }
 
                     if (latch.Wait(TimeSpan.FromTicks(t1 - t0)))
                     {

--- a/src/Messaging/test/RabbitMQ.Test/Core/BatchingRabbitTemplateTest.cs
+++ b/src/Messaging/test/RabbitMQ.Test/Core/BatchingRabbitTemplateTest.cs
@@ -231,7 +231,7 @@ namespace Steeltoe.Messaging.RabbitMQ.Core
             var provider = new ServiceCollection().BuildServiceProvider();
             var config = new ConfigurationBuilder().Build();
             var received = new List<IMessage>();
-            var count = 100000;
+            var count = 10000;
             var latch = new CountdownEvent(count);
             var context = new GenericApplicationContext(provider, config);
             context.ServiceExpressionResolver = new StandardServiceExpressionResolver();

--- a/src/Messaging/test/RabbitMQ.Test/Listener/DirectMessageListenerContainerMockTest.cs
+++ b/src/Messaging/test/RabbitMQ.Test/Listener/DirectMessageListenerContainerMockTest.cs
@@ -103,7 +103,7 @@ namespace Steeltoe.Messaging.RabbitMQ.Listener
                 {
                     qos.Value = count;
                 });
-            var latch2 = new CountdownEvent(1);
+            var latch2 = new CountdownEvent(2);
             var latch3 = new CountdownEvent(1);
             channel.Setup(c => c.BasicAck(It.IsAny<ulong>(), It.IsAny<bool>()))
                 .Callback<ulong, bool>((tag, multi) =>
@@ -152,7 +152,7 @@ namespace Steeltoe.Messaging.RabbitMQ.Listener
             Assert.True(latch2.Wait(TimeSpan.FromSeconds(10)));
             consumer.Value.HandleBasicDeliver("consumerTag", 17ul, false, string.Empty, string.Empty, props, body);
             channel.Verify(c => c.BasicAck(10ul, true));
-            channel.Verify(c => c.BasicAck(15ul, true));
+            channel.Verify(c => c.BasicAck(16ul, true));
 
             Assert.True(latch3.Wait(TimeSpan.FromSeconds(10)));
 


### PR DESCRIPTION
This PR includes two changes to Unit tests that improve reliability of those tests.   
Also includes a fix which was causing a process to hang during RabbitMQ shutdown.