### PR TITLE
Fix thread-safety issues with System.Random

### DIFF
--- a/src/CircuitBreaker/test/Hystrix.Test/Util/HystrixRollingPercentileTest.cs
+++ b/src/CircuitBreaker/test/Hystrix.Test/Util/HystrixRollingPercentileTest.cs
@@ -328,7 +328,6 @@ public class HystrixRollingPercentileTest
 
         var aggregateMetrics = new AtomicInteger(); // same as a blackhole
 
-        var r = new Random();
         var cts = new CancellationTokenSource();
 
         Task.Run(() =>
@@ -347,7 +346,7 @@ public class HystrixRollingPercentileTest
             {
                 for (int j = 1; j < numIterations / numThreads + 1; j++)
                 {
-                    int nextInt = r.Next(100);
+                    int nextInt = Random.Shared.Next(100);
                     p.AddValue(nextInt);
 
                     if (threadId == 0)
@@ -387,8 +386,6 @@ public class HystrixRollingPercentileTest
 
         var latch = new CountdownEvent(numThreads);
 
-        var r = new Random();
-
         var added = new AtomicInteger(0);
 
         for (int i = 0; i < numThreads; i++)
@@ -397,7 +394,7 @@ public class HystrixRollingPercentileTest
             {
                 for (int j = 1; j < numIterations / numThreads + 1; j++)
                 {
-                    int nextInt = r.Next(100);
+                    int nextInt = Random.Shared.Next(100);
                     p.AddValue(nextInt);
                     added.GetAndIncrement();
                 }

--- a/src/Common/src/Common/Util/MimeTypeUtils.cs
+++ b/src/Common/src/Common/Util/MimeTypeUtils.cs
@@ -22,7 +22,6 @@ public static class MimeTypeUtils
 
     private static readonly ConcurrentDictionary<string, MimeType> CachedMimeTypes = new();
     private static readonly char[] BoundaryChars = "-_1234567890abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ".ToCharArray();
-    private static readonly object Lock = new();
     public static readonly IComparer<MimeType> SpecificityComparator = new MimeType.SpecificityComparator<MimeType>();
     public static readonly MimeType All = new("*", "*");
     public static readonly MimeType ApplicationJson = new("application", "json");
@@ -34,8 +33,6 @@ public static class MimeTypeUtils
     public static readonly MimeType TextHtml = new("text", "html");
     public static readonly MimeType TextPlain = new("text", "plain");
     public static readonly MimeType TextXml = new("text", "xml");
-
-    private static volatile Random _random;
 
     public static MimeType ParseMimeType(string mimeType)
     {
@@ -131,13 +128,12 @@ public static class MimeTypeUtils
 
     public static char[] GenerateMultipartBoundary()
     {
-        Random randomToUse = InitRandom();
-        int size = randomToUse.Next(11) + 30;
+        int size = Random.Shared.Next(11) + 30;
         char[] boundary = new char[size];
 
         for (int i = 0; i < boundary.Length; i++)
         {
-            boundary[i] = BoundaryChars[randomToUse.Next(BoundaryChars.Length)];
+            boundary[i] = BoundaryChars[Random.Shared.Next(BoundaryChars.Length)];
         }
 
         return boundary;
@@ -236,26 +232,5 @@ public static class MimeTypeUtils
         {
             throw new ArgumentException($"The specified value '{mimeType}' is invalid.", ex);
         }
-    }
-
-    private static Random InitRandom()
-    {
-        Random randomToUse = _random;
-
-        if (randomToUse == null)
-        {
-            lock (Lock)
-            {
-                randomToUse = _random;
-
-                if (randomToUse == null)
-                {
-                    randomToUse = new Random();
-                    _random = randomToUse;
-                }
-            }
-        }
-
-        return randomToUse;
     }
 }

--- a/src/Common/test/Common.Expression.Test/Spring/SpelDocumentationTests.cs
+++ b/src/Common/test/Common.Expression.Test/Spring/SpelDocumentationTests.cs
@@ -86,7 +86,7 @@ public class SpelDocumentationTests : AbstractExpressionTests
     [Fact]
     public void TestXmlBasedConfig()
     {
-        Evaluate("(new Random().Next() * 100.0)>0", true, typeof(bool));
+        Evaluate("(T(Random).Shared.Next() * 100.0)>0", true, typeof(bool));
     }
 
     // Section 7.5
@@ -453,7 +453,7 @@ public class SpelDocumentationTests : AbstractExpressionTests
     [Fact]
     public void TestTemplating()
     {
-        string randomPhrase = Parser.ParseExpression("random number is ${new Random().Next()}", new TemplatedParserContext()).GetValue<string>();
+        string randomPhrase = Parser.ParseExpression("random number is ${T(Random).Shared.Next()}", new TemplatedParserContext()).GetValue<string>();
         Assert.StartsWith("random number", randomPhrase);
     }
 

--- a/src/Common/test/Common.Test/Util/MimeTypeTest.cs
+++ b/src/Common/test/Common.Test/Util/MimeTypeTest.cs
@@ -311,12 +311,11 @@ public class MimeTypeTest
         };
 
         var result = new List<MimeType>(expected);
-        var rnd = new Random();
 
         // shuffle & sort 10 times
         for (int i = 0; i < 10; i++)
         {
-            Shuffle(result, rnd);
+            Shuffle(result);
             result.Sort();
 
             for (int j = 0; j < result.Count; j++)
@@ -376,11 +375,11 @@ public class MimeTypeTest
         };
     }
 
-    private void Shuffle<T>(IList<T> list, Random rnd)
+    private void Shuffle<T>(IList<T> list)
     {
         for (int i = 0; i < list.Count - 1; i++)
         {
-            Swap(list, i, rnd.Next(i, list.Count));
+            Swap(list, i, Random.Shared.Next(i, list.Count));
         }
     }
 

--- a/src/Configuration/src/RandomValue/RandomValueProvider.cs
+++ b/src/Configuration/src/RandomValue/RandomValueProvider.cs
@@ -16,7 +16,6 @@ internal sealed class RandomValueProvider : ConfigurationProvider
 {
     private readonly ILogger<RandomValueProvider> _logger;
     private readonly string _prefix;
-    private Random _random;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="RandomValueProvider" /> class. The new placeholder resolver wraps the provided configuration.
@@ -34,7 +33,6 @@ internal sealed class RandomValueProvider : ConfigurationProvider
 
         _prefix = prefix;
         _logger = loggerFactory.CreateLogger<RandomValueProvider>();
-        _random = new Random();
     }
 
     /// <summary>
@@ -81,14 +79,6 @@ internal sealed class RandomValueProvider : ConfigurationProvider
     }
 
     /// <summary>
-    /// Creates a new underlying random number generator.
-    /// </summary>
-    public override void Load()
-    {
-        _random = new Random();
-    }
-
-    /// <summary>
     /// Returns the immediate descendant configuration keys for a given parent path, based on this <see cref="Configuration" />'s data and the set of keys
     /// returned by all the preceding providers.
     /// </summary>
@@ -123,7 +113,7 @@ internal sealed class RandomValueProvider : ConfigurationProvider
         // random:int
         if (type.Equals("int"))
         {
-            return _random.Next().ToString();
+            return Random.Shared.Next().ToString();
         }
 
         // random:long
@@ -159,7 +149,7 @@ internal sealed class RandomValueProvider : ConfigurationProvider
 
     private long GetLong()
     {
-        return ((long)_random.Next() << 32) + _random.Next();
+        return ((long)Random.Shared.Next() << 32) + Random.Shared.Next();
     }
 
     private string GetRange(string type, string prefix)
@@ -184,11 +174,11 @@ internal sealed class RandomValueProvider : ConfigurationProvider
 
         if (tokens.Length == 1)
         {
-            return _random.Next(start);
+            return Random.Shared.Next(start);
         }
 
         int.TryParse(tokens[1], out int max);
-        return _random.Next(start, max);
+        return Random.Shared.Next(start, max);
     }
 
     private long GetNextLongInRange(string range)
