### PR TITLE
Disabled eureka client should not validate server url

### DIFF
--- a/src/Discovery/src/Eureka/EurekaPostConfigurer.cs
+++ b/src/Discovery/src/Eureka/EurekaPostConfigurer.cs
@@ -36,10 +36,13 @@ namespace Steeltoe.Discovery.Eureka
         /// <param name="clientOptions">Eureka client configuration (for interacting with the Eureka Server)</param>
         public static void UpdateConfiguration(IConfiguration config, EurekaServiceInfo si, EurekaClientOptions clientOptions)
         {
-            if ((Platform.IsContainerized || Platform.IsCloudHosted) &&
+            var clientOpts = clientOptions ?? new EurekaClientOptions();
+
+            if (clientOpts.Enabled &&
+                (Platform.IsContainerized || Platform.IsCloudHosted) &&
                 si == null &&
-                clientOptions.EurekaServerServiceUrls.Contains(EurekaClientConfig.Default_ServerServiceUrl.TrimEnd('/')) &&
-                (clientOptions.Enabled || clientOptions.ShouldRegisterWithEureka || clientOptions.ShouldFetchRegistry))
+                clientOpts.EurekaServerServiceUrls.Contains(EurekaClientConfig.Default_ServerServiceUrl.TrimEnd('/')) &&
+                (clientOpts.ShouldRegisterWithEureka || clientOpts.ShouldFetchRegistry))
             {
                 throw new InvalidOperationException($"Eureka URL {EurekaClientConfig.Default_ServerServiceUrl} is not valid in containerized or cloud environments. Please configure Eureka:Client:ServiceUrl with a non-localhost address or add a service binding.");
             }

--- a/src/Discovery/test/Eureka.Test/EurekaPostConfigurerTest.cs
+++ b/src/Discovery/test/Eureka.Test/EurekaPostConfigurerTest.cs
@@ -901,5 +901,22 @@ namespace Steeltoe.Discovery.Eureka.Test
             Assert.Equal(1234, instOpts.SecurePort);
             Assert.Equal(1233, instOpts.Port);
         }
+
+        [Fact]
+        public void UpdateConfiguration_DisableClientShouldNotComplainAboutInvalidConfiguration()
+        {
+
+            var clientOptions = new EurekaClientOptions()
+            {
+                Enabled = false
+            };
+
+            Environment.SetEnvironmentVariable("DOTNET_RUNNING_IN_CONTAINER", "true");
+
+            var ex = Record.Exception(() => EurekaPostConfigurer.UpdateConfiguration(null, null, clientOptions));
+            Assert.Null(ex);
+
+            Environment.SetEnvironmentVariable("DOTNET_RUNNING_IN_CONTAINER", null);
+        }
     }
 }

--- a/src/Discovery/test/Eureka.Test/EurekaPostConfigurerTest.cs
+++ b/src/Discovery/test/Eureka.Test/EurekaPostConfigurerTest.cs
@@ -905,7 +905,6 @@ namespace Steeltoe.Discovery.Eureka.Test
         [Fact]
         public void UpdateConfiguration_DisableClientShouldNotComplainAboutInvalidConfiguration()
         {
-
             var clientOptions = new EurekaClientOptions()
             {
                 Enabled = false


### PR DESCRIPTION
This PR makes the eureka client to skip configuration validation when not enabled. 
Also includes a new unit test to check that no exception due to validation failure is thrown when the client is disabled.

Related to issue #863