### PR TITLE
RabbitMQ connector support, based on new CloudFoundry service bindings

### DIFF
--- a/src/Bootstrap/test/AutoConfiguration.Test/Steeltoe.Bootstrap.AutoConfiguration.Test.csproj
+++ b/src/Bootstrap/test/AutoConfiguration.Test/Steeltoe.Bootstrap.AutoConfiguration.Test.csproj
@@ -25,7 +25,7 @@
     <PackageReference Include="MongoDB.Driver" Version="$(MongoDbClientVersion)" />
     <PackageReference Include="Oracle.ManagedDataAccess.Core" Version="$(OracleVersion)" />
     <PackageReference Include="Npgsql" Version="$(NpgsqlVersion)" />
-    <PackageReference Include="RabbitMQ.Client" Version="$(RabbitClientVersion)" />
+    <PackageReference Include="RabbitMQ.Client" Version="$(RabbitClientTestVersion)" />
     <PackageReference Include="StackExchange.Redis" Version="$(StackExchangeVersion)" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="$(MicrosoftSqlClientVersion)" />
   </ItemGroup>

--- a/src/Common/src/Common/Reflection/ReflectionHelpers.cs
+++ b/src/Common/src/Common/Reflection/ReflectionHelpers.cs
@@ -202,7 +202,7 @@ public static class ReflectionHelpers
     /// List of suitable types.
     /// </param>
     /// <returns>
-    /// An appropriate type.
+    /// An appropriate type, or <c>null</c> when not found.
     /// </returns>
     /// <remarks>
     /// Great for finding an implementation type that could have one or more names in one or more assemblies.
@@ -240,7 +240,7 @@ public static class ReflectionHelpers
     /// The name of the type to retrieve.
     /// </param>
     /// <returns>
-    /// The type.
+    /// The type, or <c>null</c> when not found.
     /// </returns>
     public static Type FindType(Assembly assembly, string typeName)
     {
@@ -293,6 +293,32 @@ public static class ReflectionHelpers
     }
 
     /// <summary>
+    /// Find a property within a type.
+    /// </summary>
+    /// <param name="type">
+    /// The type to search.
+    /// </param>
+    /// <param name="propertyName">
+    /// The name of the property.
+    /// </param>
+    /// <returns>
+    /// The property you're searching for, or <c>null</c> when not found.
+    /// </returns>
+    public static PropertyInfo FindProperty(Type type, string propertyName)
+    {
+        try
+        {
+            return type.GetProperty(propertyName);
+        }
+        catch (Exception)
+        {
+            // Sometimes dependencies are missing... Should be handled later in framework code
+        }
+
+        return null;
+    }
+
+    /// <summary>
     /// Find a method within a type.
     /// </summary>
     /// <param name="type">
@@ -305,7 +331,7 @@ public static class ReflectionHelpers
     /// (Optional) The parameters in the signature.
     /// </param>
     /// <returns>
-    /// The method you're searching for.
+    /// The method you're searching for, or <c>null</c> when not found.
     /// </returns>
     public static MethodInfo FindMethod(Type type, string methodName, Type[] parameters = null)
     {

--- a/src/Configuration/src/Abstractions/ConfigurationDictionaryMapper.cs
+++ b/src/Configuration/src/Abstractions/ConfigurationDictionaryMapper.cs
@@ -8,11 +8,9 @@ namespace Steeltoe.Configuration;
 
 internal abstract class ConfigurationDictionaryMapper
 {
-    public string BindingKey { get; }
-
-    public string ToPrefix { get; }
-
-    public IDictionary<string, string> ConfigurationData { get; }
+    protected string BindingKey { get; }
+    protected string ToPrefix { get; }
+    protected IDictionary<string, string> ConfigurationData { get; }
 
     protected ConfigurationDictionaryMapper(IDictionary<string, string> configurationData, string bindingKey, params string[] toPrefix)
     {
@@ -25,7 +23,7 @@ internal abstract class ConfigurationDictionaryMapper
         }
     }
 
-    public void MapFromTo(string fromKey, string toKey)
+    public string MapFromTo(string fromKey, string toKey)
     {
         string value = GetFromValue(fromKey);
 
@@ -33,9 +31,11 @@ internal abstract class ConfigurationDictionaryMapper
         {
             SetToValue(toKey, value);
         }
+
+        return value;
     }
 
-    public void MapFromTo(string fromKey, params string[] toKeySegments)
+    public string MapFromTo(string fromKey, params string[] toKeySegments)
     {
         string value = GetFromValue(fromKey);
 
@@ -44,9 +44,11 @@ internal abstract class ConfigurationDictionaryMapper
             string toKey = string.Join(ConfigurationPath.KeyDelimiter, toKeySegments);
             SetToValue(toKey, value);
         }
+
+        return value;
     }
 
-    public void MapFromAppendTo(string fromKey, string appendToKey, string separator)
+    public string MapFromAppendTo(string fromKey, string appendToKey, string separator)
     {
         string valueToAppend = GetFromValue(fromKey);
 
@@ -58,11 +60,15 @@ internal abstract class ConfigurationDictionaryMapper
             {
                 string newValue = $"{existingValue}{separator}{valueToAppend}";
                 SetToValue(appendToKey, newValue);
+
+                return newValue;
             }
         }
+
+        return null;
     }
 
-    public void MapFromToFile(string fromKey, string toKey)
+    public string MapFromToFile(string fromKey, string toKey)
     {
         string value = GetFromValue(fromKey);
 
@@ -76,7 +82,10 @@ internal abstract class ConfigurationDictionaryMapper
             }
 
             SetToValue(toKey, tempPath);
+            return tempPath;
         }
+
+        return null;
     }
 
     public void SetToValue(string toKey, string value)

--- a/src/Configuration/src/CloudFoundry.ServiceBinding/ConfigurationBuilderExtensions.cs
+++ b/src/Configuration/src/CloudFoundry.ServiceBinding/ConfigurationBuilderExtensions.cs
@@ -101,6 +101,7 @@ public static class ConfigurationBuilderExtensions
         source.RegisterPostProcessor(new SqlServerPostProcessor());
         source.RegisterPostProcessor(new MongoDbPostProcessor());
         source.RegisterPostProcessor(new CosmosDbPostProcessor());
+        source.RegisterPostProcessor(new RabbitMQPostProcessor());
 
         builder.Add(source);
         return builder;

