### PR TITLE
Backport fix: Return default minimum level when category is not configured

### DIFF
--- a/src/Logging/src/Abstractions/DynamicLoggerProviderBase.cs
+++ b/src/Logging/src/Abstractions/DynamicLoggerProviderBase.cs
@@ -75,7 +75,7 @@ public class DynamicLoggerProviderBase : IDynamicLoggerProvider
                 {
                     var name = prefix;
                     var configured = GetConfiguredLevel(name);
-                    var effective = GetEffectiveLevel(name);
+                    var effective = GetEffectiveLevel(name) ?? effectiveDefault;
                     var config = new DynamicLoggerConfiguration(name, configured, effective);
                     if (results.ContainsKey(name) && !results[name].Equals(config))
                     {
@@ -208,7 +208,7 @@ public class DynamicLoggerProviderBase : IDynamicLoggerProvider
     /// </summary>
     /// <param name="name">Namespace/qualified class name</param>
     /// <returns>Minimum logging level</returns>
-    private LogLevel GetEffectiveLevel(string name)
+    private LogLevel? GetEffectiveLevel(string name)
     {
         var prefixes = GetKeyPrefixes(name);
 
@@ -222,7 +222,7 @@ public class DynamicLoggerProviderBase : IDynamicLoggerProvider
             }
         }
 
-        return LogLevel.None;
+        return null;
     }
 
     /// <summary>

--- a/src/Management/test/EndpointCore.Test/Loggers/EndpointMiddlewareTest.cs
+++ b/src/Management/test/EndpointCore.Test/Loggers/EndpointMiddlewareTest.cs
@@ -196,6 +196,7 @@ public class EndpointMiddlewareTest : BaseTest
         Assert.True(result.TryGetProperty("loggers", out var loggers));
         Assert.True(result.TryGetProperty("levels", out _));
         Assert.Equal("WARN", loggers.GetProperty("Default").GetProperty("configuredLevel").GetString());
+        Assert.Equal("WARN", loggers.GetProperty("Microsoft").GetProperty("effectiveLevel").GetString());
         Assert.Equal("INFO", loggers.GetProperty("Steeltoe.Management").GetProperty("effectiveLevel").GetString());
     }
 


### PR DESCRIPTION
## Description

Backport of #1024 into Steeltoe v3.2.
