### PR TITLE
Fix S106: Use BootstrapLoggerFactory instead of Console.WriteLine

### DIFF
--- a/Steeltoe.Debug.ruleset
+++ b/Steeltoe.Debug.ruleset
@@ -2,6 +2,7 @@
 <RuleSet Name="Steeltoe Debug" Description="Code quality rules for Steeltoe debug builds" ToolsVersion="17.0">
   <Rules AnalyzerId="SonarAnalyzer.CSharp" RuleNamespace="SonarAnalyzer.CSharp">
     <Rule Id="S100" Action="Warning" />
+    <Rule Id="S106" Action="Warning" />
     <Rule Id="S1067" Action="Warning" />
     <Rule Id="S107" Action="Info" />
     <Rule Id="S1075" Action="None" />

--- a/Steeltoe.Release.ruleset
+++ b/Steeltoe.Release.ruleset
@@ -2,6 +2,7 @@
 <RuleSet Name="Steeltoe Release" Description="Code quality rules for Steeltoe release builds" ToolsVersion="17.0">
   <Rules AnalyzerId="SonarAnalyzer.CSharp" RuleNamespace="SonarAnalyzer.CSharp">
     <Rule Id="S100" Action="Warning" />
+    <Rule Id="S106" Action="Warning" />
     <Rule Id="S1067" Action="Warning" />
     <Rule Id="S1075" Action="None" />
     <Rule Id="S110" Action="Warning" />

--- a/src/CircuitBreaker/src/Hystrix.MetricsEvents/EventSources/HystrixEventSourceService.cs
+++ b/src/CircuitBreaker/src/Hystrix.MetricsEvents/EventSources/HystrixEventSourceService.cs
@@ -5,8 +5,10 @@
 using System.Reactive.Concurrency;
 using System.Reactive.Linq;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 using Steeltoe.CircuitBreaker.Hystrix.CircuitBreaker;
 using Steeltoe.CircuitBreaker.Hystrix.Metric.Consumer;
+using Steeltoe.Common.Logging;
 using static Steeltoe.CircuitBreaker.Hystrix.Metric.Consumer.HystrixDashboardStream;
 
 namespace Steeltoe.CircuitBreaker.Hystrix.MetricsEvents.EventSources;
@@ -70,7 +72,8 @@ public class HystrixEventSourceService : IHostedService
             }
             catch (Exception ex)
             {
-                Console.WriteLine(ex);
+                ILogger logger = BootstrapLoggerFactory.Instance.CreateLogger<HystrixEventSourceService>();
+                logger.LogError(ex, "Failed to process metrics.");
             }
         }
     }

--- a/src/Common/src/Common/Reflection/ReflectionHelpers.cs
+++ b/src/Common/src/Common/Reflection/ReflectionHelpers.cs
@@ -4,7 +4,9 @@
 
 using System.Reflection;
 using System.Runtime.InteropServices;
+using Microsoft.Extensions.Logging;
 using Steeltoe.Common.Attributes;
+using Steeltoe.Common.Logging;
 
 namespace Steeltoe.Common.Reflection;
 
@@ -478,8 +480,10 @@ public static class ReflectionHelpers
 
             toReturn.Add(baseDirectory);
 
-            Console.WriteLine(
-                "File path path information for the assembly containing {0} is missing. Some Steeltoe functionality may not work with PublishSingleFile=true",
+            ILogger logger = BootstrapLoggerFactory.Instance.CreateLogger(typeof(ReflectionHelpers).FullName!);
+
+            logger.LogWarning(
+                "File path information for the assembly containing '{Name}' is missing. Some Steeltoe functionality may not work with PublishSingleFile=true",
                 attributeType.Name);
         }
         else

--- a/src/Common/test/Common.TestResources/CapturingLoggerProvider.cs
+++ b/src/Common/test/Common.TestResources/CapturingLoggerProvider.cs
@@ -1,0 +1,44 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Concurrent;
+using Microsoft.Extensions.Logging;
+
+namespace Steeltoe.Common.TestResources;
+
+public sealed class CapturingLoggerProvider : ILoggerProvider, ILogger
+{
+    private readonly ConcurrentBag<string> _messages = new();
+
+    public ILogger CreateLogger(string categoryName)
+    {
+        return this;
+    }
+
+    public IDisposable BeginScope<TState>(TState state)
+    {
+        return null;
+    }
+
+    public bool IsEnabled(LogLevel logLevel)
+    {
+        return true;
+    }
+
+    public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+    {
+        string message = $"{logLevel.ToString().ToUpperInvariant()}: {formatter(state, exception)}";
+        _messages.Add(message);
+    }
+
+    public IEnumerable<string> GetMessages()
+    {
+        return _messages.ToList();
+    }
+
+    public void Dispose()
+    {
+        // Intentionally left empty.
+    }
+}

--- a/src/Management/src/Endpoint/Metrics/ServiceCollectionExtensions.cs
+++ b/src/Management/src/Endpoint/Metrics/ServiceCollectionExtensions.cs
@@ -5,8 +5,10 @@
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
 using OpenTelemetry.Metrics;
 using Steeltoe.Common;
