### PR TITLE
Fix S4059: Property names should not match get methods

### DIFF
--- a/shared-package.props
+++ b/shared-package.props
@@ -53,6 +53,6 @@
 
   <PropertyGroup Condition="!$(MSBuildProjectName.StartsWith('Steeltoe.Configuration'))">
     <!-- Narrow the condition above as we're completing more public API reviews -->
-    <NoWarn>$(NoWarn);SA1401;S1168;S2360;S3872;S3874;S3898;S3956;S4004;S4023;S4059;S4487;S3900</NoWarn>
+    <NoWarn>$(NoWarn);SA1401;S1168;S2360;S3872;S3874;S3898;S3956;S4004;S4023;S4487;S3900</NoWarn>
   </PropertyGroup>
 </Project>

--- a/src/Connectors/src/Abstractions/Services/UriInfo.cs
+++ b/src/Connectors/src/Abstractions/Services/UriInfo.cs
@@ -18,23 +18,23 @@ public class UriInfo
         ':'
     };
 
-    public string Scheme { get; protected internal set; }
+    public string Scheme { get; }
 
-    public string Host { get; protected internal set; }
+    public string Host { get; private set; }
 
-    public string[] Hosts { get; protected internal set; }
+    public string[] Hosts { get; private set; }
 
-    public int Port { get; protected internal set; }
+    public int Port { get; }
 
-    public string UserName { get; protected internal set; }
+    public string UserName { get; }
 
-    public string Password { get; protected internal set; }
+    public string Password { get; }
 
-    public string Path { get; protected internal set; }
+    public string Path { get; }
 
-    public string Query { get; protected internal set; }
+    public string Query { get; }
 
-    public string UriString { get; protected internal set; }
+    public string UriString { get; }
 
     public Uri Uri => MakeUri(UriString);
 
@@ -96,7 +96,7 @@ public class UriInfo
         return UriString;
     }
 
-    protected internal Uri MakeUri(string scheme, string host, int port, string username, string password, string path, string query)
+    private Uri MakeUri(string scheme, string host, int port, string username, string password, string path, string query)
     {
         string cleanedPath = path == null || path.StartsWith('/') ? path : $"/{path}";
         cleanedPath = query != null ? $"{cleanedPath}?{query}" : cleanedPath;
@@ -129,7 +129,7 @@ public class UriInfo
         }
     }
 
-    protected internal Uri MakeUri(string uriString)
+    private Uri MakeUri(string uriString)
     {
         try
         {
@@ -167,7 +167,7 @@ public class UriInfo
         }
     }
 
-    protected internal void ConvertJdbcToUri(ref string uriString)
+    private void ConvertJdbcToUri(ref string uriString)
     {
         uriString = uriString.Replace("jdbc:", string.Empty, StringComparison.Ordinal).Replace(';', '&');
 
@@ -199,7 +199,7 @@ public class UriInfo
         }
     }
 
