### PR TITLE
Fixes flakey Create_WithPollingTimer Config Server Test

### DIFF
--- a/src/Configuration/test/ConfigServerBase.Test/ConfigServerConfigurationProviderTest.cs
+++ b/src/Configuration/test/ConfigServerBase.Test/ConfigServerConfigurationProviderTest.cs
@@ -389,17 +389,12 @@ namespace Steeltoe.Extensions.Configuration.ConfigServer.Test
             settings.Label = "label,testlabel";
             using var client = server.CreateClient();
             var provider = new ConfigServerConfigurationProvider(settings, client);
-            var token = provider.GetReloadToken();
-            await Task.Delay(2000);
-            var postInitialLoadToken = provider.GetReloadToken();
-
-            Assert.NotSame(token, postInitialLoadToken);
+            Assert.True(TestConfigServerStartup.InitialRequestLatch.Wait(TimeSpan.FromSeconds(60)));
+            Assert.True(TestConfigServerStartup.RequestCount >= 1);
+            await Task.Delay(1000);
             Assert.NotNull(TestConfigServerStartup.LastRequest);
-            Assert.True(TestConfigServerStartup.RequestCount > 1);
-            Assert.True(token.HasChanged);
-
-            await Task.Delay(500);
-            Assert.False(postInitialLoadToken.HasChanged);
+            Assert.True(TestConfigServerStartup.RequestCount >= 2);
+            Assert.False(provider.GetReloadToken().HasChanged);
         }
 
         [Fact]

--- a/src/Configuration/test/ConfigServerBase.Test/TestConfigServerStartup.cs
+++ b/src/Configuration/test/ConfigServerBase.Test/TestConfigServerStartup.cs
@@ -4,6 +4,7 @@
 
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
+using System.Threading;
 
 namespace Steeltoe.Extensions.Configuration.ConfigServer.Test
 {
@@ -16,11 +17,14 @@ namespace Steeltoe.Extensions.Configuration.ConfigServer.Test
             LastRequest = null;
             RequestCount = 0;
             Label = AppName = Env = string.Empty;
+            InitialRequestLatch = new CountdownEvent(1);
         }
 
         public TestConfigServerStartup()
         {
         }
+
+        public static CountdownEvent InitialRequestLatch = new CountdownEvent(1);
 
         public static string Response { get; set; }
 
@@ -47,6 +51,11 @@ namespace Steeltoe.Extensions.Configuration.ConfigServer.Test
                 {
                     context.Response.Headers.Add("content-type", "application/json");
                     await context.Response.WriteAsync(Response);
+                }
+
+                if (RequestCount == 1)
+                {
+                    InitialRequestLatch.Signal();
                 }
             });
         }


### PR DESCRIPTION
This should fix a thread race condition with this test... Added a latch to wait for the initial request, then proceed the test after that latch signals.