--- a/src/Configuration/src/CloudFoundry.ServiceBinding/RabbitMQPostProcessor.cs
+++ b/src/Configuration/src/CloudFoundry.ServiceBinding/RabbitMQPostProcessor.cs
@@ -1,0 +1,34 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+namespace Steeltoe.Configuration.CloudFoundry.ServiceBinding;
+
+internal sealed class RabbitMQPostProcessor : CloudFoundryConfigurationPostProcessor
+{
+    internal const string BindingType = "rabbitmq";
+
+    public override void PostProcessConfiguration(PostProcessorConfigurationProvider provider, IDictionary<string, string> configurationData)
+    {
+        if (!provider.IsBindingTypeEnabled(BindingType))
+        {
+            return;
+        }
+
+        foreach (string key in FilterKeys(configurationData, BindingType))
+        {
+            var mapper = ServiceBindingMapper.Create(configurationData, key, BindingType);
+
+            // See RabbitMQ connection string parameters at: https://www.rabbitmq.com/uri-spec.html
+            string useTlsValue = mapper.MapFromTo("credentials:ssl", "useTls");
+
+            string fromProtocol = bool.TryParse(useTlsValue, out bool useTls) && useTls ? "amqp+ssl" : "amqp";
+
+            mapper.MapFromTo($"credentials:protocols:{fromProtocol}:host", "host");
+            mapper.MapFromTo($"credentials:protocols:{fromProtocol}:port", "port");
+            mapper.MapFromTo($"credentials:protocols:{fromProtocol}:username", "username");
+            mapper.MapFromTo($"credentials:protocols:{fromProtocol}:password", "password");
+            mapper.MapFromTo($"credentials:protocols:{fromProtocol}:vhost", "virtualHost");
+        }
+    }
+}

--- a/src/Configuration/src/Kubernetes.ServiceBinding/PostProcessors.cs
+++ b/src/Configuration/src/Kubernetes.ServiceBinding/PostProcessors.cs
@@ -437,16 +437,14 @@ internal sealed class RabbitMQPostProcessor : IConfigurationPostProcessor
         configurationData.Filter(ServiceBindingConfigurationProvider.InputKeyPrefix, ServiceBindingConfigurationProvider.TypeKey, BindingType).ForEach(
             bindingNameKey =>
             {
-                // Spring -> spring.rabbitmq....
-                // Steeltoe -> steeltoe:service-bindings:rabbitmq:binding-name:....
                 var mapper = new ServiceBindingMapper(configurationData, bindingNameKey, ServiceBindingConfigurationProvider.OutputKeyPrefix, BindingType,
                     ConfigurationPath.GetSectionKey(bindingNameKey));
 
-                mapper.MapFromTo("addresses", "addresses");
+                // See RabbitMQ connection string parameters at: https://www.rabbitmq.com/uri-spec.html
                 mapper.MapFromTo("host", "host");
-                mapper.MapFromTo("password", "password");
                 mapper.MapFromTo("port", "port");
                 mapper.MapFromTo("username", "username");
+                mapper.MapFromTo("password", "password");
                 mapper.MapFromTo("virtual-host", "virtualHost");
             });
     }

--- a/src/Configuration/test/CloudFoundry.ServiceBinding.Test/PostProcessorsTest.cs
+++ b/src/Configuration/test/CloudFoundry.ServiceBinding.Test/PostProcessorsTest.cs
@@ -232,4 +232,81 @@ public sealed class PostProcessorsTest : BasePostProcessorsTest
         configurationData[$"{keyPrefix}:accountKey"].Should().Be("test-key");
         configurationData[$"{keyPrefix}:database"].Should().Be("test-database");
     }
+
+    [Fact]
+    public void RabbitMQTest_BindingTypeDisabled()
+    {
+        var postProcessor = new RabbitMQPostProcessor();
+
+        var secrets = new[]
+        {
+            Tuple.Create("credentials:ssl", "false")
+        };
+
+        Dictionary<string, string> configurationData = GetConfigurationData(RabbitMQPostProcessor.BindingType, TestProviderName, TestBindingName, secrets);
+        PostProcessorConfigurationProvider provider = GetConfigurationProvider(postProcessor, RabbitMQPostProcessor.BindingType, false);
+
+        postProcessor.PostProcessConfiguration(provider, configurationData);
+
+        string keyPrefix = GetOutputKeyPrefix(TestBindingName, RabbitMQPostProcessor.BindingType);
+        configurationData.Should().NotContainKey($"{keyPrefix}:useTls");
+    }
+
+    [Fact]
+    public void RabbitMQTest_BindingTypeEnabled()
+    {
+        var postProcessor = new RabbitMQPostProcessor();
+
+        var secrets = new[]
+        {
+            Tuple.Create("credentials:ssl", "false"),
+            Tuple.Create("credentials:protocols:amqp:host", "test-host"),
+            Tuple.Create("credentials:protocols:amqp:port", "test-port"),
+            Tuple.Create("credentials:protocols:amqp:username", "test-username"),
+            Tuple.Create("credentials:protocols:amqp:password", "test-password"),
+            Tuple.Create("credentials:protocols:amqp:vhost", "test-vhost")
+        };
+
+        Dictionary<string, string> configurationData = GetConfigurationData(RabbitMQPostProcessor.BindingType, TestProviderName, TestBindingName, secrets);
+        PostProcessorConfigurationProvider provider = GetConfigurationProvider(postProcessor, RabbitMQPostProcessor.BindingType, true);
+
+        postProcessor.PostProcessConfiguration(provider, configurationData);
+
+        string keyPrefix = GetOutputKeyPrefix(TestBindingName, RabbitMQPostProcessor.BindingType);
+        configurationData[$"{keyPrefix}:useTls"].Should().Be("false");
+        configurationData[$"{keyPrefix}:host"].Should().Be("test-host");
+        configurationData[$"{keyPrefix}:port"].Should().Be("test-port");
+        configurationData[$"{keyPrefix}:username"].Should().Be("test-username");
+        configurationData[$"{keyPrefix}:password"].Should().Be("test-password");
+        configurationData[$"{keyPrefix}:virtualHost"].Should().Be("test-vhost");
+    }
+
+    [Fact]
+    public void RabbitMQTest_BindingTypeEnabled_Tls()
+    {
+        var postProcessor = new RabbitMQPostProcessor();
+
+        var secrets = new[]
+        {
+            Tuple.Create("credentials:ssl", "true"),
+            Tuple.Create("credentials:protocols:amqp+ssl:host", "test-host"),
+            Tuple.Create("credentials:protocols:amqp+ssl:port", "test-port"),
+            Tuple.Create("credentials:protocols:amqp+ssl:username", "test-username"),
+            Tuple.Create("credentials:protocols:amqp+ssl:password", "test-password"),
+            Tuple.Create("credentials:protocols:amqp+ssl:vhost", "test-vhost")
+        };
+
+        Dictionary<string, string> configurationData = GetConfigurationData(RabbitMQPostProcessor.BindingType, TestProviderName, TestBindingName, secrets);
+        PostProcessorConfigurationProvider provider = GetConfigurationProvider(postProcessor, RabbitMQPostProcessor.BindingType, true);
+
+        postProcessor.PostProcessConfiguration(provider, configurationData);
+
+        string keyPrefix = GetOutputKeyPrefix(TestBindingName, RabbitMQPostProcessor.BindingType);
+        configurationData[$"{keyPrefix}:useTls"].Should().Be("true");
+        configurationData[$"{keyPrefix}:host"].Should().Be("test-host");
+        configurationData[$"{keyPrefix}:port"].Should().Be("test-port");
+        configurationData[$"{keyPrefix}:username"].Should().Be("test-username");
+        configurationData[$"{keyPrefix}:password"].Should().Be("test-password");
+        configurationData[$"{keyPrefix}:virtualHost"].Should().Be("test-vhost");
+    }
 }

