### PR TITLE
Remove assertions on provider count

### DIFF
--- a/src/Bootstrap/test/AutoConfiguration.Test/HostBuilderExtensionsTest.cs
+++ b/src/Bootstrap/test/AutoConfiguration.Test/HostBuilderExtensionsTest.cs
@@ -60,7 +60,6 @@ public class HostBuilderExtensionsTest
         IHost host = hostBuilder.AddSteeltoe(exclusions).Build();
         var configurationRoot = host.Services.GetServices<IConfiguration>().SingleOrDefault() as ConfigurationRoot;
 
-        Assert.Equal(4, configurationRoot.Providers.Count());
         Assert.Single(configurationRoot.Providers.OfType<CloudFoundryConfigurationProvider>());
         Assert.Single(configurationRoot.Providers.OfType<ConfigServerConfigurationProvider>());
     }
@@ -78,7 +77,6 @@ public class HostBuilderExtensionsTest
         IHost host = hostBuilder.AddSteeltoe(exclusions).Build();
         var configurationRoot = host.Services.GetServices<IConfiguration>().SingleOrDefault() as ConfigurationRoot;
 
-        Assert.Equal(2, configurationRoot.Providers.Count());
         Assert.Single(configurationRoot.Providers.OfType<CloudFoundryConfigurationProvider>());
     }
 
@@ -97,7 +95,6 @@ public class HostBuilderExtensionsTest
         IHost host = hostBuilder.AddSteeltoe(exclusions).Build();
         var configurationRoot = host.Services.GetServices<IConfiguration>().SingleOrDefault() as ConfigurationRoot;
 
-        Assert.Equal(5, configurationRoot.Providers.Count());
         Assert.Equal(2, configurationRoot.Providers.OfType<KubernetesConfigMapProvider>().Count());
         Assert.Equal(2, configurationRoot.Providers.OfType<KubernetesSecretProvider>().Count());
     }
@@ -115,7 +112,6 @@ public class HostBuilderExtensionsTest
         IHost host = hostBuilder.AddSteeltoe(exclusions).Build();
         var configurationRoot = host.Services.GetService<IConfiguration>() as ConfigurationRoot;
 
-        Assert.Equal(2, configurationRoot.Providers.Count());
         Assert.Single(configurationRoot.Providers.OfType<RandomValueProvider>());
     }
 
@@ -150,7 +146,6 @@ public class HostBuilderExtensionsTest
         var configurationRoot = host.Services.GetService<IConfiguration>() as ConfigurationRoot;
         IServiceProvider services = host.Services;
 
-        Assert.Equal(3, configurationRoot.Providers.Count());
         Assert.Single(configurationRoot.Providers.OfType<ConnectionStringConfigurationProvider>());
         Assert.NotNull(services.GetService<MySqlConnection>());
         Assert.NotNull(services.GetService<MongoClient>());
@@ -320,10 +315,9 @@ public class HostBuilderExtensionsTest
         IHost host = hostBuilder.AddSteeltoe(exclusions).Build();
         var configurationRoot = host.Services.GetServices<IConfiguration>().SingleOrDefault() as ConfigurationRoot;
 
-        Assert.Equal(2, configurationRoot.Providers.Count());
         Assert.Single(configurationRoot.Providers.OfType<PemCertificateProvider>());
-        Assert.NotNull(host.Services.GetRequiredService<IOptions<CertificateOptions>>());
-        Assert.NotNull(host.Services.GetRequiredService<ICertificateRotationService>());
-        Assert.NotNull(host.Services.GetRequiredService<IAuthorizationHandler>());
+        Assert.NotNull(host.Services.GetService<IOptions<CertificateOptions>>());
+        Assert.NotNull(host.Services.GetService<ICertificateRotationService>());
+        Assert.NotNull(host.Services.GetService<IAuthorizationHandler>());
     }
 }

--- a/src/Bootstrap/test/AutoConfiguration.Test/WebApplicationBuilderExtensionsTest.cs
+++ b/src/Bootstrap/test/AutoConfiguration.Test/WebApplicationBuilderExtensionsTest.cs
@@ -51,8 +51,6 @@ public class WebApplicationBuilderExtensionsTest
 
         var configurationRoot = host.Services.GetServices<IConfiguration>().First(c => c is ConfigurationManager) as IConfigurationRoot;
 
