### PR TITLE
Update version so the NuGet build of main produces 4.0.x instead 4.0.0

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,7 +1,7 @@
 {
   "$schema":
     "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "4.0.0-alpha",
+  "version": "4.0-alpha",
   "publicReleaseRefSpec": [
     "^refs/heads/main$",
     "^refs/heads/release/\\d+(?:\\.\\d+)?$"


### PR DESCRIPTION
## Description

This attempts to fix producing duplicate NuGet packages in dev feed when `main` is built. At the time we're going to publish v4.0.0 to NuGet.org, we should revert this change.