### PR TITLE
Remove support for insecure UTF-7 encoding

### DIFF
--- a/src/Common/src/Common/Util/EncodingUtils.cs
+++ b/src/Common/src/Common/Util/EncodingUtils.cs
@@ -8,9 +8,6 @@ namespace Steeltoe.Common.Util;
 
 public static class EncodingUtils
 {
-#pragma warning disable SYSLIB0001 // Type or member is obsolete
-    public static readonly Encoding Utf7 = new UTF7Encoding(true);
-#pragma warning restore SYSLIB0001 // Type or member is obsolete
     public static readonly Encoding Utf8 = new UTF8Encoding(false);
     public static readonly Encoding Utf16 = new UnicodeEncoding(false, false);
     public static readonly Encoding Utf16BigEndian = new UnicodeEncoding(true, false);
@@ -31,7 +28,7 @@ public static class EncodingUtils
 
         if (name.Equals("utf-7", StringComparison.OrdinalIgnoreCase))
         {
-            return Utf7;
+            throw new NotSupportedException("The UTF-7 encoding is insecure and should not be used. Consider using UTF-8 instead.");
         }
 
         if (name.Equals("utf-8", StringComparison.OrdinalIgnoreCase))
@@ -69,11 +66,6 @@ public static class EncodingUtils
             return "utf-8";
         }
 
-        if (encoding.Equals(Utf7))
-        {
-            return "utf-7";
-        }
-
         if (encoding.Equals(Utf16))
         {
             return "utf-16";
@@ -94,6 +86,17 @@ public static class EncodingUtils
             return "utf-32be";
         }
 
+        if (IsUtf7(encoding))
+        {
+            // https://docs.microsoft.com/en-us/dotnet/fundamentals/syslib-diagnostics/syslib0001
+            throw new NotSupportedException("The UTF-7 encoding is insecure and should not be used. Consider using UTF-8 instead.");
+        }
+
         throw new ArgumentException($"Invalid encoding '{encoding.WebName}'.", nameof(encoding));
+    }
+
+    private static bool IsUtf7(Encoding encoding)
+    {
+        return encoding.CodePage == 65000;
     }
 }

--- a/src/Common/src/Common/Util/MimeType.cs
+++ b/src/Common/src/Common/Util/MimeType.cs
@@ -493,7 +493,7 @@ public class MimeType : IComparable<MimeType>
     {
         if (name.Equals("utf-7", StringComparison.OrdinalIgnoreCase))
         {
-            return EncodingUtils.Utf7;
+            throw new NotSupportedException("The UTF-7 encoding is insecure and should not be used. Consider using UTF-8 instead.");
         }
 
         if (name.Equals("utf-8", StringComparison.OrdinalIgnoreCase))


### PR DESCRIPTION
## Description

This PR removes support for UTF-7, which was obsoleted in .NET 5 because it is considered insecure. See https://docs.microsoft.com/en-us/dotnet/fundamentals/syslib-diagnostics/syslib0001 for details.

## Quality checklist

- [x] Your code complies with our [Coding Style](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-code-style.md).
- [ ] You've updated unit and/or integration tests for your change, where applicable.
- [ ] You've updated documentation for your change, where applicable.
      If your change affects other repositories, such as [Documentation](https://github.com/SteeltoeOSS/Documentation), [Samples](https://github.com/SteeltoeOSS/Samples) and/or [MainSite](https://github.com/SteeltoeOSS/MainSite), add linked PRs here.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
- [ ] You've added required license files and/or file headers (explaining where the code came from with proper attribution), where code is copied from StackOverflow, a blog, or OSS.
