### PR TITLE
Don't override "Set" in certificate config providers

### DIFF
--- a/src/Common/src/Common.Security/CertificateProvider.cs
+++ b/src/Common/src/Common.Security/CertificateProvider.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.Configuration;
-using System;
 using System.IO;
 
 namespace Steeltoe.Common.Security;
@@ -23,11 +22,6 @@ public class CertificateProvider : ConfigurationProvider
     public override void Load()
     {
         // for future use
-    }
-
-    public override void Set(string key, string value)
-    {
-        throw new InvalidOperationException();
     }
 
     public override bool TryGet(string key, out string value)

--- a/src/Common/src/Common.Security/PemCertificateProvider.cs
+++ b/src/Common/src/Common.Security/PemCertificateProvider.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.Configuration;
-using System;
 
 namespace Steeltoe.Common.Security;
 
@@ -23,11 +22,6 @@ public class PemCertificateProvider : ConfigurationProvider
     public override void Load()
     {
         // for future use
-    }
-
-    public override void Set(string key, string value)
-    {
-        throw new InvalidOperationException();
     }
 
     public override bool TryGet(string key, out string value)


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->

<!-- If this is your first PR in this repo, please read our [Contributing Guidelines (https://github.com/SteeltoeOSS/.github/blob/master/CONTRIBUTING.md) and remember to sign the [Contributor License Agreement](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-license.md). Our bot will notify you shortly after the PR has been created. -->

## Description

Without this change, the certificate config providers have a compatibility issue with the ConfigurationManager in .NET 6 and .UseCloudHosting (which calls `webHostBuilder.UseSetting(WebHostDefaults.ServerUrlsKey, string.Join(";", urls));` and apparently tries to set the value in at least these config providers)

## Quality checklist

<!-- Please run through the checklist below to ensure a smooth review and merge process for your PR. -->

- [ ] Your code complies with our [Coding Style](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-code-style.md).
- [ ] You've updated unit and/or integration tests for your change, where applicable.
- [ ] You've updated documentation for your change, where applicable.
      If your change affects other repositories, such as [Documentation](https://github.com/SteeltoeOSS/Documentation), [Samples](https://github.com/SteeltoeOSS/Samples) and/or [MainSite](https://github.com/SteeltoeOSS/MainSite), add linked PRs here.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
- [ ] You've added required license files and/or file headers (explaining where the code came from with proper attribution), where code is copied from StackOverflow, a blog, or OSS.