--- a/src/Configuration/test/Kubernetes.ServiceBinding.Test/PostProcessorsTest.cs
+++ b/src/Configuration/test/Kubernetes.ServiceBinding.Test/PostProcessorsTest.cs
@@ -719,12 +719,7 @@ public sealed class PostProcessorsTest : BasePostProcessorsTest
 
         var secrets = new[]
         {
-            Tuple.Create("addresses", "test-addresses"),
-            Tuple.Create("host", "test-host"),
-            Tuple.Create("password", "test-password"),
-            Tuple.Create("port", "test-port"),
-            Tuple.Create("username", "test-username"),
-            Tuple.Create("virtual-host", "test-virtual-host")
+            Tuple.Create("username", "test-username")
         };
 
         Dictionary<string, string> configurationData = GetConfigurationData(TestBindingName, RabbitMQPostProcessor.BindingType, secrets);
@@ -733,7 +728,7 @@ public sealed class PostProcessorsTest : BasePostProcessorsTest
         postProcessor.PostProcessConfiguration(provider, configurationData);
 
         string keyPrefix = GetOutputKeyPrefix(TestBindingName, RabbitMQPostProcessor.BindingType);
-        configurationData.Should().NotContainKey($"{keyPrefix}:addresses");
+        configurationData.Should().NotContainKey($"{keyPrefix}:username");
     }
 
     [Fact]
@@ -743,11 +738,10 @@ public sealed class PostProcessorsTest : BasePostProcessorsTest
 
         var secrets = new[]
         {
-            Tuple.Create("addresses", "test-addresses"),
             Tuple.Create("host", "test-host"),
-            Tuple.Create("password", "test-password"),
             Tuple.Create("port", "test-port"),
             Tuple.Create("username", "test-username"),
+            Tuple.Create("password", "test-password"),
             Tuple.Create("virtual-host", "test-virtual-host")
         };
 
@@ -757,11 +751,10 @@ public sealed class PostProcessorsTest : BasePostProcessorsTest
         postProcessor.PostProcessConfiguration(provider, configurationData);
 
         string keyPrefix = GetOutputKeyPrefix(TestBindingName, RabbitMQPostProcessor.BindingType);
-        configurationData[$"{keyPrefix}:addresses"].Should().Be("test-addresses");
         configurationData[$"{keyPrefix}:host"].Should().Be("test-host");
-        configurationData[$"{keyPrefix}:password"].Should().Be("test-password");
         configurationData[$"{keyPrefix}:port"].Should().Be("test-port");
         configurationData[$"{keyPrefix}:username"].Should().Be("test-username");
+        configurationData[$"{keyPrefix}:password"].Should().Be("test-password");
         configurationData[$"{keyPrefix}:virtualHost"].Should().Be("test-virtual-host");
     }
 

