### PR TITLE
catch missing delimiters when building connection strings

### DIFF
--- a/src/Connectors/src/ConnectorBase/AbstractServiceConnectorOptions.cs
+++ b/src/Connectors/src/ConnectorBase/AbstractServiceConnectorOptions.cs
@@ -57,7 +57,7 @@ public abstract class AbstractServiceConnectorOptions
     {
         if (!string.IsNullOrEmpty(value))
         {
-            if (sb.Length > 1 && !sb.ToString().EndsWith(_keyValueTerm.ToString()))
+            if (sb.Length > 1 && !sb.ToString().EndsWith(_keyValueTerm.ToString()) && !sb.ToString().EndsWith("?"))
             {
                 sb.Append(_keyValueTerm);
             }

--- a/src/Connectors/src/ConnectorBase/AbstractServiceConnectorOptions.cs
+++ b/src/Connectors/src/ConnectorBase/AbstractServiceConnectorOptions.cs
@@ -57,6 +57,11 @@ public abstract class AbstractServiceConnectorOptions
     {
         if (!string.IsNullOrEmpty(value))
         {
+            if (sb.Length > 1 && !sb.ToString().EndsWith(_keyValueTerm.ToString()))
+            {
+                sb.Append(_keyValueTerm);
+            }
+
             sb.Append(key);
             sb.Append(_keyValueSep);
             sb.Append(value);

--- a/src/Connectors/test/ConnectorBase.Test/PostgreSQL/PostgresProviderConnectorOptionsTest.cs
+++ b/src/Connectors/test/ConnectorBase.Test/PostgreSQL/PostgresProviderConnectorOptionsTest.cs
@@ -135,4 +135,25 @@ public class PostgresProviderConnectorOptionsTest
         Assert.DoesNotContain(appsettings["postgres:client:ConnectionString"], sconfig.ToString());
         Assert.EndsWith($"Search Path={sconfig.SearchPath};", sconfig.ToString());
     }
+
+    [Fact]
+    public void ConnectionStringWithoutTrailingSemicolonResultsInValidConnection()
+    {
+        var appSettings = new Dictionary<string, string>()
+        {
+            ["postgres:client:ConnectionString"] = "Server=fake;Database=test;User Id=steeltoe;Password=password",
+            ["postgres:client:SearchPath"] = "SomeSchema"
+        };
+
+        // add settings to config
+        var configurationBuilder = new ConfigurationBuilder();
+        configurationBuilder.AddInMemoryCollection(appSettings);
+        configurationBuilder.AddEnvironmentVariables();
+        var config = configurationBuilder.Build();
+
+        var connectorOptions = new PostgresProviderConnectorOptions(config);
+
+        var expectedConnection = $"{appSettings["postgres:client:ConnectionString"]};Timeout={connectorOptions.Timeout};Command Timeout={connectorOptions.CommandTimeout};Search Path={connectorOptions.SearchPath};";
+        Assert.Equal(expectedConnection, connectorOptions.ToString());
+    }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->

<!-- If this is your first PR in this repo, please read our [Contributing Guidelines (https://github.com/SteeltoeOSS/.github/blob/master/CONTRIBUTING.md) and remember to sign the [Contributor License Agreement](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-license.md). Our bot will notify you shortly after the PR has been created. -->

## Description

Handle cases where a user-provided connection string does not end with the delimiter and other settings are appended

Addresses #1076 in release/3.2 - A similar fix needs to happen for 4.0 but for that release we can choose to _only_ prepend the delimiter instead of appending

## Quality checklist

<!-- Please run through the checklist below to ensure a smooth review and merge process for your PR. -->

- [ ] Your code complies with our [Coding Style](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-code-style.md).
- [ ] You've updated unit and/or integration tests for your change, where applicable.
- [ ] You've updated documentation for your change, where applicable.
      If your change affects other repositories, such as [Documentation](https://github.com/SteeltoeOSS/Documentation), [Samples](https://github.com/SteeltoeOSS/Samples) and/or [MainSite](https://github.com/SteeltoeOSS/MainSite), add linked PRs here.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
- [ ] You've added required license files and/or file headers (explaining where the code came from with proper attribution), where code is copied from StackOverflow, a blog, or OSS.
