### PR TITLE
Add default for Cache timeout

### DIFF
--- a/src/Management/src/EndpointBase/Metrics/MetricsEndpointOptions.cs
+++ b/src/Management/src/EndpointBase/Metrics/MetricsEndpointOptions.cs
@@ -46,5 +46,5 @@ public class MetricsEndpointOptions : AbstractEndpointOptions, IMetricsEndpointO
 
     public string EgressIgnorePattern { get; set; }
 
-    public int ScrapeResponseCacheDurationMilliseconds { get; set; }
+    public int ScrapeResponseCacheDurationMilliseconds { get; set; } = 5000;
 }

--- a/src/Management/src/OpenTelemetryBase/Metrics/MetricsCollection.cs
+++ b/src/Management/src/OpenTelemetryBase/Metrics/MetricsCollection.cs
@@ -2,14 +2,12 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
-using System.Text;
+using System.Collections.Concurrent;
 
 namespace Steeltoe.Management.OpenTelemetry.Metrics;
 
 public class MetricsCollection<T>
-    : Dictionary<string, T>
+    : ConcurrentDictionary<string, T>
     where T : new()
 {
     internal MetricsCollection()


### PR DESCRIPTION
## Description
Fixes this bug: When there is no Scrape interval, the opentelemetry collector does not cache previous collection and causes a performance issue. This fixes this problem by setting the default to 5 seconds.

## Quality checklist

<!-- Please run through the checklist below to ensure a smooth review and merge process for your PR. -->

- [ ] Your code complies with our [Coding Style](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-code-style.md).
- [ ] You've updated unit and/or integration tests for your change, where applicable.
- [ ] You've updated documentation for your change, where applicable.
      If your change affects other repositories, such as [Documentation](https://github.com/SteeltoeOSS/Documentation), [Samples](https://github.com/SteeltoeOSS/Samples) and/or [MainSite](https://github.com/SteeltoeOSS/MainSite), add linked PRs here.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
- [ ] You've added required license files and/or file headers (explaining where the code came from with proper attribution), where code is copied from StackOverflow, a blog, or OSS.