--- a/src/Connectors/src/Connector/ConnectionProvider.cs
+++ b/src/Connectors/src/Connector/ConnectionProvider.cs
@@ -85,14 +85,6 @@ public sealed class ConnectionProvider<TOptions, TConnection> : IDisposable
     private (object Connection, TOptions OptionsSnapshot) CreateConnectionFromOptions()
     {
         TOptions optionsSnapshot = _optionsMonitor.Get(_name);
-
-        if (optionsSnapshot.ConnectionString == null)
-        {
-            throw new InvalidOperationException(_name == string.Empty
-                ? "Connection string for default service binding not found."
-                : $"Connection string for service binding '{_name}' not found.");
-        }
-
         object connection = _createConnection(optionsSnapshot, _name);
 
         if (connection == null)

--- a/src/Connectors/src/Connector/RabbitMQ/RabbitMQConnectionStringPostProcessor.cs
+++ b/src/Connectors/src/Connector/RabbitMQ/RabbitMQConnectionStringPostProcessor.cs
@@ -1,0 +1,134 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace Steeltoe.Connector.RabbitMQ;
+
+internal sealed class RabbitMQConnectionStringPostProcessor : ConnectionStringPostProcessor
+{
+    protected override string BindingType => "rabbitmq";
+
+    protected override IConnectionStringBuilder CreateConnectionStringBuilder()
+    {
+        return new RabbitMQConnectionStringBuilder();
+    }
+
+    private sealed class RabbitMQConnectionStringBuilder : IConnectionStringBuilder
+    {
+        private readonly Dictionary<string, string> _settings = new(StringComparer.OrdinalIgnoreCase);
+        private string _explicitUrl;
+
+        [MaybeNull]
+        [AllowNull]
+        public string ConnectionString
+        {
+            get
+            {
+                if (_explicitUrl != null)
+                {
+                    return _explicitUrl;
+                }
+
+                if (_settings.Count == 0)
+                {
+                    return null;
+                }
+
+                return BuildConnectionString();
+            }
+            set => _explicitUrl = value;
+        }
+
+        [AllowNull]
+        public object this[string keyword]
+        {
+            get
+            {
+                if (keyword == KnownKeywords.Url)
+                {
+                    return ConnectionString;
+                }
+
+                if (_settings.TryGetValue(keyword, out string value))
+                {
+                    return value;
+                }
+
+                throw new ArgumentException($"Keyword not supported: '{keyword}'.");
+            }
+            set
+            {
+                if (keyword == KnownKeywords.Url)
+                {
+                    ConnectionString = value?.ToString();
+                }
+                else
+                {
+                    // Discard connection string from appsettings.json
+                    _explicitUrl = null;
+
+                    string stringValue = value?.ToString();
+
+                    if (stringValue == null)
+                    {
+                        _settings.Remove(keyword);
+                    }
+                    else
+                    {
+                        _settings[keyword] = stringValue;
+                    }
+                }
+            }
+        }
+
+        private string BuildConnectionString()
+        {
+            var builder = new UriBuilder
+            {
+                Scheme = _settings.TryGetValue(KnownKeywords.UseTls, out string useTlsString) && bool.TryParse(useTlsString, out bool useTls) && useTls
+                    ? "amqps://"
+                    : "amqp://"
+            };
+
+            if (_settings.TryGetValue(KnownKeywords.Username, out string username))
+            {
+                builder.UserName = Uri.EscapeDataString(username);
+
+                if (_settings.TryGetValue(KnownKeywords.Password, out string password))
+                {
+                    builder.Password = Uri.EscapeDataString(password);
+                }
+            }
+
+            if (_settings.TryGetValue(KnownKeywords.Host, out string server))
+            {
+                builder.Host = server;
+
+                if (_settings.TryGetValue(KnownKeywords.Port, out string portString) && int.TryParse(portString, out int port))
+                {
+                    builder.Port = port;
+                }
+            }
+
+            if (_settings.TryGetValue(KnownKeywords.VirtualHost, out string virtualHost))
+            {
+                builder.Path = Uri.EscapeDataString(virtualHost);
+            }
+
+            return builder.Uri.AbsoluteUri;
+        }
+
+        private static class KnownKeywords
+        {
+            public const string UseTls = "useTls";
+            public const string Host = "host";
+            public const string Port = "port";
+            public const string Username = "username";
+            public const string Password = "password";
+            public const string VirtualHost = "virtualHost";
+            public const string Url = "url";
+        }
+    }
+}

--- a/src/Connectors/src/Connector/RabbitMQ/RabbitMQHealthContributor.cs
+++ b/src/Connectors/src/Connector/RabbitMQ/RabbitMQHealthContributor.cs
@@ -18,14 +18,28 @@ public class RabbitMQHealthContributor : IHealthContributor
 {
     private readonly ILogger<RabbitMQHealthContributor> _logger;
     private readonly object _connFactory;
+    private readonly string _hostName;
     private object _connection;
 
-    public string Id => "RabbitMQ";
+    public string Id { get; } = "RabbitMQ";
 
     public RabbitMQHealthContributor(RabbitMQProviderConnectorFactory factory, ILogger<RabbitMQHealthContributor> logger = null)
     {
         _logger = logger;
         _connFactory = factory.Create(null);
+    }
+
+    internal RabbitMQHealthContributor(object connection, string serviceName, string hostName, ILogger<RabbitMQHealthContributor> logger)
+    {
+        ArgumentGuard.NotNull(connection);
+        ArgumentGuard.NotNull(serviceName);
+        ArgumentGuard.NotNull(hostName);
+        ArgumentGuard.NotNull(logger);
+
+        _connection = connection;
+        Id = serviceName;
+        _hostName = hostName;
+        _logger = logger;
     }
 
     public static IHealthContributor GetRabbitMQContributor(IConfiguration configuration, ILogger<RabbitMQHealthContributor> logger = null)
@@ -45,6 +59,11 @@ public class RabbitMQHealthContributor : IHealthContributor
     {
         _logger?.LogTrace("Checking RabbitMQ connection health");
         var result = new HealthCheckResult();
+
+        if (_hostName != null)
+        {
+            result.Details.Add("host", _hostName);
+        }
 
         try
         {

--- a/src/Connectors/src/Connector/RabbitMQ/RabbitMQOptions.cs
+++ b/src/Connectors/src/Connector/RabbitMQ/RabbitMQOptions.cs
@@ -1,0 +1,9 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+namespace Steeltoe.Connector.RabbitMQ;
+
+public sealed class RabbitMQOptions : ConnectionStringOptions
+{
+}

--- a/src/Connectors/src/Connector/RabbitMQ/RabbitMQTypeLocator.cs
+++ b/src/Connectors/src/Connector/RabbitMQ/RabbitMQTypeLocator.cs
@@ -67,22 +67,39 @@ public static class RabbitMQTypeLocator
     /// <summary>
     /// Gets the CreateConnection method of ConnectionFactory.
     /// </summary>
-    public static MethodInfo CreateConnectionMethod => FindMethodOrThrow(ConnectionFactory, "CreateConnection", Array.Empty<Type>());
+    public static MethodInfo CreateConnectionMethod => FindMethodOrThrow(ConnectionFactoryInterface, "CreateConnection", Array.Empty<Type>());
 
     /// <summary>
     /// Gets the Close method for IConnection.
     /// </summary>
     public static MethodInfo CloseConnectionMethod => FindMethodOrThrow(ConnectionInterface, "Close", Array.Empty<Type>());
 
+    /// <summary>
+    /// Gets the Url property for IConnectionFactory.
+    /// </summary>
+    public static MethodInfo ConnectionFactoryUrlPropertySetter => FindPropertyOrThrow(ConnectionFactoryInterface, "Url").GetSetMethod();
+
     private static MethodInfo FindMethodOrThrow(Type type, string methodName, Type[] parameters = null)
     {
-        MethodInfo returnType = ReflectionHelpers.FindMethod(type, methodName, parameters);
+        MethodInfo method = ReflectionHelpers.FindMethod(type, methodName, parameters);
 
-        if (returnType == null)
+        if (method == null)
         {
-            throw new ConnectorException("Unable to find required RabbitMQ type, are you missing the RabbitMQ.Client Nuget package?");
+            throw new ConnectorException("Unable to find required RabbitMQ method, are you missing the RabbitMQ.Client Nuget package?");
         }
 
-        return returnType;
+        return method;
+    }
+
+    private static PropertyInfo FindPropertyOrThrow(Type type, string propertyName)
+    {
+        PropertyInfo property = ReflectionHelpers.FindProperty(type, propertyName);
+
+        if (property == null)
+        {
+            throw new ConnectorException("Unable to find required RabbitMQ property, are you missing the RabbitMQ.Client Nuget package?");
+        }
+
+        return property;
     }
 }

--- a/src/Connectors/src/Connector/RabbitMQ/RabbitMQWebApplicationBuilderExtensions.cs
+++ b/src/Connectors/src/Connector/RabbitMQ/RabbitMQWebApplicationBuilderExtensions.cs
@@ -1,0 +1,77 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Steeltoe.Common;
+using Steeltoe.Common.HealthChecks;
+
+namespace Steeltoe.Connector.RabbitMQ;
+
+public delegate object CreateRabbitConnection(RabbitMQOptions options, string serviceBindingName);
+
+public static class RabbitMQWebApplicationBuilderExtensions
+{
+    private static readonly Type ConnectionInterface = RabbitMQTypeLocator.ConnectionInterface;
+
+    public static WebApplicationBuilder AddRabbitMQ(this WebApplicationBuilder builder)
+    {
+        return AddRabbitMQ(builder, CreateDefaultRabbitConnection);
+    }
+
+    public static WebApplicationBuilder AddRabbitMQ(this WebApplicationBuilder builder, CreateRabbitConnection createRabbitConnection)
+    {
+        ArgumentGuard.NotNull(builder);
+        ArgumentGuard.NotNull(createRabbitConnection);
+
+        var connectionStringPostProcessor = new RabbitMQConnectionStringPostProcessor();
+
+        Func<RabbitMQOptions, string, object> createConnection = (options, serviceBindingName) => createRabbitConnection(options, serviceBindingName);
+
+        BaseWebApplicationBuilderExtensions.RegisterConfigurationSource(builder.Configuration, connectionStringPostProcessor);
+        BaseWebApplicationBuilderExtensions.RegisterNamedOptions<RabbitMQOptions>(builder, "rabbitmq", CreateHealthContributor);
+        BaseWebApplicationBuilderExtensions.RegisterConnectionFactory(builder.Services, ConnectionInterface, true, createConnection);
+
+        return builder;
+    }
+
+    private static object CreateDefaultRabbitConnection(RabbitMQOptions options, string serviceBindingName)
+    {
+        // In RabbitMQ, connections are long-lived and auto-recover from network failures. Channels are multiplexed over a single connection.
+        object factory = Activator.CreateInstance(RabbitMQTypeLocator.ConnectionFactory, null);
+
+        if (options.ConnectionString != null)
+        {
+            RabbitMQTypeLocator.ConnectionFactoryUrlPropertySetter.Invoke(factory, new object[]
+            {
+                new Uri(options.ConnectionString)
+            });
+        }
+
+        return RabbitMQTypeLocator.CreateConnectionMethod.Invoke(factory, Array.Empty<object>());
+    }
+
+    private static IHealthContributor CreateHealthContributor(IServiceProvider serviceProvider, string bindingName)
+    {
+        string connectionString = ConnectionFactoryInvoker.GetConnectionString<RabbitMQOptions>(serviceProvider, bindingName, ConnectionInterface);
+        string serviceName = $"RabbitMQ-{bindingName}";
+        string hostName = GetHostNameFromConnectionString(connectionString);
+        object connection = ConnectionFactoryInvoker.CreateConnection<RabbitMQOptions>(serviceProvider, bindingName, ConnectionInterface);
+        var logger = serviceProvider.GetRequiredService<ILogger<RabbitMQHealthContributor>>();
+
+        return new RabbitMQHealthContributor(connection, serviceName, hostName, logger);
+    }
+
+    private static string GetHostNameFromConnectionString(string connectionString)
+    {
+        if (connectionString == null)
+        {
+            return "localhost";
+        }
+
+        var uri = new Uri(connectionString);
+        return uri.Host;
+    }
+}

--- a/src/Connectors/test/Connector.Test/RabbitMQ/RabbitMQConnectorTests.cs
+++ b/src/Connectors/test/Connector.Test/RabbitMQ/RabbitMQConnectorTests.cs
@@ -1,0 +1,460 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+using FluentAssertions;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using RabbitMQ.Client;
+using RabbitMQ.Client.Events;
+using Steeltoe.Common.HealthChecks;
+using Steeltoe.Configuration.CloudFoundry.ServiceBinding;
+using Steeltoe.Connector.RabbitMQ;
+using Xunit;
+
+namespace Steeltoe.Connector.Test.RabbitMQ;
+
+public sealed class RabbitMQConnectorTests
+{
+    private const string MultiVcapServicesJson = @"{
+  ""p.rabbitmq"": [
+    {
+      ""label"": ""p.rabbitmq"",
+      ""provider"": null,
+      ""plan"": ""single-node"",
+      ""name"": ""myRabbitMQServiceOne"",
+      ""tags"": [
+        ""rabbitmq""
+      ],
+      ""instance_guid"": ""377d9d72-e951-4a1c-82e8-99c3c4933368"",
+      ""instance_name"": ""myRabbitMQServiceOne"",
+      ""binding_guid"": ""d2fd2c9d-ef84-406b-8401-f2ffacaafda6"",
+      ""binding_name"": null,
+      ""credentials"": {
+        ""dashboard_url"": ""https://rmq-377d9d72-e951-4a1c-82e8-99c3c4933368.sys.benicia.cf-app.com"",
+        ""hostname"": ""q-s0.rabbitmq-server.benicia-services-subnet.service-instance-377d9d72-e951-4a1c-82e8-99c3c4933368.bosh"",
+        ""hostnames"": [
+          ""q-s0.rabbitmq-server.benicia-services-subnet.service-instance-377d9d72-e951-4a1c-82e8-99c3c4933368.bosh""
+        ],
+        ""http_api_uri"": ""https://d2fd2c9d-ef84-406b-8401-f2ffacaafda6:AqntL6IwehKOGssE51psrJYd@rmq-377d9d72-e951-4a1c-82e8-99c3c4933368.sys.benicia.cf-app.com/api/"",
+        ""http_api_uris"": [
+          ""https://d2fd2c9d-ef84-406b-8401-f2ffacaafda6:AqntL6IwehKOGssE51psrJYd@rmq-377d9d72-e951-4a1c-82e8-99c3c4933368.sys.benicia.cf-app.com/api/""
+        ],
+        ""password"": ""AqntL6IwehKOGssE51psrJYd"",
+        ""protocols"": {
+          ""amqp"": {
+            ""host"": ""q-s0.rabbitmq-server.benicia-services-subnet.service-instance-377d9d72-e951-4a1c-82e8-99c3c4933368.bosh"",
+            ""hosts"": [
+              ""q-s0.rabbitmq-server.benicia-services-subnet.service-instance-377d9d72-e951-4a1c-82e8-99c3c4933368.bosh""
+            ],
+            ""password"": ""AqntL6IwehKOGssE51psrJYd"",
+            ""port"": 5672,
+            ""ssl"": false,
+            ""uri"": ""amqp://d2fd2c9d-ef84-406b-8401-f2ffacaafda6:AqntL6IwehKOGssE51psrJYd@q-s0.rabbitmq-server.benicia-services-subnet.service-instance-377d9d72-e951-4a1c-82e8-99c3c4933368.bosh/377d9d72-e951-4a1c-82e8-99c3c4933368"",
+            ""uris"": [
+              ""amqp://d2fd2c9d-ef84-406b-8401-f2ffacaafda6:AqntL6IwehKOGssE51psrJYd@q-s0.rabbitmq-server.benicia-services-subnet.service-instance-377d9d72-e951-4a1c-82e8-99c3c4933368.bosh/377d9d72-e951-4a1c-82e8-99c3c4933368""
+            ],
+            ""username"": ""d2fd2c9d-ef84-406b-8401-f2ffacaafda6"",
+            ""vhost"": ""377d9d72-e951-4a1c-82e8-99c3c4933368""
+          }
+        },
+        ""ssl"": false,
+        ""uri"": ""amqp://d2fd2c9d-ef84-406b-8401-f2ffacaafda6:AqntL6IwehKOGssE51psrJYd@q-s0.rabbitmq-server.benicia-services-subnet.service-instance-377d9d72-e951-4a1c-82e8-99c3c4933368.bosh/377d9d72-e951-4a1c-82e8-99c3c4933368"",
+        ""uris"": [
+          ""amqp://d2fd2c9d-ef84-406b-8401-f2ffacaafda6:AqntL6IwehKOGssE51psrJYd@q-s0.rabbitmq-server.benicia-services-subnet.service-instance-377d9d72-e951-4a1c-82e8-99c3c4933368.bosh/377d9d72-e951-4a1c-82e8-99c3c4933368""
+        ],
+        ""username"": ""d2fd2c9d-ef84-406b-8401-f2ffacaafda6"",
+        ""vhost"": ""377d9d72-e951-4a1c-82e8-99c3c4933368""
+      },
+      ""syslog_drain_url"": null,
+      ""volume_mounts"": []
+    },
+    {
+      ""label"": ""p.rabbitmq"",
+      ""provider"": null,
+      ""plan"": ""single-node"",
+      ""name"": ""myRabbitMQServiceTwo"",
+      ""tags"": [
+        ""rabbitmq""
+      ],
+      ""instance_guid"": ""eda94023-757e-4ef4-9315-dcba2e96efb5"",
+      ""instance_name"": ""myRabbitMQServiceTwo"",
+      ""binding_guid"": ""799815ea-9f6d-40e3-9317-7cc8ca43552f"",
+      ""binding_name"": null,
+      ""credentials"": {
+        ""dashboard_url"": ""https://rmq-eda94023-757e-4ef4-9315-dcba2e96efb5.sys.benicia.cf-app.com"",
+        ""hostname"": ""q-s0.rabbitmq-server.benicia-services-subnet.service-instance-eda94023-757e-4ef4-9315-dcba2e96efb5.bosh"",
+        ""hostnames"": [
+          ""q-s0.rabbitmq-server.benicia-services-subnet.service-instance-eda94023-757e-4ef4-9315-dcba2e96efb5.bosh""
+        ],
+        ""http_api_uri"": ""https://799815ea-9f6d-40e3-9317-7cc8ca43552f:mw2cCEufc9biidCBA_lYILxc@rmq-eda94023-757e-4ef4-9315-dcba2e96efb5.sys.benicia.cf-app.com/api/"",
+        ""http_api_uris"": [
+          ""https://799815ea-9f6d-40e3-9317-7cc8ca43552f:mw2cCEufc9biidCBA_lYILxc@rmq-eda94023-757e-4ef4-9315-dcba2e96efb5.sys.benicia.cf-app.com/api/""
+        ],
+        ""password"": ""mw2cCEufc9biidCBA_lYILxc"",
+        ""protocols"": {
+          ""amqp"": {
+            ""host"": ""q-s0.rabbitmq-server.benicia-services-subnet.service-instance-eda94023-757e-4ef4-9315-dcba2e96efb5.bosh"",
+            ""hosts"": [
+              ""q-s0.rabbitmq-server.benicia-services-subnet.service-instance-eda94023-757e-4ef4-9315-dcba2e96efb5.bosh""
+            ],
+            ""password"": ""mw2cCEufc9biidCBA_lYILxc"",
+            ""port"": 5672,
+            ""ssl"": false,
+            ""uri"": ""amqp://799815ea-9f6d-40e3-9317-7cc8ca43552f:mw2cCEufc9biidCBA_lYILxc@q-s0.rabbitmq-server.benicia-services-subnet.service-instance-eda94023-757e-4ef4-9315-dcba2e96efb5.bosh/eda94023-757e-4ef4-9315-dcba2e96efb5"",
+            ""uris"": [
+              ""amqp://799815ea-9f6d-40e3-9317-7cc8ca43552f:mw2cCEufc9biidCBA_lYILxc@q-s0.rabbitmq-server.benicia-services-subnet.service-instance-eda94023-757e-4ef4-9315-dcba2e96efb5.bosh/eda94023-757e-4ef4-9315-dcba2e96efb5""
+            ],
+            ""username"": ""799815ea-9f6d-40e3-9317-7cc8ca43552f"",
+            ""vhost"": ""eda94023-757e-4ef4-9315-dcba2e96efb5""
+          }
+        },
+        ""ssl"": false,
+        ""uri"": ""amqp://799815ea-9f6d-40e3-9317-7cc8ca43552f:mw2cCEufc9biidCBA_lYILxc@q-s0.rabbitmq-server.benicia-services-subnet.service-instance-eda94023-757e-4ef4-9315-dcba2e96efb5.bosh/eda94023-757e-4ef4-9315-dcba2e96efb5"",
+        ""uris"": [
+          ""amqp://799815ea-9f6d-40e3-9317-7cc8ca43552f:mw2cCEufc9biidCBA_lYILxc@q-s0.rabbitmq-server.benicia-services-subnet.service-instance-eda94023-757e-4ef4-9315-dcba2e96efb5.bosh/eda94023-757e-4ef4-9315-dcba2e96efb5""
+        ],
+        ""username"": ""799815ea-9f6d-40e3-9317-7cc8ca43552f"",
+        ""vhost"": ""eda94023-757e-4ef4-9315-dcba2e96efb5""
+      },
+      ""syslog_drain_url"": null,
+      ""volume_mounts"": []
+    }
+  ]
+}";
+
+    private const string SingleVcapServicesJson = @"{
+  ""p.rabbitmq"": [
+    {
+      ""label"": ""p.rabbitmq"",
+      ""provider"": null,
+      ""plan"": ""single-node"",
+      ""name"": ""myRabbitMQService"",
+      ""tags"": [
+        ""rabbitmq""
+      ],
+      ""instance_guid"": ""e73ca795-53a8-4ba1-9a38-45424ad28248"",
+      ""instance_name"": ""myRabbitMQService"",
+      ""binding_guid"": ""0a1ad792-8937-4770-8868-542f5f14126f"",
+      ""binding_name"": null,
+      ""credentials"": {
+        ""dashboard_url"": ""https://rmq-e73ca795-53a8-4ba1-9a38-45424ad28248.sys.cotati.cf-app.com"",
+        ""hostname"": ""q-s0.rabbitmq-server.cotati-services-subnet.service-instance-e73ca795-53a8-4ba1-9a38-45424ad28248.bosh"",
+        ""hostnames"": [
+          ""q-s0.rabbitmq-server.cotati-services-subnet.service-instance-e73ca795-53a8-4ba1-9a38-45424ad28248.bosh""
+        ],
+        ""http_api_uri"": ""https://0a1ad792-8937-4770-8868-542f5f14126f:b2Npj1K_eZOrD-fyoewg46rA@rmq-e73ca795-53a8-4ba1-9a38-45424ad28248.sys.cotati.cf-app.com/api/"",
+        ""http_api_uris"": [
+          ""https://0a1ad792-8937-4770-8868-542f5f14126f:b2Npj1K_eZOrD-fyoewg46rA@rmq-e73ca795-53a8-4ba1-9a38-45424ad28248.sys.cotati.cf-app.com/api/""
+        ],
+        ""password"": ""b2Npj1K_eZOrD-fyoewg46rA"",
+        ""protocols"": {
+          ""amqp"": {
+            ""host"": ""q-s0.rabbitmq-server.cotati-services-subnet.service-instance-e73ca795-53a8-4ba1-9a38-45424ad28248.bosh"",
+            ""hosts"": [
+              ""q-s0.rabbitmq-server.cotati-services-subnet.service-instance-e73ca795-53a8-4ba1-9a38-45424ad28248.bosh""
+            ],
+            ""password"": ""b2Npj1K_eZOrD-fyoewg46rA"",
+            ""port"": 5672,
+            ""ssl"": false,
+            ""uri"": ""amqp://0a1ad792-8937-4770-8868-542f5f14126f:b2Npj1K_eZOrD-fyoewg46rA@q-s0.rabbitmq-server.cotati-services-subnet.service-instance-e73ca795-53a8-4ba1-9a38-45424ad28248.bosh/e73ca795-53a8-4ba1-9a38-45424ad28248"",
+            ""uris"": [
+              ""amqp://0a1ad792-8937-4770-8868-542f5f14126f:b2Npj1K_eZOrD-fyoewg46rA@q-s0.rabbitmq-server.cotati-services-subnet.service-instance-e73ca795-53a8-4ba1-9a38-45424ad28248.bosh/e73ca795-53a8-4ba1-9a38-45424ad28248""
+            ],
+            ""username"": ""0a1ad792-8937-4770-8868-542f5f14126f"",
+            ""vhost"": ""e73ca795-53a8-4ba1-9a38-45424ad28248""
+          }
+        },
+        ""ssl"": false,
+        ""uri"": ""amqp://0a1ad792-8937-4770-8868-542f5f14126f:b2Npj1K_eZOrD-fyoewg46rA@q-s0.rabbitmq-server.cotati-services-subnet.service-instance-e73ca795-53a8-4ba1-9a38-45424ad28248.bosh/e73ca795-53a8-4ba1-9a38-45424ad28248"",
+        ""uris"": [
+          ""amqp://0a1ad792-8937-4770-8868-542f5f14126f:b2Npj1K_eZOrD-fyoewg46rA@q-s0.rabbitmq-server.cotati-services-subnet.service-instance-e73ca795-53a8-4ba1-9a38-45424ad28248.bosh/e73ca795-53a8-4ba1-9a38-45424ad28248""
+        ],
+        ""username"": ""0a1ad792-8937-4770-8868-542f5f14126f"",
+        ""vhost"": ""e73ca795-53a8-4ba1-9a38-45424ad28248""
+      },
+      ""syslog_drain_url"": null,
+      ""volume_mounts"": []
+    }
+  ]
+}";
+
+    [Fact]
+    public async Task Binds_options_without_service_bindings()
+    {
+        WebApplicationBuilder builder = WebApplication.CreateBuilder();
+
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string>
+        {
+            ["Steeltoe:Client:RabbitMQ:myRabbitMQServiceOne:ConnectionString"] = "amqp://user1:pass1@host1:5672/virtual-host-1",
+            ["Steeltoe:Client:RabbitMQ:myRabbitMQServiceTwo:ConnectionString"] = "amqps://user2:pass2@host2:5672/virtual-host-2"
+        });
+
+        builder.AddRabbitMQ();
+
+        await using WebApplication app = builder.Build();
+        var optionsSnapshot = app.Services.GetRequiredService<IOptionsSnapshot<RabbitMQOptions>>();
+
+        RabbitMQOptions optionsOne = optionsSnapshot.Get("myRabbitMQServiceOne");
+        optionsOne.ConnectionString.Should().Be("amqp://user1:pass1@host1:5672/virtual-host-1");
+
+        RabbitMQOptions optionsTwo = optionsSnapshot.Get("myRabbitMQServiceTwo");
+        optionsTwo.ConnectionString.Should().Be("amqps://user2:pass2@host2:5672/virtual-host-2");
+    }
+
+    [Fact]
+    public async Task Binds_options_with_CloudFoundry_service_bindings()
+    {
+        WebApplicationBuilder builder = WebApplication.CreateBuilder();
+        builder.Configuration.AddCloudFoundryServiceBindings(new StringServiceBindingsReader(MultiVcapServicesJson));
+
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string>
+        {
+            ["Steeltoe:Client:RabbitMQ:myRabbitMQServiceOne:ConnectionString"] = "amqps://user:pass@localhost:5672"
+        });
+
+        builder.AddRabbitMQ();
+
+        await using WebApplication app = builder.Build();
+        var optionsMonitor = app.Services.GetRequiredService<IOptionsMonitor<RabbitMQOptions>>();
+
+        RabbitMQOptions optionsOne = optionsMonitor.Get("myRabbitMQServiceOne");
+        optionsOne.Should().NotBeNull();
+
+        optionsOne.ConnectionString.Should().Be(
+            "amqp://d2fd2c9d-ef84-406b-8401-f2ffacaafda6:AqntL6IwehKOGssE51psrJYd@q-s0.rabbitmq-server.benicia-services-subnet.service-instance-377d9d72-e951-4a1c-82e8-99c3c4933368.bosh:5672/377d9d72-e951-4a1c-82e8-99c3c4933368");
+
+        RabbitMQOptions optionsTwo = optionsMonitor.Get("myRabbitMQServiceTwo");
+        optionsTwo.Should().NotBeNull();
+
+        optionsTwo.ConnectionString.Should().Be(
+            "amqp://799815ea-9f6d-40e3-9317-7cc8ca43552f:mw2cCEufc9biidCBA_lYILxc@q-s0.rabbitmq-server.benicia-services-subnet.service-instance-eda94023-757e-4ef4-9315-dcba2e96efb5.bosh:5672/eda94023-757e-4ef4-9315-dcba2e96efb5");
+    }
+
+    [Fact]
+    public async Task Registers_ConnectionFactory()
+    {
+        WebApplicationBuilder builder = WebApplication.CreateBuilder();
+
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string>
+        {
+            ["Steeltoe:Client:RabbitMQ:myRabbitMQServiceOne:ConnectionString"] = "amqp://user1:pass1@host1:5672/virtual-host-1",
+            ["Steeltoe:Client:RabbitMQ:myRabbitMQServiceTwo:ConnectionString"] = "amqps://user2:pass2@host2:5672/virtual-host-2"
+        });
+
+        builder.AddRabbitMQ((options, _) => new FakeConnection(options.ConnectionString));
+
+        await using WebApplication app = builder.Build();
+
+        var connectionFactory = app.Services.GetRequiredService<ConnectionFactory<RabbitMQOptions, IConnection>>();
+
+        var connectionOne = (FakeConnection)connectionFactory.GetNamed("myRabbitMQServiceOne").CreateConnection();
+        connectionOne.ConnectionString.Should().Be("amqp://user1:pass1@host1:5672/virtual-host-1");
+
+        var connectionTwo = (FakeConnection)connectionFactory.GetNamed("myRabbitMQServiceTwo").CreateConnection();
+        connectionTwo.ConnectionString.Should().Be("amqps://user2:pass2@host2:5672/virtual-host-2");
+
+        IConnection connectionOneAgain = connectionFactory.GetNamed("myRabbitMQServiceOne").CreateConnection();
+        connectionOneAgain.Should().BeSameAs(connectionOne);
+    }
+
+    [Fact]
+    public async Task Registers_HealthContributors()
+    {
+        WebApplicationBuilder builder = WebApplication.CreateBuilder();
+
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string>
+        {
+            ["Steeltoe:Client:RabbitMQ:myRabbitMQServiceOne:ConnectionString"] = "amqp://user1:pass1@host1:5672/virtual-host-1",
+            ["Steeltoe:Client:RabbitMQ:myRabbitMQServiceTwo:ConnectionString"] = "amqps://user2:pass2@host2:5672/virtual-host-2"
+        });
+
+        builder.AddRabbitMQ((options, _) => new FakeConnection(options.ConnectionString));
+
+        await using WebApplication app = builder.Build();
+
+        IHealthContributor[] healthContributors = app.Services.GetServices<IHealthContributor>().ToArray();
+        healthContributors.Should().AllBeOfType<RabbitMQHealthContributor>();
+
+        healthContributors.Should().HaveCount(2);
+        healthContributors[0].Id.Should().Be("RabbitMQ-myRabbitMQServiceOne");
+        healthContributors[1].Id.Should().Be("RabbitMQ-myRabbitMQServiceTwo");
+    }
+
+    [Fact]
+    public async Task Registers_default_connection_string_when_only_single_server_binding_found()
+    {
+        WebApplicationBuilder builder = WebApplication.CreateBuilder();
+        builder.Configuration.AddCloudFoundryServiceBindings(new StringServiceBindingsReader(SingleVcapServicesJson));
+
+        builder.AddRabbitMQ((options, _) => new FakeConnection(options.ConnectionString));
+
+        await using WebApplication app = builder.Build();
+
+        var connectionFactory = app.Services.GetRequiredService<ConnectionFactory<RabbitMQOptions, IConnection>>();
+
+        RabbitMQOptions defaultOptions = connectionFactory.GetDefault().Options;
+        defaultOptions.ConnectionString.Should().NotBeNull();
+
+        RabbitMQOptions namedOptions = connectionFactory.GetNamed("myRabbitMQService").Options;
+        namedOptions.ConnectionString.Should().Be(defaultOptions.ConnectionString);
+
+        app.Services.GetServices<IHealthContributor>().Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task Registers_default_connection_string_when_only_default_client_binding_found()
+    {
+        WebApplicationBuilder builder = WebApplication.CreateBuilder();
+
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string>
+        {
+            ["Steeltoe:Client:RabbitMQ:Default:ConnectionString"] = "amqp://localhost:5672/my-virtual-host"
+        });
+
+        builder.AddRabbitMQ((options, _) => new FakeConnection(options.ConnectionString));
+
+        await using WebApplication app = builder.Build();
+
+        var connectionFactory = app.Services.GetRequiredService<ConnectionFactory<RabbitMQOptions, IConnection>>();
+
+        RabbitMQOptions defaultOptions = connectionFactory.GetDefault().Options;
+        defaultOptions.ConnectionString.Should().NotBeNull();
+
+        app.Services.GetServices<IHealthContributor>().Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task Registers_default_connection_string_when_no_bindings_found()
+    {
+        WebApplicationBuilder builder = WebApplication.CreateBuilder();
+        builder.AddRabbitMQ((options, _) => new FakeConnection(options.ConnectionString));
+
+        await using WebApplication app = builder.Build();
+
+        var connectionFactory = app.Services.GetRequiredService<ConnectionFactory<RabbitMQOptions, IConnection>>();
+
+        RabbitMQOptions defaultOptions = connectionFactory.GetDefault().Options;
+        defaultOptions.ConnectionString.Should().BeNull();
+
+        var connection = (FakeConnection)connectionFactory.GetDefault().CreateConnection();
+        connection.ConnectionString.Should().BeNull();
+
+        app.Services.GetServices<IHealthContributor>().Should().HaveCount(1);
+    }
+
+    private sealed class FakeConnection : IConnection
+    {
+        public string ConnectionString { get; }
+
+        public int LocalPort => throw new NotImplementedException();
+        public int RemotePort => throw new NotImplementedException();
+        public ushort ChannelMax => throw new NotImplementedException();
+        public IDictionary<string, object> ClientProperties => throw new NotImplementedException();
+        public ShutdownEventArgs CloseReason => throw new NotImplementedException();
+        public AmqpTcpEndpoint Endpoint => throw new NotImplementedException();
+        public uint FrameMax => throw new NotImplementedException();
+        public TimeSpan Heartbeat => throw new NotImplementedException();
+        public bool IsOpen => throw new NotImplementedException();
+        public AmqpTcpEndpoint[] KnownHosts => throw new NotImplementedException();
+        public IProtocol Protocol => throw new NotImplementedException();
+        public IDictionary<string, object> ServerProperties => throw new NotImplementedException();
+        public IList<ShutdownReportEntry> ShutdownReport => throw new NotImplementedException();
+        public string ClientProvidedName => throw new NotImplementedException();
+
+        public event EventHandler<CallbackExceptionEventArgs> CallbackException
+        {
+            add => throw new NotImplementedException();
+            remove => throw new NotImplementedException();
+        }
+
+        public event EventHandler<ConnectionBlockedEventArgs> ConnectionBlocked
+        {
+            add => throw new NotImplementedException();
+            remove => throw new NotImplementedException();
+        }
+
+        public event EventHandler<ShutdownEventArgs> ConnectionShutdown
+        {
+            add => throw new NotImplementedException();
+            remove => throw new NotImplementedException();
+        }
+
+        public event EventHandler<EventArgs> ConnectionUnblocked
+        {
+            add => throw new NotImplementedException();
+            remove => throw new NotImplementedException();
+        }
+
+        public FakeConnection(string connectionString)
+        {
+            ConnectionString = connectionString;
+        }
+
+        public void Dispose()
+        {
+        }
+
+        public void UpdateSecret(string newSecret, string reason)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Abort()
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Abort(ushort reasonCode, string reasonText)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Abort(TimeSpan timeout)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Abort(ushort reasonCode, string reasonText, TimeSpan timeout)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Close()
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Close(ushort reasonCode, string reasonText)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Close(TimeSpan timeout)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Close(ushort reasonCode, string reasonText, TimeSpan timeout)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IModel CreateModel()
+        {
+            throw new NotImplementedException();
+        }
+
+        public void HandleConnectionBlocked(string reason)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void HandleConnectionUnblocked()
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/Connectors/test/Connector.Test/RabbitMQ/RabbitMQHealthContributorTest.cs
+++ b/src/Connectors/test/Connector.Test/RabbitMQ/RabbitMQHealthContributorTest.cs
@@ -78,7 +78,7 @@ public class RabbitMQHealthContributorTest
             { "version", Encoding.UTF8.GetBytes("test") }
         });
 
