### PR TITLE
Add empty arrays for Headers, Params instead of missing json objects

### DIFF
--- a/src/Management/src/Endpoint/Mappings/AspNetCoreRouteDetails.cs
+++ b/src/Management/src/Endpoint/Mappings/AspNetCoreRouteDetails.cs
@@ -13,4 +13,8 @@ public class AspNetCoreRouteDetails : IRouteDetails
     public IList<string> Produces { get; set; }
 
     public IList<string> Consumes { get; set; }
+
+    public IList<string> Params { get; set; }
+
+    public IList<string> Headers { get; set; }
 }

--- a/src/Management/src/Endpoint/Mappings/IRouteDetails.cs
+++ b/src/Management/src/Endpoint/Mappings/IRouteDetails.cs
@@ -13,4 +13,8 @@ public interface IRouteDetails
     IList<string> Produces { get; }
 
     IList<string> Consumes { get; }
+
+    IList<string> Params { get; }
+
+    IList<string> Headers { get; }
 }

--- a/src/Management/src/Endpoint/Mappings/MappingDescription.cs
+++ b/src/Management/src/Endpoint/Mappings/MappingDescription.cs
@@ -43,23 +43,17 @@ public class MappingDescription
 
     private RouteMappingDetails CreateMappingDetails(IRouteDetails routeDetails)
     {
-        return new RouteMappingDetails
+        
+        return new RouteMappingDetails()
         {
             RequestMappingConditions = new RequestMappingConditions
             {
-                Consumes = routeDetails.Consumes.Select(consumes => new MediaTypeDescriptor
-                {
-                    MediaType = consumes
-                }).ToArray(),
-                Produces = routeDetails.Produces.Select(produces => new MediaTypeDescriptor
-                {
-                    MediaType = produces
-                }).ToArray(),
-                Methods = routeDetails.HttpMethods.ToArray(),
-                Patterns = new[]
-                {
-                    routeDetails.RouteTemplate
-                }
+                Consumes = routeDetails.Consumes.Select(consumes => new MediaTypeDescriptor() { MediaType = consumes }).ToList(),
+                Produces = routeDetails.Produces.Select(produces => new MediaTypeDescriptor() { MediaType = produces }).ToList(),
+                Methods = routeDetails.HttpMethods.ToList(),
+                Patterns = new[] { routeDetails.RouteTemplate },
+                Params = new string[] {}, // does not apply for .NET
+                Headers = new string[] {}, // Cannot infer here for .NET 
             }
         };
     }

--- a/src/Management/src/Endpoint/Mappings/MappingDescription.cs
+++ b/src/Management/src/Endpoint/Mappings/MappingDescription.cs
@@ -56,16 +56,12 @@ public class MappingDescription
                     MediaType = produces
                 }).ToList(),
                 Methods = routeDetails.HttpMethods.ToList(),
-                Patterns = new[]
+                Patterns = new List<string>
                 {
                     routeDetails.RouteTemplate
                 },
-                Params = new string[]
-                {
-                }, // does not apply for .NET
-                Headers = new string[]
-                {
-                } // Cannot infer here for .NET 
+                Params = new List<string> (), // Does not apply for .NET
+                Headers = new List<string> (), // Cannot infer here for .NET 
             }
         };
     }

