### PR TITLE
Fix S3872: Parameter names should not duplicate the names of their methods

### DIFF
--- a/shared-package.props
+++ b/shared-package.props
@@ -53,6 +53,6 @@
 
   <PropertyGroup Condition="!$(MSBuildProjectName.StartsWith('Steeltoe.Configuration'))">
     <!-- Narrow the condition above as we're completing more public API reviews -->
-    <NoWarn>$(NoWarn);SA1401;S1168;S2360;S3872;S3874;S3898;S3956;S4004;S4023;S4059;S4487;S3900</NoWarn>
+    <NoWarn>$(NoWarn);SA1401;S1168;S2360;S3874;S3898;S3956;S4004;S4023;S4059;S4487;S3900</NoWarn>
   </PropertyGroup>
 </Project>

--- a/src/CircuitBreaker/src/Hystrix/Util/ObservableExtensions.cs
+++ b/src/CircuitBreaker/src/Hystrix/Util/ObservableExtensions.cs
@@ -8,11 +8,11 @@ namespace Steeltoe.CircuitBreaker.Hystrix.Util;
 
 public static class ObservableExtensions
 {
-    public static IObservable<TSource> OnSubscribe<TSource>(this IObservable<TSource> source, Action onSubscribe)
+    public static IObservable<TSource> OnSubscribe<TSource>(this IObservable<TSource> source, Action handler)
     {
         return Observable.Create<TSource>(o =>
         {
-            onSubscribe();
+            handler();
             IDisposable d = source.Subscribe(o);
             return d;
         });

--- a/src/Integration/src/Integration/Support/IntegrationMessageBuilder.cs
+++ b/src/Integration/src/Integration/Support/IntegrationMessageBuilder.cs
@@ -65,9 +65,9 @@ public class IntegrationMessageBuilder<T> : IntegrationMessageBuilder, IMessageB
         return this;
     }
 
-    public new IMessageBuilder<T> ReadOnlyHeaders(IList<string> readOnlyHeaders)
+    public new IMessageBuilder<T> ReadOnlyHeaders(IList<string> values)
     {
-        base.ReadOnlyHeaders(readOnlyHeaders);
+        base.ReadOnlyHeaders(values);
         return this;
     }
 
@@ -248,10 +248,10 @@ public class IntegrationMessageBuilder : AbstractMessageBuilder
         return this;
     }
 
-    public IMessageBuilder ReadOnlyHeaders(IList<string> readOnlyHeaders)
+    public IMessageBuilder ReadOnlyHeaders(IList<string> values)
     {
-        this.readOnlyHeaders = readOnlyHeaders;
-        HeaderAccessor.SetReadOnlyHeaders(readOnlyHeaders);
+        readOnlyHeaders = values;
+        HeaderAccessor.SetReadOnlyHeaders(values);
         return this;
     }
 

--- a/src/Messaging/src/RabbitMQ/Configuration/ExchangeBuilder.cs
+++ b/src/Messaging/src/RabbitMQ/Configuration/ExchangeBuilder.cs
@@ -128,12 +128,12 @@ public class ExchangeBuilder : AbstractBuilder
         return this;
     }
 
-    public ExchangeBuilder Admins(params object[] admins)
+    public ExchangeBuilder Admins(params object[] declaringAdmins)
     {
-        ArgumentGuard.NotNull(admins);
-        ArgumentGuard.ElementsNotNull(admins);
+        ArgumentGuard.NotNull(declaringAdmins);
+        ArgumentGuard.ElementsNotNull(declaringAdmins);
 
-        _declaringAdmins = new List<object>(admins);
+        _declaringAdmins = new List<object>(declaringAdmins);
         return this;
     }
 

--- a/src/Messaging/src/RabbitMQ/Configuration/QueueBuilder.cs
+++ b/src/Messaging/src/RabbitMQ/Configuration/QueueBuilder.cs
@@ -72,14 +72,14 @@ public class QueueBuilder : AbstractBuilder
         return this;
     }
 
-    public QueueBuilder Ttl(int ttl)
+    public QueueBuilder Ttl(int value)
     {
-        return WithArgument("x-message-ttl", ttl);
+        return WithArgument("x-message-ttl", value);
     }
 
-    public QueueBuilder Expires(int expires)
+    public QueueBuilder Expires(int value)
     {
-        return WithArgument("x-expires", expires);
+        return WithArgument("x-expires", value);
     }
 
     public QueueBuilder MaxLength(int count)
@@ -92,9 +92,9 @@ public class QueueBuilder : AbstractBuilder
         return WithArgument("x-max-length-bytes", bytes);
     }
 
-    public QueueBuilder Overflow(OverFlow overflow)
+    public QueueBuilder Overflow(OverFlow value)
     {
-        return WithArgument("x-overflow", overflow.Value);
+        return WithArgument("x-overflow", value.Value);
     }
 
     public QueueBuilder DeadLetterExchange(string exchange)
@@ -107,9 +107,9 @@ public class QueueBuilder : AbstractBuilder
         return WithArgument("x-dead-letter-routing-key", key);
     }
 
-    public QueueBuilder MaxPriority(int maxPriority)
+    public QueueBuilder MaxPriority(int value)
     {
-        return WithArgument("x-max-priority", maxPriority);
+        return WithArgument("x-max-priority", value);
     }
 
     public QueueBuilder Lazy()

--- a/src/Messaging/src/RabbitMQ/Core/RabbitTemplate.cs
+++ b/src/Messaging/src/RabbitMQ/Core/RabbitTemplate.cs
@@ -2595,9 +2595,9 @@ public class RabbitTemplate
             }
         }
 
-        public void Reply(IMessage reply)
+        public void Reply(IMessage message)
         {
-            _future.TrySetResult(reply);
+            _future.TrySetResult(message);
         }
 
         public void Returned(RabbitMessageReturnedException e)


### PR DESCRIPTION
## Description

Renames parameters to comply with [S3872](https://rules.sonarsource.com/csharp/RSPEC-3872).

Fixes #936

## Quality checklist

- [x] Your code complies with our [Coding Style](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-code-style.md).
- [x] You've updated unit and/or integration tests for your change, where applicable.
- [ ] You've updated documentation for your change, where applicable.
      If your change affects other repositories, such as [Documentation](https://github.com/SteeltoeOSS/Documentation), [Samples](https://github.com/SteeltoeOSS/Samples) and/or [MainSite](https://github.com/SteeltoeOSS/MainSite), add linked PRs here.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
- [ ] You've added required license files and/or file headers (explaining where the code came from with proper attribution), where code is copied from StackOverflow, a blog, or OSS.
