### PR TITLE
Fix new warnings/errors from updated Xunit version

### DIFF
--- a/src/CircuitBreaker/test/HystrixBase.Test/HystrixRequestCacheTest.cs
+++ b/src/CircuitBreaker/test/HystrixBase.Test/HystrixRequestCacheTest.cs
@@ -65,11 +65,11 @@ public class HystrixRequestCacheTest : HystrixTestBase
     }
 
     [Fact]
-    public void TestCacheWithoutContext()
+    public async Task TestCacheWithoutContext()
     {
         context.Dispose();
 
-        Assert.Throws<InvalidOperationException>(() => { HystrixRequestCache.GetInstance(HystrixCommandKeyDefault.AsKey("command1")).Get<Task<string>>("any"); });
+        await Assert.ThrowsAsync<InvalidOperationException>(() => HystrixRequestCache.GetInstance(HystrixCommandKeyDefault.AsKey("command1")).Get<Task<string>>("any"));
     }
 
     [Fact]
@@ -91,7 +91,7 @@ public class HystrixRequestCacheTest : HystrixTestBase
     }
 
     [Fact]
-    public void TestCacheWithoutRequestContext()
+    public async Task TestCacheWithoutRequestContext()
     {
         context.Dispose();
 
@@ -99,6 +99,6 @@ public class HystrixRequestCacheTest : HystrixTestBase
         var t1 = Task.FromResult("a1");
 
         // this should fail, as there's no HystrixRequestContext instance to place the cache into
-        Assert.Throws<InvalidOperationException>(() => { cache1.PutIfAbsent("valueA", t1); });
+        await Assert.ThrowsAsync<InvalidOperationException>(() => cache1.PutIfAbsent("valueA", t1));
     }
 }

--- a/src/Management/test/EndpointBase.Test/Metrics/MetricsObserverOptionsTest.cs
+++ b/src/Management/test/EndpointBase.Test/Metrics/MetricsObserverOptionsTest.cs
@@ -14,8 +14,8 @@ public class MetricsObserverOptionsTest : BaseTest
     public void Constructor_InitializesWithDefaults()
     {
         var opts = new MetricsObserverOptions();
-        Assert.Equal(opts.IngressIgnorePattern, MetricsObserverOptions.DefaultIngressIgnorePattern);
-        Assert.Equal(opts.EgressIgnorePattern, MetricsObserverOptions.DefaultEgressIgnorePattern);
+        Assert.Equal(MetricsObserverOptions.DefaultIngressIgnorePattern, opts.IngressIgnorePattern);
+        Assert.Equal(MetricsObserverOptions.DefaultEgressIgnorePattern, opts.EgressIgnorePattern);
         Assert.True(opts.AspNetCoreHosting);
         Assert.True(opts.GCEvents);
         Assert.False(opts.EventCounterEvents);


### PR DESCRIPTION
## Description
The cibuild of the main branch is currently failing, because a new version of Xunit was [published](https://www.nuget.org/packages/xunit) several hours ago. We're seeing this failure (which is a good thing) due to `<XunitVersion>2.4.*</XunitVersion>` in `versions.props`: the `*` notifies us of new issues early, so we can address them before it harms Steeltoe consumers.

## Quality checklist

- [x] Your code complies with our [Coding Style](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-code-style.md).
- [x] You've updated unit and/or integration tests for your change, where applicable.
- [ ] You've updated documentation for your change, where applicable.
      If your change affects other repositories, such as [Documentation](https://github.com/SteeltoeOSS/Documentation), [Samples](https://github.com/SteeltoeOSS/Samples) and/or [MainSite](https://github.com/SteeltoeOSS/MainSite), add linked PRs here.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
- [ ] You've added required license files and/or file headers (explaining where the code came from with proper attribution), where code is copied from StackOverflow, a blog, or OSS.