--- a/src/Management/src/Endpoint/Mappings/MappingDescription.cs
+++ b/src/Management/src/Endpoint/Mappings/MappingDescription.cs
@@ -43,17 +43,29 @@ public class MappingDescription
 
     private RouteMappingDetails CreateMappingDetails(IRouteDetails routeDetails)
     {
-        
-        return new RouteMappingDetails()
+        return new RouteMappingDetails
         {
             RequestMappingConditions = new RequestMappingConditions
             {
-                Consumes = routeDetails.Consumes.Select(consumes => new MediaTypeDescriptor() { MediaType = consumes }).ToList(),
-                Produces = routeDetails.Produces.Select(produces => new MediaTypeDescriptor() { MediaType = produces }).ToList(),
+                Consumes = routeDetails.Consumes.Select(consumes => new MediaTypeDescriptor
+                {
+                    MediaType = consumes
+                }).ToList(),
+                Produces = routeDetails.Produces.Select(produces => new MediaTypeDescriptor
+                {
+                    MediaType = produces
+                }).ToList(),
                 Methods = routeDetails.HttpMethods.ToList(),
-                Patterns = new[] { routeDetails.RouteTemplate },
-                Params = new string[] {}, // does not apply for .NET
-                Headers = new string[] {}, // Cannot infer here for .NET 
+                Patterns = new[]
+                {
+                    routeDetails.RouteTemplate
+                },
+                Params = new string[]
+                {
+                }, // does not apply for .NET
+                Headers = new string[]
+                {
+                } // Cannot infer here for .NET 
             }
         };
     }

--- a/src/Management/src/Endpoint/Mappings/MappingDescription.cs
+++ b/src/Management/src/Endpoint/Mappings/MappingDescription.cs
@@ -60,8 +60,8 @@ public class MappingDescription
                 {
                     routeDetails.RouteTemplate
                 },
-                Params = new List<string> (), // Does not apply for .NET
-                Headers = new List<string> (), // Cannot infer here for .NET 
+                Params = new List<string>(), // Does not apply for .NET
+                Headers = new List<string>() // Cannot infer here for .NET 
             }
         };
     }

--- a/src/Management/src/Endpoint/Mappings/RequestMappingConditions.cs
+++ b/src/Management/src/Endpoint/Mappings/RequestMappingConditions.cs
@@ -23,4 +23,7 @@ public class RequestMappingConditions
 
     [JsonPropertyName("patterns")]
     public IList<string> Patterns { get; set; }
+
+    [JsonPropertyName("params")]
+    public IList<string> Params { get; set; }
 }

--- a/src/Management/test/Endpoint.Test/Mappings/EndpointMiddlewareTest.cs
+++ b/src/Management/test/Endpoint.Test/Mappings/EndpointMiddlewareTest.cs
@@ -85,10 +85,11 @@ public class EndpointMiddlewareTest : BaseTest
         string json = await result.Content.ReadAsStringAsync();
 
         string expected = "{\"contexts\":{\"application\":{\"mappings\":{\"dispatcherServlets\":{\"" + typeof(HomeController).FullName + "\":[{\"handler\":\"" +
-            typeof(Person).FullName + " Index()\",\"predicate\":\"{[/Home/Index],methods=[GET],produces=[text/plain || application/json || text/json]," +
-            "consumes=[text/plain || application/json || text/json]}\",\"details\":" +
-            "{\"requestMappingConditions\":{\"consumes\":[{\"mediaType\":\"text/plain\",\"negated\":false},{\"mediaType\":\"application/json\",\"negated\":false},{\"mediaType\":\"text/json\",\"negated\":false}]," +
-            "\"produces\":[{\"mediaType\":\"text/plain\",\"negated\":false},{\"mediaType\":\"application/json\",\"negated\":false},{\"mediaType\":\"text/json\",\"negated\":false}],\"methods\":[\"GET\"],\"patterns\":[\"/Home/Index\"]}}}]}}}}}";
+            typeof(Person).FullName +
+            " Index()\",\"predicate\":\"{[/Home/Index],methods=[GET],produces=[text/plain || application/json || text/json],"+
+            "consumes=[text/plain || application/json || text/json]}\",\"details\":"+
+            "{\"requestMappingConditions\":{\"consumes\":[{\"mediaType\":\"text/plain\",\"negated\":false},{\"mediaType\":\"application/json\",\"negated\":false},{\"mediaType\":\"text/json\",\"negated\":false}],"+
+            "\"produces\":[{\"mediaType\":\"text/plain\",\"negated\":false},{\"mediaType\":\"application/json\",\"negated\":false},{\"mediaType\":\"text/json\",\"negated\":false}],\"headers\":[],\"methods\":[\"GET\"],\"patterns\":[\"/Home/Index\"],\"params\":[]}}}]}}}}}";
 
         Assert.Equal(expected, json);
     }