@@ -210,7 +200,7 @@ internal sealed class RandomValueProvider : ConfigurationProvider
     private string GetRandomBytes()
     {
         byte[] bytes = new byte[16];
-        _random.NextBytes(bytes);
+        Random.Shared.NextBytes(bytes);
         return BitConverter.ToString(bytes).Replace("-", string.Empty);
     }
 }

--- a/src/Discovery/src/Consul/Registry/ConsulRegistration.cs
+++ b/src/Discovery/src/Consul/Registry/ConsulRegistration.cs
@@ -194,8 +194,7 @@ public class ConsulRegistration : IConsulRegistration
 
         if (string.IsNullOrEmpty(instanceId))
         {
-            var rand = new Random();
-            instanceId = rand.Next().ToString();
+            instanceId = Random.Shared.Next().ToString();
         }
 
         return $"{appName}:{instanceId}";

--- a/src/Messaging/test/RabbitMQ.Test/Core/RabbitTemplateIntegrationTest.cs
+++ b/src/Messaging/test/RabbitMQ.Test/Core/RabbitTemplateIntegrationTest.cs
@@ -931,8 +931,7 @@ public abstract class RabbitTemplateIntegrationTest : IDisposable
         {
             tasks.Add(Task.Run(() =>
             {
-                var random = new Random();
-                double request = random.NextDouble() * 100;
+                double request = Random.Shared.NextDouble() * 100;
                 object reply = rabbitTemplate.ConvertSendAndReceive<object>(request);
                 results.TryAdd(request, reply);
             }));
@@ -942,8 +941,7 @@ public abstract class RabbitTemplateIntegrationTest : IDisposable
         {
             tasks.Add(Task.Run(() =>
             {
-                var random = new Random();
-                double request = random.NextDouble() * 100;
+                double request = Random.Shared.NextDouble() * 100;
 
                 var messageHeaders = new RabbitHeaderAccessor(new MessageHeaders())
                 {


### PR DESCRIPTION
## Description

Fixes thread-safety issues with usage of [System.Random](https://learn.microsoft.com/en-us/dotnet/api/system.random?view=net-6.0), explained at https://andrewlock.net/building-a-thread-safe-random-implementation-for-dotnet-framework/.

Follow-up on https://github.com/SteeltoeOSS/Steeltoe/pull/1008#issuecomment-1251035209.

## Quality checklist

- [x] Your code complies with our [Coding Style](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-code-style.md).
- [x] You've updated unit and/or integration tests for your change, where applicable.
- [ ] You've updated documentation for your change, where applicable.
      If your change affects other repositories, such as [Documentation](https://github.com/SteeltoeOSS/Documentation), [Samples](https://github.com/SteeltoeOSS/Samples) and/or [MainSite](https://github.com/SteeltoeOSS/MainSite), add linked PRs here.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
- [ ] You've added required license files and/or file headers (explaining where the code came from with proper attribution), where code is copied from StackOverflow, a blog, or OSS.
