### PR TITLE
Fix conditional cibuild: always build on global config change

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,7 +6,6 @@ trigger:
     exclude:
     - README.md
     - build/*
-    - project-docs/*
     - roadmaps/*
 
 jobs:

--- a/build/circuitbreaker.yml
+++ b/build/circuitbreaker.yml
@@ -1,12 +1,13 @@
 pr:
   paths:
     exclude:
-    - /
+    - build
+    - src
     include:
-    - /.editorconfig
-    - /stylecop.json
-    - /*.props
-    - /*.ruleset
+    - .editorconfig
+    - stylecop.json
+    - '*.props'
+    - '*.ruleset'
     - build/templates
     - build/circuitbreaker.yml
     - src/CircuitBreaker

--- a/build/common.yml
+++ b/build/common.yml
@@ -1,12 +1,13 @@
 pr:
   paths:
     exclude:
-    - /
+    - build
+    - src
     include:
-    - /.editorconfig
-    - /stylecop.json
-    - /*.props
-    - /*.ruleset
+    - .editorconfig
+    - stylecop.json
+    - '*.props'
+    - '*.ruleset'
     - build/templates
     - build/common.yml
     - src/Common

--- a/build/configuration.yml
+++ b/build/configuration.yml
@@ -1,12 +1,13 @@
 pr:
   paths:
     exclude:
-    - /
+    - build
+    - src
     include:
-    - /.editorconfig
-    - /stylecop.json
-    - /*.props
-    - /*.ruleset
+    - .editorconfig
+    - stylecop.json
+    - '*.props'
+    - '*.ruleset'
     - build/templates
     - build/configuration.yml
     - src/Configuration

--- a/build/connectors.yml
+++ b/build/connectors.yml
@@ -1,12 +1,13 @@
 pr:
   paths:
     exclude:
-    - /
+    - build
+    - src
     include:
-    - /.editorconfig
-    - /stylecop.json
-    - /*.props
-    - /*.ruleset
+    - .editorconfig
+    - stylecop.json
+    - '*.props'
+    - '*.ruleset'
     - build/templates
     - build/connectors.yml
     - src/Connectors

--- a/build/discovery.yml
+++ b/build/discovery.yml
@@ -1,12 +1,13 @@
 pr:
   paths:
     exclude:
-    - /
+    - build
+    - src
     include:
-    - /.editorconfig
-    - /stylecop.json
-    - /*.props
-    - /*.ruleset
+    - .editorconfig
+    - stylecop.json
+    - '*.props'
+    - '*.ruleset'
     - build/templates
     - build/discovery.yml
     - src/Discovery

--- a/build/integration.yml
+++ b/build/integration.yml
@@ -1,12 +1,13 @@
 pr:
   paths:
     exclude:
-    - /
+    - build
+    - src
     include:
-    - /.editorconfig
-    - /stylecop.json
-    - /*.props
-    - /*.ruleset
+    - .editorconfig
+    - stylecop.json
+    - '*.props'
+    - '*.ruleset'
     - build/templates
     - build/integration.yml
     - src/Integration

--- a/build/logging.yml
+++ b/build/logging.yml
@@ -1,12 +1,13 @@
 pr:
   paths:
     exclude:
-    - /
+    - build
+    - src
     include:
-    - /.editorconfig
-    - /stylecop.json
-    - /*.props
-    - /*.ruleset
+    - .editorconfig
+    - stylecop.json
+    - '*.props'
+    - '*.ruleset'
     - build/templates
     - build/logging.yml
     - src/Logging

--- a/build/management.yml
+++ b/build/management.yml
@@ -1,12 +1,13 @@
 pr:
   paths:
     exclude:
-    - /
+    - build
+    - src
     include:
-    - /.editorconfig
-    - /stylecop.json
-    - /*.props
-    - /*.ruleset
+    - .editorconfig
+    - stylecop.json
+    - '*.props'
+    - '*.ruleset'
     - build/templates
     - build/management.yml
     - src/Management

--- a/build/messaging.yml
+++ b/build/messaging.yml
@@ -1,12 +1,13 @@
 pr:
   paths:
     exclude:
-    - /
+    - build
+    - src
     include:
-    - /.editorconfig
-    - /stylecop.json
-    - /*.props
-    - /*.ruleset
+    - .editorconfig
+    - stylecop.json
+    - '*.props'
+    - '*.ruleset'
     - build/templates
     - build/messaging.yml
     - src/Messaging

--- a/build/security.yml
+++ b/build/security.yml
@@ -1,12 +1,13 @@
 pr:
   paths:
     exclude:
-    - /
+    - build
+    - src
     include:
-    - /.editorconfig
-    - /stylecop.json
-    - /*.props
-    - /*.ruleset
+    - .editorconfig
+    - stylecop.json
+    - '*.props'
+    - '*.ruleset'
     - build/templates
     - build/security.yml
     - src/Security

--- a/build/stream.yml
+++ b/build/stream.yml
@@ -1,12 +1,13 @@
 pr:
   paths:
     exclude:
-    - /
+    - build
+    - src
     include:
-    - /.editorconfig
-    - /stylecop.json
-    - /*.props
-    - /*.ruleset
+    - .editorconfig
+    - stylecop.json
+    - '*.props'
+    - '*.ruleset'
     - build/templates
     - build/stream.yml
     - src/Stream

--- a/build/verify-code-style.yml
+++ b/build/verify-code-style.yml
@@ -1,7 +1,7 @@
 trigger:
   branches:
     include:
-    - master
+    - main
     - release/*
 
 jobs:


### PR DESCRIPTION
## Description

It turns out that a PR containing a change to a global file such as `/Steeltoe.Debug.ruleset` does not trigger builds for all the components. This PR fixes that.

From https://docs.microsoft.com/en-us/azure/devops/pipelines/repos/azure-repos-git?view=azure-devops&tabs=yaml&WT.mc_id=AZ-MVP-5003781#paths:

> When you specify paths, you must explicitly specify branches to trigger on. You can't trigger a pipeline with only a path filter; you must also have a branch filter, and the changed files that match the path filter must be from a branch that matches the branch filter.
> 
> Wilds cards are supported for path filters. For instance, you can include all paths that match src/app/**/myapp*. You can use wild card characters (**, *, or ?) when specifying path filters.
> 
> - Paths are always specified relative to the root of the repository.
> - If you don't set path filters, then the root folder of the repo is implicitly included by default.
> - If you exclude a path, you cannot also include it unless you qualify it to a deeper folder. For example if you exclude /tools then you could include /tools/trigger-runs-on-these
> - The order of path filters doesn't matter.
> - Paths in Git are case-sensitive. Be sure to use the same case as the real folders.
> - You cannot use [variables](https://docs.microsoft.com/en-us/azure/devops/pipelines/process/variables?view=azure-devops) in paths, as variables are evaluated at runtime (after the trigger has fired).

The first paragraph is not true. We don't have a branch filter, yet path filters for components are working fine.

The culprit is in the third bullet. To be able to include individual files in `/`, you cannot have an exclude filter on `/` itself. So I changed the exclude filter from `/` into `/src` and `/build`.

I've tested the correctness of these changes in #1002 (see commit history).

## Quality checklist

- [ ] Your code complies with our [Coding Style](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-code-style.md).
- [ ] You've updated unit and/or integration tests for your change, where applicable.
- [ ] You've updated documentation for your change, where applicable.
      If your change affects other repositories, such as [Documentation](https://github.com/SteeltoeOSS/Documentation), [Samples](https://github.com/SteeltoeOSS/Samples) and/or [MainSite](https://github.com/SteeltoeOSS/MainSite), add linked PRs here.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
- [ ] You've added required license files and/or file headers (explaining where the code came from with proper attribution), where code is copied from StackOverflow, a blog, or OSS.
