### PR TITLE
Fix crash in Hystrix logging when uninitialized

### DIFF
--- a/src/CircuitBreaker/src/Hystrix/AbstractCommand.cs
+++ b/src/CircuitBreaker/src/Hystrix/AbstractCommand.cs
@@ -34,7 +34,7 @@ public abstract class AbstractCommand<TResult> : AbstractCommandBase, IHystrixIn
 
     protected readonly IHystrixCommandOptions InnerOptions;
 
-    protected internal readonly HystrixRequestLog CurrentRequestLog;
+    protected internal readonly IHystrixRequestLog CurrentRequestLog;
     protected internal readonly HystrixRequestCache RequestCache;
     protected internal readonly HystrixCommandExecutionHook ExecutionHook;
     protected internal readonly HystrixCommandMetrics InnerMetrics;
@@ -308,7 +308,7 @@ public abstract class AbstractCommand<TResult> : AbstractCommandBase, IHystrixIn
         return fromConstructor;
     }
 
-    protected static HystrixRequestLog InitRequestLog(bool enabled)
+    protected static IHystrixRequestLog InitRequestLog(bool enabled)
     {
         if (enabled)
         {

--- a/src/CircuitBreaker/src/Hystrix/IHystrixRequestLog.cs
+++ b/src/CircuitBreaker/src/Hystrix/IHystrixRequestLog.cs
@@ -1,0 +1,14 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+namespace Steeltoe.CircuitBreaker.Hystrix;
+
+public interface IHystrixRequestLog
+{
+    ICollection<IHystrixInvokableInfo> AllExecutedCommands { get; }
+
+    void AddExecutedCommand(IHystrixInvokableInfo command);
+
+    string GetExecutedCommandsAsString();
+}

--- a/src/CircuitBreaker/test/Hystrix.Test/CommonHystrixCommandTests.cs
+++ b/src/CircuitBreaker/test/Hystrix.Test/CommonHystrixCommandTests.cs
@@ -72,7 +72,7 @@ public abstract class CommonHystrixCommandTests<TCommand> : HystrixTestBase
 
     protected void AssertSaneHystrixRequestLog(int numCommands)
     {
-        HystrixRequestLog currentRequestLog = HystrixRequestLog.CurrentRequestLog;
+        IHystrixRequestLog currentRequestLog = HystrixRequestLog.CurrentRequestLog;
 
         Assert.Equal(numCommands, currentRequestLog.AllExecutedCommands.Count);
         Assert.DoesNotContain("Executed", currentRequestLog.GetExecutedCommandsAsString());

--- a/src/CircuitBreaker/test/Hystrix.Test/HystrixCommandTest.cs
+++ b/src/CircuitBreaker/test/Hystrix.Test/HystrixCommandTest.cs
@@ -981,7 +981,7 @@ public class HystrixCommandTest : CommonHystrixCommandTests<TestHystrixCommand<i
         Assert.True(numInFlight <= 1, "Pool-filler NOT still going"); // pool-filler still going
 
         // This is a case where we knowingly walk away from executing Hystrix threads. They should have an in-flight status ("Executed").  You should avoid this in a production environment
-        HystrixRequestLog requestLog = HystrixRequestLog.CurrentRequestLog;
+        IHystrixRequestLog requestLog = HystrixRequestLog.CurrentRequestLog;
         Assert.Equal(3, requestLog.AllExecutedCommands.Count);
         Assert.Contains("Executed", requestLog.GetExecutedCommandsAsString());
 
@@ -1498,7 +1498,7 @@ public class HystrixCommandTest : CommonHystrixCommandTests<TestHystrixCommand<i
 
         // verifies that some executions failed
         // Assert.Equal(sharedSemaphore.numberOfPermits.get().longValue(), failureCount.get());
-        HystrixRequestLog requestLog = HystrixRequestLog.CurrentRequestLog;
+        IHystrixRequestLog requestLog = HystrixRequestLog.CurrentRequestLog;
         Assert.Contains("SEMAPHORE_REJECTED", requestLog.GetExecutedCommandsAsString());
         Assert.Equal(0, circuitBreaker.Metrics.CurrentConcurrentExecutionCount);
     }

--- a/src/CircuitBreaker/test/Hystrix.Test/HystrixSubclassCommandTest.cs
+++ b/src/CircuitBreaker/test/Hystrix.Test/HystrixSubclassCommandTest.cs
@@ -41,7 +41,7 @@ public class HystrixSubclassCommandTest : HystrixTestBase
         HystrixCommand<int> superCmd3 = new SuperCommand("no-cache", true);
         Assert.Equal(1, superCmd3.Execute());
         _output.WriteLine("REQ LOG : " + HystrixRequestLog.CurrentRequestLog.GetExecutedCommandsAsString());
-        HystrixRequestLog reqLog = HystrixRequestLog.CurrentRequestLog;
+        IHystrixRequestLog reqLog = HystrixRequestLog.CurrentRequestLog;
         Assert.Equal(3, reqLog.AllExecutedCommands.Count);
         var infos = new List<IHystrixInvokableInfo>(reqLog.AllExecutedCommands);
         IHystrixInvokableInfo info1 = infos[0];
@@ -66,7 +66,7 @@ public class HystrixSubclassCommandTest : HystrixTestBase
         HystrixCommand<int> subCmd3 = new SubCommandNoOverride("no-cache", true);
         Assert.Equal(1, subCmd3.Execute());
         _output.WriteLine("REQ LOG : " + HystrixRequestLog.CurrentRequestLog.GetExecutedCommandsAsString());
-        HystrixRequestLog reqLog = HystrixRequestLog.CurrentRequestLog;
+        IHystrixRequestLog reqLog = HystrixRequestLog.CurrentRequestLog;
         Assert.Equal(3, reqLog.AllExecutedCommands.Count);
         var infos = new List<IHystrixInvokableInfo>(reqLog.AllExecutedCommands);
 
@@ -88,7 +88,7 @@ public class HystrixSubclassCommandTest : HystrixTestBase
         HystrixCommand<int> superCmd = new SuperCommand("cache", true);
         Assert.Equal(1, superCmd.Execute());
         _output.WriteLine("REQ LOG : " + HystrixRequestLog.CurrentRequestLog.GetExecutedCommandsAsString());
-        HystrixRequestLog reqLog = HystrixRequestLog.CurrentRequestLog;
+        IHystrixRequestLog reqLog = HystrixRequestLog.CurrentRequestLog;
         Assert.Equal(1, reqLog.AllExecutedCommands.Count);
         IHystrixInvokableInfo info = reqLog.AllExecutedCommands.ToList()[0];
         Assert.Equal("SuperCommand", info.CommandKey.Name);
@@ -100,7 +100,7 @@ public class HystrixSubclassCommandTest : HystrixTestBase
         HystrixCommand<int> subCmd = new SubCommandNoOverride("cache", true);
         Assert.Equal(1, subCmd.Execute());
         _output.WriteLine("REQ LOG : " + HystrixRequestLog.CurrentRequestLog.GetExecutedCommandsAsString());
-        HystrixRequestLog reqLog = HystrixRequestLog.CurrentRequestLog;
+        IHystrixRequestLog reqLog = HystrixRequestLog.CurrentRequestLog;
         Assert.Equal(1, reqLog.AllExecutedCommands.Count);
         IHystrixInvokableInfo info = reqLog.AllExecutedCommands.ToList()[0];
         Assert.Equal("SubCommandNoOverride", info.CommandKey.Name);


### PR DESCRIPTION
## Description

From time to time, I'm seeing Hystrix test failures in cibuild, caused by a `NullReferenceException`. For example, this one:

```
Starting test execution, please wait...
A total of 1 test files matched the specified pattern.
The active test run was aborted. Reason: Test host process crashed : Unhandled exception. System.NullReferenceException: Object reference not set to an instance of an object.
   at Steeltoe.CircuitBreaker.Hystrix.Test.TestObserverBase`1.OnNextCore(T value) in /home/vsts/work/1/s/src/CircuitBreaker/test/Hystrix.Test/TestObserverBase.cs:line 63
   at System.Reactive.SafeObserver`1.WrappingSafeObserver.OnNext(TSource value) in /_/Rx.NET/Source/src/System.Reactive/Internal/SafeObserver.cs:line 40
   at System.Reactive.Subjects.Subject`1.OnNext(T value) in /_/Rx.NET/Source/src/System.Reactive/Subjects/Subject.cs:line 145
   at System.Reactive.AutoDetachObserver`1.OnNextCore(T value) in /_/Rx.NET/Source/src/System.Reactive/Internal/AutoDetachObserver.cs:line 71
   at System.Reactive.SafeObserver`1.WrappingSafeObserver.OnNext(TSource value) in /_/Rx.NET/Source/src/System.Reactive/Internal/SafeObserver.cs:line 40
   at System.Reactive.Linq.ObservableImpl.SelectMany`2.ObservableSelector._.InnerObserver.OnNext(TResult value) in /_/Rx.NET/Source/src/System.Reactive/Linq/Observable/SelectMany.cs:line 952
   at System.Reactive.Linq.ObservableImpl.Aggregate`2._.OnCompleted() in /_/Rx.NET/Source/src/System.Reactive/Linq/Observable/Aggregate.cs:line 138
   at System.Reactive.Sink`1.ForwardOnCompleted() in /_/Rx.NET/Source/src/System.Reactive/Internal/Sink.cs:line 55
   at System.Reactive.Subjects.Subject`1.OnCompleted() in /_/Rx.NET/Source/src/System.Reactive/Subjects/Subject.cs:line 78
   at System.Reactive.Linq.ObservableImpl.Window`1.TimeHopping._.Tick() in /_/Rx.NET/Source/src/System.Reactive/Linq/Observable/Window.cs:line 330
   at System.Reactive.Concurrency.Scheduler.<>c__67`1.<SchedulePeriodic>b__67_0(ValueTuple`2 t) in /_/Rx.NET/Source/src/System.Reactive/Concurrency/Scheduler.Services.Emulation.cs:line 79
   at System.Reactive.Concurrency.NewThreadScheduler.Periodic`1.Run() in /_/Rx.NET/Source/src/System.Reactive/Concurrency/NewThreadScheduler.cs:line 169
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
```

The affected line is:

```c#
_output.WriteLine("ReqLog" + "@ " + Time.CurrentTimeMillis + " : " + HystrixRequestLog.CurrentRequestLog.GetExecutedCommandsAsString());
```

Apparently, `HystrixRequestLog.CurrentRequestLog` returns `null` when `HystrixRequestContext.IsCurrentThreadInitialized` is `false` at: https://github.com/SteeltoeOSS/Steeltoe/blob/095967c0f58afa27d3e5968dc2af5548a04f9dd6/src/CircuitBreaker/src/Hystrix/HystrixRequestLog.cs#L20-L31

There are a lot of usages in the codebase. So instead of updating them all to account for `null` using the `?.` operator, it now returns an immutable empty instance to avoid the crash.

## Quality checklist

- [x] Your code complies with our [Coding Style](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-code-style.md).
- [ ] You've updated unit and/or integration tests for your change, where applicable.
- [ ] You've updated documentation for your change, where applicable.
      If your change affects other repositories, such as [Documentation](https://github.com/SteeltoeOSS/Documentation), [Samples](https://github.com/SteeltoeOSS/Samples) and/or [MainSite](https://github.com/SteeltoeOSS/MainSite), add linked PRs here.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
- [ ] You've added required license files and/or file headers (explaining where the code came from with proper attribution), where code is copied from StackOverflow, a blog, or OSS.