-        // WebApplication.CreateBuilder() automatically includes a few builders
-        Assert.Equal(9, configurationRoot.Providers.Count());
         Assert.Single(configurationRoot.Providers.OfType<CloudFoundryConfigurationProvider>());
         Assert.Single(configurationRoot.Providers.OfType<ConfigServerConfigurationProvider>());
     }
@@ -63,7 +61,6 @@ public class WebApplicationBuilderExtensionsTest
         WebApplication host = GetWebApplicationWithSteeltoe(SteeltoeAssemblies.SteeltoeExtensionsConfigurationCloudFoundry);
         var configurationRoot = host.Services.GetServices<IConfiguration>().First(c => c is ConfigurationManager) as IConfigurationRoot;
 
-        Assert.Equal(8, configurationRoot.Providers.Count());
         Assert.Single(configurationRoot.Providers.OfType<CloudFoundryConfigurationProvider>());
     }
 
@@ -74,7 +71,6 @@ public class WebApplicationBuilderExtensionsTest
         WebApplication host = GetWebApplicationWithSteeltoe(SteeltoeAssemblies.SteeltoeExtensionsConfigurationKubernetes);
         var configurationRoot = host.Services.GetServices<IConfiguration>().First(c => c is ConfigurationManager) as IConfigurationRoot;
 
-        Assert.Equal(11, configurationRoot.Providers.Count());
         Assert.Equal(2, configurationRoot.Providers.OfType<KubernetesConfigMapProvider>().Count());
         Assert.Equal(2, configurationRoot.Providers.OfType<KubernetesSecretProvider>().Count());
     }
@@ -85,7 +81,6 @@ public class WebApplicationBuilderExtensionsTest
         WebApplication host = GetWebApplicationWithSteeltoe(SteeltoeAssemblies.SteeltoeExtensionsConfigurationRandomValue);
         var configurationRoot = host.Services.GetServices<IConfiguration>().First(c => c is ConfigurationManager) as IConfigurationRoot;
 
-        Assert.Equal(8, configurationRoot.Providers.Count());
         Assert.Single(configurationRoot.Providers.OfType<RandomValueProvider>());
     }
 
@@ -104,7 +99,6 @@ public class WebApplicationBuilderExtensionsTest
         var configurationRoot = host.Services.GetServices<IConfiguration>().First(c => c is ConfigurationManager) as IConfigurationRoot;
         IServiceProvider services = host.Services;
 
-        Assert.Equal(8, configurationRoot.Providers.Count());
         Assert.Single(configurationRoot.Providers.OfType<ConnectionStringConfigurationProvider>());
         Assert.NotNull(services.GetService<MySqlConnection>());
         Assert.NotNull(services.GetService<MongoClient>());
@@ -244,11 +238,10 @@ public class WebApplicationBuilderExtensionsTest
         WebApplication host = GetWebApplicationWithSteeltoe(SteeltoeAssemblies.SteeltoeSecurityAuthenticationCloudFoundry);
         var configurationRoot = host.Services.GetServices<IConfiguration>().First(c => c is ConfigurationManager) as IConfigurationRoot;
 
-        Assert.Equal(8, configurationRoot.Providers.Count());
         Assert.Single(configurationRoot.Providers.OfType<PemCertificateProvider>());
-        Assert.NotNull(host.Services.GetRequiredService<IOptions<CertificateOptions>>());
-        Assert.NotNull(host.Services.GetRequiredService<ICertificateRotationService>());
-        Assert.NotNull(host.Services.GetRequiredService<IAuthorizationHandler>());
+        Assert.NotNull(host.Services.GetService<IOptions<CertificateOptions>>());
+        Assert.NotNull(host.Services.GetService<ICertificateRotationService>());
+        Assert.NotNull(host.Services.GetService<IAuthorizationHandler>());
     }
 
     private WebApplication GetWebApplicationWithSteeltoe(params string[] steeltoeInclusions)

--- a/src/Bootstrap/test/AutoConfiguration.Test/WebHostBuilderExtensionsTest.cs
+++ b/src/Bootstrap/test/AutoConfiguration.Test/WebHostBuilderExtensionsTest.cs
@@ -63,7 +63,6 @@ public class WebHostBuilderExtensionsTest
         IWebHost host = hostBuilder.AddSteeltoe(exclusions).Build();
         var configurationRoot = host.Services.GetServices<IConfiguration>().SingleOrDefault() as ConfigurationRoot;
 
