### PR TITLE
Fix crash in AddSqlServerHealthContributor

### DIFF
--- a/src/Bootstrap/test/AutoConfiguration.Test/HostBuilderExtensionsTest.cs
+++ b/src/Bootstrap/test/AutoConfiguration.Test/HostBuilderExtensionsTest.cs
@@ -2,13 +2,13 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-using System.Data.SqlClient;
 using System.Net;
 using System.Reflection;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.TestHost;
+using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;

--- a/src/Bootstrap/test/AutoConfiguration.Test/Steeltoe.Bootstrap.AutoConfiguration.Test.csproj
+++ b/src/Bootstrap/test/AutoConfiguration.Test/Steeltoe.Bootstrap.AutoConfiguration.Test.csproj
@@ -27,6 +27,6 @@
     <PackageReference Include="Npgsql" Version="$(NpgsqlVersion)" />
     <PackageReference Include="RabbitMQ.Client" Version="$(RabbitClientVersion)" />
     <PackageReference Include="StackExchange.Redis" Version="$(StackExchangeVersion)" />
-    <PackageReference Include="System.Data.SqlClient" Version="$(SqlClientVersion)" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="$(MicrosoftSqlClientVersion)" />
   </ItemGroup>
 </Project>

--- a/src/Bootstrap/test/AutoConfiguration.Test/WebApplicationBuilderExtensionsTest.cs
+++ b/src/Bootstrap/test/AutoConfiguration.Test/WebApplicationBuilderExtensionsTest.cs
@@ -2,13 +2,13 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-using System.Data.SqlClient;
 using System.Net;
 using System.Reflection;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.TestHost;
+using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;

--- a/src/Bootstrap/test/AutoConfiguration.Test/WebHostBuilderExtensionsTest.cs
+++ b/src/Bootstrap/test/AutoConfiguration.Test/WebHostBuilderExtensionsTest.cs
@@ -2,13 +2,13 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-using System.Data.SqlClient;
 using System.Net;
 using System.Reflection;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.TestHost;
+using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;

--- a/src/Connectors/src/Connector/SqlServer/SqlServerTypeLocator.cs
+++ b/src/Connectors/src/Connector/SqlServer/SqlServerTypeLocator.cs
@@ -26,6 +26,7 @@ public static class SqlServerTypeLocator
     /// </summary>
     public static string[] Assemblies { get; internal set; } =
     {
+        "Microsoft.Data.SqlClient",
         "System.Data.SqlClient"
     };
 
@@ -34,6 +35,7 @@ public static class SqlServerTypeLocator
     /// </summary>
     public static string[] ConnectionTypeNames { get; internal set; } =
     {
+        "Microsoft.Data.SqlClient.SqlConnection",
         "System.Data.SqlClient.SqlConnection"
     };
 }

--- a/src/Connectors/test/Connector.Test/SqlServer/SqlServerTypeLocatorTest.cs
+++ b/src/Connectors/test/Connector.Test/SqlServer/SqlServerTypeLocatorTest.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
+using FluentAssertions;
 using Steeltoe.Connector.SqlServer;
 using Xunit;
 
