### PR TITLE
Reduce binary serialization

### DIFF
--- a/src/CircuitBreaker/src/Hystrix/Exceptions/HystrixBadRequestException.cs
+++ b/src/CircuitBreaker/src/Hystrix/Exceptions/HystrixBadRequestException.cs
@@ -2,29 +2,21 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-using System.Runtime.Serialization;
-
 namespace Steeltoe.CircuitBreaker.Hystrix.Exceptions;
 
-[Serializable]
 public class HystrixBadRequestException : Exception
 {
+    public HystrixBadRequestException()
+    {
+    }
+
     public HystrixBadRequestException(string message)
         : base(message)
     {
     }
 
-    public HystrixBadRequestException(string message, Exception cause)
-        : base(message, cause)
-    {
-    }
-
-    public HystrixBadRequestException()
-    {
-    }
-
-    protected HystrixBadRequestException(SerializationInfo info, StreamingContext context)
-        : base(info, context)
+    public HystrixBadRequestException(string message, Exception innerException)
+        : base(message, innerException)
     {
     }
 }

--- a/src/CircuitBreaker/src/Hystrix/Exceptions/HystrixRuntimeException.cs
+++ b/src/CircuitBreaker/src/Hystrix/Exceptions/HystrixRuntimeException.cs
@@ -7,9 +7,7 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Exceptions;
 public class HystrixRuntimeException : Exception
 {
     public FailureType FailureType { get; }
-
     public Exception FallbackException { get; }
-
     public Type ImplementingType { get; }
 
     public HystrixRuntimeException()

--- a/src/CircuitBreaker/src/Hystrix/Exceptions/HystrixRuntimeException.cs
+++ b/src/CircuitBreaker/src/Hystrix/Exceptions/HystrixRuntimeException.cs
@@ -2,11 +2,8 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-using System.Runtime.Serialization;
-
 namespace Steeltoe.CircuitBreaker.Hystrix.Exceptions;
 
-[Serializable]
 public class HystrixRuntimeException : Exception
 {
     public FailureType FailureType { get; }
@@ -14,22 +11,6 @@ public class HystrixRuntimeException : Exception
     public Exception FallbackException { get; }
 
     public Type ImplementingType { get; }
-
-    public HystrixRuntimeException(FailureType failureType, Type commandType, string message)
-        : base(message)
-    {
-        FailureType = failureType;
-        ImplementingType = commandType;
-        FallbackException = null;
-    }
-
-    public HystrixRuntimeException(FailureType failureType, Type commandType, string message, Exception cause, Exception fallbackException)
-        : base(message, cause)
-    {
-        FailureType = failureType;
-        ImplementingType = commandType;
-        FallbackException = fallbackException;
-    }
 
     public HystrixRuntimeException()
     {
@@ -45,8 +26,19 @@ public class HystrixRuntimeException : Exception
     {
     }
 
-    protected HystrixRuntimeException(SerializationInfo info, StreamingContext context)
-        : base(info, context)
+    public HystrixRuntimeException(FailureType failureType, Type commandType, string message)
+        : base(message)
     {
+        FailureType = failureType;
+        ImplementingType = commandType;
+        FallbackException = null;
+    }
+
+    public HystrixRuntimeException(FailureType failureType, Type commandType, string message, Exception innerException, Exception fallbackException)
+        : base(message, innerException)
+    {
+        FailureType = failureType;
+        ImplementingType = commandType;
+        FallbackException = fallbackException;
     }
 }

--- a/src/CircuitBreaker/src/Hystrix/Exceptions/HystrixTimeoutException.cs
+++ b/src/CircuitBreaker/src/Hystrix/Exceptions/HystrixTimeoutException.cs
@@ -2,11 +2,8 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-using System.Runtime.Serialization;
-
 namespace Steeltoe.CircuitBreaker.Hystrix.Exceptions;
 
-[Serializable]
 public class HystrixTimeoutException : Exception
 {
     public HystrixTimeoutException(string message)
@@ -14,17 +11,12 @@ public class HystrixTimeoutException : Exception
     {
     }
 
-    public HystrixTimeoutException(string message, Exception inner)
-        : base(message, inner)
-    {
-    }
-
     public HystrixTimeoutException()
     {
     }
 
-    protected HystrixTimeoutException(SerializationInfo info, StreamingContext context)
-        : base(info, context)
+    public HystrixTimeoutException(string message, Exception innerException)
+        : base(message, innerException)
     {
     }
 }

--- a/src/CircuitBreaker/src/Hystrix/Exceptions/HystrixTimeoutException.cs
+++ b/src/CircuitBreaker/src/Hystrix/Exceptions/HystrixTimeoutException.cs
@@ -6,12 +6,12 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Exceptions;
 
 public class HystrixTimeoutException : Exception
 {
-    public HystrixTimeoutException(string message)
-        : base(message)
+    public HystrixTimeoutException()
     {
     }
 
-    public HystrixTimeoutException()
+    public HystrixTimeoutException(string message)
+        : base(message)
     {
     }
 

--- a/src/CircuitBreaker/src/Hystrix/Exceptions/RejectedExecutionException.cs
+++ b/src/CircuitBreaker/src/Hystrix/Exceptions/RejectedExecutionException.cs
@@ -2,29 +2,21 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-using System.Runtime.Serialization;
-
 namespace Steeltoe.CircuitBreaker.Hystrix.Exceptions;
 
-[Serializable]
 public class RejectedExecutionException : Exception
 {
+    public RejectedExecutionException()
+    {
+    }
+
     public RejectedExecutionException(string message)
         : base(message)
     {
     }
 
-    public RejectedExecutionException()
-    {
-    }
-
     public RejectedExecutionException(string message, Exception innerException)
         : base(message, innerException)
-    {
-    }
-
-    protected RejectedExecutionException(SerializationInfo info, StreamingContext context)
-        : base(info, context)
     {
     }
 }

--- a/src/CircuitBreaker/test/Hystrix.Test/BusinessException.cs
+++ b/src/CircuitBreaker/test/Hystrix.Test/BusinessException.cs
@@ -6,8 +6,8 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Test;
 
 public class BusinessException : Exception
 {
-    public BusinessException(string msg)
-        : base(msg)
+    public BusinessException(string message)
+        : base(message)
     {
     }
 }

--- a/src/Common/src/Common.Expression/AccessException.cs
+++ b/src/Common/src/Common.Expression/AccessException.cs
@@ -11,8 +11,8 @@ public class AccessException : Exception
     {
     }
 
-    public AccessException(string message, Exception cause)
-        : base(message, cause)
+    public AccessException(string message, Exception innerException)
+        : base(message, innerException)
     {
     }
 }

--- a/src/Common/src/Common.Expression/EvaluationException.cs
+++ b/src/Common/src/Common.Expression/EvaluationException.cs
@@ -11,8 +11,8 @@ public class EvaluationException : ExpressionException
     {
     }
 
-    public EvaluationException(string message, Exception cause)
-        : base(message, cause)
+    public EvaluationException(string message, Exception innerException)
+        : base(message, innerException)
     {
     }
 
@@ -26,8 +26,8 @@ public class EvaluationException : ExpressionException
     {
     }
 
-    public EvaluationException(int position, string message, Exception cause)
-        : base(position, message, cause)
+    public EvaluationException(int position, string message, Exception innerException)
+        : base(position, message, innerException)
     {
     }
 }

--- a/src/Common/src/Common.Expression/ExpressionException.cs
+++ b/src/Common/src/Common.Expression/ExpressionException.cs
@@ -9,11 +9,8 @@ namespace Steeltoe.Common.Expression.Internal;
 public class ExpressionException : Exception
 {
     public string ExpressionString { get; }
-
     public int Position { get; set; }
-
     public override string Message => ToDetailedString();
-
     public string SimpleMessage => base.Message;
 
     public ExpressionException(string message)
@@ -23,8 +20,8 @@ public class ExpressionException : Exception
         Position = 0;
     }
 
-    public ExpressionException(string message, Exception cause)
-        : base(message, cause)
+    public ExpressionException(string message, Exception innerException)
+        : base(message, innerException)
     {
         ExpressionString = null;
         Position = 0;
@@ -51,8 +48,8 @@ public class ExpressionException : Exception
         Position = position;
     }
 
-    public ExpressionException(int position, string message, Exception cause)
-        : base(message, cause)
+    public ExpressionException(int position, string message, Exception innerException)
+        : base(message, innerException)
     {
         ExpressionString = null;
         Position = position;

--- a/src/Common/src/Common.Expression/ExpressionInvocationTargetException.cs
+++ b/src/Common/src/Common.Expression/ExpressionInvocationTargetException.cs
@@ -6,8 +6,13 @@ namespace Steeltoe.Common.Expression.Internal;
 
 public class ExpressionInvocationTargetException : EvaluationException
 {
-    public ExpressionInvocationTargetException(int position, string message, Exception cause)
-        : base(position, message, cause)
+    public ExpressionInvocationTargetException(string message)
+        : base(message)
+    {
+    }
+
+    public ExpressionInvocationTargetException(string message, Exception innerException)
+        : base(message, innerException)
     {
     }
 
@@ -16,18 +21,13 @@ public class ExpressionInvocationTargetException : EvaluationException
     {
     }
 
+    public ExpressionInvocationTargetException(int position, string message, Exception innerException)
+        : base(position, message, innerException)
+    {
+    }
+
     public ExpressionInvocationTargetException(string expressionString, string message)
         : base(expressionString, message)
-    {
-    }
-
-    public ExpressionInvocationTargetException(string message, Exception cause)
-        : base(message, cause)
-    {
-    }
-
-    public ExpressionInvocationTargetException(string message)
-        : base(message)
     {
     }
 }

--- a/src/Common/src/Common.Expression/ParseException.cs
+++ b/src/Common/src/Common.Expression/ParseException.cs
@@ -6,18 +6,18 @@ namespace Steeltoe.Common.Expression.Internal;
 
 public class ParseException : ExpressionException
 {
+    public ParseException(int position, string message)
+        : base(position, message)
+    {
+    }
+
     public ParseException(string expressionString, int position, string message)
         : base(expressionString, position, message)
     {
     }
 
-    public ParseException(int position, string message, Exception cause)
-        : base(position, message, cause)
-    {
-    }
-
-    public ParseException(int position, string message)
-        : base(position, message)
+    public ParseException(int position, string message, Exception innerException)
+        : base(position, message, innerException)
     {
     }
 }

--- a/src/Common/src/Common.Expression/ParseException.cs
+++ b/src/Common/src/Common.Expression/ParseException.cs
@@ -11,13 +11,13 @@ public class ParseException : ExpressionException
     {
     }
 
-    public ParseException(string expressionString, int position, string message)
-        : base(expressionString, position, message)
+    public ParseException(int position, string message, Exception innerException)
+        : base(position, message, innerException)
     {
     }
 
-    public ParseException(int position, string message, Exception innerException)
-        : base(position, message, innerException)
+    public ParseException(string expressionString, int position, string message)
+        : base(expressionString, position, message)
     {
     }
 }

--- a/src/Common/src/Common.Expression/Spring/InternalParseException.cs
+++ b/src/Common/src/Common.Expression/Spring/InternalParseException.cs
@@ -8,8 +8,8 @@ public class InternalParseException : Exception
 {
     public SpelParseException Cause => (SpelParseException)InnerException;
 
-    public InternalParseException(SpelParseException cause)
-        : base("Internal Parse Error", cause)
+    public InternalParseException(SpelParseException innerException)
+        : base("Internal Parse Error", innerException)
     {
     }
 }

--- a/src/Common/src/Common.Expression/Spring/SpelEvaluationException.cs
+++ b/src/Common/src/Common.Expression/Spring/SpelEvaluationException.cs
@@ -7,7 +7,6 @@ namespace Steeltoe.Common.Expression.Internal.Spring;
 public class SpelEvaluationException : EvaluationException
 {
     public SpelMessage MessageCode { get; }
-
     public object[] Inserts { get; }
 
     public SpelEvaluationException(SpelMessage message, params object[] inserts)
@@ -24,15 +23,15 @@ public class SpelEvaluationException : EvaluationException
         Inserts = inserts;
     }
 
-    public SpelEvaluationException(int position, Exception cause, SpelMessage message, params object[] inserts)
-        : base(position, message.FormatMessage(inserts), cause)
+    public SpelEvaluationException(int position, Exception innerException, SpelMessage message, params object[] inserts)
+        : base(position, message.FormatMessage(inserts), innerException)
     {
         MessageCode = message;
         Inserts = inserts;
     }
 
-    public SpelEvaluationException(Exception cause, SpelMessage message, params object[] inserts)
-        : base(message.FormatMessage(inserts), cause)
+    public SpelEvaluationException(Exception innerException, SpelMessage message, params object[] inserts)
+        : base(message.FormatMessage(inserts), innerException)
     {
         MessageCode = message;
         Inserts = inserts;

--- a/src/Common/src/Common.Expression/Spring/SpelParseException.cs
+++ b/src/Common/src/Common.Expression/Spring/SpelParseException.cs
@@ -7,15 +7,7 @@ namespace Steeltoe.Common.Expression.Internal.Spring;
 public class SpelParseException : ParseException
 {
     public SpelMessage MessageCode { get; }
-
     public object[] Inserts { get; }
-
-    public SpelParseException(string expressionString, int position, SpelMessage message, params object[] inserts)
-        : base(expressionString, position, message.FormatMessage(inserts))
-    {
-        MessageCode = message;
-        Inserts = inserts;
-    }
 
     public SpelParseException(int position, SpelMessage message, params object[] inserts)
         : base(position, message.FormatMessage(inserts))
@@ -24,8 +16,15 @@ public class SpelParseException : ParseException
         Inserts = inserts;
     }
 
-    public SpelParseException(int position, Exception cause, SpelMessage message, params object[] inserts)
-        : base(position, message.FormatMessage(inserts), cause)
+    public SpelParseException(string expressionString, int position, SpelMessage message, params object[] inserts)
+        : base(expressionString, position, message.FormatMessage(inserts))
+    {
+        MessageCode = message;
+        Inserts = inserts;
+    }
+
+    public SpelParseException(int position, Exception innerException, SpelMessage message, params object[] inserts)
+        : base(position, message.FormatMessage(inserts), innerException)
     {
         MessageCode = message;
         Inserts = inserts;

--- a/src/Common/src/Common/Converter/ConversionException.cs
+++ b/src/Common/src/Common/Converter/ConversionException.cs
@@ -11,8 +11,8 @@ public class ConversionException : Exception
     {
     }
 
-    public ConversionException(string message, Exception cause)
-        : base(message, cause)
+    public ConversionException(string message, Exception innerException)
+        : base(message, innerException)
     {
     }
 }

--- a/src/Common/src/Common/Converter/ConversionFailedException.cs
+++ b/src/Common/src/Common/Converter/ConversionFailedException.cs
@@ -7,13 +7,11 @@ namespace Steeltoe.Common.Converter;
 public class ConversionFailedException : ConversionException
 {
     public Type SourceType { get; }
-
     public Type TargetType { get; }
-
     public object Value { get; }
 
-    public ConversionFailedException(Type sourceType, Type targetType, object value, Exception cause)
-        : base($"Failed to convert from type [{sourceType}] to type [{targetType}] for value '{(value == null ? "null" : value.ToString())}'", cause)
+    public ConversionFailedException(Type sourceType, Type targetType, object value, Exception innerException)
+        : base($"Failed to convert from type [{sourceType}] to type [{targetType}] for value '{(value == null ? "null" : value.ToString())}'", innerException)
     {
         SourceType = sourceType;
         TargetType = targetType;

--- a/src/Common/src/Common/Converter/ConverterNotFoundException.cs
+++ b/src/Common/src/Common/Converter/ConverterNotFoundException.cs
@@ -7,7 +7,6 @@ namespace Steeltoe.Common.Converter;
 public class ConverterNotFoundException : ConversionException
 {
     public Type SourceType { get; }
-
     public Type TargetType { get; }
 
     public ConverterNotFoundException(Type sourceType, Type targetType)

--- a/src/Common/src/Common/Discovery/JsonSerializableServiceInstance.cs
+++ b/src/Common/src/Common/Discovery/JsonSerializableServiceInstance.cs
@@ -2,10 +2,11 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
+using System.Text.Json;
+
 namespace Steeltoe.Common.Discovery;
 
-[Serializable]
-public class SerializableIServiceInstance : IServiceInstance
+public class JsonSerializableServiceInstance : IServiceInstance
 {
     public string ServiceId { get; set; }
 
@@ -20,13 +21,13 @@ public class SerializableIServiceInstance : IServiceInstance
     public IDictionary<string, string> Metadata { get; set; }
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="SerializableIServiceInstance" /> class. For use with JsonSerializer.
+    /// Initializes a new instance of the <see cref="JsonSerializableServiceInstance" /> class. For use with <see cref="JsonSerializer" />.
     /// </summary>
-    public SerializableIServiceInstance()
+    public JsonSerializableServiceInstance()
     {
     }
 
-    public SerializableIServiceInstance(IServiceInstance instance)
+    public JsonSerializableServiceInstance(IServiceInstance instance)
     {
         ServiceId = instance.ServiceId;
         Host = instance.Host;

--- a/src/Common/src/Common/Retry/RetryException.cs
+++ b/src/Common/src/Common/Retry/RetryException.cs
@@ -6,13 +6,13 @@ namespace Steeltoe.Common.Retry;
 
 public class RetryException : Exception
 {
-    public RetryException(string msg)
-        : base(msg)
+    public RetryException(string message)
+        : base(message)
     {
     }
 
-    public RetryException(string msg, Exception cause)
-        : base(msg, cause)
+    public RetryException(string message, Exception innerException)
+        : base(message, innerException)
     {
     }
 }

--- a/src/Common/src/Common/Retry/TerminatedRetryException.cs
+++ b/src/Common/src/Common/Retry/TerminatedRetryException.cs
@@ -6,13 +6,13 @@ namespace Steeltoe.Common.Retry;
 
 public class TerminatedRetryException : RetryException
 {
-    public TerminatedRetryException(string msg, Exception cause)
-        : base(msg, cause)
+    public TerminatedRetryException(string message)
+        : base(message)
     {
     }
 
-    public TerminatedRetryException(string msg)
-        : base(msg)
+    public TerminatedRetryException(string message, Exception innerException)
+        : base(message, innerException)
     {
     }
 }

--- a/src/Common/src/Common/Transaction/CannotCreateTransactionException.cs
+++ b/src/Common/src/Common/Transaction/CannotCreateTransactionException.cs
@@ -6,13 +6,13 @@ namespace Steeltoe.Common.Transaction;
 
 public class CannotCreateTransactionException : TransactionException
 {
-    public CannotCreateTransactionException(string msg)
-        : base(msg)
+    public CannotCreateTransactionException(string message)
+        : base(message)
     {
     }
 
-    public CannotCreateTransactionException(string msg, Exception cause)
-        : base(msg, cause)
+    public CannotCreateTransactionException(string message, Exception innerException)
+        : base(message, innerException)
     {
     }
 }

--- a/src/Common/src/Common/Transaction/IllegalTransactionStateException.cs
+++ b/src/Common/src/Common/Transaction/IllegalTransactionStateException.cs
@@ -6,13 +6,13 @@ namespace Steeltoe.Common.Transaction;
 
 public class IllegalTransactionStateException : TransactionUsageException
 {
-    public IllegalTransactionStateException(string msg)
-        : base(msg)
+    public IllegalTransactionStateException(string message)
+        : base(message)
     {
     }
 
-    public IllegalTransactionStateException(string msg, Exception cause)
-        : base(msg, cause)
+    public IllegalTransactionStateException(string message, Exception innerException)
+        : base(message, innerException)
     {
     }
 }

--- a/src/Common/src/Common/Transaction/InvalidIsolationLevelException.cs
+++ b/src/Common/src/Common/Transaction/InvalidIsolationLevelException.cs
@@ -6,8 +6,8 @@ namespace Steeltoe.Common.Transaction;
 
 public class InvalidIsolationLevelException : TransactionUsageException
 {
-    public InvalidIsolationLevelException(string msg)
-        : base(msg)
+    public InvalidIsolationLevelException(string message)
+        : base(message)
     {
     }
 }

--- a/src/Common/src/Common/Transaction/InvalidTimeoutException.cs
+++ b/src/Common/src/Common/Transaction/InvalidTimeoutException.cs
@@ -8,8 +8,8 @@ public class InvalidTimeoutException : TransactionUsageException
 {
     public int Timeout { get; }
 
-    public InvalidTimeoutException(string msg, int timeout)
-        : base(msg)
+    public InvalidTimeoutException(string message, int timeout)
+        : base(message)
     {
         Timeout = timeout;
     }

--- a/src/Common/src/Common/Transaction/NestedTransactionNotSupportedException.cs
+++ b/src/Common/src/Common/Transaction/NestedTransactionNotSupportedException.cs
@@ -6,13 +6,13 @@ namespace Steeltoe.Common.Transaction;
 
 public class NestedTransactionNotSupportedException : CannotCreateTransactionException
 {
-    public NestedTransactionNotSupportedException(string msg)
-        : base(msg)
+    public NestedTransactionNotSupportedException(string message)
+        : base(message)
     {
     }
 
-    public NestedTransactionNotSupportedException(string msg, Exception cause)
-        : base(msg, cause)
+    public NestedTransactionNotSupportedException(string message, Exception innerException)
+        : base(message, innerException)
     {
     }
 }

--- a/src/Common/src/Common/Transaction/TransactionException.cs
+++ b/src/Common/src/Common/Transaction/TransactionException.cs
@@ -6,13 +6,13 @@ namespace Steeltoe.Common.Transaction;
 
 public abstract class TransactionException : Exception
 {
-    protected TransactionException(string msg)
-        : base(msg)
+    protected TransactionException(string message)
+        : base(message)
     {
     }
 
-    protected TransactionException(string msg, Exception cause)
-        : base(msg, cause)
+    protected TransactionException(string message, Exception innerException)
+        : base(message, innerException)
     {
     }
 }

--- a/src/Common/src/Common/Transaction/TransactionSuspensionNotSupportedException.cs
+++ b/src/Common/src/Common/Transaction/TransactionSuspensionNotSupportedException.cs
@@ -6,13 +6,13 @@ namespace Steeltoe.Common.Transaction;
 
 public class TransactionSuspensionNotSupportedException : CannotCreateTransactionException
 {
-    public TransactionSuspensionNotSupportedException(string msg)
-        : base(msg)
+    public TransactionSuspensionNotSupportedException(string message)
+        : base(message)
     {
     }
 
-    public TransactionSuspensionNotSupportedException(string msg, Exception cause)
-        : base(msg, cause)
+    public TransactionSuspensionNotSupportedException(string message, Exception innerException)
+        : base(message, innerException)
     {
     }
 }

--- a/src/Common/src/Common/Transaction/TransactionSystemException.cs
+++ b/src/Common/src/Common/Transaction/TransactionSystemException.cs
@@ -7,16 +7,15 @@ namespace Steeltoe.Common.Transaction;
 public class TransactionSystemException : TransactionException
 {
     public Exception ApplicationException { get; private set; }
-
     public Exception OriginalException => ApplicationException ?? InnerException;
 
-    public TransactionSystemException(string msg)
-        : base(msg)
+    public TransactionSystemException(string message)
+        : base(message)
     {
     }
 
-    public TransactionSystemException(string msg, Exception cause)
-        : base(msg, cause)
+    public TransactionSystemException(string message, Exception innerException)
+        : base(message, innerException)
     {
     }
 

--- a/src/Common/src/Common/Transaction/TransactionTimedOutException.cs
+++ b/src/Common/src/Common/Transaction/TransactionTimedOutException.cs
@@ -6,13 +6,13 @@ namespace Steeltoe.Common.Transaction;
 
 public class TransactionTimedOutException : TransactionException
 {
-    public TransactionTimedOutException(string msg)
-        : base(msg)
+    public TransactionTimedOutException(string message)
+        : base(message)
     {
     }
 
-    public TransactionTimedOutException(string msg, Exception cause)
-        : base(msg, cause)
+    public TransactionTimedOutException(string message, Exception innerException)
+        : base(message, innerException)
     {
     }
 }

--- a/src/Common/src/Common/Transaction/TransactionUsageException.cs
+++ b/src/Common/src/Common/Transaction/TransactionUsageException.cs
@@ -6,13 +6,13 @@ namespace Steeltoe.Common.Transaction;
 
 public class TransactionUsageException : TransactionException
 {
-    public TransactionUsageException(string msg)
-        : base(msg)
+    public TransactionUsageException(string message)
+        : base(message)
     {
     }
 
-    public TransactionUsageException(string msg, Exception cause)
-        : base(msg, cause)
+    public TransactionUsageException(string message, Exception innerException)
+        : base(message, innerException)
     {
     }
 }

--- a/src/Common/src/Common/Transaction/UnexpectedRollbackException.cs
+++ b/src/Common/src/Common/Transaction/UnexpectedRollbackException.cs
@@ -6,13 +6,13 @@ namespace Steeltoe.Common.Transaction;
 
 public class UnexpectedRollbackException : TransactionException
 {
-    public UnexpectedRollbackException(string msg)
-        : base(msg)
+    public UnexpectedRollbackException(string message)
+        : base(message)
     {
     }
 
-    public UnexpectedRollbackException(string msg, Exception cause)
-        : base(msg, cause)
+    public UnexpectedRollbackException(string message, Exception innerException)
+        : base(message, innerException)
     {
     }
 }

--- a/src/Common/src/Common/Util/EncodingUtils.cs
+++ b/src/Common/src/Common/Util/EncodingUtils.cs
@@ -8,6 +8,9 @@ namespace Steeltoe.Common.Util;
 
 public static class EncodingUtils
 {
+#pragma warning disable SYSLIB0001 // Type or member is obsolete
+    public static readonly Encoding Utf7 = new UTF7Encoding(true);
+#pragma warning restore SYSLIB0001 // Type or member is obsolete
     public static readonly Encoding Utf8 = new UTF8Encoding(false);
     public static readonly Encoding Utf16 = new UnicodeEncoding(false, false);
     public static readonly Encoding Utf16BigEndian = new UnicodeEncoding(true, false);
@@ -28,7 +31,7 @@ public static class EncodingUtils
 
         if (name.Equals("utf-7", StringComparison.OrdinalIgnoreCase))
         {
-            throw new NotSupportedException("The UTF-7 encoding is insecure and should not be used. Consider using UTF-8 instead.");
+            return Utf7;
         }
 
         if (name.Equals("utf-8", StringComparison.OrdinalIgnoreCase))
@@ -64,6 +67,11 @@ public static class EncodingUtils
         if (encoding == null || encoding.Equals(Utf8))
         {
             return "utf-8";
+        }
+
+        if (encoding.Equals(Utf7))
+        {
+            return "utf-7";
         }
 
         if (encoding.Equals(Utf16))

--- a/src/Common/src/Common/Util/EncodingUtils.cs
+++ b/src/Common/src/Common/Util/EncodingUtils.cs
@@ -8,12 +8,9 @@ namespace Steeltoe.Common.Util;
 
 public static class EncodingUtils
 {
+    public static readonly Encoding Utf8 = new UTF8Encoding(false);
     public static readonly Encoding Utf16 = new UnicodeEncoding(false, false);
     public static readonly Encoding Utf16BigEndian = new UnicodeEncoding(true, false);
-#pragma warning disable SYSLIB0001 // Type or member is obsolete
-    public static readonly Encoding Utf7 = new UTF7Encoding(true);
-#pragma warning restore SYSLIB0001 // Type or member is obsolete
-    public static readonly Encoding Utf8 = new UTF8Encoding(false);
     public static readonly Encoding Utf32 = new UTF32Encoding(false, false);
     public static readonly Encoding Utf32BigEndian = new UTF32Encoding(true, false);
 
@@ -29,47 +26,42 @@ public static class EncodingUtils
             return Utf8;
         }
 
-        if (name.Equals("utf-8", StringComparison.InvariantCultureIgnoreCase))
+        if (name.Equals("utf-7", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new NotSupportedException("The UTF-7 encoding is insecure and should not be used. Consider using UTF-8 instead.");
+        }
+
+        if (name.Equals("utf-8", StringComparison.OrdinalIgnoreCase))
         {
             return Utf8;
         }
 
-        if (name.Equals("utf-16", StringComparison.InvariantCultureIgnoreCase))
+        if (name.Equals("utf-16", StringComparison.OrdinalIgnoreCase))
         {
             return Utf16;
         }
 
-        if (name.Equals("utf-7", StringComparison.InvariantCultureIgnoreCase))
-        {
-            return Utf7;
-        }
-
-        if (name.Equals("utf-32", StringComparison.InvariantCultureIgnoreCase))
-        {
-            return Utf32;
-        }
-
-        if (name.Equals("utf-32be", StringComparison.InvariantCultureIgnoreCase))
-        {
-            return Utf32BigEndian;
-        }
-
-        if (name.Equals("utf-16be", StringComparison.InvariantCultureIgnoreCase))
+        if (name.Equals("utf-16be", StringComparison.OrdinalIgnoreCase))
         {
             return Utf16BigEndian;
         }
 
-        throw new ArgumentException("Invalid encoding name.", nameof(name));
+        if (name.Equals("utf-32", StringComparison.OrdinalIgnoreCase))
+        {
+            return Utf32;
+        }
+
+        if (name.Equals("utf-32be", StringComparison.OrdinalIgnoreCase))
+        {
+            return Utf32BigEndian;
+        }
+
+        throw new ArgumentException($"Invalid encoding name '{name}'.", nameof(name));
     }
 
     public static string GetEncoding(Encoding encoding)
     {
-        if (encoding == null)
-        {
-            return "utf-8";
-        }
-
-        if (encoding.Equals(Utf8))
+        if (encoding == null || encoding.Equals(Utf8))
         {
             return "utf-8";
         }
@@ -79,9 +71,9 @@ public static class EncodingUtils
             return "utf-16";
         }
 
-        if (encoding.Equals(Utf7))
+        if (encoding.Equals(Utf16BigEndian))
         {
-            return "utf-7";
+            return "utf-16be";
         }
 
         if (encoding.Equals(Utf32))
@@ -94,11 +86,6 @@ public static class EncodingUtils
             return "utf-32be";
         }
 
-        if (encoding.Equals(Utf16BigEndian))
-        {
-            return "utf-16be";
-        }
-
-        throw new ArgumentException("Invalid encoding.", nameof(encoding));
+        throw new ArgumentException($"Invalid encoding '{encoding.WebName}'.", nameof(encoding));
     }
 }

--- a/src/Common/src/Common/Util/MimeType.cs
+++ b/src/Common/src/Common/Util/MimeType.cs
@@ -494,7 +494,7 @@ public class MimeType : IComparable<MimeType>
     {
         if (name.Equals("utf-7", StringComparison.OrdinalIgnoreCase))
         {
-            throw new NotSupportedException("The UTF-7 encoding is insecure and should not be used. Consider using UTF-8 instead.");
+            return EncodingUtils.Utf7;
         }
 
         if (name.Equals("utf-8", StringComparison.OrdinalIgnoreCase))

--- a/src/Common/src/Common/Util/MimeType.cs
+++ b/src/Common/src/Common/Util/MimeType.cs
@@ -492,32 +492,32 @@ public class MimeType : IComparable<MimeType>
 
     private Encoding GetEncoding(string name)
     {
-        if (name.Equals("utf-16", StringComparison.InvariantCultureIgnoreCase))
+        if (name.Equals("utf-7", StringComparison.OrdinalIgnoreCase))
         {
-            return EncodingUtils.Utf16;
+            throw new NotSupportedException("The UTF-7 encoding is insecure and should not be used. Consider using UTF-8 instead.");
         }
 
-        if (name.Equals("utf-16be", StringComparison.InvariantCultureIgnoreCase))
-        {
-            return EncodingUtils.Utf16BigEndian;
-        }
-
-        if (name.Equals("utf-7", StringComparison.InvariantCultureIgnoreCase))
-        {
-            return EncodingUtils.Utf7;
-        }
-
-        if (name.Equals("utf-8", StringComparison.InvariantCultureIgnoreCase))
+        if (name.Equals("utf-8", StringComparison.OrdinalIgnoreCase))
         {
             return EncodingUtils.Utf8;
         }
 
-        if (name.Equals("utf-32", StringComparison.InvariantCultureIgnoreCase))
+        if (name.Equals("utf-16", StringComparison.OrdinalIgnoreCase))
+        {
+            return EncodingUtils.Utf16;
+        }
+
+        if (name.Equals("utf-16be", StringComparison.OrdinalIgnoreCase))
+        {
+            return EncodingUtils.Utf16BigEndian;
+        }
+
+        if (name.Equals("utf-32", StringComparison.OrdinalIgnoreCase))
         {
             return EncodingUtils.Utf32;
         }
 
-        if (name.Equals("utf-32BE", StringComparison.InvariantCultureIgnoreCase))
+        if (name.Equals("utf-32BE", StringComparison.OrdinalIgnoreCase))
         {
             return EncodingUtils.Utf32BigEndian;
         }

--- a/src/Configuration/src/Abstractions/Credential.cs
+++ b/src/Configuration/src/Abstractions/Credential.cs
@@ -3,11 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 using System.ComponentModel;
-using System.Runtime.Serialization;
 
 namespace Steeltoe.Extensions.Configuration;
 
-[Serializable]
 [TypeConverter(typeof(CredentialConverter))]
 public class Credential : Dictionary<string, Credential>
 {
@@ -20,10 +18,5 @@ public class Credential : Dictionary<string, Credential>
     public Credential(string value)
     {
         Value = value;
-    }
-
-    protected Credential(SerializationInfo info, StreamingContext context)
-        : base(info, context)
-    {
     }
 }

--- a/src/Configuration/src/ConfigServer/ConfigServerException.cs
+++ b/src/Configuration/src/ConfigServer/ConfigServerException.cs
@@ -2,18 +2,14 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-using System.Runtime.Serialization;
-
 namespace Steeltoe.Extensions.Configuration.ConfigServer;
 
 /// <summary>
 /// Exception thrown by Config Server client when problems occur.
 /// </summary>
-[Serializable]
 public class ConfigServerException : Exception
 {
-    public ConfigServerException(string message, Exception error)
-        : base(message, error)
+    public ConfigServerException()
     {
     }
 
@@ -22,12 +18,8 @@ public class ConfigServerException : Exception
     {
     }
 
-    public ConfigServerException()
-    {
-    }
-
-    protected ConfigServerException(SerializationInfo info, StreamingContext context)
-        : base(info, context)
+    public ConfigServerException(string message, Exception innerException)
+        : base(message, innerException)
     {
     }
 }

--- a/src/Connectors/src/Connector/ConnectorException.cs
+++ b/src/Connectors/src/Connector/ConnectorException.cs
@@ -2,11 +2,8 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-using System.Runtime.Serialization;
-
 namespace Steeltoe.Connector;
 
-[Serializable]
 public class ConnectorException : Exception
 {
     public ConnectorException()
@@ -18,13 +15,8 @@ public class ConnectorException : Exception
     {
     }
 
-    public ConnectorException(string message, Exception nested)
-        : base(message, nested)
-    {
-    }
-
-    protected ConnectorException(SerializationInfo info, StreamingContext context)
-        : base(info, context)
+    public ConnectorException(string message, Exception innerException)
+        : base(message, innerException)
     {
     }
 }

--- a/src/Discovery/src/Eureka/Transport/EurekaTransportException.cs
+++ b/src/Discovery/src/Eureka/Transport/EurekaTransportException.cs
@@ -2,29 +2,21 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-using System.Runtime.Serialization;
-
 namespace Steeltoe.Discovery.Eureka.Transport;
 
-[Serializable]
 public class EurekaTransportException : Exception
 {
+    public EurekaTransportException()
+    {
+    }
+
     public EurekaTransportException(string message)
         : base(message)
     {
     }
 
-    public EurekaTransportException(string message, Exception cause)
-        : base(message, cause)
-    {
-    }
-
-    public EurekaTransportException()
-    {
-    }
-
-    protected EurekaTransportException(SerializationInfo info, StreamingContext context)
-        : base(info, context)
+    public EurekaTransportException(string message, Exception innerException)
+        : base(message, innerException)
     {
     }
 }

--- a/src/Integration/src/Integration/Channel/AbstractTaskSchedulerChannel.cs
+++ b/src/Integration/src/Integration/Channel/AbstractTaskSchedulerChannel.cs
@@ -155,7 +155,7 @@ public abstract class AbstractTaskSchedulerChannel : AbstractSubscribableChannel
 
                 if (ex is MessagingException exception)
                 {
-                    throw new MessagingExceptionWrapperException(message, exception);
+                    throw new MessagingWrapperException(message, exception);
                 }
 
                 string description = $"Failed to handle {message} to {this} in {messageHandler}";

--- a/src/Integration/src/Integration/Channel/MessagePublishingErrorHandler.cs
+++ b/src/Integration/src/Integration/Channel/MessagePublishingErrorHandler.cs
@@ -79,7 +79,7 @@ public class MessagePublishingErrorHandler : ErrorMessagePublisher, IErrorHandle
     {
         Exception actualThrowable = exception;
 
-        if (exception is MessagingExceptionWrapperException)
+        if (exception is MessagingWrapperException)
         {
             actualThrowable = exception.InnerException;
         }
@@ -121,7 +121,7 @@ public class MessagePublishingErrorHandler : ErrorMessagePublisher, IErrorHandle
     {
         public ErrorMessage BuildErrorMessage(Exception exception, IAttributeAccessor attributeAccessor)
         {
-            return exception is MessagingExceptionWrapperException wrapperException
+            return exception is MessagingWrapperException wrapperException
                 ? new ErrorMessage(exception.InnerException, wrapperException.FailedMessage)
                 : new ErrorMessage(exception);
         }

--- a/src/Integration/src/Integration/Dispatcher/AggregateMessageDeliveryException.cs
+++ b/src/Integration/src/Integration/Dispatcher/AggregateMessageDeliveryException.cs
@@ -30,8 +30,8 @@ public class AggregateMessageDeliveryException : MessageDeliveryException
         }
     }
 
-    public AggregateMessageDeliveryException(IMessage undeliveredMessage, string description, List<Exception> aggregatedExceptions)
-        : base(undeliveredMessage, description, aggregatedExceptions[0])
+    public AggregateMessageDeliveryException(IMessage failedMessage, string message, List<Exception> aggregatedExceptions)
+        : base(failedMessage, message, aggregatedExceptions[0])
     {
         _aggregatedExceptions = new List<Exception>(aggregatedExceptions);
     }
@@ -43,7 +43,7 @@ public class AggregateMessageDeliveryException : MessageDeliveryException
             return string.Empty;
         }
 
-        if (!baseMessage.EndsWith("."))
+        if (!baseMessage.EndsWith(".", StringComparison.Ordinal))
         {
             return $"{baseMessage}.";
         }

--- a/src/Integration/src/Integration/Handler/ReplyRequiredException.cs
+++ b/src/Integration/src/Integration/Handler/ReplyRequiredException.cs
@@ -8,13 +8,13 @@ namespace Steeltoe.Integration.Handler;
 
 public class ReplyRequiredException : MessagingException
 {
-    public ReplyRequiredException(IMessage failedMessage, string description)
-        : base(failedMessage, description)
+    public ReplyRequiredException(IMessage failedMessage, string message)
+        : base(failedMessage, message)
     {
     }
 
-    public ReplyRequiredException(IMessage failedMessage, string description, Exception e)
-        : base(failedMessage, description, e)
+    public ReplyRequiredException(IMessage failedMessage, string message, Exception innerException)
+        : base(failedMessage, message, innerException)
     {
     }
 }

--- a/src/Integration/src/Integration/MessageDispatchingException.cs
+++ b/src/Integration/src/Integration/MessageDispatchingException.cs
@@ -8,23 +8,23 @@ namespace Steeltoe.Integration;
 
 public class MessageDispatchingException : MessageDeliveryException
 {
-    public MessageDispatchingException(string description)
-        : base(description)
+    public MessageDispatchingException(string message)
+        : base(message)
     {
     }
 
-    public MessageDispatchingException(IMessage undeliveredMessage, string description, Exception cause)
-        : base(undeliveredMessage, description, cause)
+    public MessageDispatchingException(IMessage failedMessage)
+        : base(failedMessage)
     {
     }
 
-    public MessageDispatchingException(IMessage undeliveredMessage, string description)
-        : base(undeliveredMessage, description)
+    public MessageDispatchingException(IMessage failedMessage, string message)
+        : base(failedMessage, message)
     {
     }
 
-    public MessageDispatchingException(IMessage undeliveredMessage)
-        : base(undeliveredMessage)
+    public MessageDispatchingException(IMessage failedMessage, string message, Exception innerException)
+        : base(failedMessage, message, innerException)
     {
     }
 }

--- a/src/Integration/src/Integration/MessageRejectedException.cs
+++ b/src/Integration/src/Integration/MessageRejectedException.cs
@@ -8,13 +8,13 @@ namespace Steeltoe.Integration;
 
 public class MessageRejectedException : MessageHandlingException
 {
-    public MessageRejectedException(IMessage failedMessage, string description)
-        : base(failedMessage, description)
+    public MessageRejectedException(IMessage failedMessage, string message)
+        : base(failedMessage, message)
     {
     }
 
-    public MessageRejectedException(IMessage failedMessage, string description, Exception cause)
-        : base(failedMessage, description, cause)
+    public MessageRejectedException(IMessage failedMessage, string message, Exception innerException)
+        : base(failedMessage, message, innerException)
     {
     }
 }

--- a/src/Integration/src/Integration/MessageTimeoutException.cs
+++ b/src/Integration/src/Integration/MessageTimeoutException.cs
@@ -8,23 +8,23 @@ namespace Steeltoe.Integration;
 
 public class MessageTimeoutException : MessageDeliveryException
 {
-    public MessageTimeoutException(string description)
-        : base(description)
-    {
-    }
-
-    public MessageTimeoutException(IMessage failedMessage, string description, Exception cause)
-        : base(failedMessage, description, cause)
-    {
-    }
-
-    public MessageTimeoutException(IMessage failedMessage, string description)
-        : base(failedMessage, description)
+    public MessageTimeoutException(string message)
+        : base(message)
     {
     }
 
     public MessageTimeoutException(IMessage failedMessage)
         : base(failedMessage)
+    {
+    }
+
+    public MessageTimeoutException(IMessage failedMessage, string message)
+        : base(failedMessage, message)
+    {
+    }
+
+    public MessageTimeoutException(IMessage failedMessage, string message, Exception innerException)
+        : base(failedMessage, message, innerException)
     {
     }
 }

--- a/src/Integration/src/Integration/RetryExceptionNotAvailableException.cs
+++ b/src/Integration/src/Integration/RetryExceptionNotAvailableException.cs
@@ -8,13 +8,13 @@ namespace Steeltoe.Integration;
 
 public class RetryExceptionNotAvailableException : MessagingException
 {
-    public RetryExceptionNotAvailableException(IMessage message, string description)
-        : base(message, description)
+    public RetryExceptionNotAvailableException(IMessage failedMessage, string message)
+        : base(failedMessage, message)
     {
     }
 
-    internal RetryExceptionNotAvailableException(string description)
-        : base(description)
+    internal RetryExceptionNotAvailableException(string message)
+        : base(message)
     {
     }
 }

--- a/src/Integration/src/Integration/Support/MessagingWrapperException.cs
+++ b/src/Integration/src/Integration/Support/MessagingWrapperException.cs
@@ -6,10 +6,10 @@ using Steeltoe.Messaging;
 
 namespace Steeltoe.Integration.Support;
 
-public class MessagingExceptionWrapperException : MessagingException
+public class MessagingWrapperException : MessagingException
 {
-    public MessagingExceptionWrapperException(IMessage originalMessage, MessagingException cause)
-        : base(originalMessage, cause)
+    public MessagingWrapperException(IMessage failedMessage, MessagingException innerException)
+        : base(failedMessage, innerException)
     {
     }
 }

--- a/src/Integration/src/Integration/Transformer/MessageTransformationException.cs
+++ b/src/Integration/src/Integration/Transformer/MessageTransformationException.cs
@@ -8,23 +8,23 @@ namespace Steeltoe.Integration.Transformer;
 
 public class MessageTransformationException : MessagingException
 {
-    public MessageTransformationException(IMessage message, string description, Exception cause)
-        : base(message, description, cause)
+    public MessageTransformationException(string message)
+        : base(message)
     {
     }
 
-    public MessageTransformationException(IMessage message, string description)
-        : base(message, description)
+    public MessageTransformationException(string message, Exception innerException)
+        : base(message, innerException)
     {
     }
 
-    public MessageTransformationException(string description, Exception cause)
-        : base(description, cause)
+    public MessageTransformationException(IMessage failedMessage, string message)
+        : base(failedMessage, message)
     {
     }
 
-    public MessageTransformationException(string description)
-        : base(description)
+    public MessageTransformationException(IMessage failedMessage, string message, Exception innerException)
+        : base(failedMessage, message, innerException)
     {
     }
 }

--- a/src/Integration/src/RabbitMQ/Support/ManualAckListenerExecutionFailedException.cs
+++ b/src/Integration/src/RabbitMQ/Support/ManualAckListenerExecutionFailedException.cs
@@ -11,11 +11,10 @@ namespace Steeltoe.Integration.Rabbit.Support;
 public class ManualAckListenerExecutionFailedException : ListenerExecutionFailedException
 {
     public IModel Channel { get; }
-
     public ulong DeliveryTag { get; }
 
-    public ManualAckListenerExecutionFailedException(string message, Exception cause, IMessage failedMessage, IModel channel, ulong deliveryTag)
-        : base(message, cause, failedMessage)
+    public ManualAckListenerExecutionFailedException(string message, Exception innerException, IMessage failedMessage, IModel channel, ulong deliveryTag)
+        : base(message, innerException, failedMessage)
     {
         Channel = channel;
         DeliveryTag = deliveryTag;

--- a/src/Integration/src/RabbitMQ/Support/NackedRabbitMessageException.cs
+++ b/src/Integration/src/RabbitMQ/Support/NackedRabbitMessageException.cs
@@ -9,11 +9,10 @@ namespace Steeltoe.Integration.Rabbit.Support;
 public class NackedRabbitMessageException : MessagingException
 {
     public object CorrelationData { get; }
-
     public string NackReason { get; }
 
-    public NackedRabbitMessageException(IMessage message, object correlationData, string nackReason)
-        : base(message)
+    public NackedRabbitMessageException(IMessage failedMessage, object correlationData, string nackReason)
+        : base(failedMessage)
     {
         CorrelationData = correlationData;
         NackReason = nackReason;

--- a/src/Integration/src/RabbitMQ/Support/ReturnedRabbitMessageException.cs
+++ b/src/Integration/src/RabbitMQ/Support/ReturnedRabbitMessageException.cs
@@ -9,15 +9,12 @@ namespace Steeltoe.Integration.Rabbit.Support;
 public class ReturnedRabbitMessageException : MessagingException
 {
     public int ReplyCode { get; }
-
     public string ReplyText { get; }
-
     public string Exchange { get; }
-
     public string RoutingKey { get; }
 
-    public ReturnedRabbitMessageException(IMessage message, int replyCode, string replyText, string exchange, string routingKey)
-        : base(message)
+    public ReturnedRabbitMessageException(IMessage failedMessage, int replyCode, string replyText, string exchange, string routingKey)
+        : base(failedMessage)
     {
         ReplyCode = replyCode;
         ReplyText = replyText;

--- a/src/Management/test/Tracing.Test/TestSamplerException.cs
+++ b/src/Management/test/Tracing.Test/TestSamplerException.cs
@@ -2,11 +2,8 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-using System.Runtime.Serialization;
-
 namespace Steeltoe.Management.Tracing.Test;
 
-[Serializable]
 public class TestSamplerException : Exception
 {
     public TestSamplerException()
@@ -20,11 +17,6 @@ public class TestSamplerException : Exception
 
     public TestSamplerException(string message, Exception innerException)
         : base(message, innerException)
-    {
-    }
-
-    protected TestSamplerException(SerializationInfo info, StreamingContext context)
-        : base(info, context)
     {
     }
 }

--- a/src/Messaging/src/Messaging/Converter/MessageConversionException.cs
+++ b/src/Messaging/src/Messaging/Converter/MessageConversionException.cs
@@ -6,23 +6,23 @@ namespace Steeltoe.Messaging.Converter;
 
 public class MessageConversionException : MessagingException
 {
-    public MessageConversionException(string description)
-        : base(description)
+    public MessageConversionException(string message)
+        : base(message)
     {
     }
 
-    public MessageConversionException(string description, Exception cause)
-        : base(description, cause)
+    public MessageConversionException(string message, Exception innerException)
+        : base(message, innerException)
     {
     }
 
-    public MessageConversionException(IMessage failedMessage, string description)
-        : base(failedMessage, description)
+    public MessageConversionException(IMessage failedMessage, string message)
+        : base(failedMessage, message)
     {
     }
 
-    public MessageConversionException(IMessage failedMessage, string description, Exception cause)
-        : base(failedMessage, description, cause)
+    public MessageConversionException(IMessage failedMessage, string message, Exception innerException)
+        : base(failedMessage, message, innerException)
     {
     }
 }

--- a/src/Messaging/src/Messaging/Core/DestinationResolutionException.cs
+++ b/src/Messaging/src/Messaging/Core/DestinationResolutionException.cs
@@ -6,13 +6,13 @@ namespace Steeltoe.Messaging.Core;
 
 public class DestinationResolutionException : MessagingException
 {
-    public DestinationResolutionException(string description)
-        : base(description)
+    public DestinationResolutionException(string message)
+        : base(message)
     {
     }
 
-    public DestinationResolutionException(string description, Exception cause)
-        : base(description, cause)
+    public DestinationResolutionException(string message, Exception innerException)
+        : base(message, innerException)
     {
     }
 }

--- a/src/Messaging/src/Messaging/Handler/Attributes/Support/MethodArgumentNotValidException.cs
+++ b/src/Messaging/src/Messaging/Handler/Attributes/Support/MethodArgumentNotValidException.cs
@@ -9,13 +9,13 @@ namespace Steeltoe.Messaging.Handler.Attributes.Support;
 
 public class MethodArgumentNotValidException : MethodArgumentResolutionException
 {
-    public MethodArgumentNotValidException(IMessage message, ParameterInfo parameter)
-        : base(message, parameter)
+    public MethodArgumentNotValidException(IMessage failedMessage, ParameterInfo parameter)
+        : base(failedMessage, parameter)
     {
     }
 
-    public MethodArgumentNotValidException(IMessage message, ParameterInfo parameter, string description)
-        : base(message, parameter, description)
+    public MethodArgumentNotValidException(IMessage failedMessage, ParameterInfo parameter, string message)
+        : base(failedMessage, parameter, message)
     {
     }
 }

--- a/src/Messaging/src/Messaging/Handler/Attributes/Support/MethodArgumentTypeMismatchException.cs
+++ b/src/Messaging/src/Messaging/Handler/Attributes/Support/MethodArgumentTypeMismatchException.cs
@@ -9,8 +9,8 @@ namespace Steeltoe.Messaging.Handler.Attributes.Support;
 
 public class MethodArgumentTypeMismatchException : MethodArgumentResolutionException
 {
-    public MethodArgumentTypeMismatchException(IMessage message, ParameterInfo parameter, string description)
-        : base(message, parameter, description)
+    public MethodArgumentTypeMismatchException(IMessage failedMessage, ParameterInfo parameter, string message)
+        : base(failedMessage, parameter, message)
     {
     }
 }

--- a/src/Messaging/src/Messaging/Handler/Invocation/MethodArgumentResolutionException.cs
+++ b/src/Messaging/src/Messaging/Handler/Invocation/MethodArgumentResolutionException.cs
@@ -10,14 +10,14 @@ public class MethodArgumentResolutionException : MessagingException
 {
     public ParameterInfo Parameter { get; }
 
-    public MethodArgumentResolutionException(IMessage message, ParameterInfo parameter)
-        : base(message, GetMethodParameterMessage(parameter))
+    public MethodArgumentResolutionException(IMessage failedMessage, ParameterInfo parameter)
+        : base(failedMessage, GetMethodParameterMessage(parameter))
     {
         Parameter = parameter;
     }
 
-    public MethodArgumentResolutionException(IMessage message, ParameterInfo parameter, string description)
-        : base(message, $"{GetMethodParameterMessage(parameter)}: {description}")
+    public MethodArgumentResolutionException(IMessage failedMessage, ParameterInfo parameter, string message)
+        : base(failedMessage, $"{GetMethodParameterMessage(parameter)}: {message}")
     {
         Parameter = parameter;
     }

--- a/src/Messaging/src/Messaging/MessageDeliveryException.cs
+++ b/src/Messaging/src/Messaging/MessageDeliveryException.cs
@@ -6,28 +6,28 @@ namespace Steeltoe.Messaging;
 
 public class MessageDeliveryException : MessagingException
 {
-    public MessageDeliveryException(string description)
-        : base(description)
+    public MessageDeliveryException(string message)
+        : base(message)
     {
     }
 
-    public MessageDeliveryException(IMessage undeliveredMessage)
-        : base(undeliveredMessage)
+    public MessageDeliveryException(IMessage failedMessage)
+        : base(failedMessage)
     {
     }
 
-    public MessageDeliveryException(IMessage undeliveredMessage, string description)
-        : base(undeliveredMessage, description)
+    public MessageDeliveryException(IMessage failedMessage, string message)
+        : base(failedMessage, message)
     {
     }
 
-    public MessageDeliveryException(IMessage message, Exception cause)
-        : base(message, cause)
+    public MessageDeliveryException(IMessage failedMessage, Exception innerException)
+        : base(failedMessage, innerException)
     {
     }
 
-    public MessageDeliveryException(IMessage undeliveredMessage, string description, Exception cause)
-        : base(undeliveredMessage, description, cause)
+    public MessageDeliveryException(IMessage failedMessage, string message, Exception innerException)
+        : base(failedMessage, message, innerException)
     {
     }
 }

--- a/src/Messaging/src/Messaging/MessageHandlingException.cs
+++ b/src/Messaging/src/Messaging/MessageHandlingException.cs
@@ -11,18 +11,18 @@ public class MessageHandlingException : MessagingException
     {
     }
 
-    public MessageHandlingException(IMessage message, string description)
-        : base(message, description)
+    public MessageHandlingException(IMessage failedMessage, string message)
+        : base(failedMessage, message)
     {
     }
 
-    public MessageHandlingException(IMessage failedMessage, Exception cause)
-        : base(failedMessage, cause)
+    public MessageHandlingException(IMessage failedMessage, Exception innerException)
+        : base(failedMessage, innerException)
     {
     }
 
-    public MessageHandlingException(IMessage message, string description, Exception cause)
-        : base(message, description, cause)
+    public MessageHandlingException(IMessage failedMessage, string message, Exception innerException)
+        : base(failedMessage, message, innerException)
     {
     }
 }

--- a/src/Messaging/src/Messaging/MessageHeaders.cs
+++ b/src/Messaging/src/Messaging/MessageHeaders.cs
@@ -24,7 +24,7 @@ public class MessageHeaders : IMessageHeaders
     public const string ContentTypeJsonAlt = "text/x-json";
     public const string ContentTypeXml = "application/xml";
     public const string ContentTypeJavaSerializedObject = "application/x-java-serialized-object";
-    public const string ContentTypeDotnetSerializedObject = "application/x-dotnet-serialized-object";
+    public const string ContentTypeDotNetSerializedObject = "application/x-dotnet-serialized-object";
 
     public const string TypeId = "__TypeId__";
     public const string ContentTypeId = "__ContentTypeId__";

--- a/src/Messaging/src/Messaging/MessagingException.cs
+++ b/src/Messaging/src/Messaging/MessagingException.cs
@@ -8,40 +8,39 @@ public class MessagingException : Exception
 {
     public IMessage FailedMessage { get; }
 
-    public MessagingException(IMessage message)
-        : base(null, null)
+    public MessagingException(IMessage failedMessage)
     {
-        FailedMessage = message;
+        FailedMessage = failedMessage;
     }
 
-    public MessagingException(string description)
-        : base(description)
+    public MessagingException(string message)
+        : base(message)
     {
         FailedMessage = null;
     }
 
-    public MessagingException(string description, Exception cause)
-        : base(description, cause)
+    public MessagingException(string message, Exception innerException)
+        : base(message, innerException)
     {
         FailedMessage = null;
     }
 
-    public MessagingException(IMessage message, string description)
-        : base(description)
+    public MessagingException(IMessage failedMessage, string message)
+        : base(message)
     {
-        FailedMessage = message;
+        FailedMessage = failedMessage;
     }
 
-    public MessagingException(IMessage message, Exception cause)
-        : base(null, cause)
+    public MessagingException(IMessage failedMessage, Exception innerException)
+        : base(null, innerException)
     {
-        FailedMessage = message;
+        FailedMessage = failedMessage;
     }
 
-    public MessagingException(IMessage message, string description, Exception cause)
-        : base(description, cause)
+    public MessagingException(IMessage failedMessage, string message, Exception innerException)
+        : base(message, innerException)
     {
-        FailedMessage = message;
+        FailedMessage = failedMessage;
     }
 
     public override string ToString()

--- a/src/Messaging/src/RabbitMQ/Exceptions/ImmediateAcknowledgeException.cs
+++ b/src/Messaging/src/RabbitMQ/Exceptions/ImmediateAcknowledgeException.cs
@@ -11,13 +11,13 @@ public class ImmediateAcknowledgeException : RabbitException
     {
     }
 
-    public ImmediateAcknowledgeException(Exception cause)
-        : base(cause)
+    public ImmediateAcknowledgeException(Exception innerException)
+        : base(innerException)
     {
     }
 
-    public ImmediateAcknowledgeException(string message, Exception cause)
-        : base(message, cause)
+    public ImmediateAcknowledgeException(string message, Exception innerException)
+        : base(message, innerException)
     {
     }
 }

--- a/src/Messaging/src/RabbitMQ/Exceptions/ImmediateRequeueException.cs
+++ b/src/Messaging/src/RabbitMQ/Exceptions/ImmediateRequeueException.cs
@@ -11,13 +11,13 @@ public class ImmediateRequeueException : RabbitException
     {
     }
 
-    public ImmediateRequeueException(Exception cause)
-        : base(cause)
+    public ImmediateRequeueException(Exception innerException)
+        : base(innerException)
     {
     }
 
-    public ImmediateRequeueException(string message, Exception cause)
-        : base(message, cause)
+    public ImmediateRequeueException(string message, Exception innerException)
+        : base(message, innerException)
     {
     }
 }

--- a/src/Messaging/src/RabbitMQ/Exceptions/RabbitAuthenticationException.cs
+++ b/src/Messaging/src/RabbitMQ/Exceptions/RabbitAuthenticationException.cs
@@ -6,8 +6,8 @@ namespace Steeltoe.Messaging.RabbitMQ.Exceptions;
 
 public class RabbitAuthenticationException : RabbitException
 {
-    public RabbitAuthenticationException(Exception cause)
-        : base(cause)
+    public RabbitAuthenticationException(Exception innerException)
+        : base(innerException)
     {
     }
 }

--- a/src/Messaging/src/RabbitMQ/Exceptions/RabbitClientException.cs
+++ b/src/Messaging/src/RabbitMQ/Exceptions/RabbitClientException.cs
@@ -8,13 +8,13 @@ namespace Steeltoe.Messaging.RabbitMQ.Exceptions;
 
 public class RabbitClientException : RabbitException
 {
-    public RabbitClientException(RabbitMQClientException cause)
-        : base(cause)
+    public RabbitClientException(RabbitMQClientException innerException)
+        : base(innerException)
     {
     }
 
-    public RabbitClientException(string message, RabbitMQClientException cause)
-        : base(message, cause)
+    public RabbitClientException(string message, RabbitMQClientException innerException)
+        : base(message, innerException)
     {
     }
 }

--- a/src/Messaging/src/RabbitMQ/Exceptions/RabbitConnectException.cs
+++ b/src/Messaging/src/RabbitMQ/Exceptions/RabbitConnectException.cs
@@ -6,13 +6,13 @@ namespace Steeltoe.Messaging.RabbitMQ.Exceptions;
 
 public class RabbitConnectException : RabbitException
 {
-    public RabbitConnectException(Exception cause)
-        : base(cause)
+    public RabbitConnectException(Exception innerException)
+        : base(innerException)
     {
     }
 
-    public RabbitConnectException(string message, Exception cause)
-        : base(message, cause)
+    public RabbitConnectException(string message, Exception innerException)
+        : base(message, innerException)
     {
     }
 }

--- a/src/Messaging/src/RabbitMQ/Exceptions/RabbitException.cs
+++ b/src/Messaging/src/RabbitMQ/Exceptions/RabbitException.cs
@@ -11,13 +11,13 @@ public class RabbitException : Exception
     {
     }
 
-    public RabbitException(Exception cause)
-        : base(null, cause)
+    public RabbitException(Exception innerException)
+        : base(null, innerException)
     {
     }
 
-    public RabbitException(string message, Exception cause)
-        : base(message, cause)
+    public RabbitException(string message, Exception innerException)
+        : base(message, innerException)
     {
     }
 }

--- a/src/Messaging/src/RabbitMQ/Exceptions/RabbitIOException.cs
+++ b/src/Messaging/src/RabbitMQ/Exceptions/RabbitIOException.cs
@@ -6,13 +6,13 @@ namespace Steeltoe.Messaging.RabbitMQ.Exceptions;
 
 public class RabbitIOException : RabbitException
 {
-    public RabbitIOException(Exception cause)
-        : base(cause)
+    public RabbitIOException(Exception innerException)
+        : base(innerException)
     {
     }
 
-    public RabbitIOException(string message, Exception cause)
-        : base(message, cause)
+    public RabbitIOException(string message, Exception innerException)
+        : base(message, innerException)
     {
     }
 }

--- a/src/Messaging/src/RabbitMQ/Exceptions/RabbitIllegalStateException.cs
+++ b/src/Messaging/src/RabbitMQ/Exceptions/RabbitIllegalStateException.cs
@@ -11,8 +11,8 @@ public class RabbitIllegalStateException : RabbitException
     {
     }
 
-    public RabbitIllegalStateException(string message, Exception cause)
-        : base(message, cause)
+    public RabbitIllegalStateException(string message, Exception innerException)
+        : base(message, innerException)
     {
     }
 }

--- a/src/Messaging/src/RabbitMQ/Exceptions/RabbitMessageReturnedException.cs
+++ b/src/Messaging/src/RabbitMQ/Exceptions/RabbitMessageReturnedException.cs
@@ -7,13 +7,9 @@ namespace Steeltoe.Messaging.RabbitMQ.Exceptions;
 public class RabbitMessageReturnedException : RabbitException
 {
     public IMessage ReturnedMessage { get; }
-
     public int ReplyCode { get; }
-
     public string ReplyText { get; }
-
     public string Exchange { get; }
-
     public string RoutingKey { get; }
 
     public RabbitMessageReturnedException(string message, IMessage returnedMessage, int replyCode, string replyText, string exchange, string routingKey)

--- a/src/Messaging/src/RabbitMQ/Exceptions/RabbitRejectAndDoNotRequeueException.cs
+++ b/src/Messaging/src/RabbitMQ/Exceptions/RabbitRejectAndDoNotRequeueException.cs
@@ -13,18 +13,18 @@ public class RabbitRejectAndDoNotRequeueException : RabbitException
     {
     }
 
-    public RabbitRejectAndDoNotRequeueException(Exception cause)
-        : this(null, false, cause)
+    public RabbitRejectAndDoNotRequeueException(Exception innerException)
+        : this(null, false, innerException)
     {
     }
 
-    public RabbitRejectAndDoNotRequeueException(string message, Exception cause)
-        : this(message, false, cause)
+    public RabbitRejectAndDoNotRequeueException(string message, Exception innerException)
+        : this(message, false, innerException)
     {
     }
 
-    public RabbitRejectAndDoNotRequeueException(string message, bool rejectManual, Exception cause)
-        : base(message, cause)
+    public RabbitRejectAndDoNotRequeueException(string message, bool rejectManual, Exception innerException)
+        : base(message, innerException)
     {
         IsRejectManual = rejectManual;
     }

--- a/src/Messaging/src/RabbitMQ/Exceptions/RabbitRemoteException.cs
+++ b/src/Messaging/src/RabbitMQ/Exceptions/RabbitRemoteException.cs
@@ -6,8 +6,8 @@ namespace Steeltoe.Messaging.RabbitMQ.Exceptions;
 
 public class RabbitRemoteException : RabbitException
 {
-    public RabbitRemoteException(Exception cause)
-        : base(cause)
+    public RabbitRemoteException(Exception innerException)
+        : base(innerException)
     {
     }
 }

--- a/src/Messaging/src/RabbitMQ/Exceptions/RabbitResourceNotAvailableException.cs
+++ b/src/Messaging/src/RabbitMQ/Exceptions/RabbitResourceNotAvailableException.cs
@@ -11,13 +11,13 @@ public class RabbitResourceNotAvailableException : RabbitException
     {
     }
 
-    public RabbitResourceNotAvailableException(Exception cause)
-        : base(cause)
+    public RabbitResourceNotAvailableException(Exception innerException)
+        : base(innerException)
     {
     }
 
-    public RabbitResourceNotAvailableException(string message, Exception cause)
-        : base(message, cause)
+    public RabbitResourceNotAvailableException(string message, Exception innerException)
+        : base(message, innerException)
     {
     }
 }

--- a/src/Messaging/src/RabbitMQ/Exceptions/RabbitTimeoutException.cs
+++ b/src/Messaging/src/RabbitMQ/Exceptions/RabbitTimeoutException.cs
@@ -6,18 +6,18 @@ namespace Steeltoe.Messaging.RabbitMQ.Exceptions;
 
 public class RabbitTimeoutException : RabbitException
 {
-    public RabbitTimeoutException(string message, Exception cause)
-        : base(message, cause)
-    {
-    }
-
     public RabbitTimeoutException(string message)
         : base(message)
     {
     }
 
-    public RabbitTimeoutException(Exception cause)
-        : base(cause)
+    public RabbitTimeoutException(Exception innerException)
+        : base(innerException)
+    {
+    }
+
+    public RabbitTimeoutException(string message, Exception innerException)
+        : base(message, innerException)
     {
     }
 }

--- a/src/Messaging/src/RabbitMQ/Exceptions/RabbitUncategorizedException.cs
+++ b/src/Messaging/src/RabbitMQ/Exceptions/RabbitUncategorizedException.cs
@@ -6,13 +6,13 @@ namespace Steeltoe.Messaging.RabbitMQ.Exceptions;
 
 public class RabbitUncategorizedException : RabbitException
 {
-    public RabbitUncategorizedException(Exception cause)
-        : base(cause)
+    public RabbitUncategorizedException(Exception innerException)
+        : base(innerException)
     {
     }
 
-    public RabbitUncategorizedException(string message, Exception cause)
-        : base(message, cause)
+    public RabbitUncategorizedException(string message, Exception innerException)
+        : base(message, innerException)
     {
     }
 }

--- a/src/Messaging/src/RabbitMQ/Exceptions/RabbitUnsupportedEncodingException.cs
+++ b/src/Messaging/src/RabbitMQ/Exceptions/RabbitUnsupportedEncodingException.cs
@@ -6,8 +6,8 @@ namespace Steeltoe.Messaging.RabbitMQ.Exceptions;
 
 public class RabbitUnsupportedEncodingException : RabbitException
 {
-    public RabbitUnsupportedEncodingException(Exception cause)
-        : base(cause)
+    public RabbitUnsupportedEncodingException(Exception innerException)
+        : base(innerException)
     {
     }
 }

--- a/src/Messaging/src/RabbitMQ/Listener/Adapters/ReplyFailureException.cs
+++ b/src/Messaging/src/RabbitMQ/Listener/Adapters/ReplyFailureException.cs
@@ -6,8 +6,8 @@ namespace Steeltoe.Messaging.RabbitMQ.Listener.Adapters;
 
 public class ReplyFailureException : Exception
 {
-    public ReplyFailureException(string message, Exception cause)
-        : base(message, cause)
+    public ReplyFailureException(string message, Exception innerException)
+        : base(message, innerException)
     {
     }
 }

--- a/src/Messaging/src/RabbitMQ/Listener/BlockingQueueConsumer.cs
+++ b/src/Messaging/src/RabbitMQ/Listener/BlockingQueueConsumer.cs
@@ -745,17 +745,18 @@ public class BlockingQueueConsumer
 
     private sealed class DeclarationException : RabbitException
     {
-        public List<string> FailedQueues { get; } = new();
+        private const string MessageText = "Failed to declare queue(s):";
 
+        public List<string> FailedQueues { get; } = new();
         public override string Message => base.Message + string.Join(',', FailedQueues);
 
         public DeclarationException()
-            : base("Failed to declare queue(s):")
+            : base(MessageText)
         {
         }
 
-        public DeclarationException(Exception e)
-            : base("Failed to declare queue(s):", e)
+        public DeclarationException(Exception innerException)
+            : base(MessageText, innerException)
         {
         }
 

--- a/src/Messaging/src/RabbitMQ/Listener/DefaultExceptionStrategy.cs
+++ b/src/Messaging/src/RabbitMQ/Listener/DefaultExceptionStrategy.cs
@@ -40,7 +40,7 @@ public class DefaultExceptionStrategy : IFatalExceptionStrategy
         }
     }
 
-    protected virtual bool IsUserCauseFatal(Exception cause)
+    protected virtual bool IsUserCauseFatal(Exception exception)
     {
         return false;
     }

--- a/src/Messaging/src/RabbitMQ/Listener/Exceptions/FatalListenerExecutionException.cs
+++ b/src/Messaging/src/RabbitMQ/Listener/Exceptions/FatalListenerExecutionException.cs
@@ -6,13 +6,13 @@ namespace Steeltoe.Messaging.RabbitMQ.Listener.Exceptions;
 
 public class FatalListenerExecutionException : Exception
 {
-    public FatalListenerExecutionException(string msg, Exception cause)
-        : base(msg, cause)
+    public FatalListenerExecutionException(string message)
+        : base(message)
     {
     }
 
-    public FatalListenerExecutionException(string msg)
-        : base(msg)
+    public FatalListenerExecutionException(string message, Exception innerException)
+        : base(message, innerException)
     {
     }
 }

--- a/src/Messaging/src/RabbitMQ/Listener/Exceptions/FatalListenerStartupException.cs
+++ b/src/Messaging/src/RabbitMQ/Listener/Exceptions/FatalListenerStartupException.cs
@@ -6,8 +6,8 @@ namespace Steeltoe.Messaging.RabbitMQ.Listener.Exceptions;
 
 public class FatalListenerStartupException : Exception
 {
-    public FatalListenerStartupException(string msg, Exception cause)
-        : base(msg, cause)
+    public FatalListenerStartupException(string message, Exception innerException)
+        : base(message, innerException)
     {
     }
 }

--- a/src/Messaging/src/RabbitMQ/Listener/Exceptions/ListenerExecutionFailedException.cs
+++ b/src/Messaging/src/RabbitMQ/Listener/Exceptions/ListenerExecutionFailedException.cs
@@ -21,8 +21,8 @@ public class ListenerExecutionFailedException : Exception
 
     public List<IMessage> FailedMessages { get; } = new();
 
-    public ListenerExecutionFailedException(string message, Exception cause, params IMessage[] failedMessages)
-        : base(message, cause)
+    public ListenerExecutionFailedException(string message, Exception innerException, params IMessage[] failedMessages)
+        : base(message, innerException)
     {
         FailedMessages.AddRange(failedMessages);
     }

--- a/src/Messaging/src/RabbitMQ/Listener/Exceptions/QueuesNotAvailableException.cs
+++ b/src/Messaging/src/RabbitMQ/Listener/Exceptions/QueuesNotAvailableException.cs
@@ -6,8 +6,8 @@ namespace Steeltoe.Messaging.RabbitMQ.Listener.Exceptions;
 
 public class QueuesNotAvailableException : FatalListenerStartupException
 {
-    public QueuesNotAvailableException(string message, Exception cause)
-        : base(message, cause)
+    public QueuesNotAvailableException(string message, Exception innerException)
+        : base(message, innerException)
     {
     }
 }

--- a/src/Messaging/src/RabbitMQ/Support/ConsumerCancelledException.cs
+++ b/src/Messaging/src/RabbitMQ/Support/ConsumerCancelledException.cs
@@ -10,8 +10,8 @@ public class ConsumerCancelledException : Exception
     {
     }
 
-    public ConsumerCancelledException(Exception cause)
-        : base(null, cause)
+    public ConsumerCancelledException(Exception innerException)
+        : base(null, innerException)
     {
     }
 }

--- a/src/Messaging/src/RabbitMQ/Support/Converter/SimpleMessageConverter.cs
+++ b/src/Messaging/src/RabbitMQ/Support/Converter/SimpleMessageConverter.cs
@@ -52,7 +52,7 @@ public class SimpleMessageConverter : AbstractMessageConverter
                     throw new MessageConversionException("failed to convert text-based Message content", e);
                 }
             }
-            else if (contentType != null && contentType.Equals(MessageHeaders.ContentTypeDotnetSerializedObject))
+            else if (contentType != null && contentType.Equals(MessageHeaders.ContentTypeDotNetSerializedObject))
             {
                 try
                 {
@@ -115,7 +115,7 @@ public class SimpleMessageConverter : AbstractMessageConverter
                 if (payload != null && payload.GetType().IsSerializable)
                 {
                     bytes = SerializeObject(payload);
-                    accessor.ContentType = MessageHeaders.ContentTypeDotnetSerializedObject;
+                    accessor.ContentType = MessageHeaders.ContentTypeDotNetSerializedObject;
                 }
 
                 break;

--- a/src/Messaging/src/RabbitMQ/Support/Converter/SimpleMessageConverter.cs
+++ b/src/Messaging/src/RabbitMQ/Support/Converter/SimpleMessageConverter.cs
@@ -57,9 +57,10 @@ public class SimpleMessageConverter : AbstractMessageConverter
                 try
                 {
                     var formatter = new BinaryFormatter();
-                    var stream = new MemoryStream(bytesMessage.Payload);
+                    using var stream = new MemoryStream(bytesMessage.Payload);
 
                     // TODO: [BREAKING] Don't use binary serialization, it's insecure! https://aka.ms/binaryformatter
+                    // Tracked at: https://github.com/SteeltoeOSS/Steeltoe/issues/487.
 #pragma warning disable SYSLIB0011 // Type or member is obsolete
                     content = formatter.Deserialize(stream);
 #pragma warning restore SYSLIB0011 // Type or member is obsolete
@@ -138,9 +139,10 @@ public class SimpleMessageConverter : AbstractMessageConverter
         try
         {
             var formatter = new BinaryFormatter();
-            var stream = new MemoryStream(512);
+            using var stream = new MemoryStream(512);
 
             // TODO: [BREAKING] Don't use binary serialization, it's insecure! https://aka.ms/binaryformatter
+            // Tracked at: https://github.com/SteeltoeOSS/Steeltoe/issues/487.
 #pragma warning disable SYSLIB0011 // Type or member is obsolete
             formatter.Serialize(stream, payload);
 #pragma warning restore SYSLIB0011 // Type or member is obsolete

--- a/src/Messaging/src/RabbitMQ/Support/ShutdownSignalException.cs
+++ b/src/Messaging/src/RabbitMQ/Support/ShutdownSignalException.cs
@@ -8,18 +8,6 @@ namespace Steeltoe.Messaging.RabbitMQ.Support;
 
 public class ShutdownSignalException : Exception
 {
-    public ushort ClassId => Args.ClassId;
-
-    public ushort MethodId => Args.MethodId;
-
-    public ushort ReplyCode => Args.ReplyCode;
-
-    public string ReplyText => Args.ReplyText;
-
-    public RC.ShutdownInitiator Initiator => Args.Initiator;
-
-    public object Cause => Args.Cause;
-
     public RC.ShutdownEventArgs Args { get; }
 
     public ShutdownSignalException(RC.ShutdownEventArgs args)

--- a/src/Messaging/test/RabbitMQ.Test/Core/RabbitTemplateIntegrationTest.cs
+++ b/src/Messaging/test/RabbitMQ.Test/Core/RabbitTemplateIntegrationTest.cs
@@ -946,7 +946,7 @@ public abstract class RabbitTemplateIntegrationTest : IDisposable
 
                 var messageHeaders = new RabbitHeaderAccessor(new MessageHeaders())
                 {
-                    ContentType = MessageHeaders.ContentTypeDotnetSerializedObject
+                    ContentType = MessageHeaders.ContentTypeDotNetSerializedObject
                 };
 
                 var formatter = new BinaryFormatter();

--- a/src/Security/src/DataProtection.CredHub/CredHubException.cs
+++ b/src/Security/src/DataProtection.CredHub/CredHubException.cs
@@ -2,11 +2,8 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-using System.Runtime.Serialization;
-
 namespace Steeltoe.Security.DataProtection.CredHub;
 
-[Serializable]
 public class CredHubException : Exception
 {
     public CredHubException()
@@ -20,11 +17,6 @@ public class CredHubException : Exception
 
     public CredHubException(string message, Exception innerException)
         : base(message, innerException)
-    {
-    }
-
-    protected CredHubException(SerializationInfo info, StreamingContext context)
-        : base(info, context)
     {
     }
 }

--- a/src/Stream/src/Stream/Binder/BinderException.cs
+++ b/src/Stream/src/Stream/Binder/BinderException.cs
@@ -11,8 +11,8 @@ public class BinderException : Exception
     {
     }
 
-    public BinderException(string message, Exception cause)
-        : base(message, cause)
+    public BinderException(string message, Exception innerException)
+        : base(message, innerException)
     {
     }
 }

--- a/src/Stream/src/Stream/Binder/RequeueCurrentMessageException.cs
+++ b/src/Stream/src/Stream/Binder/RequeueCurrentMessageException.cs
@@ -10,18 +10,18 @@ public class RequeueCurrentMessageException : Exception
     {
     }
 
-    public RequeueCurrentMessageException(string message, Exception cause)
-        : base(message, cause)
-    {
-    }
-
     public RequeueCurrentMessageException(string message)
         : base(message)
     {
     }
 
-    public RequeueCurrentMessageException(Exception cause)
-        : base(string.Empty, cause)
+    public RequeueCurrentMessageException(Exception innerException)
+        : base(null, innerException)
+    {
+    }
+
+    public RequeueCurrentMessageException(string message, Exception innerException)
+        : base(message, innerException)
     {
     }
 }

--- a/src/Stream/src/Stream/Converter/ConversionException.cs
+++ b/src/Stream/src/Stream/Converter/ConversionException.cs
@@ -11,8 +11,8 @@ public class ConversionException : Exception
     {
     }
 
-    public ConversionException(string message, Exception t)
-        : base(message, t)
+    public ConversionException(string message, Exception innerException)
+        : base(message, innerException)
     {
     }
 }

--- a/src/Stream/src/Stream/Provisioning/ProvisioningException.cs
+++ b/src/Stream/src/Stream/Provisioning/ProvisioningException.cs
@@ -6,13 +6,13 @@ namespace Steeltoe.Stream.Provisioning;
 
 public class ProvisioningException : Exception
 {
-    public ProvisioningException(string msg)
-        : base(msg)
+    public ProvisioningException(string message)
+        : base(message)
     {
     }
 
-    public ProvisioningException(string msg, Exception cause)
-        : base(msg, cause)
+    public ProvisioningException(string message, Exception innerException)
+        : base(message, innerException)
     {
     }
 }

--- a/src/Stream/test/Binder.Test/AbstractBinderTests.cs
+++ b/src/Stream/test/Binder.Test/AbstractBinderTests.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Reflection;
-using System.Runtime.Serialization;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -581,18 +580,13 @@ public abstract class AbstractBinderTests<TTestBinder, TBinder>
     {
         public List<Readings> ReadingsList { get; set; }
 
-        public class Readings : ISerializable
+        public class Readings
         {
             public string StationId { get; set; }
 
             public string CustomerId { get; set; }
 
             public string TimeStamp { get; set; }
-
-            public void GetObjectData(SerializationInfo info, StreamingContext context)
-            {
-                throw new NotImplementedException();
-            }
         }
     }
 


### PR DESCRIPTION
## Description

This PR removes `[Serializable]` from exceptions (most exceptions didn't have it), followed by more cleanup of exception classes.

~Also removes utf-7 encoding, which is obsolete because it is insecure.~ Moved this change to #1004.

## Quality checklist

- [x] Your code complies with our [Coding Style](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-code-style.md).
- [x] You've updated unit and/or integration tests for your change, where applicable.
- [ ] You've updated documentation for your change, where applicable.
      If your change affects other repositories, such as [Documentation](https://github.com/SteeltoeOSS/Documentation), [Samples](https://github.com/SteeltoeOSS/Samples) and/or [MainSite](https://github.com/SteeltoeOSS/MainSite), add linked PRs here.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
- [ ] You've added required license files and/or file headers (explaining where the code came from with proper attribution), where code is copied from StackOverflow, a blog, or OSS.
