### PR TITLE
Move TraceOptions/ITraceOptions into Common

### DIFF
--- a/src/Bootstrap/test/AutoConfiguration.Test/HostBuilderExtensionsTest.cs
+++ b/src/Bootstrap/test/AutoConfiguration.Test/HostBuilderExtensionsTest.cs
@@ -20,6 +20,7 @@ using OpenTelemetry.Trace;
 using Oracle.ManagedDataAccess.Client;
 using RabbitMQ.Client;
 using StackExchange.Redis;
+using Steeltoe.Common;
 using Steeltoe.Common.Options;
 using Steeltoe.Common.Security;
 using Steeltoe.Configuration.CloudFoundry;
@@ -35,7 +36,6 @@ using Steeltoe.Extensions.Logging.DynamicSerilog;
 using Steeltoe.Management.Endpoint;
 using Steeltoe.Management.Endpoint.Hypermedia;
 using Steeltoe.Management.OpenTelemetry.Exporters;
-using Steeltoe.Management.OpenTelemetry.Trace;
 using Xunit;
 
 namespace Steeltoe.Bootstrap.AutoConfiguration.Test;

--- a/src/Bootstrap/test/AutoConfiguration.Test/WebApplicationBuilderExtensionsTest.cs
+++ b/src/Bootstrap/test/AutoConfiguration.Test/WebApplicationBuilderExtensionsTest.cs
@@ -20,6 +20,7 @@ using OpenTelemetry.Trace;
 using Oracle.ManagedDataAccess.Client;
 using RabbitMQ.Client;
 using StackExchange.Redis;
+using Steeltoe.Common;
 using Steeltoe.Common.Options;
 using Steeltoe.Common.Security;
 using Steeltoe.Configuration.CloudFoundry;
@@ -35,7 +36,6 @@ using Steeltoe.Extensions.Logging.DynamicSerilog;
 using Steeltoe.Management.Endpoint;
 using Steeltoe.Management.Endpoint.Hypermedia;
 using Steeltoe.Management.OpenTelemetry.Exporters;
-using Steeltoe.Management.OpenTelemetry.Trace;
 using Xunit;
 
 namespace Steeltoe.Bootstrap.AutoConfiguration.Test;

--- a/src/Bootstrap/test/AutoConfiguration.Test/WebHostBuilderExtensionsTest.cs
+++ b/src/Bootstrap/test/AutoConfiguration.Test/WebHostBuilderExtensionsTest.cs
@@ -20,6 +20,7 @@ using OpenTelemetry.Trace;
 using Oracle.ManagedDataAccess.Client;
 using RabbitMQ.Client;
 using StackExchange.Redis;
+using Steeltoe.Common;
 using Steeltoe.Common.Options;
 using Steeltoe.Common.Security;
 using Steeltoe.Configuration.CloudFoundry;
@@ -35,7 +36,6 @@ using Steeltoe.Extensions.Logging.DynamicSerilog;
 using Steeltoe.Management.Endpoint;
 using Steeltoe.Management.Endpoint.Hypermedia;
 using Steeltoe.Management.OpenTelemetry.Exporters;
-using Steeltoe.Management.OpenTelemetry.Trace;
 using Xunit;
 
 namespace Steeltoe.Bootstrap.AutoConfiguration.Test;

--- a/src/Common/src/Abstractions/ITracingOptions.cs
+++ b/src/Common/src/Abstractions/ITracingOptions.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-namespace Steeltoe.Management.OpenTelemetry.Trace;
+namespace Steeltoe.Common;
 
 public interface ITracingOptions
 {

--- a/src/Common/src/Common/Properties/AssemblyInfo.cs
+++ b/src/Common/src/Common/Properties/AssemblyInfo.cs
@@ -7,3 +7,5 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("Steeltoe.Common.Test")]
 [assembly: InternalsVisibleTo("Steeltoe.Common.Hosting")]
 [assembly: InternalsVisibleTo("Steeltoe.Common.Hosting.Test")]
+[assembly: InternalsVisibleTo("Steeltoe.Management.Tracing")]
+[assembly: InternalsVisibleTo("Steeltoe.Management.Tracing.Test")]

--- a/src/Common/src/Common/TracingOptions.cs
+++ b/src/Common/src/Common/TracingOptions.cs
@@ -3,10 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.Configuration;
-using Steeltoe.Common;
-using Steeltoe.Management.OpenTelemetry.Trace;
 
-namespace Steeltoe.Management.Tracing;
+namespace Steeltoe.Common;
 
 public class TracingOptions : ITracingOptions
 {

--- a/src/Management/src/Tracing/TracingBaseServiceCollectionExtensions.cs
+++ b/src/Management/src/Tracing/TracingBaseServiceCollectionExtensions.cs
@@ -17,7 +17,6 @@ using Steeltoe.Common.Reflection;
 using Steeltoe.Extensions.Logging;
 using Steeltoe.Management.OpenTelemetry.Exporters;
 using Steeltoe.Management.OpenTelemetry.Exporters.Wavefront;
-using Steeltoe.Management.OpenTelemetry.Trace;
 
 namespace Steeltoe.Management.Tracing;
 

--- a/src/Management/src/Tracing/TracingCoreServiceCollectionExtensions.cs
+++ b/src/Management/src/Tracing/TracingCoreServiceCollectionExtensions.cs
@@ -7,7 +7,6 @@ using Microsoft.Extensions.DependencyInjection;
 using OpenTelemetry.Instrumentation.AspNetCore;
 using OpenTelemetry.Trace;
 using Steeltoe.Common;
-using Steeltoe.Management.OpenTelemetry.Trace;
 
 namespace Steeltoe.Management.Tracing;
 

--- a/src/Management/src/Tracing/TracingLogProcessor.cs
+++ b/src/Management/src/Tracing/TracingLogProcessor.cs
@@ -4,8 +4,8 @@
 
 using System.Text;
 using OpenTelemetry.Trace;
+using Steeltoe.Common;
 using Steeltoe.Extensions.Logging;
-using Steeltoe.Management.OpenTelemetry.Trace;
 
 namespace Steeltoe.Management.Tracing;
 

--- a/src/Management/test/Tracing.Test/TestBase.cs
+++ b/src/Management/test/Tracing.Test/TestBase.cs
@@ -8,8 +8,8 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using OpenTelemetry.Context.Propagation;
 using OpenTelemetry.Trace;
+using Steeltoe.Common;
 using Steeltoe.Extensions.Logging;
-using Steeltoe.Management.OpenTelemetry.Trace;
 using Xunit;
 
 namespace Steeltoe.Management.Tracing.Test;


### PR DESCRIPTION
## Description

Move `TracingOptions`/`ITracingOptions` into `Common`, so it can be shared between `Management.Tracing` and `Logging.DynamicSerilog`.

## Quality checklist

- [x] Your code complies with our [Coding Style](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-code-style.md).
- [ ] You've updated unit and/or integration tests for your change, where applicable.
- [ ] You've updated documentation for your change, where applicable.
      If your change affects other repositories, such as [Documentation](https://github.com/SteeltoeOSS/Documentation), [Samples](https://github.com/SteeltoeOSS/Samples) and/or [MainSite](https://github.com/SteeltoeOSS/MainSite), add linked PRs here.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
- [ ] You've added required license files and/or file headers (explaining where the code came from with proper attribution), where code is copied from StackOverflow, a blog, or OSS.