@@ -10,12 +11,59 @@ namespace Steeltoe.Connector.Test.SqlServer;
 public class SqlServerTypeLocatorTest
 {
     [Fact]
-    public void Property_Can_Locate_ConnectionType()
+    public void Driver_Found_In_System_Assembly()
     {
-        // arrange -- handled by including System.Data.SqlClient
-        Type type = SqlServerTypeLocator.SqlConnection;
+        string[] backupAssemblies = SqlServerTypeLocator.Assemblies;
+        string[] backupTypes = SqlServerTypeLocator.ConnectionTypeNames;
 
-        Assert.NotNull(type);
+        try
+        {
+            SqlServerTypeLocator.Assemblies = new[]
+            {
+                "System.Data.SqlClient"
+            };
+
+            SqlServerTypeLocator.ConnectionTypeNames = new[]
+            {
+                "System.Data.SqlClient.SqlConnection"
+            };
+
+            Type type = SqlServerTypeLocator.SqlConnection;
+            type.Should().NotBeNull();
+        }
+        finally
+        {
+            SqlServerTypeLocator.Assemblies = backupAssemblies;
+            SqlServerTypeLocator.ConnectionTypeNames = backupTypes;
+        }
+    }
+
+    [Fact]
+    public void Driver_Found_In_Microsoft_Assembly()
+    {
+        string[] backupAssemblies = SqlServerTypeLocator.Assemblies;
+        string[] backupTypes = SqlServerTypeLocator.ConnectionTypeNames;
+
+        try
+        {
+            SqlServerTypeLocator.Assemblies = new[]
+            {
+                "Microsoft.Data.SqlClient"
+            };
+
+            SqlServerTypeLocator.ConnectionTypeNames = new[]
+            {
+                "Microsoft.Data.SqlClient.SqlConnection"
+            };
+
+            Type type = SqlServerTypeLocator.SqlConnection;
+            type.Should().NotBeNull();
+        }
+        finally
+        {
+            SqlServerTypeLocator.Assemblies = backupAssemblies;
+            SqlServerTypeLocator.ConnectionTypeNames = backupTypes;
+        }
     }
 
     [Fact]

--- a/src/Connectors/test/Connector.Test/Steeltoe.Connector.Test.csproj
+++ b/src/Connectors/test/Connector.Test/Steeltoe.Connector.Test.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="$(MicrosoftAzureCosmosVersion)" />
     <PackageReference Include="Oracle.ManagedDataAccess.Core" Version="$(OracleVersion)" />
     <PackageReference Include="System.Data.SqlClient" Version="$(SqlClientVersion)" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="$(MicrosoftSqlClientVersion)" />
     <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="$(ExtensionsVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="$(ExtensionsVersion)" />
     <PackageReference Include="MongoDB.Driver" Version="$(MongoDbClientVersion)" />

--- a/versions.props
+++ b/versions.props
@@ -11,6 +11,7 @@
     <NpgsqlVersion>6.0.*</NpgsqlVersion>
     <OracleVersion>3.21.*</OracleVersion>
     <SqlClientVersion>4.8.*</SqlClientVersion>
+    <MicrosoftSqlClientVersion>5.0.*</MicrosoftSqlClientVersion>
     <MicrosoftAzureCosmosVersion>3.28.*</MicrosoftAzureCosmosVersion>
     <StackExchangeVersion>2.6.*</StackExchangeVersion>
     <CoverletVersion>3.2.*</CoverletVersion>


### PR DESCRIPTION
## Description

Since EF Core 3.0, the [Microsoft.EntityFrameworkCore.SqlServer NuGet package](https://www.nuget.org/packages/Microsoft.EntityFrameworkCore.SqlServer/3.0.0#dependencies-body-tab) switched its dependency from `System.Data.SqlClient` to `Microsoft.Data.SqlClient`. Because of that, calling `AddSqlServerHealthContributor()` crashes, as it was still looking for the old `System.Data.SqlClient` assembly.

## Quality checklist

<!-- Please run through the checklist below to ensure a smooth review and merge process for your PR. -->

- [x] Your code complies with our [Coding Style](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-code-style.md).
- [x] You've updated unit and/or integration tests for your change, where applicable.
- [ ] You've updated documentation for your change, where applicable.
      If your change affects other repositories, such as [Documentation](https://github.com/SteeltoeOSS/Documentation), [Samples](https://github.com/SteeltoeOSS/Samples) and/or [MainSite](https://github.com/SteeltoeOSS/MainSite), add linked PRs here.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
- [ ] You've added required license files and/or file headers (explaining where the code came from with proper attribution), where code is copied from StackOverflow, a blog, or OSS.