--- a/src/Management/test/Endpoint.Test/Mappings/EndpointMiddlewareTest.cs
+++ b/src/Management/test/Endpoint.Test/Mappings/EndpointMiddlewareTest.cs
@@ -85,10 +85,9 @@ public class EndpointMiddlewareTest : BaseTest
         string json = await result.Content.ReadAsStringAsync();
 
         string expected = "{\"contexts\":{\"application\":{\"mappings\":{\"dispatcherServlets\":{\"" + typeof(HomeController).FullName + "\":[{\"handler\":\"" +
-            typeof(Person).FullName +
-            " Index()\",\"predicate\":\"{[/Home/Index],methods=[GET],produces=[text/plain || application/json || text/json],"+
-            "consumes=[text/plain || application/json || text/json]}\",\"details\":"+
-            "{\"requestMappingConditions\":{\"consumes\":[{\"mediaType\":\"text/plain\",\"negated\":false},{\"mediaType\":\"application/json\",\"negated\":false},{\"mediaType\":\"text/json\",\"negated\":false}],"+
+            typeof(Person).FullName + " Index()\",\"predicate\":\"{[/Home/Index],methods=[GET],produces=[text/plain || application/json || text/json]," +
+            "consumes=[text/plain || application/json || text/json]}\",\"details\":" +
+            "{\"requestMappingConditions\":{\"consumes\":[{\"mediaType\":\"text/plain\",\"negated\":false},{\"mediaType\":\"application/json\",\"negated\":false},{\"mediaType\":\"text/json\",\"negated\":false}]," +
             "\"produces\":[{\"mediaType\":\"text/plain\",\"negated\":false},{\"mediaType\":\"application/json\",\"negated\":false},{\"mediaType\":\"text/json\",\"negated\":false}],\"headers\":[],\"methods\":[\"GET\"],\"patterns\":[\"/Home/Index\"],\"params\":[]}}}]}}}}}";
 
         Assert.Equal(expected, json);

--- a/src/Management/test/Endpoint.Test/Mappings/TestRouteDetails.cs
+++ b/src/Management/test/Endpoint.Test/Mappings/TestRouteDetails.cs
@@ -15,4 +15,8 @@ public class TestRouteDetails : IRouteDetails
     public IList<string> Produces { get; set; }
 
     public IList<string> Consumes { get; set; }
+
+    public IList<string> Params { get; set; }
+
+    public IList<string> Headers { get; set; }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->

<!-- If this is your first PR in this repo, please read our [Contributing Guidelines (https://github.com/SteeltoeOSS/.github/blob/master/CONTRIBUTING.md) and remember to sign the [Contributor License Agreement](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-license.md). Our bot will notify you shortly after the PR has been created. -->

## Description

Adding additional fields in Json output to support Spring Boot Admin. The fields in question 'Headers' and 'Params' are Spring boot features on @RequestMapping annotation to match routes to controller actions. In .Net this is accomplished differently and is hard to infer as easily as in Spring. So, we will just add empty arrays to cause SpringBootAdmin not to error on this page.

Fixes #1151 

## Quality checklist

<!-- Please run through the checklist below to ensure a smooth review and merge process for your PR. -->

- [x] Your code complies with our [Coding Style](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-code-style.md).
- [x] You've updated unit and/or integration tests for your change, where applicable.
- [ ] You've updated documentation for your change, where applicable.
      If your change affects other repositories, such as [Documentation](https://github.com/SteeltoeOSS/Documentation), [Samples](https://github.com/SteeltoeOSS/Samples) and/or [MainSite](https://github.com/SteeltoeOSS/MainSite), add linked PRs here.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
- [x] You've added required license files and/or file headers (explaining where the code came from with proper attribution), where code is copied from StackOverflow, a blog, or OSS.
