### PR TITLE
Handle content type information in Details

### DIFF
--- a/src/Management/src/Endpoint/Mappings/MappingDescription.cs
+++ b/src/Management/src/Endpoint/Mappings/MappingDescription.cs
@@ -20,7 +20,7 @@ public class MappingDescription
     public string Predicate { get; }
 
     [JsonPropertyName("details")]
-    public object Details { get; } // Always null for .NET
+    public MappingDetails Details { get; } 
 
     public MappingDescription(string routeHandler, IRouteDetails routeDetails)
     {
@@ -38,6 +38,22 @@ public class MappingDescription
 
         Predicate = CreatePredicateString(routeDetails);
         Handler = CreateHandlerString(routeHandler);
+        Details = CreateMappingDetails(routeDetails);
+        
+    }
+
+    private MappingDetails CreateMappingDetails(IRouteDetails routeDetails)
+    {
+        return new MappingDetails()
+        {
+            RequestMappingConditions = new RequestMappingConditions()
+            {
+                Consumes = routeDetails.Consumes.Select(consumes => new MediaTypeDescriptor() { MediaType = consumes }).ToArray(),
+                Produces = routeDetails.Produces.Select(produces => new MediaTypeDescriptor() { MediaType = produces }).ToArray(),
+                Methods = routeDetails.HttpMethods.ToArray(),
+                Patterns = new[] { routeDetails.RouteTemplate }
+            }
+        };
     }
 
     private string CreateHandlerString(MethodInfo actionHandlerMethod)

--- a/src/Management/src/Endpoint/Mappings/MappingDetails.cs
+++ b/src/Management/src/Endpoint/Mappings/MappingDetails.cs
@@ -1,0 +1,13 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+using System.Text.Json.Serialization;
+
+namespace Steeltoe.Management.Endpoint.Mappings;
+
+public class MappingDetails
+{ 
+    [JsonPropertyName("requestMappingConditions")]
+    public RequestMappingConditions RequestMappingConditions{ get; set; }
+}

--- a/src/Management/src/Endpoint/Mappings/MappingsEndpoint.cs
+++ b/src/Management/src/Endpoint/Mappings/MappingsEndpoint.cs
@@ -146,6 +146,11 @@ public class MappingsEndpoint : IMappingsEndpoint
             consumes.Add(reqTypes.MediaType);
         }
 
+        foreach (ConsumesAttribute consumesAttribute in desc.ActionDescriptor.ActionConstraints.Where(constraint => constraint.GetType() == typeof(ConsumesAttribute)).Select(constraint => constraint as ConsumesAttribute))
+        {
+            consumes.AddRange(consumesAttribute.ContentTypes);
+        }
+
         routeDetails.Consumes = consumes;
 
         return routeDetails;

--- a/src/Management/src/Endpoint/Mappings/MediaTypeDescriptor.cs
+++ b/src/Management/src/Endpoint/Mappings/MediaTypeDescriptor.cs
@@ -1,0 +1,16 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+using System.Text.Json.Serialization;
+
+namespace Steeltoe.Management.Endpoint.Mappings;
+
+public class MediaTypeDescriptor
+{
+    [JsonPropertyName("mediaType")]
+    public string MediaType { get; set; }
+
+    [JsonPropertyName("negated")]
+    public bool Negated { get; set; }
+}

--- a/src/Management/src/Endpoint/Mappings/RequestMappingConditions.cs
+++ b/src/Management/src/Endpoint/Mappings/RequestMappingConditions.cs
@@ -1,0 +1,26 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+using System.Text.Json.Serialization;
+
+namespace Steeltoe.Management.Endpoint.Mappings;
+
+public class RequestMappingConditions
+{
+    [JsonPropertyName("consumes")]
+    public MediaTypeDescriptor[] Consumes  { get; set; }
+
+    [JsonPropertyName("produces")]
+    public MediaTypeDescriptor[] Produces { get; set; }
+
+    [JsonPropertyName("headers")]
+    public string [] Headers { get; set; }
+
+    [JsonPropertyName("methods")]
+
+    public string[] Methods { get; set; }
+
+    [JsonPropertyName("patterns")]
+    public string[] Patterns { get; set; }
+}

--- a/src/Management/src/Endpoint/Mappings/ServiceCollectionExtensions.cs
+++ b/src/Management/src/Endpoint/Mappings/ServiceCollectionExtensions.cs
@@ -32,6 +32,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<MappingsEndpointMiddleware>();
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IEndpointMiddleware, MappingsEndpointMiddleware>());
 
+        services.ConfigureEndpointOptions<MappingsEndpointOptions, ConfigureMappingsEndpointOptions>();
         return services;
     }
 }

--- a/src/Management/test/Endpoint.Test/Mappings/EndpointMiddlewareTest.cs
+++ b/src/Management/test/Endpoint.Test/Mappings/EndpointMiddlewareTest.cs
@@ -86,7 +86,10 @@ public class EndpointMiddlewareTest : BaseTest
 
         string expected = "{\"contexts\":{\"application\":{\"mappings\":{\"dispatcherServlets\":{\"" + typeof(HomeController).FullName + "\":[{\"handler\":\"" +
             typeof(Person).FullName +
-            " Index()\",\"predicate\":\"{[/Home/Index],methods=[GET],produces=[text/plain || application/json || text/json]}\"}]}}}}}";
+            " Index()\",\"predicate\":\"{[/Home/Index],methods=[GET],produces=[text/plain || application/json || text/json],"+
+            "consumes=[text/plain || application/json || text/json]}\",\"details\":"+
+            "{\"requestMappingConditions\":{\"consumes\":[{\"mediaType\":\"text/plain\",\"negated\":false},{\"mediaType\":\"application/json\",\"negated\":false},{\"mediaType\":\"text/json\",\"negated\":false}],"+
+            "\"produces\":[{\"mediaType\":\"text/plain\",\"negated\":false},{\"mediaType\":\"application/json\",\"negated\":false},{\"mediaType\":\"text/json\",\"negated\":false}],\"methods\":[\"GET\"],\"patterns\":[\"/Home/Index\"]}}}]}}}}}";
 
         Assert.Equal(expected, json);
     }

--- a/src/Management/test/Endpoint.Test/Mappings/HomeController.cs
+++ b/src/Management/test/Endpoint.Test/Mappings/HomeController.cs
@@ -10,6 +10,7 @@ public class HomeController : Controller
 {
     [HttpGet]
     [Produces("text/plain", "application/json", "text/json")]
+    [Consumes("text/plain", "application/json", "text/json")]
     public Person Index()
     {
         return new Person();


### PR DESCRIPTION


## Description

 MappingsEndpoint response prior to the changes in this PR did not include the details object. This details object included the Produces/Consumes mediaType header constraints on route mappings. This PR makes this information available in a format that tools like SpringBootAdmin, CF apps manager and App Live View can use. 

Fixes #752 

## Quality checklist

<!-- Please run through the checklist below to ensure a smooth review and merge process for your PR. -->

- [x] Your code complies with our [Coding Style](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-code-style.md).
- [x] You've updated unit and/or integration tests for your change, where applicable.
- [ ] You've updated documentation for your change, where applicable.
      If your change affects other repositories, such as [Documentation](https://github.com/SteeltoeOSS/Documentation), [Samples](https://github.com/SteeltoeOSS/Samples) and/or [MainSite](https://github.com/SteeltoeOSS/MainSite), add linked PRs here.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
- [x] You've added required license files and/or file headers (explaining where the code came from with proper attribution), where code is copied from StackOverflow, a blog, or OSS.
