### PR TITLE
Fix type checking for IHttpClientHandlerProvider in Eureka client

### DIFF
--- a/src/Discovery/src/Eureka/EurekaDiscoveryClientExtension.cs
+++ b/src/Discovery/src/Eureka/EurekaDiscoveryClientExtension.cs
@@ -147,10 +147,10 @@ public class EurekaDiscoveryClientExtension : IDiscoveryClientExtension
 
         var existingHandler = services.FirstOrDefault(descriptor => descriptor.ServiceType == typeof(IHttpClientHandlerProvider));
 
-        if (existingHandler is IHttpClientHandlerProvider handlerProvider)
+        if (existingHandler != null && typeof(IHttpClientHandlerProvider).IsAssignableFrom(existingHandler.ImplementationType))
         {
             AddEurekaHttpClient(services)
-                .ConfigurePrimaryHttpMessageHandler(() => handlerProvider.GetHttpClientHandler());
+                .ConfigurePrimaryHttpMessageHandler(serviceProvider => serviceProvider.GetService<IHttpClientHandlerProvider>().GetHttpClientHandler());
         }
         else
         {

--- a/src/Discovery/test/ClientBase.Test/DiscoveryServiceCollectionExtensionsTest.cs
+++ b/src/Discovery/test/ClientBase.Test/DiscoveryServiceCollectionExtensionsTest.cs
@@ -796,15 +796,4 @@ public class DiscoveryServiceCollectionExtensionsTest : IDisposable
         Environment.SetEnvironmentVariable("VCAP_APPLICATION", null);
         Environment.SetEnvironmentVariable("VCAP_SERVICES", null);
     }
-
-    internal class TestClientHandlerProvider : IHttpClientHandlerProvider
-    {
-        public bool Called { get; set; } = false;
-
-        public HttpClientHandler GetHttpClientHandler()
-        {
-            Called = true;
-            return new HttpClientHandler();
-        }
-    }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->

<!-- If this is your first PR in this repo, please read our [Contributing Guidelines (https://github.com/SteeltoeOSS/.github/blob/master/CONTRIBUTING.md) and remember to sign the [Contributor License Agreement](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-license.md). Our bot will notify you shortly after the PR has been created. -->

## Description

Use `IsAssignableFrom` instead of `is` operator, get IHttpClientHandlerProvider from the service collection at runtime
Addresses #1137 in Steeltoe 3.2

## Quality checklist

<!-- Please run through the checklist below to ensure a smooth review and merge process for your PR. -->

- [ ] Your code complies with our [Coding Style](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-code-style.md).
- [x] You've updated unit and/or integration tests for your change, where applicable.
- [ ] You've updated documentation for your change, where applicable.
      If your change affects other repositories, such as [Documentation](https://github.com/SteeltoeOSS/Documentation), [Samples](https://github.com/SteeltoeOSS/Samples) and/or [MainSite](https://github.com/SteeltoeOSS/MainSite), add linked PRs here.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
- [x] You've added required license files and/or file headers (explaining where the code came from with proper attribution), where code is copied from StackOverflow, a blog, or OSS.