+using Steeltoe.Common.Logging;
 using Steeltoe.Management.Endpoint.Metrics.Prometheus;
 using Steeltoe.Management.OpenTelemetry.Exporters;
 using Steeltoe.Management.OpenTelemetry.Exporters.Prometheus;
@@ -126,8 +128,10 @@ public static class ServiceCollectionExtensions
         {
             if (!services.Any(sd => sd.ImplementationInstance?.ToString() == "{ ConfiguredSteeltoeMetrics = True }"))
             {
-                Console.WriteLine(
-                    "Warning!! Make sure one of the extension methods that calls ConfigureSteeltoeMetrics is used to correctly configure metrics using OpenTelemetry for Steeltoe.");
+                ILogger logger = BootstrapLoggerFactory.Instance.CreateLogger(typeof(ServiceCollectionExtensions).FullName!);
+
+                logger.LogWarning(
+                    $"Make sure one of the extension methods that calls {nameof(ConfigureSteeltoeMetrics)} is used to correctly configure metrics using OpenTelemetry for Steeltoe.");
             }
 
             return services; // Already Configured, get out of here

--- a/src/Management/test/Endpoint.Test/ManagementWebHostBuilderExtensionsTest.cs
+++ b/src/Management/test/Endpoint.Test/ManagementWebHostBuilderExtensionsTest.cs
@@ -779,7 +779,7 @@ public class ManagementWebHostBuilderExtensionsTest
         HttpResponseMessage response = await client.GetAsync("/actuator/metrics");
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
-        // Assert warning is nog logged
+        // Assert warning is not logged
         logger.GetMessages().Should().NotContain("WARNING: Make sure one of the extension methods that calls ConfigureSteeltoeMetrics " +
             "is used to correctly configure metrics using OpenTelemetry for Steeltoe.");
 

--- a/src/Stream/test/Stream.Test/Tck/ContentTypeTckTest.cs
+++ b/src/Stream/test/Stream.Test/Tck/ContentTypeTckTest.cs
@@ -774,7 +774,7 @@ public class ContentTypeTckTest : AbstractTest
     [Fact]
     public async Task TestWithTypelessInputParameterAndServiceActivator()
     {
-        _container.AddServiceActivators<TypelessPayloadConfigurationSa>();
+        _container.AddServiceActivators<TypelessPayloadConfigurationServiceActivator>();
         ServiceProvider provider = _container.BuildServiceProvider();
 
         var streamProcessor = provider.GetRequiredService<ServiceActivatorAttributeProcessor>();
@@ -794,7 +794,7 @@ public class ContentTypeTckTest : AbstractTest
     [Fact]
     public async Task TestWithTypelessMessageInputParameterAndServiceActivator()
     {
-        _container.AddServiceActivators<TypelessMessageConfigurationSa>();
+        _container.AddServiceActivators<TypelessMessageConfigurationServiceActivator>();
         ServiceProvider provider = _container.BuildServiceProvider();
 
         var streamProcessor = provider.GetRequiredService<ServiceActivatorAttributeProcessor>();

--- a/src/Stream/test/Stream.Test/Tck/TypelessMessageConfigurationServiceActivator.cs
+++ b/src/Stream/test/Stream.Test/Tck/TypelessMessageConfigurationServiceActivator.cs
@@ -8,7 +8,7 @@ using Steeltoe.Stream.Messaging;
 
 namespace Steeltoe.Stream.Test.Tck;
 
-public class TypelessMessageConfigurationSa
+public class TypelessMessageConfigurationServiceActivator
 {
     [ServiceActivator(InputChannel = ISink.InputName, OutputChannel = ISource.OutputName)]
     public object Echo(IMessage value)

--- a/src/Stream/test/Stream.Test/Tck/TypelessPayloadConfigurationServiceActivator.cs
+++ b/src/Stream/test/Stream.Test/Tck/TypelessPayloadConfigurationServiceActivator.cs
@@ -7,7 +7,7 @@ using Steeltoe.Stream.Messaging;
 
 namespace Steeltoe.Stream.Test.Tck;
 
-public class TypelessPayloadConfigurationSa
+public class TypelessPayloadConfigurationServiceActivator
 {
     [ServiceActivator(InputChannel = ISink.InputName, OutputChannel = ISource.OutputName)]
     public object Echo(object value)


### PR DESCRIPTION
## Description

This PR replaces `Console.WriteLine` usage with `BootstrapLoggerFactory`. Although we don't actually upgrade the logger from configuration, it writes to the console by default, which is sufficient for our use cases.

Fixes #911.

## Quality checklist

- [x] Your code complies with our [Coding Style](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-code-style.md).
- [x] You've updated unit and/or integration tests for your change, where applicable.
- [ ] You've updated documentation for your change, where applicable.
      If your change affects other repositories, such as [Documentation](https://github.com/SteeltoeOSS/Documentation), [Samples](https://github.com/SteeltoeOSS/Samples) and/or [MainSite](https://github.com/SteeltoeOSS/MainSite), add linked PRs here.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
- [ ] You've added required license files and/or file headers (explaining where the code came from with proper attribution), where code is copied from StackOverflow, a blog, or OSS.
