### PR TITLE
use Eureka proxy & decompression settings in HttpClientFactory setup

### DIFF
--- a/src/Discovery/src/Eureka/EurekaDiscoveryClientExtension.cs
+++ b/src/Discovery/src/Eureka/EurekaDiscoveryClientExtension.cs
@@ -15,6 +15,7 @@ using Steeltoe.Common.Options;
 using Steeltoe.Common.Reflection;
 using Steeltoe.Connector.Services;
 using Steeltoe.Discovery.Client;
+using Steeltoe.Discovery.Eureka.Transport;
 using System;
 using System.Linq;
 using static Steeltoe.Discovery.Client.DiscoveryServiceCollectionExtensions;
@@ -82,7 +83,7 @@ public class EurekaDiscoveryClientExtension : IDiscoveryClientExtension
                 var inetOptions = config.GetSection(InetOptions.PREFIX).Get<InetOptions>();
                 options.NetUtils = new InetUtils(inetOptions);
                 options.ApplyNetUtils();
-                var endpointAssembly = "Steeltoe.Management.EndpointBase";
+                const string endpointAssembly = "Steeltoe.Management.EndpointBase";
                 if (ReflectionHelpers.IsAssemblyLoaded(endpointAssembly))
                 {
                     var actuatorOptionsType = ReflectionHelpers.FindType(new[] { endpointAssembly }, new[] { "Steeltoe.Management.Endpoint.Hypermedia.ActuatorManagementOptions" });
@@ -97,7 +98,7 @@ public class EurekaDiscoveryClientExtension : IDiscoveryClientExtension
                             var healthOptions = serviceProvider.GetService(healthOptionsType);
                             if (healthOptions != null)
                             {
-                                options.HealthCheckUrlPath = basePath + ((string)endpointOptionsBaseType.GetProperty("Path").GetValue(healthOptions)).TrimStart('/');
+                                options.HealthCheckUrlPath = basePath + ((string)endpointOptionsBaseType.GetProperty("Path")?.GetValue(healthOptions))?.TrimStart('/');
                             }
                         }
 
@@ -107,7 +108,7 @@ public class EurekaDiscoveryClientExtension : IDiscoveryClientExtension
                             var infoOptions = serviceProvider.GetService(infoOptionsType);
                             if (infoOptions != null)
                             {
-                                options.StatusPageUrlPath = basePath + ((string)endpointOptionsBaseType.GetProperty("Path").GetValue(infoOptions)).TrimStart('/');
+                                options.StatusPageUrlPath = basePath + ((string)endpointOptionsBaseType.GetProperty("Path")?.GetValue(infoOptions))?.TrimStart('/');
                             }
                         }
                     }
@@ -144,7 +145,6 @@ public class EurekaDiscoveryClientExtension : IDiscoveryClientExtension
 
         services.AddSingleton<IHealthContributor, EurekaServerHealthContributor>();
 
-        var certOptions = services.FirstOrDefault(descriptor => descriptor.ServiceType == typeof(IConfigureOptions<CertificateOptions>));
         var existingHandler = services.FirstOrDefault(descriptor => descriptor.ServiceType == typeof(IHttpClientHandlerProvider));
 
         if (existingHandler is IHttpClientHandlerProvider handlerProvider)
@@ -154,15 +154,13 @@ public class EurekaDiscoveryClientExtension : IDiscoveryClientExtension
         }
         else
         {
-            if (certOptions is null)
-            {
-                AddEurekaHttpClient(services);
-            }
-            else
-            {
-                AddEurekaHttpClient(services)
-                    .ConfigurePrimaryHttpMessageHandler(services => new ClientCertificateHttpHandler(services.GetRequiredService<IOptionsMonitor<CertificateOptions>>()));
-            }
+            AddEurekaHttpClient(services)
+                .ConfigurePrimaryHttpMessageHandler(serviceProvider =>
+                {
+                    var certOptions = serviceProvider.GetService<IOptionsMonitor<CertificateOptions>>();
+                    var eurekaOptions = serviceProvider.GetService<IOptionsMonitor<EurekaClientOptions>>();
+                    return EurekaHttpClient.ConfigureEurekaHttpClientHandler(eurekaOptions.CurrentValue, certOptions is null ? null : new ClientCertificateHttpHandler(certOptions));
+                });
         }
     }
 


### PR DESCRIPTION
## Description

Fix bug introduced in #778 where client settings (like AutomaticDecompression and proxy config) aren't applied during HttpClientFactory setup

Addresses #865, and will need to be backported to `release/3.2`

## Quality checklist

- [ ] Your code complies with our [Coding Style](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-code-style.md).
- [ ] You've updated unit and/or integration tests for your change, where applicable.
- [ ] You've updated documentation for your change, where applicable.
      If your change affects other repositories, such as [Documentation](https://github.com/SteeltoeOSS/Documentation), [Samples](https://github.com/SteeltoeOSS/Samples) and/or [MainSite](https://github.com/SteeltoeOSS/MainSite), add linked PRs here.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
- [ ] You've added required license files and/or file headers (explaining where the code came from with proper attribution), where code is copied from StackOverflow, a blog, or OSS.
