### PR TITLE
Remove explicit line endings setting from .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,7 +8,6 @@ indent_style = space
 # (Please don't specify an indent_size here; that has too many unintended consequences.)
 charset = utf-8
 trim_trailing_whitespace = true
-end_of_line = lf
 insert_final_newline = true
 
 [*.{build,config,csproj,js,json,proj,props,targets,xml,ruleset,xsd}]


### PR DESCRIPTION
## Description

I recently added `end_of_line = lf` to `.editorconfig` for completeness, but we found that this sometimes results in the following pop-up in Visual Studio on Windows:

![image](https://user-images.githubusercontent.com/104792814/185696416-8acf091c-e6e7-4ffb-a359-70efdb0d017d.png)

The reason is that the default git-windows installation converts `\n` to `\r\n` on fetch. Which is okay, because it converts back when pushing to the server.

While the problem goes away by unchecking "Always show this dialog", I'm removing this to avoid the barrier for new contributors. Modern editors can handle different line endings fine, so this is mostly a concern from the past.

Though I've seen failing test assertions on multi-line strings on different OSes, but that's easy to work around.

## Quality checklist

- [ ] Your code complies with our [Coding Style](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-code-style.md).
- [ ] You've updated unit and/or integration tests for your change, where applicable.
- [ ] You've updated documentation for your change, where applicable.
      If your change affects other repositories, such as [Documentation](https://github.com/SteeltoeOSS/Documentation), [Samples](https://github.com/SteeltoeOSS/Samples) and/or [MainSite](https://github.com/SteeltoeOSS/MainSite), add linked PRs here.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
- [ ] You've added required license files and/or file headers (explaining where the code came from with proper attribution), where code is copied from StackOverflow, a blog, or OSS.
