### PR TITLE
Add tools for automated code cleanup

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -7,6 +7,12 @@
       "commands": [
         "jb"
       ]
+    },
+    "regitlint": {
+      "version": "6.1.1",
+      "commands": [
+        "regitlint"
+      ]
     }
   }
 }

--- a/build/pr-code-cleanup.yml
+++ b/build/pr-code-cleanup.yml
@@ -75,7 +75,7 @@ jobs:
     inputs:
       targetType: 'inline'
       script: |
-        git config --global user.email "cibuild@steeltoe.com"
+        git config --global user.email "cibuild@steeltoe.io"
         git config --global user.name "steeltoe-cibuild"
 
         Write-Output "Committing changes."

--- a/build/pr-code-cleanup.yml
+++ b/build/pr-code-cleanup.yml
@@ -1,0 +1,120 @@
+trigger: none
+
+jobs:
+- job: PR_Code_Cleanup
+  variables:
+    DOTNET_NOLOGO: true
+    DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+    DOTNET_CLI_TELEMETRY_OPTOUT: 1
+  pool:
+    vmImage: windows-latest
+  steps:
+  - task: PowerShell@2
+    displayName: Validate preconditions
+    inputs:
+      targetType: 'inline'
+      script: |
+        if (-not $env:SYSTEM_PULLREQUEST_TARGETBRANCH) {
+          throw 'This pipeline can only be run from pull requests. Use "/azp run cleanup-code" in a GitHub PR comment.'
+        }
+  - checkout: self
+    persistCredentials: true
+  - task: PowerShell@2
+    displayName: Checkout PR branch
+    inputs:
+      targetType: 'inline'
+      script: |
+        # We're going to push changes, so we need to be on the PR branch
+        # instead of the detached head that contains the merge result.
+        Write-Output "Switching to branch $env:SYSTEM_PULLREQUEST_SOURCEBRANCH"
+        git checkout $env:SYSTEM_PULLREQUEST_SOURCEBRANCH
+  - task: PowerShell@2
+    displayName: Restore tools
+    inputs:
+      targetType: 'inline'
+      script: |
+        dotnet tool restore
+  - task: PowerShell@2
+    displayName: Restore packages
+    inputs:
+      targetType: 'inline'
+      script: |
+        dotnet restore src
+  - task: PowerShell@2
+    displayName: Code cleanup
+    inputs:
+      targetType: 'inline'
+      script: |
+        # Find the most-recent common ancestor to diff against. Using the target branch name is incorrect because this PR may be
+        # out-of-date (which means the target branch has newer commits, and we should ignore those).
+        $baseCommitHash = git merge-base origin/$env:SYSTEM_PULLREQUEST_SOURCEBRANCH origin/$env:SYSTEM_PULLREQUEST_TARGETBRANCH
+        if ($LastExitCode -ne 0) { throw "Command 'git merge-base' failed with exit code $LastExitCode." }
+
+        $headCommitHash = git rev-parse HEAD
+        if ($LastExitCode -ne 0) { throw "Command 'git rev-parse' failed with exit code $LastExitCode." }
+
+        if ($baseCommitHash -ne $headCommitHash) {
+          Write-Output "Running code cleanup on commit range $baseCommitHash..$headCommitHash in pull request."
+          dotnet regitlint -s src/Steeltoe.All.sln --print-command --skip-tool-check --jb-profile="Steeltoe Full Cleanup" --jb --properties:Configuration=Release --jb --verbosity=WARN -f commits -a $headCommitHash -b $baseCommitHash
+        }
+  - task: PowerShell@2
+    displayName: Detect changes
+    inputs:
+      targetType: 'inline'
+      script: |
+        git add -A
+        git diff-index --quiet HEAD --
+        $hasChangesToCommit = $LastExitCode -ne 0
+        Write-Output "##vso[task.setvariable variable=hasChangesToCommit]$hasChangesToCommit"
+        exit 0
+  - task: PowerShell@2
+    displayName: Push changes
+    condition: and(succeeded(), eq(variables['hasChangesToCommit'], 'True'))
+    env:
+      SYSTEM_ACCESSTOKEN: $(System.AccessToken)  
+    inputs:
+      targetType: 'inline'
+      script: |
+        git config --global user.email "cibuild@steeltoe.com"
+        git config --global user.name "steeltoe-cibuild"
+
+        Write-Output "Committing changes."
+        git commit -m "Automated code cleanup from Steeltoe cibuild"
+        if ($LastExitCode -ne 0) { throw "Command 'git commit' failed with exit code $LastExitCode." }
+
+        Write-Output "Pushing changes."
+        git push origin
+        if ($LastExitCode -ne 0) { throw "Command 'git push' failed with exit code $LastExitCode." }
+
+        Write-Output "##vso[task.setvariable variable=hasCommitted]True"
+        exit 0
+  - task: PowerShell@2
+    displayName: Compose status message
+    condition: always()
+    inputs:
+      targetType: 'inline'
+      script: |
+        if ($env:HASCOMMITTED -eq 'True') {
+          $statusMessage = "<samp>Code cleanup successfully reformatted files and pushed changes.</samp>"
+        }
+        elseif ($env:AGENT_JOBSTATUS -eq "Canceled") {
+          $statusMessage = "<samp>Code cleanup was canceled, no changes were pushed.</samp>"
+        }
+        elseif ($env:AGENT_JOBSTATUS -eq "Failed") {
+          $url = "$(System.TeamFoundationCollectionUri)$(System.TeamProject)/_build/results?buildId=$(Build.BuildId)" 
+          $statusMessage = "<samp>Code cleanup failed to reformat and push changes.</samp><p>View details [here]($url).</p>"
+        }
+        else {
+          $statusMessage = "<samp>Code cleanup successfully reformatted files, but there were no changes to push.</samp>"
+        }
+
+        Write-Output "Status: $statusMessage"
+        Write-Output "##vso[task.setvariable variable=statusMessage]$statusMessage"
+        exit 0
+  - task: GitHubComment@0
+    displayName: Notify status in PR comment
+    condition: and(always(), not(eq(variables['statusMessage'], '')))
+    inputs:
+      gitHubConnection: 'SteeltoeOSS (1)'
+      repositoryName: '$(Build.Repository.Name)'
+      comment: $(statusMessage)