-    protected internal string GetPath(string pathAndQuery)
+    private string GetPath(string pathAndQuery)
     {
         if (string.IsNullOrEmpty(pathAndQuery))
         {
@@ -216,7 +216,7 @@ public class UriInfo
         return split[0].Substring(1);
     }
 
-    protected internal string GetQuery(string pathAndQuery)
+    private string GetQuery(string pathAndQuery)
     {
         if (string.IsNullOrEmpty(pathAndQuery))
         {
@@ -233,7 +233,7 @@ public class UriInfo
         return split[1];
     }
 
-    protected internal string[] GetUserInfo(string userPass)
+    private string[] GetUserInfo(string userPass)
     {
         if (string.IsNullOrEmpty(userPass))
         {

--- a/src/Connectors/src/Connector/ConfigurationExtensions.cs
+++ b/src/Connectors/src/Connector/ConfigurationExtensions.cs
@@ -25,7 +25,7 @@ public static class ConfigurationExtensions
     public static IEnumerable<TServiceInfo> GetServiceInfos<TServiceInfo>(this IConfiguration configuration)
         where TServiceInfo : class
     {
-        return ServiceInfoCreatorFactory.GetServiceInfoCreator(configuration).GetServiceInfos<TServiceInfo>();
+        return ServiceInfoCreatorFactory.GetServiceInfoCreator(configuration).GetServiceInfosOfType<TServiceInfo>();
     }
 
     /// <summary>
@@ -42,7 +42,7 @@ public static class ConfigurationExtensions
     /// </returns>
     public static IEnumerable<IServiceInfo> GetServiceInfos(this IConfiguration configuration, Type infoType)
     {
-        return ServiceInfoCreatorFactory.GetServiceInfoCreator(configuration).GetServiceInfos(infoType);
+        return ServiceInfoCreatorFactory.GetServiceInfoCreator(configuration).GetServiceInfosOfType(infoType);
     }
 
     /// <summary>

--- a/src/Connectors/src/Connector/ServiceInfoCreator.cs
+++ b/src/Connectors/src/Connector/ServiceInfoCreator.cs
@@ -67,7 +67,7 @@ public class ServiceInfoCreator
     /// <returns>
     /// List of matching Service Infos.
     /// </returns>
-    public IEnumerable<TServiceInfo> GetServiceInfos<TServiceInfo>()
+    public IEnumerable<TServiceInfo> GetServiceInfosOfType<TServiceInfo>()
         where TServiceInfo : class
     {
         return ServiceInfos.Where(si => si is TServiceInfo).Cast<TServiceInfo>();
@@ -82,7 +82,7 @@ public class ServiceInfoCreator
     /// <returns>
     /// List of matching Service Infos.
     /// </returns>
-    public IEnumerable<IServiceInfo> GetServiceInfos(Type type)
+    public IEnumerable<IServiceInfo> GetServiceInfosOfType(Type type)
     {
         return ServiceInfos.Where(info => info.GetType() == type);
     }
@@ -102,7 +102,7 @@ public class ServiceInfoCreator
     public TServiceInfo GetServiceInfo<TServiceInfo>(string name)
         where TServiceInfo : class
     {
-        IEnumerable<TServiceInfo> typed = GetServiceInfos<TServiceInfo>();
+        IEnumerable<TServiceInfo> typed = GetServiceInfosOfType<TServiceInfo>();
 
         foreach (TServiceInfo si in typed)
         {

--- a/src/Connectors/test/Connector.CloudFoundry.Test/CloudFoundryServiceInfoCreatorTest.cs
+++ b/src/Connectors/test/Connector.CloudFoundry.Test/CloudFoundryServiceInfoCreatorTest.cs
@@ -174,19 +174,19 @@ public class CloudFoundryServiceInfoCreatorTest
         builder.AddCloudFoundry();
         IConfigurationRoot configurationRoot = builder.Build();
         var creator = CloudFoundryServiceInfoCreator.Instance(configurationRoot);
-        IEnumerable<RedisServiceInfo> result = creator.GetServiceInfos<RedisServiceInfo>();
+        IEnumerable<RedisServiceInfo> result = creator.GetServiceInfosOfType<RedisServiceInfo>();
         Assert.NotNull(result);
         Assert.Empty(result);
 
-        IEnumerable<IServiceInfo> result2 = creator.GetServiceInfos(typeof(MySqlServiceInfo));
+        IEnumerable<IServiceInfo> result2 = creator.GetServiceInfosOfType(typeof(MySqlServiceInfo));
         Assert.NotNull(result2);
         Assert.Empty(result2);
 
-        IEnumerable<RedisServiceInfo> result3 = creator.GetServiceInfos<RedisServiceInfo>();
+        IEnumerable<RedisServiceInfo> result3 = creator.GetServiceInfosOfType<RedisServiceInfo>();
         Assert.NotNull(result3);
         Assert.Empty(result3);
 
-        IEnumerable<IServiceInfo> result4 = creator.GetServiceInfos(typeof(RedisServiceInfo));
+        IEnumerable<IServiceInfo> result4 = creator.GetServiceInfosOfType(typeof(RedisServiceInfo));
         Assert.NotNull(result4);
         Assert.Empty(result4);
 
@@ -258,17 +258,17 @@ public class CloudFoundryServiceInfoCreatorTest
         IConfigurationRoot configurationRoot = builder.Build();
         var creator = CloudFoundryServiceInfoCreator.Instance(configurationRoot);
 
-        IEnumerable<MySqlServiceInfo> result = creator.GetServiceInfos<MySqlServiceInfo>();
+        IEnumerable<MySqlServiceInfo> result = creator.GetServiceInfosOfType<MySqlServiceInfo>();
         Assert.Equal(2, result.Count(si => si != null));
 
-        IEnumerable<IServiceInfo> result2 = creator.GetServiceInfos(typeof(MySqlServiceInfo));
+        IEnumerable<IServiceInfo> result2 = creator.GetServiceInfosOfType(typeof(MySqlServiceInfo));
         Assert.Equal(2, result2.Count(si => si is MySqlServiceInfo));
 
-        IEnumerable<RedisServiceInfo> result3 = creator.GetServiceInfos<RedisServiceInfo>();
+        IEnumerable<RedisServiceInfo> result3 = creator.GetServiceInfosOfType<RedisServiceInfo>();
         Assert.NotNull(result3);
         Assert.Empty(result3);
 
-        IEnumerable<IServiceInfo> result4 = creator.GetServiceInfos(typeof(RedisServiceInfo));
+        IEnumerable<IServiceInfo> result4 = creator.GetServiceInfosOfType(typeof(RedisServiceInfo));
         Assert.NotNull(result4);
         Assert.Empty(result4);
 
@@ -410,17 +410,17 @@ public class CloudFoundryServiceInfoCreatorTest
         Assert.NotNull(creator.ServiceInfos);
         Assert.Equal(4, creator.ServiceInfos.Count);
 
-        IEnumerable<RedisServiceInfo> result1 = creator.GetServiceInfos<RedisServiceInfo>();
+        IEnumerable<RedisServiceInfo> result1 = creator.GetServiceInfosOfType<RedisServiceInfo>();
         Assert.NotNull(result1);
         Assert.Single(result1);
 
         RedisServiceInfo redis1 = result1.First();
         Assert.Equal("10.66.32.54", redis1.Host);
 
-        IEnumerable<MongoDbServiceInfo> result2 = creator.GetServiceInfos<MongoDbServiceInfo>();
+        IEnumerable<MongoDbServiceInfo> result2 = creator.GetServiceInfosOfType<MongoDbServiceInfo>();
         Assert.Equal(2, result2.Count());
 
-        IEnumerable<EurekaServiceInfo> result3 = creator.GetServiceInfos<EurekaServiceInfo>();
+        IEnumerable<EurekaServiceInfo> result3 = creator.GetServiceInfosOfType<EurekaServiceInfo>();
         Assert.Single(result3);
         Assert.Equal("eureka-a015d976-af2e-430c-81f6-4f99272ccd24.apps.preprdpcf01.foo.com", result3.First().Host);
     }

--- a/src/Discovery/src/Consul/Discovery/ConsulDiscoveryClient.cs
+++ b/src/Discovery/src/Consul/Discovery/ConsulDiscoveryClient.cs
@@ -40,7 +40,7 @@ public class ConsulDiscoveryClient : IConsulDiscoveryClient
     public string Description { get; } = "HashiCorp Consul Client";
 
     /// <inheritdoc />
-    public IList<string> Services => GetServicesAsync().GetAwaiter().GetResult();
+    public IList<string> Services => GetServiceNamesAsync().GetAwaiter().GetResult();
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ConsulDiscoveryClient" /> class.
@@ -160,7 +160,7 @@ public class ConsulDiscoveryClient : IConsulDiscoveryClient
         {
             queryOptions ??= QueryOptions.Default;
             var instances = new List<IServiceInstance>();
-            IList<string> result = await GetServicesAsync();
+            IList<string> result = await GetServiceNamesAsync();
 
             foreach (string serviceId in result)
             {
@@ -180,10 +180,10 @@ public class ConsulDiscoveryClient : IConsulDiscoveryClient
     /// <returns>
     /// the list of services.
     /// </returns>
-    public IList<string> GetServices(QueryOptions queryOptions = null)
+    public IList<string> GetServiceNames(QueryOptions queryOptions = null)
     {
         queryOptions ??= QueryOptions.Default;
-        return GetServicesAsync(queryOptions).GetAwaiter().GetResult();
+        return GetServiceNamesAsync(queryOptions).GetAwaiter().GetResult();
     }
 
     internal async Task<IList<IServiceInstance>> GetInstancesAsync(string serviceId, QueryOptions queryOptions)
@@ -193,7 +193,7 @@ public class ConsulDiscoveryClient : IConsulDiscoveryClient
         return instances;
     }
 
-    internal async Task<IList<string>> GetServicesAsync(QueryOptions queryOptions = null)
+    internal async Task<IList<string>> GetServiceNamesAsync(QueryOptions queryOptions = null)
     {
         queryOptions ??= QueryOptions.Default;
         QueryResult<Dictionary<string, string[]>> result = await _client.Catalog.Services(queryOptions);

--- a/src/Discovery/src/Consul/Discovery/IConsulDiscoveryClient.cs
+++ b/src/Discovery/src/Consul/Discovery/IConsulDiscoveryClient.cs
@@ -46,5 +46,5 @@ public interface IConsulDiscoveryClient : IDiscoveryClient, IDisposable
     /// <returns>
     /// list of found services.
     /// </returns>
-    IList<string> GetServices(QueryOptions queryOptions = null);
+    IList<string> GetServiceNames(QueryOptions queryOptions = null);
 }

--- a/src/Discovery/src/Eureka/AppInfo/InstanceInfo.cs
+++ b/src/Discovery/src/Eureka/AppInfo/InstanceInfo.cs
@@ -189,10 +189,10 @@ public class InstanceInfo
 
         if (string.IsNullOrEmpty(info.InstanceId))
         {
-            info.InstanceId = instanceConfig.GetHostName(false);
+            info.InstanceId = instanceConfig.ResolveHostName(false);
         }
 
-        string defaultAddress = instanceConfig.GetHostName(false);
+        string defaultAddress = instanceConfig.ResolveHostName(false);
 
         if (instanceConfig.PreferIPAddress || string.IsNullOrEmpty(defaultAddress))
         {

--- a/src/Discovery/src/Eureka/EurekaDiscoveryClient.cs
+++ b/src/Discovery/src/Eureka/EurekaDiscoveryClient.cs
@@ -19,7 +19,7 @@ public class EurekaDiscoveryClient : DiscoveryClient, IDiscoveryClient
 
     public override IEurekaClientConfiguration ClientConfiguration => _configOptions.CurrentValue;
 
-    public IList<string> Services => GetServices();
+    public IList<string> Services => GetRegisteredServices();
 
     public string Description => "Spring Cloud Eureka Client";
 
@@ -35,7 +35,7 @@ public class EurekaDiscoveryClient : DiscoveryClient, IDiscoveryClient
         Initialize();
     }
 
-    public IList<string> GetServices()
+    public IList<string> GetRegisteredServices()
     {
         Applications applications = Applications;
 

--- a/src/Discovery/src/Eureka/EurekaInstanceConfiguration.cs
+++ b/src/Discovery/src/Eureka/EurekaInstanceConfiguration.cs
@@ -96,7 +96,7 @@ public class EurekaInstanceConfiguration : IEurekaInstanceConfig
     public EurekaInstanceConfiguration()
     {
 #pragma warning disable S1699 // Constructors should only call non-overridable methods
-        HostName = GetHostName(true);
+        HostName = ResolveHostName(true);
         thisHostAddress = GetHostAddress(true);
 #pragma warning restore S1699 // Constructors should only call non-overridable methods
 
@@ -134,7 +134,7 @@ public class EurekaInstanceConfiguration : IEurekaInstanceConfig
         }
     }
 
-    public virtual string GetHostName(bool refresh)
+    public virtual string ResolveHostName(bool refresh)
     {
         if (refresh || string.IsNullOrEmpty(HostName))
         {
@@ -159,7 +159,7 @@ public class EurekaInstanceConfiguration : IEurekaInstanceConfig
             }
             else
             {
-                string hostName = GetHostName(refresh);
+                string hostName = ResolveHostName(refresh);
 
                 if (!string.IsNullOrEmpty(hostName))
                 {

--- a/src/Discovery/src/Eureka/EurekaInstanceOptions.cs
+++ b/src/Discovery/src/Eureka/EurekaInstanceOptions.cs
@@ -69,7 +69,7 @@ public class EurekaInstanceOptions : EurekaInstanceConfiguration, IDiscoveryRegi
 
     public override string HostName
     {
-        get => GetHostName(false);
+        get => ResolveHostName(false);
         set
         {
             if (value != base.HostName)
@@ -86,10 +86,10 @@ public class EurekaInstanceOptions : EurekaInstanceConfiguration, IDiscoveryRegi
         IsInstanceEnabledOnInit = true;
         VirtualHostName = null;
         SecureVirtualHostName = null;
-        InstanceId = $"{GetHostName(false)}:{AppName}:{NonSecurePort}";
+        InstanceId = $"{ResolveHostName(false)}:{AppName}:{NonSecurePort}";
     }
 
-    public override string GetHostName(bool refresh)
+    public override string ResolveHostName(bool refresh)
     {
         if (_hostName != null)
         {

--- a/src/Discovery/src/Eureka/EurekaPostConfigurer.cs
+++ b/src/Discovery/src/Eureka/EurekaPostConfigurer.cs
@@ -124,8 +124,8 @@ public static class EurekaPostConfigurer
             else
             {
                 options.InstanceId = options.SecurePortEnabled
-                    ? $"{options.GetHostName(false)}:{options.AppName}:{options.SecurePort}"
-                    : $"{options.GetHostName(false)}:{options.AppName}:{options.NonSecurePort}";
+                    ? $"{options.ResolveHostName(false)}:{options.AppName}:{options.SecurePort}"
+                    : $"{options.ResolveHostName(false)}:{options.AppName}:{options.NonSecurePort}";
             }
         }
     }

--- a/src/Discovery/src/Eureka/EurekaServiceInstance.cs
+++ b/src/Discovery/src/Eureka/EurekaServiceInstance.cs
@@ -24,11 +24,11 @@ public class EurekaServiceInstance : IServiceInstance
         get
         {
             string scheme = IsSecure ? "https" : "http";
-            return new Uri($"{scheme}://{GetHost()}:{Port}");
+            return new Uri($"{scheme}://{GetHostName()}:{Port}");
         }
     }
 
-    public string Host => GetHost();
+    public string Host => GetHostName();
 
     public string InstanceId => _info.InstanceId;
 
@@ -37,7 +37,7 @@ public class EurekaServiceInstance : IServiceInstance
         _info = info;
     }
 
-    public string GetHost()
+    public string GetHostName()
     {
         return _info.HostName;
     }

--- a/src/Discovery/src/Eureka/IEurekaInstanceConfig.cs
+++ b/src/Discovery/src/Eureka/IEurekaInstanceConfig.cs
@@ -123,13 +123,13 @@ public interface IEurekaInstanceConfig
 
     /// <summary>
     /// Gets or sets the IPAddress of the instance. This information is for academic purposes only as the communication from other instances primarily happen
-    /// using the information supplied in <see cref="GetHostName(bool)" />.
+    /// using the information supplied in <see cref="ResolveHostName" />.
     /// </summary>
     string IPAddress { get; set; }
 
     /// <summary>
     /// Gets or sets the relative status page <em>Path</em> for this instance. The status page URL is then constructed out of the
-    /// <see cref="GetHostName(bool)" /> and the type of communication - secure or insecure as specified in <see cref="SecurePort" /> and
+    /// <see cref="ResolveHostName" /> and the type of communication - secure or insecure as specified in <see cref="SecurePort" /> and
     /// <see cref="NonSecurePort" />. It is normally used for informational purposes for other services to find about the status of this instance. Users can
     /// provide a simple <c>HTML</c> indicating what is the current status of the instance. Configuration property: eureka:instance:statusPageUrlPath.
     /// </summary>
@@ -146,7 +146,7 @@ public interface IEurekaInstanceConfig
 
     /// <summary>
     /// Gets or sets gets the relative home page URL <em>Path</em> for this instance. The home page URL is then constructed out of the
-    /// <see cref="GetHostName(bool)" /> and the type of communication - secure or insecure as specified in <see cref="SecurePort" /> and
+    /// <see cref="ResolveHostName" /> and the type of communication - secure or insecure as specified in <see cref="SecurePort" /> and
     /// <see cref="NonSecurePort" /> It is normally used for informational purposes for other services to use it as a landing page. Configuration property:
     /// eureka:instance:homePageUrlPath.
     /// </summary>
@@ -163,7 +163,7 @@ public interface IEurekaInstanceConfig
 
     /// <summary>
     /// Gets or sets gets the relative health check URL <em>Path</em> for this instance. The health check page URL is then constructed out of the
-    /// <see cref="GetHostName(bool)" /> and the type of communication - secure or insecure as specified in <see cref="SecurePort" /> and
+    /// <see cref="ResolveHostName" /> and the type of communication - secure or insecure as specified in <see cref="SecurePort" /> and
     /// <see cref="NonSecurePort" /> It is normally used for making educated decisions based on the health of the instance - for example, it can be used to
     /// determine whether to proceed deployments to an entire farm or stop the deployments without causing further damage. Configuration property:
     /// eureka:instance:healthCheckUrlPath.
@@ -212,5 +212,5 @@ public interface IEurekaInstanceConfig
     /// <returns>
     /// hostname.
     /// </returns>
-    string GetHostName(bool refresh);
+    string ResolveHostName(bool refresh);
 }

--- a/src/Discovery/src/Eureka/ThisServiceInstance.cs
+++ b/src/Discovery/src/Eureka/ThisServiceInstance.cs
@@ -29,20 +29,20 @@ public class ThisServiceInstance : IServiceInstance
         {
             string scheme = IsSecure ? "https" : "http";
             int uriPort = IsSecure ? SecurePort : Port;
-            var uri = new Uri($"{scheme}://{GetHost()}:{uriPort}");
+            var uri = new Uri($"{scheme}://{GetHostName()}:{uriPort}");
             return uri;
         }
     }
 
-    public string Host => GetHost();
+    public string Host => GetHostName();
 
     public ThisServiceInstance(IOptionsMonitor<EurekaInstanceOptions> instConfig)
     {
         _instConfig = instConfig;
     }
 
-    public string GetHost()
+    public string GetHostName()
     {
-        return InstConfig.GetHostName(false);
+        return InstConfig.ResolveHostName(false);
     }
 }

--- a/src/Discovery/src/Kubernetes/Discovery/KubernetesDiscoveryClient.cs
+++ b/src/Discovery/src/Kubernetes/Discovery/KubernetesDiscoveryClient.cs
@@ -21,7 +21,7 @@ public class KubernetesDiscoveryClient : IDiscoveryClient
 
     public string Description => "Steeltoe provided Kubernetes native service discovery client";
 
-    public IList<string> Services => GetServices(null);
+    public IList<string> Services => GetLabeledServices(null);
 
     public IKubernetes KubernetesClient { get; set; }
 
@@ -34,7 +34,7 @@ public class KubernetesDiscoveryClient : IDiscoveryClient
         _logger = logger;
     }
 
-    public IList<string> GetServices(IDictionary<string, string> labels)
+    public IList<string> GetLabeledServices(IDictionary<string, string> labels)
     {
         if (!_discoveryOptions.CurrentValue.Enabled)
         {

--- a/src/Discovery/test/Consul.Test/Discovery/ConsulDiscoveryClientTest.cs
+++ b/src/Discovery/test/Consul.Test/Discovery/ConsulDiscoveryClientTest.cs
@@ -129,7 +129,7 @@ public class ConsulDiscoveryClientTest
         catMoq.Setup(c => c.Services(QueryOptions.Default, default)).Returns(result);
 
         var dc = new ConsulDiscoveryClient(clientMoq.Object, options);
-        IList<string> services = await dc.GetServicesAsync();
+        IList<string> services = await dc.GetServiceNamesAsync();
         Assert.Equal(2, services.Count);
         Assert.Contains("foo", services);
         Assert.Contains("bar", services);
@@ -168,7 +168,7 @@ public class ConsulDiscoveryClientTest
         catMoq.Setup(c => c.Services(QueryOptions.Default, default)).Returns(result);
 
         var dc = new ConsulDiscoveryClient(clientMoq.Object, options);
-        IList<string> services = dc.GetServices();
+        IList<string> services = dc.GetServiceNames();
         Assert.Equal(2, services.Count);
         Assert.Contains("foo", services);
         Assert.Contains("bar", services);

--- a/src/Discovery/test/Eureka.Test/AppInfo/InstanceInfoTest.cs
+++ b/src/Discovery/test/Eureka.Test/AppInfo/InstanceInfoTest.cs
@@ -121,7 +121,7 @@ public class InstanceInfoTest : AbstractBaseTest
         Assert.NotNull(info);
 
         // Verify
-        Assert.Equal(configuration.GetHostName(false), info.InstanceId);
+        Assert.Equal(configuration.ResolveHostName(false), info.InstanceId);
         Assert.Equal(EurekaInstanceConfiguration.DefaultAppName.ToUpperInvariant(), info.AppName);
         Assert.Null(info.AppGroupName);
         Assert.Equal(configuration.IPAddress, info.IPAddress);
@@ -130,15 +130,15 @@ public class InstanceInfoTest : AbstractBaseTest
         Assert.True(info.IsInsecurePortEnabled);
         Assert.Equal(443, info.SecurePort);
         Assert.False(info.IsSecurePortEnabled);
-        Assert.Equal($"http://{configuration.GetHostName(false)}:{80}/", info.HomePageUrl);
-        Assert.Equal($"http://{configuration.GetHostName(false)}:{80}/Status", info.StatusPageUrl);
-        Assert.Equal($"http://{configuration.GetHostName(false)}:{80}/healthcheck", info.HealthCheckUrl);
+        Assert.Equal($"http://{configuration.ResolveHostName(false)}:{80}/", info.HomePageUrl);
+        Assert.Equal($"http://{configuration.ResolveHostName(false)}:{80}/Status", info.StatusPageUrl);
+        Assert.Equal($"http://{configuration.ResolveHostName(false)}:{80}/healthcheck", info.HealthCheckUrl);
         Assert.Null(info.SecureHealthCheckUrl);
-        Assert.Equal($"{configuration.GetHostName(false)}:{80}", info.VipAddress);
-        Assert.Equal($"{configuration.GetHostName(false)}:{443}", info.SecureVipAddress);
+        Assert.Equal($"{configuration.ResolveHostName(false)}:{80}", info.VipAddress);
+        Assert.Equal($"{configuration.ResolveHostName(false)}:{443}", info.SecureVipAddress);
         Assert.Equal(1, info.CountryId);
         Assert.Equal("MyOwn", info.DataCenterInfo.Name.ToString());
-        Assert.Equal(configuration.GetHostName(false), info.HostName);
+        Assert.Equal(configuration.ResolveHostName(false), info.HostName);
         Assert.Equal(InstanceStatus.Starting, info.Status);
         Assert.Equal(InstanceStatus.Unknown, info.OverriddenStatus);
         Assert.NotNull(info.LeaseInfo);
@@ -170,7 +170,7 @@ public class InstanceInfoTest : AbstractBaseTest
         Assert.NotNull(info);
 
         // Verify
-        Assert.Equal(configuration.GetHostName(false), info.InstanceId);
+        Assert.Equal(configuration.ResolveHostName(false), info.InstanceId);
         Assert.Equal(EurekaInstanceConfiguration.DefaultAppName.ToUpperInvariant(), info.AppName);
         Assert.Null(info.AppGroupName);
         Assert.Equal(configuration.IPAddress, info.IPAddress);
@@ -179,15 +179,15 @@ public class InstanceInfoTest : AbstractBaseTest
         Assert.False(info.IsInsecurePortEnabled);
         Assert.Equal(443, info.SecurePort);
         Assert.True(info.IsSecurePortEnabled);
-        Assert.Equal($"https://{configuration.GetHostName(false)}:{443}/", info.HomePageUrl);
-        Assert.Equal($"https://{configuration.GetHostName(false)}:{443}/Status", info.StatusPageUrl);
-        Assert.Equal($"https://{configuration.GetHostName(false)}:{443}/healthcheck", info.HealthCheckUrl);
+        Assert.Equal($"https://{configuration.ResolveHostName(false)}:{443}/", info.HomePageUrl);
+        Assert.Equal($"https://{configuration.ResolveHostName(false)}:{443}/Status", info.StatusPageUrl);
+        Assert.Equal($"https://{configuration.ResolveHostName(false)}:{443}/healthcheck", info.HealthCheckUrl);
         Assert.Null(info.SecureHealthCheckUrl);
-        Assert.Equal($"{configuration.GetHostName(false)}:{80}", info.VipAddress);
-        Assert.Equal($"{configuration.GetHostName(false)}:{443}", info.SecureVipAddress);
+        Assert.Equal($"{configuration.ResolveHostName(false)}:{80}", info.VipAddress);
+        Assert.Equal($"{configuration.ResolveHostName(false)}:{443}", info.SecureVipAddress);
         Assert.Equal(1, info.CountryId);
         Assert.Equal("MyOwn", info.DataCenterInfo.Name.ToString());
-        Assert.Equal(configuration.GetHostName(false), info.HostName);
+        Assert.Equal(configuration.ResolveHostName(false), info.HostName);
         Assert.Equal(InstanceStatus.Starting, info.Status);
         Assert.Equal(InstanceStatus.Unknown, info.OverriddenStatus);
         Assert.NotNull(info.LeaseInfo);
@@ -216,7 +216,7 @@ public class InstanceInfoTest : AbstractBaseTest
         JsonInstanceInfo instanceInfo = info.ToJsonInstance();
 
         // Verify
-        Assert.Equal(configuration.GetHostName(false), instanceInfo.InstanceId);
+        Assert.Equal(configuration.ResolveHostName(false), instanceInfo.InstanceId);
         Assert.Equal(EurekaInstanceConfiguration.DefaultAppName.ToUpperInvariant(), instanceInfo.AppName);
         Assert.Null(instanceInfo.AppGroupName);
         Assert.Equal(configuration.IPAddress, instanceInfo.IPAddress);
@@ -227,17 +227,17 @@ public class InstanceInfoTest : AbstractBaseTest
         Assert.NotNull(instanceInfo.SecurePort);
         Assert.Equal(443, instanceInfo.SecurePort.Port);
         Assert.False(instanceInfo.SecurePort.Enabled);
-        Assert.Equal($"http://{configuration.GetHostName(false)}:{80}/", instanceInfo.HomePageUrl);
-        Assert.Equal($"http://{configuration.GetHostName(false)}:{80}/Status", instanceInfo.StatusPageUrl);
-        Assert.Equal($"http://{configuration.GetHostName(false)}:{80}/healthcheck", instanceInfo.HealthCheckUrl);
+        Assert.Equal($"http://{configuration.ResolveHostName(false)}:{80}/", instanceInfo.HomePageUrl);
+        Assert.Equal($"http://{configuration.ResolveHostName(false)}:{80}/Status", instanceInfo.StatusPageUrl);
+        Assert.Equal($"http://{configuration.ResolveHostName(false)}:{80}/healthcheck", instanceInfo.HealthCheckUrl);
         Assert.Null(instanceInfo.SecureHealthCheckUrl);
-        Assert.Equal($"{configuration.GetHostName(false)}:{80}", instanceInfo.VipAddress);
-        Assert.Equal($"{configuration.GetHostName(false)}:{443}", instanceInfo.SecureVipAddress);
+        Assert.Equal($"{configuration.ResolveHostName(false)}:{80}", instanceInfo.VipAddress);
+        Assert.Equal($"{configuration.ResolveHostName(false)}:{443}", instanceInfo.SecureVipAddress);
         Assert.Equal(1, instanceInfo.CountryId);
         Assert.NotNull(instanceInfo.DataCenterInfo);
         Assert.Equal("MyOwn", instanceInfo.DataCenterInfo.Name);
         Assert.Equal("com.netflix.appinfo.InstanceInfo$DefaultDataCenterInfo", instanceInfo.DataCenterInfo.ClassName);
-        Assert.Equal(configuration.GetHostName(false), instanceInfo.HostName);
+        Assert.Equal(configuration.ResolveHostName(false), instanceInfo.HostName);
         Assert.Equal(InstanceStatus.Starting, instanceInfo.Status);
         Assert.Equal(InstanceStatus.Unknown, instanceInfo.OverriddenStatus);
         Assert.NotNull(instanceInfo.LeaseInfo);

--- a/src/Discovery/test/Eureka.Test/EurekaDiscoveryClientTest.cs
+++ b/src/Discovery/test/Eureka.Test/EurekaDiscoveryClientTest.cs
@@ -35,7 +35,7 @@ public class EurekaDiscoveryClientTest : AbstractBaseTest
 
         IServiceInstance thisService = client.GetLocalServiceInstance();
         Assert.NotNull(thisService);
-        Assert.Equal(instanceConfig.GetHostName(false), thisService.Host);
+        Assert.Equal(instanceConfig.ResolveHostName(false), thisService.Host);
         Assert.Equal(instanceConfig.SecurePortEnabled, thisService.IsSecure);
         Assert.NotNull(thisService.Metadata);
         Assert.Equal(instanceConfig.NonSecurePort, thisService.Port);
@@ -43,7 +43,7 @@ public class EurekaDiscoveryClientTest : AbstractBaseTest
         Assert.NotNull(thisService.Uri);
         string scheme = instanceConfig.SecurePortEnabled ? "https" : "http";
         int uriPort = instanceConfig.SecurePortEnabled ? instanceConfig.SecurePort : instanceConfig.NonSecurePort;
-        var uri = new Uri($"{scheme}://{instanceConfig.GetHostName(false)}:{uriPort}");
+        var uri = new Uri($"{scheme}://{instanceConfig.ResolveHostName(false)}:{uriPort}");
         Assert.Equal(uri, thisService.Uri);
     }
 }

--- a/src/Discovery/test/Eureka.Test/EurekaInstanceConfigTest.cs
+++ b/src/Discovery/test/Eureka.Test/EurekaInstanceConfigTest.cs
@@ -14,7 +14,7 @@ public class EurekaInstanceConfigTest : AbstractBaseTest
     {
         var configuration = new EurekaInstanceConfiguration();
 
-        string thisHostName = configuration.GetHostName(false);
+        string thisHostName = configuration.ResolveHostName(false);
         string thisHostAddress = configuration.GetHostAddress(false);
 
         Assert.False(configuration.IsInstanceEnabledOnInit);

--- a/src/Discovery/test/Eureka.Test/EurekaInstanceOptionsTest.cs
+++ b/src/Discovery/test/Eureka.Test/EurekaInstanceOptionsTest.cs
@@ -146,7 +146,7 @@ public class EurekaInstanceOptionsTest : AbstractBaseTest
         Assert.Equal("healthCheckUrlPath", ro.HealthCheckUrlPath);
         Assert.Equal("healthCheckUrl", ro.HealthCheckUrl);
         Assert.Equal("secureHealthCheckUrl", ro.SecureHealthCheckUrl);
-        Assert.Equal("myHostName", ro.GetHostName(false));
+        Assert.Equal("myHostName", ro.ResolveHostName(false));
         Assert.Equal("myHostName", ro.HostName);
         Assert.Equal("foobar", ro.RegistrationMethod);
         IDictionary<string, string> map = ro.MetadataMap;

--- a/src/Discovery/test/Kubernetes.Test/Discovery/KubernetesDiscoveryClientTest.cs
+++ b/src/Discovery/test/Kubernetes.Test/Discovery/KubernetesDiscoveryClientTest.cs
@@ -259,7 +259,7 @@ public class KubernetesDiscoveryClientTest
 
         var discoveryClient = new KubernetesDiscoveryClient(new DefaultIsServicePortSecureResolver(options.CurrentValue), client, options);
 
-        IList<string>? services = discoveryClient.GetServices(new Dictionary<string, string>
+        IList<string>? services = discoveryClient.GetLabeledServices(new Dictionary<string, string>
         {
             { "label", "value" }
         });

--- a/src/Integration/src/Integration/Util/AbstractExpressionEvaluator.cs
+++ b/src/Integration/src/Integration/Util/AbstractExpressionEvaluator.cs
@@ -26,7 +26,7 @@ public abstract class AbstractExpressionEvaluator
     {
         get
         {
-            _evaluationContext ??= GetEvaluationContext();
+            _evaluationContext ??= CreateEvaluationContext();
             return _evaluationContext;
         }
         set => _evaluationContext = value;
@@ -45,7 +45,7 @@ public abstract class AbstractExpressionEvaluator
     {
         get
         {
-            _messageBuilderFactory ??= GetMessageBuilderFactory();
+            _messageBuilderFactory ??= CreateMessageBuilderFactory();
             return _messageBuilderFactory;
         }
         set => _messageBuilderFactory = value;
@@ -60,12 +60,12 @@ public abstract class AbstractExpressionEvaluator
         ApplicationContext = context;
     }
 
-    protected virtual IMessageBuilderFactory GetMessageBuilderFactory()
+    protected virtual IMessageBuilderFactory CreateMessageBuilderFactory()
     {
         return IntegrationServices.MessageBuilderFactory;
     }
 
-    protected virtual IEvaluationContext GetEvaluationContext(bool contextRequired = true)
+    protected virtual IEvaluationContext CreateEvaluationContext(bool contextRequired = true)
     {
         if (_evaluationContext == null)
         {

--- a/src/Integration/src/RabbitMQ/Outbound/AbstractRabbitOutboundEndpoint.cs
+++ b/src/Integration/src/RabbitMQ/Outbound/AbstractRabbitOutboundEndpoint.cs
@@ -147,7 +147,7 @@ public abstract class AbstractRabbitOutboundEndpoint : AbstractReplyProducingMes
 
                 DoStart();
 
-                if (ConfirmTimeout != null && GetConfirmNackChannel() != null && GetRabbitTemplate() != null)
+                if (ConfirmTimeout != null && GetResolvedConfirmNackChannel() != null && GetRabbitTemplate() != null)
                 {
                     TokenSource = new CancellationTokenSource();
                     ConfirmChecker = Task.Run(() => CheckUnconfirmed(TokenSource.Token));
@@ -207,7 +207,7 @@ public abstract class AbstractRabbitOutboundEndpoint : AbstractReplyProducingMes
     {
     }
 
-    protected virtual IMessageChannel GetConfirmAckChannel()
+    protected virtual IMessageChannel GetResolvedConfirmAckChannel()
     {
         if (ConfirmAckChannel == null && ConfirmAckChannelName != null)
         {
@@ -217,7 +217,7 @@ public abstract class AbstractRabbitOutboundEndpoint : AbstractReplyProducingMes
         return ConfirmAckChannel;
     }
 
-    protected virtual IMessageChannel GetConfirmNackChannel()
+    protected virtual IMessageChannel GetResolvedConfirmNackChannel()
     {
         if (ConfirmNackChannel == null && ConfirmNackChannelName != null)
         {
@@ -353,13 +353,13 @@ public abstract class AbstractRabbitOutboundEndpoint : AbstractReplyProducingMes
         IMessage confirmMessage;
         confirmMessage = BuildConfirmMessage(ack, cause, wrapper, userCorrelationData);
 
-        if (ack && GetConfirmAckChannel() != null)
+        if (ack && GetResolvedConfirmAckChannel() != null)
         {
-            SendOutput(confirmMessage, GetConfirmAckChannel(), true);
+            SendOutput(confirmMessage, GetResolvedConfirmAckChannel(), true);
         }
-        else if (!ack && GetConfirmNackChannel() != null)
+        else if (!ack && GetResolvedConfirmNackChannel() != null)
         {
-            SendOutput(confirmMessage, GetConfirmNackChannel(), true);
+            SendOutput(confirmMessage, GetResolvedConfirmNackChannel(), true);
         }
         else
         {

--- a/src/Messaging/src/RabbitMQ/Listener/AbstractMessageListenerContainer.cs
+++ b/src/Messaging/src/RabbitMQ/Listener/AbstractMessageListenerContainer.cs
@@ -280,7 +280,7 @@ public abstract class AbstractMessageListenerContainer : IMessageListenerContain
         MessageListener = messageListener;
     }
 
-    public virtual IConnectionFactory GetConnectionFactory()
+    public virtual IConnectionFactory ResolveConnectionFactory()
     {
         IConnectionFactory connectionFactory = ConnectionFactory;
 


### PR DESCRIPTION
## Description

Renamed methods to avoid clashes with property names. I'm open to suggestions for better names.

Fixes #950

## Quality checklist

- [x] Your code complies with our [Coding Style](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-code-style.md).
- [x] You've updated unit and/or integration tests for your change, where applicable.
- [ ] You've updated documentation for your change, where applicable.
      If your change affects other repositories, such as [Documentation](https://github.com/SteeltoeOSS/Documentation), [Samples](https://github.com/SteeltoeOSS/Samples) and/or [MainSite](https://github.com/SteeltoeOSS/MainSite), add linked PRs here.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
- [ ] You've added required license files and/or file headers (explaining where the code came from with proper attribution), where code is copied from StackOverflow, a blog, or OSS.
