### PR TITLE
Change HeapDumpActuator_ReturnsExpectedData() to initiate gcdumps

### DIFF
--- a/src/Management/test/EndpointCore.Test/HeapDump/EndpointMiddlewareTest.cs
+++ b/src/Management/test/EndpointCore.Test/HeapDump/EndpointMiddlewareTest.cs
@@ -34,7 +34,8 @@ namespace Steeltoe.Management.Endpoint.HeapDump.Test
             ["Logging:LogLevel:Pivotal"] = "Information",
             ["Logging:LogLevel:Steeltoe"] = "Information",
             ["management:endpoints:enabled"] = "true",
-            ["management:endpoints:heapdump:enabled"] = "true"
+            ["management:endpoints:heapdump:enabled"] = "true",
+            ["management:endpoints:heapdump:heapdumptype"] = "gcdump",
         };
 
         [Fact]


### PR DESCRIPTION
This unit test on .NET 6 defaults to Full Core dump which can result in a very large dump file (e.g. approx 4 gig bytes) and can at times cause the test to timeout during downloading of data to a file.  The default for .NET 3.1 is gcdump  which is much smaller.

Change this to do gcdump by default for all .NET runtimes which will reduce file size and make unit test more reliable.

GCDumps should eventually be set to default for all .NET