### PR TITLE
Metrics updates

### DIFF
--- a/src/Management/src/EndpointBase/Metrics/IMetricsObserverOptions.cs
+++ b/src/Management/src/EndpointBase/Metrics/IMetricsObserverOptions.cs
@@ -20,6 +20,15 @@ public interface IMetricsObserverOptions
     string EgressIgnorePattern { get; }
 
     /// <summary>
+    /// Gets Allow list of metrics that should not be captured
+    /// </summary>
+    /// <remarks>
+    ///     Currently only applies to System.Runtime metrics captured by <see cref="EventCounterListener"/><para />
+    ///     See this list for values to choose from: <see href="https://docs.microsoft.com/dotnet/core/diagnostics/available-counters#systemruntime-counters" />
+    /// </remarks>
+    List<string> IncludedMetrics { get; }
+
+    /// <summary>
     /// Gets a list of metrics that should not be captured
     /// </summary>
     /// <remarks>

--- a/src/Management/src/EndpointBase/Metrics/MetricsObserverOptions.cs
+++ b/src/Management/src/EndpointBase/Metrics/MetricsObserverOptions.cs
@@ -66,5 +66,8 @@ public class MetricsObserverOptions : IMetricsObserverOptions
     public bool HystrixEvents { get; set; } = false;
 
     /// <inheritdoc/>
+    public List<string> IncludedMetrics { get; set; } = new List<string>();
+
+    /// <inheritdoc/>
     public List<string> ExcludedMetrics { get; set; } = new List<string>();
 }

--- a/src/Management/src/EndpointBase/Metrics/Observer/CLRRuntimeObserver.cs
+++ b/src/Management/src/EndpointBase/Metrics/Observer/CLRRuntimeObserver.cs
@@ -33,6 +33,7 @@ public class CLRRuntimeObserver : IRuntimeDiagnosticSource
     private ObservableGauge<long> _activeThreadsMeasure;
     private ObservableGauge<long> _availThreadsMeasure;
     private ObservableGauge<double> _processUptimeMeasure;
+    private ObservableGauge<int> _cpuCountMeasure;
 
     private CLRRuntimeSource.HeapMetrics _previous = default(CLRRuntimeSource.HeapMetrics);
 
@@ -46,6 +47,8 @@ public class CLRRuntimeObserver : IRuntimeDiagnosticSource
         _availThreadsMeasure = meter.CreateObservableGauge("clr.threadpool.avail", GetAvailableThreadPoolWorkers, "Available thread count", "count");
 
         _processUptimeMeasure = meter.CreateObservableGauge("clr.process.uptime", GetUptime, "Process uptime in seconds", "count");
+
+        _cpuCountMeasure = meter.CreateObservableGauge("clr.cpu.count", () => Environment.ProcessorCount, "Process uptime in seconds", "count");
         RegisterViews(viewRegistry);
     }
 

--- a/src/Management/src/EndpointBase/Metrics/Observer/EventCounterListener.cs
+++ b/src/Management/src/EndpointBase/Metrics/Observer/EventCounterListener.cs
@@ -12,6 +12,7 @@ using System.Collections.Generic;
 using System.Diagnostics.Metrics;
 using System.Diagnostics.Tracing;
 using System.Globalization;
+using System.Linq;
 
 namespace Steeltoe.Management.Endpoint.Metrics.Observer;
 
@@ -121,23 +122,20 @@ public class EventCounterListener : EventListener
         long? longValue = null;
         var counterName = string.Empty;
         var labelSet = new List<KeyValuePair<string, object>>();
-        var excludedMetric = false;
+
         string counterDisplayUnit = null, counterDisplayName = null;
         foreach (var payload in eventPayload)
         {
-            if (excludedMetric)
-            {
-                break;
-            }
-
             var key = payload.Key;
             switch (key)
             {
                 case var kn when key.Equals("Name", StringComparison.OrdinalIgnoreCase):
                     counterName = payload.Value.ToString();
-                    if (_options.ExcludedMetrics.Contains(counterName))
+                    if ((_options.IncludedMetrics.Any()
+                        && !_options.IncludedMetrics.Contains(counterName))
+                        || _options.ExcludedMetrics.Contains(counterName))
                     {
-                        excludedMetric = true;
+                        return;
                     }
 
                     break;

--- a/src/Management/test/EndpointCore.Test/ManagementWebHostBuilderExtensionsTest.cs
+++ b/src/Management/test/EndpointCore.Test/ManagementWebHostBuilderExtensionsTest.cs
@@ -677,6 +677,7 @@ public class ManagementWebHostBuilderExtensionsTest
 
             // Assert Steeltoe configuration is respected
             Assert.Contains("Export clr.process.uptime", output);
+            Assert.Contains("Export clr.cpu.count", output);
         }
     }
 


### PR DESCRIPTION
## Description
Adds metrics for clr.cpu.count 
Adds an AllowList Option to only add metrics needed, as opposed to listing all unneeded metrics
for example: 
```json
 "Metrics":{                                              
   "Observer":{                                 
     "EventCounterEvents": true,                
     "IncludedMetrics": ["cpu-usage"]           
     }                                            
  }                                              
```
## Quality checklist

<!-- Please run through the checklist below to ensure a smooth review and merge process for your PR. -->

- [x] Your code complies with our [Coding Style](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-code-style.md).
- [x] You've updated unit and/or integration tests for your change, where applicable.
- [ ] You've updated documentation for your change, where applicable.
      If your change affects other repositories, such as [Documentation](https://github.com/SteeltoeOSS/Documentation), [Samples](https://github.com/SteeltoeOSS/Samples) and/or [MainSite](https://github.com/SteeltoeOSS/MainSite), add linked PRs here.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
- [x] You've added required license files and/or file headers (explaining where the code came from with proper attribution), where code is copied from StackOverflow, a blog, or OSS.