-        Assert.Equal(4, configurationRoot.Providers.Count());
         Assert.Single(configurationRoot.Providers.OfType<CloudFoundryConfigurationProvider>());
         Assert.Single(configurationRoot.Providers.OfType<ConfigServerConfigurationProvider>());
     }
@@ -83,7 +82,6 @@ public class WebHostBuilderExtensionsTest
         IWebHost host = hostBuilder.AddSteeltoe(exclusions).Build();
         var configurationRoot = host.Services.GetServices<IConfiguration>().SingleOrDefault() as ConfigurationRoot;
 
-        Assert.Equal(2, configurationRoot.Providers.Count());
         Assert.Single(configurationRoot.Providers.OfType<CloudFoundryConfigurationProvider>());
     }
 
@@ -104,7 +102,6 @@ public class WebHostBuilderExtensionsTest
         IWebHost host = hostBuilder.AddSteeltoe(exclusions).Build();
         var configurationRoot = host.Services.GetServices<IConfiguration>().SingleOrDefault() as ConfigurationRoot;
 
-        Assert.Equal(5, configurationRoot.Providers.Count());
         Assert.Equal(2, configurationRoot.Providers.OfType<KubernetesConfigMapProvider>().Count());
         Assert.Equal(2, configurationRoot.Providers.OfType<KubernetesSecretProvider>().Count());
     }
@@ -124,7 +121,6 @@ public class WebHostBuilderExtensionsTest
         IWebHost host = hostBuilder.AddSteeltoe(exclusions).Build();
         var configurationRoot = host.Services.GetService<IConfiguration>() as ConfigurationRoot;
 
-        Assert.Equal(2, configurationRoot.Providers.Count());
         Assert.Single(configurationRoot.Providers.OfType<RandomValueProvider>());
     }
 
@@ -164,7 +160,6 @@ public class WebHostBuilderExtensionsTest
         var configurationRoot = host.Services.GetService<IConfiguration>() as ConfigurationRoot;
         IServiceProvider services = host.Services;
 
-        Assert.Equal(3, configurationRoot.Providers.Count());
         Assert.Single(configurationRoot.Providers.OfType<ConnectionStringConfigurationProvider>());
         Assert.NotNull(services.GetService<MySqlConnection>());
         Assert.NotNull(services.GetService<MongoClient>());
@@ -349,10 +344,9 @@ public class WebHostBuilderExtensionsTest
         IWebHost host = hostBuilder.AddSteeltoe(exclusions).Build();
         var configurationRoot = host.Services.GetServices<IConfiguration>().SingleOrDefault() as ConfigurationRoot;
 
-        Assert.Equal(2, configurationRoot.Providers.Count());
         Assert.Single(configurationRoot.Providers.OfType<PemCertificateProvider>());
-        Assert.NotNull(host.Services.GetRequiredService<IOptions<CertificateOptions>>());
-        Assert.NotNull(host.Services.GetRequiredService<ICertificateRotationService>());
-        Assert.NotNull(host.Services.GetRequiredService<IAuthorizationHandler>());
+        Assert.NotNull(host.Services.GetService<IOptions<CertificateOptions>>());
+        Assert.NotNull(host.Services.GetService<ICertificateRotationService>());
+        Assert.NotNull(host.Services.GetService<IAuthorizationHandler>());
     }
 }


### PR DESCRIPTION
## Description

The number of configuration providers you'll get out of the box changed in .NET 7. As we discussed during a team meeting, it makes no sense to assert on the exact count, so this PR removes those assertions.

## Quality checklist
- [x] Your code complies with our [Coding Style](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-code-style.md).
- [x] You've updated unit and/or integration tests for your change, where applicable.
- [ ] You've updated documentation for your change, where applicable.
      If your change affects other repositories, such as [Documentation](https://github.com/SteeltoeOSS/Documentation), [Samples](https://github.com/SteeltoeOSS/Samples) and/or [MainSite](https://github.com/SteeltoeOSS/MainSite), add linked PRs here.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
- [ ] You've added required license files and/or file headers (explaining where the code came from with proper attribution), where code is copied from StackOverflow, a blog, or OSS.
