### PR TITLE
Allow return of empty string values through placeholder resolver

### DIFF
--- a/src/Configuration/src/PlaceholderBase/PlaceholderResolverProvider.cs
+++ b/src/Configuration/src/PlaceholderBase/PlaceholderResolverProvider.cs
@@ -85,7 +85,7 @@ public class PlaceholderResolverProvider : IPlaceholderResolverProvider
             ResolvedKeys.Add(key);
         }
 
-        return !string.IsNullOrEmpty(value);
+        return value != null;
     }
 
     /// <summary>

--- a/src/Configuration/test/PlaceholderBase.Test/PlaceholderResolverProviderTest.cs
+++ b/src/Configuration/test/PlaceholderBase.Test/PlaceholderResolverProviderTest.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
+using FluentAssertions;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Configuration.Memory;
 using Microsoft.Extensions.Logging;
@@ -312,5 +313,21 @@ public class PlaceholderResolverProviderTest
         Assert.Equal(2, list.Count);
         Assert.Contains("bar", list);
         Assert.Contains("cloud", list);
+    }
+
+    [Fact]
+    public void EmptyValuesHandledAsExpected()
+    {
+        var builder = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string> { { "valueIsEmptyString", string.Empty } })
+            .AddPlaceholderResolver();
+
+        var config = builder.Build();
+
+        config.AsEnumerable().Should().ContainSingle();
+        config["valueIsEmptyString"].Should().BeEmpty();
+
+        // for comparison, keys not defined return null values
+        config["undefinedKey"].Should().BeNull();
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->

<!-- If this is your first PR in this repo, please read our [Contributing Guidelines (https://github.com/SteeltoeOSS/.github/blob/master/CONTRIBUTING.md) and remember to sign the [Contributor License Agreement](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-license.md). Our bot will notify you shortly after the PR has been created. -->

## Description

Patch to return the expected empty string instead of `null` when placeholder resolver is used

addresses #1132 in 3.2, will need to be applied to 4.0 as well.

## Quality checklist

<!-- Please run through the checklist below to ensure a smooth review and merge process for your PR. -->

- [ ] Your code complies with our [Coding Style](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-code-style.md).
- [ ] You've updated unit and/or integration tests for your change, where applicable.
- [ ] You've updated documentation for your change, where applicable.
      If your change affects other repositories, such as [Documentation](https://github.com/SteeltoeOSS/Documentation), [Samples](https://github.com/SteeltoeOSS/Samples) and/or [MainSite](https://github.com/SteeltoeOSS/MainSite), add linked PRs here.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
- [ ] You've added required license files and/or file headers (explaining where the code came from with proper attribution), where code is copied from StackOverflow, a blog, or OSS.
