### PR TITLE
Duplicate host port

### DIFF
--- a/src/Common/src/Common.Hosting/HostBuilderExtensions.cs
+++ b/src/Common/src/Common.Hosting/HostBuilderExtensions.cs
@@ -107,17 +107,8 @@ public static class HostBuilderExtensions
             AddRunLocalPorts(urls, runLocalHttpPort, runLocalHttpsPort);
         }
 
-        if (urls.Any())
+        if (!urls.Any())
         {
-            // setting ASPNETCORE_URLS should only be needed to override launchSettings.json
-            if (string.IsNullOrWhiteSpace(portStr) && !Platform.IsKubernetes)
-            {
-                Environment.SetEnvironmentVariable("ASPNETCORE_URLS", string.Join(";", urls));
-            }
-        }
-        else
-        {
-            Environment.SetEnvironmentVariable("ASPNETCORE_URLS", DEFAULT_URL);
             urls.Add(DEFAULT_URL);
         }
 

--- a/src/Common/src/Common.Hosting/HostBuilderExtensions.cs
+++ b/src/Common/src/Common.Hosting/HostBuilderExtensions.cs
@@ -18,7 +18,7 @@ namespace Steeltoe.Common.Hosting;
 public static class HostBuilderExtensions
 {
     public const string DEFAULT_URL = "http://*:8080";
-    private const string DeprecatedServerUrlsKey = "server.urls";
+    internal const string DeprecatedServerUrlsKey = "server.urls";
 
     /// <summary>
     /// Configure the application to listen on port(s) provided by the environment at runtime. Defaults to port 8080.
@@ -88,7 +88,6 @@ public static class HostBuilderExtensions
         var urls = new HashSet<string>();
 
         var portStr = Environment.GetEnvironmentVariable("PORT") ?? Environment.GetEnvironmentVariable("SERVER_PORT");
-        var aspnetUrls = Environment.GetEnvironmentVariable("ASPNETCORE_URLS");
         var serverUrlSetting = webHostBuilder.GetSetting(DeprecatedServerUrlsKey); // check for deprecated setting
         var urlSetting = webHostBuilder.GetSetting(WebHostDefaults.ServerUrlsKey);
 
@@ -97,7 +96,7 @@ public static class HostBuilderExtensions
 
         if (!string.IsNullOrWhiteSpace(portStr))
         {
-            AddPortAndAspNetCoreUrls(urls, portStr, aspnetUrls);
+            AddPortAndAspNetCoreUrls(urls, portStr);
         }
         else if (Platform.IsKubernetes)
         {
@@ -194,7 +193,7 @@ public static class HostBuilderExtensions
         return canonicalUrl;
     }
 
-    private static void AddPortAndAspNetCoreUrls(HashSet<string> urls, string portStr, string aspnetUrls)
+    private static void AddPortAndAspNetCoreUrls(HashSet<string> urls, string portStr)
     {
         if (int.TryParse(portStr, out var port))
         {
@@ -202,19 +201,9 @@ public static class HostBuilderExtensions
         }
         else if (portStr?.Contains(";") == true)
         {
-            if (!string.IsNullOrEmpty(aspnetUrls))
-            {
-                foreach (var url in aspnetUrls.Split(';'))
-                {
-                   urls.Add(GetCanonical(url));
-                }
-            }
-            else
-            {
-                var ports = portStr.Split(';');
-                urls.Add($"http://*:{ports[0]}");
-                urls.Add($"https://*:{ports[1]}");
-            }
+            var ports = portStr.Split(';');
+            urls.Add($"http://*:{ports[0]}");
+            urls.Add($"https://*:{ports[1]}");
         }
     }
 

--- a/src/Common/src/Common.Hosting/HostBuilderExtensions.cs
+++ b/src/Common/src/Common.Hosting/HostBuilderExtensions.cs
@@ -147,7 +147,7 @@ public static class HostBuilderExtensions
 
         foreach (IGrouping<int, UrlEntry> group in entries.GroupBy(entry => entry.Port))
         {
-            var wildCardEntry = group.Where(entry => entry.Host == "*").FirstOrDefault();
+            var wildCardEntry = group.FirstOrDefault(entry => entry.Host == "*");
             if (!wildCardEntry.Equals(default(UrlEntry)))
             {
                 uniqueUrls.Add(wildCardEntry.ToString());

--- a/src/Common/test/Common.Hosting.Test/HostBuilderExtensionsTest.cs
+++ b/src/Common/test/Common.Hosting.Test/HostBuilderExtensionsTest.cs
@@ -156,10 +156,12 @@ public class HostBuilderExtensionsTest
     [Fact]
     public void UseCloudHosting_UsesCommandLine_ServerUrls()
     {
-        var config = new ConfigurationBuilder().AddCommandLine(new[]
+        var config = new ConfigurationBuilder().AddCommandLine(new string[]
         {
             "--server.urls",
-            "http://*:8081"
+            "http://*:8088",
+            "--urls",
+            "http://*:8088"
         }).Build();
 
         var hostBuilder = new WebHostBuilder().UseConfiguration(config).UseStartup<TestServerStartup>().UseKestrel();
@@ -169,30 +171,55 @@ public class HostBuilderExtensionsTest
 
         var addresses = server.ServerFeatures.Get<IServerAddressesFeature>();
 
-        Assert.Single(addresses.Addresses);
-        Assert.Contains("http://*:8081", addresses.Addresses);
+        Assert.Collection(addresses.Addresses,  (address) => Assert.Equal("http://*:8088", address));
     }
 
     [Fact]
-    public void UseCloudHosting_UsesCommandLine_ServerUrls_And_Params()
+    public void UseCloudHosting_AnyWildCard_Overrides_SpecificIps()
     {
-        var config = new ConfigurationBuilder().AddCommandLine(new[]
+        try
         {
-            "--server.urls",
-            "http://fob+:8081;http://:::8081"
-        }).Build();
+            Environment.SetEnvironmentVariable("ASPNETCORE_URLS", "http://192.168.1.2:8085;http://*:8085");
 
-        var hostBuilder = new WebHostBuilder().UseConfiguration(config).UseStartup<TestServerStartup>().UseKestrel();
+            var hostBuilder = new WebHostBuilder().UseStartup<TestServerStartup>().UseKestrel();
 
-        hostBuilder.UseCloudHosting(8081, null);
-        var server = hostBuilder.Build();
+            hostBuilder.UseCloudHosting();
+            var server = hostBuilder.Build();
 
-        var addresses = server.ServerFeatures.Get<IServerAddressesFeature>();
+            var addresses = server.ServerFeatures.Get<IServerAddressesFeature>();
 
-        Assert.Single(addresses.Addresses);
-        Assert.Contains("http://*:8081", addresses.Addresses);
+            Assert.Collection(addresses.Addresses, (address) => Assert.Equal("http://*:8085", address));
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("ASPNETCORE_URLS", string.Empty);
+        }
     }
 
+    [Fact]
+    public void UseCloudHosting_MultipleIps_With_Same_Port()
+    {
+        try
+        {
+            Environment.SetEnvironmentVariable("ASPNETCORE_URLS", "http://192.168.1.2:8085;http://192.168.1.3:8085");
+
+            var hostBuilder = new WebHostBuilder().UseStartup<TestServerStartup>().UseKestrel();
+
+            hostBuilder.UseCloudHosting();
+            var server = hostBuilder.Build();
+
+            var addresses = server.ServerFeatures.Get<IServerAddressesFeature>();
+
+            Assert.Collection(
+                addresses.Addresses,
+                address => Assert.Equal("http://192.168.1.2:8085", address),
+                address => Assert.Equal("http://192.168.1.3:8085", address));
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("ASPNETCORE_URLS", string.Empty);
+        }
+    }
 
     [Fact]
     public void UseCloudHosting_UsesCommandLine_Urls()
@@ -210,7 +237,7 @@ public class HostBuilderExtensionsTest
 
         var addresses = server.ServerFeatures.Get<IServerAddressesFeature>();
 
-        Assert.Single(addresses.Addresses);
+        Assert.Single(addresses.Addresses, "http://*:8081");
         Assert.Contains("http://*:8081", addresses.Addresses);
     }
 

--- a/src/Common/test/Common.Hosting.Test/HostBuilderExtensionsTest.cs
+++ b/src/Common/test/Common.Hosting.Test/HostBuilderExtensionsTest.cs
@@ -154,6 +154,26 @@ public class HostBuilderExtensionsTest
     }
 
     [Fact]
+    public void UseCloudHosting_UsesCommandLine_Urls()
+    {
+        var config = new ConfigurationBuilder().AddCommandLine(new[]
+        {
+            "--urls",
+            "http://*:8099"
+        }).Build();
+
+        var hostBuilder = new WebHostBuilder().UseConfiguration(config).UseStartup<TestServerStartup>().UseKestrel();
+
+        hostBuilder.UseCloudHosting();
+        var server = hostBuilder.Build();
+
+        var addresses = server.ServerFeatures.Get<IServerAddressesFeature>();
+
+        Assert.Single(addresses.Addresses, "http://*:8099");
+        Assert.Contains("http://*:8099", addresses.Addresses);
+    }
+
+    [Fact]
     public void UseCloudHosting_UsesCommandLine_ServerUrls()
     {
         var config = new ConfigurationBuilder().AddCommandLine(new string[]
@@ -169,7 +189,7 @@ public class HostBuilderExtensionsTest
 
         var addresses = server.ServerFeatures.Get<IServerAddressesFeature>();
 
-        Assert.Collection(addresses.Addresses,  (address) => Assert.Equal("http://*:8088", address));
+        Assert.Contains(addresses.Addresses, address => address == "http://*:8088");
     }
 
     [Fact]
@@ -238,26 +258,6 @@ public class HostBuilderExtensionsTest
         {
             Environment.SetEnvironmentVariable("ASPNETCORE_URLS", string.Empty);
         }
-    }
-
-    [Fact]
-    public void UseCloudHosting_UsesCommandLine_Urls()
-    {
-        var config = new ConfigurationBuilder().AddCommandLine(new[]
-        {
-            "--urls",
-            "http://*:8081"
-        }).Build();
-
-        var hostBuilder = new WebHostBuilder().UseConfiguration(config).UseStartup<TestServerStartup>().UseKestrel();
-
-        hostBuilder.UseCloudHosting();
-        var server = hostBuilder.Build();
-
-        var addresses = server.ServerFeatures.Get<IServerAddressesFeature>();
-
-        Assert.Single(addresses.Addresses, "http://*:8081");
-        Assert.Contains("http://*:8081", addresses.Addresses);
     }
 
     [Fact]

--- a/src/Common/test/Common.Hosting.Test/HostBuilderExtensionsTest.cs
+++ b/src/Common/test/Common.Hosting.Test/HostBuilderExtensionsTest.cs
@@ -192,6 +192,7 @@ public class HostBuilderExtensionsTest
 
         Assert.Collection(addresses.Addresses, (address) => Assert.Equal("http://*:8088", address));
     }