--- a/build/verify-code-style.yml
+++ b/build/verify-code-style.yml
@@ -1,3 +1,9 @@
+trigger:
+  branches:
+    include:
+    - master
+    - release/*
+
 jobs:
 - job: Verify_Code_Style
   variables:

--- a/build/verify-code-style.yml
+++ b/build/verify-code-style.yml
@@ -1,0 +1,43 @@
+jobs:
+- job: Verify_Code_Style
+  variables:
+    DOTNET_NOLOGO: true
+    DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+    DOTNET_CLI_TELEMETRY_OPTOUT: 1
+  pool:
+    vmImage: windows-latest
+  steps:
+  - checkout: self
+    persistCredentials: true
+  - task: PowerShell@2
+    displayName: Restore tools
+    inputs:
+      targetType: 'inline'
+      script: |
+        dotnet tool restore
+  - task: PowerShell@2
+    displayName: Restore packages
+    inputs:
+      targetType: 'inline'
+      script: |
+        dotnet restore src
+  - task: PowerShell@2
+    displayName: Verify code style
+    inputs:
+      targetType: 'inline'
+      script: |
+        if (-not $env:SYSTEM_PULLREQUEST_TARGETBRANCH) {
+          Write-Output "Running code cleanup on all files in branch."
+          dotnet regitlint -s src/Steeltoe.All.sln --print-command --skip-tool-check --jb-profile="Steeltoe Full Cleanup" --jb --properties:Configuration=Release --jb --verbosity=WARN --fail-on-diff --print-diff
+        }
+        else {
+          # We are in detached head (the merge result), so there's no need to account for an out-of-date PR.
+          $baseCommitHash = git rev-parse origin/$env:SYSTEM_PULLREQUEST_TARGETBRANCH
+          if ($LastExitCode -ne 0) { throw "Command 'git rev-parse (1)' failed with exit code $LastExitCode." }
+  
+          $headCommitHash = git rev-parse HEAD
+          if ($LastExitCode -ne 0) { throw "Command 'git rev-parse (2)' failed with exit code $LastExitCode." }
+  
+          Write-Output "Running code cleanup on commit range $baseCommitHash..$headCommitHash in pull request."
+          dotnet regitlint -s src/Steeltoe.All.sln --print-command --skip-tool-check --jb-profile="Steeltoe Full Cleanup" --jb --properties:Configuration=Release --jb --verbosity=WARN --fail-on-diff --print-diff -f commits -a $headCommitHash -b $baseCommitHash
+        }

--- a/cleanupcode.ps1
+++ b/cleanupcode.ps1
@@ -1,0 +1,44 @@
+#Requires -Version 7.0
+
+# This script reformats (part of) the codebase to make it compliant with our coding guidelines.
+
+param(
+    # Git branch name or base commit hash to reformat only the subset of changed files. Omit for all files.
+    [string] $revision
+)
+
+function VerifySuccessExitCode {
+    if ($LastExitCode -ne 0) {
+        throw "Command failed with exit code $LastExitCode."
+    }
+}
+
+dotnet tool restore
+VerifySuccessExitCode
+
+dotnet restore src
+VerifySuccessExitCode
+
+if ($revision) {
+    $headCommitHash = git rev-parse HEAD
+    VerifySuccessExitCode
+
+    $baseCommitHash = git rev-parse $revision
+    VerifySuccessExitCode
+
+    if ($baseCommitHash -eq $headCommitHash) {
+        Write-Output "Running code cleanup on staged/unstaged files."
+        dotnet regitlint -s src/Steeltoe.All.sln --print-command --skip-tool-check --jb-profile="Steeltoe Full Cleanup" --jb --properties:Configuration=Release --jb --verbosity=WARN -f staged,modified
+        VerifySuccessExitCode
+    }
+    else {
+        Write-Output "Running code cleanup on commit range $baseCommitHash..$headCommitHash, including staged/unstaged files."
+        dotnet regitlint -s src/Steeltoe.All.sln --print-command --skip-tool-check --jb-profile="Steeltoe Full Cleanup" --jb --properties:Configuration=Release --jb --verbosity=WARN -f staged,modified,commits -a $headCommitHash -b $baseCommitHash
+        VerifySuccessExitCode
+    }
+}
+else {
+    Write-Output "Running code cleanup on all files."
+    dotnet regitlint -s src/Steeltoe.All.sln --print-command --skip-tool-check --jb-profile="Steeltoe Full Cleanup" --jb --properties:Configuration=Release --jb --verbosity=WARN
+    VerifySuccessExitCode
+}


### PR DESCRIPTION
## Description

This PR adds tooling for automated code cleanup.
- An Azure DevOps pipeline to cleanup code, which is started using `/azp run cleanup-code` in a PR comment
- An Azure DevOps pipeline to validate code style, which runs as part of PR validation steps
- A PowerShell script to run locally, which takes an optional base branch name to reformat only changed files:
  ```
  C:\Source\Repos\Steeltoe [some-feature-branch ≡]> ./cleanupcode.ps1 main
  ```

Code cleanup performs the following steps, which are configured in src/Steeltoe.All.sln.DotSettings:

![image](https://user-images.githubusercontent.com/104792814/182142591-94f74caf-be99-4504-92e5-a496c34330f8.png)


Fixes #963.

## Quality checklist

- [x] Your code complies with our [Coding Style](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-code-style.md).
- [ ] You've updated unit and/or integration tests for your change, where applicable.
- [ ] You've updated documentation for your change, where applicable.
      If your change affects other repositories, such as [Documentation](https://github.com/SteeltoeOSS/Documentation), [Samples](https://github.com/SteeltoeOSS/Samples) and/or [MainSite](https://github.com/SteeltoeOSS/MainSite), add linked PRs here.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
- [ ] You've added required license files and/or file headers (explaining where the code came from with proper attribution), where code is copied from StackOverflow, a blog, or OSS.