-        var mockConnFactory = new Mock<ConnectionFactory>();
+        var mockConnFactory = new Mock<IConnectionFactory>();
         mockConnFactory.Setup(s => s.CreateConnection()).Returns(mockConnection.Object);
 
         var mockProviderFactory =

--- a/src/Connectors/test/Connector.Test/Steeltoe.Connector.Test.csproj
+++ b/src/Connectors/test/Connector.Test/Steeltoe.Connector.Test.csproj
@@ -23,7 +23,7 @@
     <PackageReference Include="MySqlConnector" Version="$(MySqlConnectorVersion)" />
     <PackageReference Include="MySql.Data" Version="$(MySqlV8)" />
     <PackageReference Include="Npgsql" Version="$(NpgsqlVersion)" />
-    <PackageReference Include="RabbitMQ.Client" Version="$(RabbitClientVersion)" />
+    <PackageReference Include="RabbitMQ.Client" Version="$(RabbitClientTestVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/versions.props
+++ b/versions.props
@@ -37,6 +37,7 @@
     <EFCoreOracleTestVersion>6.21.*</EFCoreOracleTestVersion>
     <NerdbankGitVersioningVersion>3.5.*</NerdbankGitVersioningVersion>
     <PublicApiAnalyzersVersion>3.3.*</PublicApiAnalyzersVersion>
+    <RabbitClientTestVersion>6.4.*</RabbitClientTestVersion>
 
     <!--
       Exposed dependencies, observable by Steeltoe consumers.


### PR DESCRIPTION
## Description

Builds on top of the CloudFoundry service bindings, providing IOptions support and health checks.

Updated to support `options.ConnectionString` being `null`, which happens when running locally without any configuration. In that case, the RabbitMQ client connects using defaults for all parameters. And Steeltoe registers a default health contributor.

## Quality checklist

- [x] Your code complies with our [Coding Style](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-code-style.md).
- [x] You've updated unit and/or integration tests for your change, where applicable.
- [ ] You've updated documentation for your change, where applicable.
      If your change affects other repositories, such as [Documentation](https://github.com/SteeltoeOSS/Documentation), [Samples](https://github.com/SteeltoeOSS/Samples) and/or [MainSite](https://github.com/SteeltoeOSS/MainSite), add linked PRs here.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
- [x] You've added required license files and/or file headers (explaining where the code came from with proper attribution), where code is copied from StackOverflow, a blog, or OSS.