+
     [Fact]
     public void UseCloudHosting_AnyWildCard_Overrides_SpecificIps()
     {

--- a/src/Common/test/Common.Hosting.Test/HostBuilderExtensionsTest.cs
+++ b/src/Common/test/Common.Hosting.Test/HostBuilderExtensionsTest.cs
@@ -174,6 +174,27 @@ public class HostBuilderExtensionsTest
     }
 
     [Fact]
+    public void UseCloudHosting_UsesCommandLine_ServerUrls_And_Params()
+    {
+        var config = new ConfigurationBuilder().AddCommandLine(new[]
+        {
+            "--server.urls",
+            "http://fob+:8081;http://:::8081"
+        }).Build();
+
+        var hostBuilder = new WebHostBuilder().UseConfiguration(config).UseStartup<TestServerStartup>().UseKestrel();
+
+        hostBuilder.UseCloudHosting(8081, null);
+        var server = hostBuilder.Build();
+
+        var addresses = server.ServerFeatures.Get<IServerAddressesFeature>();
+
+        Assert.Single(addresses.Addresses);
+        Assert.Contains("http://*:8081", addresses.Addresses);
+    }
+
+
+    [Fact]
     public void UseCloudHosting_UsesCommandLine_Urls()
     {
         var config = new ConfigurationBuilder().AddCommandLine(new[]

--- a/src/Common/test/Common.Hosting.Test/HostBuilderExtensionsTest.cs
+++ b/src/Common/test/Common.Hosting.Test/HostBuilderExtensionsTest.cs
@@ -158,9 +158,7 @@ public class HostBuilderExtensionsTest
     {
         var config = new ConfigurationBuilder().AddCommandLine(new string[]
         {
-            "--server.urls",
-            "http://*:8088",
-            "--urls",
+            $"--{HostBuilderExtensions.DeprecatedServerUrlsKey}",
             "http://*:8088"
         }).Build();
 
@@ -174,6 +172,26 @@ public class HostBuilderExtensionsTest
         Assert.Collection(addresses.Addresses,  (address) => Assert.Equal("http://*:8088", address));
     }
 
+    [Fact]
+    public void UseCloudHosting_UsesCommandLine_ServerUrls_Handles_Duplicates()
+    {
+        var config = new ConfigurationBuilder().AddCommandLine(new string[]
+        {
+            "--server.urls",
+            "http://*:8088",
+            "--urls",
+            "http://*:8088"
+        }).Build();
+
+        var hostBuilder = new WebHostBuilder().UseConfiguration(config).UseStartup<TestServerStartup>().UseKestrel();
+
+        hostBuilder.UseCloudHosting();
+        var server = hostBuilder.Build();
+
+        var addresses = server.ServerFeatures.Get<IServerAddressesFeature>();
+
+        Assert.Collection(addresses.Addresses, (address) => Assert.Equal("http://*:8088", address));
+    }
     [Fact]
     public void UseCloudHosting_AnyWildCard_Overrides_SpecificIps()
     {


### PR DESCRIPTION
## Description

Using the extension method UseCloudHosting will ocassionally throw an exception similar to this: 'Failed to bind to address https://127.0.0.1:8083/: address already in use.'

This PR fixes the problem by adds additional filtering for various URL specification to detect duplicates and remove them. In addition when a wild card address is present, it will take precedence over specific ip addresses for a given port. 


## Quality checklist

<!-- Please run through the checklist below to ensure a smooth review and merge process for your PR. -->

- [x] Your code complies with our [Coding Style](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-code-style.md).
- [x] You've updated unit and/or integration tests for your change, where applicable.
- [ ] You've updated documentation for your change, where applicable.
      If your change affects other repositories, such as [Documentation](https://github.com/SteeltoeOSS/Documentation), [Samples](https://github.com/SteeltoeOSS/Samples) and/or [MainSite](https://github.com/SteeltoeOSS/MainSite), add linked PRs here.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
- [x] You've added required license files and/or file headers (explaining where the code came from with proper attribution), where code is copied from StackOverflow, a blog, or OSS.
