### PR TITLE
Workaround for CloudFoundry URI escape bug

### DIFF
--- a/src/Connectors/src/Abstractions/Services/UriInfo.cs
+++ b/src/Connectors/src/Abstractions/Services/UriInfo.cs
@@ -136,6 +136,8 @@ public class UriInfo
             uriString = ConvertJdbcToUri(uriString);
         }
 
+        uriString = EscapeFirstAtSignIfMultipleOccurrences(uriString);
+
         try
         {
             return new Uri(uriString);
@@ -165,6 +167,15 @@ public class UriInfo
 
             return null;
         }
+    }
+
+    private static string EscapeFirstAtSignIfMultipleOccurrences(string uriString)
+    {
+        // Workaround for CloudFoundry bug: it forgets to uri-escape the '@' character in username field when using Azure, resulting in an invalid Uri.
+        // For example: postgresql://<user>@<host>:<password>@<host>:5432/vsbdb -> postgresql://<user>%40<host>:<password>@<host>:5432/vsbdb
+
+        string[] parts = uriString.Split('@', 3);
+        return parts.Length == 3 ? $"{parts[0]}%40{parts[1]}@{parts[2]}" : uriString;
     }
 
     private string ConvertJdbcToUri(string uriString)

--- a/src/Connectors/test/Connector.Test/PostgreSQL/PostgreSqlProviderServiceCollectionExtensionsTest.cs
+++ b/src/Connectors/test/Connector.Test/PostgreSQL/PostgreSqlProviderServiceCollectionExtensionsTest.cs
@@ -143,7 +143,10 @@ public class PostgreSqlProviderServiceCollectionExtensionsTest
         Assert.Contains("Host=2980cfbe-e198-46fd-8f81-966584bb4678.postgres.database.azure.com;", connString, StringComparison.Ordinal);
         Assert.Contains("Port=5432;", connString, StringComparison.Ordinal);
         Assert.Contains("Database=g01w0qnrb7;", connString, StringComparison.Ordinal);
-        Assert.Contains("Username=c2cdhwt4nd@2980cfbe-e198-46fd-8f81-966584bb4678;", connString, StringComparison.Ordinal);
+
+        Assert.Contains("Username=c2cdhwt4nd@2980cfbe-e198-46fd-8f81-966584bb4678@2980cfbe-e198-46fd-8f81-966584bb4678.postgres.database.azure.com;",
+            connString, StringComparison.Ordinal);
+
         Assert.Contains("Password=Dko4PGJAsQyEj5gj;", connString, StringComparison.Ordinal);
     }
 

--- a/src/Connectors/test/Connector.Test/PostgreSQL/PostgreSqlTestHelpers.cs
+++ b/src/Connectors/test/Connector.Test/PostgreSQL/PostgreSqlTestHelpers.cs
@@ -103,7 +103,7 @@ public static class PostgreSqlTestHelpers
                         ""database"": ""g01w0qnrb7"",
                         ""username"": ""c2cdhwt4nd@2980cfbe-e198-46fd-8f81-966584bb4678"",
                         ""password"": ""Dko4PGJAsQyEj5gj"",
-                        ""uri"": ""postgresql://c2cdhwt4nd%402980cfbe-e198-46fd-8f81-966584bb4678:Dko4PGJAsQyEj5gj@2980cfbe-e198-46fd-8f81-966584bb4678.postgres.database.azure.com:5432/g01w0qnrb7?&sslmode=require"",
+                        ""uri"": ""postgresql://c2cdhwt4nd%402980cfbe-e198-46fd-8f81-966584bb4678@2980cfbe-e198-46fd-8f81-966584bb4678.postgres.database.azure.com:Dko4PGJAsQyEj5gj@2980cfbe-e198-46fd-8f81-966584bb4678.postgres.database.azure.com:5432/g01w0qnrb7?&sslmode=require"",
                         ""sslRequired"": true,
                         ""tags"": [
                             ""postgresql""


### PR DESCRIPTION
## Description

Workaround for CloudFoundry bug: it forgets to uri-escape the '@' character in username field when using Azure, resulting in an invalid Uri.

## Quality checklist

- [x] Your code complies with our [Coding Style](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-code-style.md).
- [x] You've updated unit and/or integration tests for your change, where applicable.
- [ ] You've updated documentation for your change, where applicable.
      If your change affects other repositories, such as [Documentation](https://github.com/SteeltoeOSS/Documentation), [Samples](https://github.com/SteeltoeOSS/Samples) and/or [MainSite](https://github.com/SteeltoeOSS/MainSite), add linked PRs here.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
- [ ] You've added required license files and/or file headers (explaining where the code came from with proper attribution), where code is copied from StackOverflow, a blog, or OSS.
