### PR TITLE
Management: fix crash in middleware at startup

### DIFF
--- a/src/Management/src/Endpoint/ActuatorServiceCollectionExtensions.cs
+++ b/src/Management/src/Endpoint/ActuatorServiceCollectionExtensions.cs
@@ -31,7 +31,11 @@ public static class ActuatorServiceCollectionExtensions
         ArgumentGuard.NotNull(services);
 
         services.TryAddScoped<ActuatorEndpointMapper>();
-        services.ConfigureOptions<ConfigureManagementOptions>();
+
+        // Workaround for services.ConfigureOptions<ConfigureManagementOptions>() registering multiple times,
+        // see https://github.com/dotnet/runtime/issues/42358.
+        services.AddOptions();
+        services.TryAddTransient<IConfigureOptions<ManagementOptions>, ConfigureManagementOptions>();
     }
 
     public static void ConfigureEndpointOptions<TOptions, TConfigureOptions>(this IServiceCollection services)

--- a/src/Management/src/Endpoint/Loggers/LoggersEndpointMiddleware.cs
+++ b/src/Management/src/Endpoint/Loggers/LoggersEndpointMiddleware.cs
@@ -105,7 +105,7 @@ internal sealed class LoggersEndpointMiddleware : EndpointMiddleware<LoggersRequ
         else
         {
             context.HandleContentNegotiation(_logger);
-            JsonSerializerOptions options = GetSerializerOptions();
+            JsonSerializerOptions options = ManagementOptionsMonitor.CurrentValue.SerializerOptions;
             await JsonSerializer.SerializeAsync(context.Response.Body, result.Data, options, cancellationToken);
         }
     }

--- a/src/Management/src/Endpoint/Middleware/EndpointMiddleware.cs
+++ b/src/Management/src/Endpoint/Middleware/EndpointMiddleware.cs
@@ -4,15 +4,12 @@
 
 using System.Net;
 using System.Text.Json;
-using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Steeltoe.Common;
 using Steeltoe.Management.Endpoint.ContentNegotiation;
-using Steeltoe.Management.Endpoint.Health;
 using Steeltoe.Management.Endpoint.Options;
-using Steeltoe.Management.Endpoint.Trace;
 
 namespace Steeltoe.Management.Endpoint.Middleware;
 
@@ -83,34 +80,7 @@ public abstract class EndpointMiddleware<TArgument, TResult> : IEndpointMiddlewa
             return;
         }
 
-        JsonSerializerOptions options = GetSerializerOptions();
+        JsonSerializerOptions options = ManagementOptionsMonitor.CurrentValue.SerializerOptions;
         await JsonSerializer.SerializeAsync(context.Response.Body, result, options, cancellationToken);
-    }
-
-    protected JsonSerializerOptions GetSerializerOptions()
-    {
-        JsonSerializerOptions serializerOptions = ManagementOptionsMonitor.CurrentValue.SerializerOptions;
-
-        if (serializerOptions.DefaultIgnoreCondition != JsonIgnoreCondition.WhenWritingNull)
-        {
-            serializerOptions.DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull;
-        }
-
-        if (!serializerOptions.Converters.Any(converter => converter is JsonStringEnumConverter))
-        {
-            serializerOptions.Converters.Add(new JsonStringEnumConverter());
-        }
-
-        if (!serializerOptions.Converters.Any(converter => converter is HealthConverter or HealthConverterV3))
-        {
-            serializerOptions.Converters.Add(new HealthConverter());
-        }
-
-        if (!serializerOptions.Converters.Any(converter => converter is HttpTraceResultConverter))
-        {
-            serializerOptions.Converters.Add(new HttpTraceResultConverter());
-        }
-
-        return serializerOptions;
     }
 }

--- a/src/Management/src/Endpoint/PublicAPI.Unshipped.txt
+++ b/src/Management/src/Endpoint/PublicAPI.Unshipped.txt
@@ -313,7 +313,6 @@ Steeltoe.Management.Endpoint.Middleware.EndpointMiddleware<TArgument, TResult>
 Steeltoe.Management.Endpoint.Middleware.EndpointMiddleware<TArgument, TResult>.EndpointHandler.get -> Steeltoe.Management.IEndpointHandler<TArgument, TResult>!
 Steeltoe.Management.Endpoint.Middleware.EndpointMiddleware<TArgument, TResult>.EndpointMiddleware(Steeltoe.Management.IEndpointHandler<TArgument, TResult>! endpointHandler, Microsoft.Extensions.Options.IOptionsMonitor<Steeltoe.Management.Endpoint.Options.ManagementOptions!>! managementOptionsMonitor, Microsoft.Extensions.Logging.ILoggerFactory! loggerFactory) -> void
 Steeltoe.Management.Endpoint.Middleware.EndpointMiddleware<TArgument, TResult>.EndpointOptions.get -> Steeltoe.Management.EndpointOptions!
-Steeltoe.Management.Endpoint.Middleware.EndpointMiddleware<TArgument, TResult>.GetSerializerOptions() -> System.Text.Json.JsonSerializerOptions!
 Steeltoe.Management.Endpoint.Middleware.EndpointMiddleware<TArgument, TResult>.InvokeAsync(Microsoft.AspNetCore.Http.HttpContext! context, Microsoft.AspNetCore.Http.RequestDelegate? next) -> System.Threading.Tasks.Task!
 Steeltoe.Management.Endpoint.Middleware.EndpointMiddleware<TArgument, TResult>.ManagementOptionsMonitor.get -> Microsoft.Extensions.Options.IOptionsMonitor<Steeltoe.Management.Endpoint.Options.ManagementOptions!>!
 Steeltoe.Management.Endpoint.Middleware.IEndpointMiddleware

--- a/src/Management/src/Endpoint/SpringBootAdminClient/ServiceCollectionExtensions.cs
+++ b/src/Management/src/Endpoint/SpringBootAdminClient/ServiceCollectionExtensions.cs
@@ -3,6 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
 using Steeltoe.Common;
 using Steeltoe.Management.Endpoint.Health;
 using Steeltoe.Management.Endpoint.Options;
@@ -25,7 +27,12 @@ public static class ServiceCollectionExtensions
         ArgumentGuard.NotNull(services);
 
         services.RegisterDefaultApplicationInstanceInfo();
-        services.ConfigureOptions<ConfigureManagementOptions>();
+
+        // Workaround for services.ConfigureOptions<ConfigureManagementOptions>() registering multiple times,
+        // see https://github.com/dotnet/runtime/issues/42358.
+        services.AddOptions();
+        services.TryAddTransient<IConfigureOptions<ManagementOptions>, ConfigureManagementOptions>();
+
         services.ConfigureEndpointOptions<HealthEndpointOptions, ConfigureHealthEndpointOptions>();
         services.ConfigureOptions<ConfigureSpringBootAdminClientOptions>();
 


### PR DESCRIPTION
## Description

When deploying to TAP, the following error occurs at startup:
```
fail: Microsoft.AspNetCore.Diagnostics.ExceptionHandlerMiddleware[1]
      An unhandled exception has occurred while executing the request.
      System.InvalidOperationException: Collection was modified; enumeration operation may not execute.
         at System.Collections.Generic.List`1.Enumerator.MoveNext()
         at System.Linq.Enumerable.Any[TSource](IEnumerable`1 source, Func`2 predicate)
         at Steeltoe.Management.Endpoint.Middleware.EndpointMiddleware`2.GetSerializerOptions()
         at Steeltoe.Management.Endpoint.Middleware.EndpointMiddleware`2.WriteResponseAsync(TResult result, HttpContext context, CancellationToken cancellationToken)
         at Steeltoe.Management.Endpoint.Middleware.EndpointMiddleware`2.InvokeAsync(HttpContext context, RequestDelegate next)
         at Microsoft.AspNetCore.Builder.UseMiddlewareExtensions.<>c__DisplayClass6_1.<<UseMiddlewareInterface>b__1>d.MoveNext()
      --- End of stack trace from previous location ---
         at Microsoft.AspNetCore.Routing.EndpointMiddleware.<Invoke>g__AwaitRequestTask|6_0(Endpoint endpoint, Task requestTask, ILogger logger)
         at Microsoft.AspNetCore.Authorization.AuthorizationMiddleware.Invoke(HttpContext context)
         at Microsoft.AspNetCore.Diagnostics.ExceptionHandlerMiddleware.<Invoke>g__Awaited|6_0(ExceptionHandlerMiddleware middleware, HttpContext context, Task task)
```

This happens because connectors are reloading configuration via post-processors (from a background thread), at the same time that JSON converters are being added (at request execution). It is unsafe to read-and-modify a singleton-scoped `JsonSerializerOptions` instance that is being replaced concurrently. Therefore I've moved the serialization changes into `ConfigureManagementOptions`. This is also more efficient because, before this change, each request would try to reapply the changes (which is not thread-safe either, as a concurrent request could observe an intermediate state, -or- add the converter twice).

Then I found that `ConfigureManagementOptions.Configure()` executes a dozen times at startup, because all endpoint bootstrappers call `services.ConfigureOptions<ConfigureManagementOptions>()`. Surprisingly, `ConfigureOptions()` adds a registration _each time_ it is called, as opposed to most other IoC calls in ASP.NET (tracking issue at https://github.com/dotnet/runtime/issues/42358).

## Quality checklist

- [x] Your code complies with our [Coding Style](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-code-style.md).
- [ ] You've updated unit and/or integration tests for your change, where applicable.
- [ ] You've updated documentation for your change, where applicable.
      If your change affects other repositories, such as [Documentation](https://github.com/SteeltoeOSS/Documentation), [Samples](https://github.com/SteeltoeOSS/Samples) and/or [MainSite](https://github.com/SteeltoeOSS/MainSite), add linked PRs here.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
- [ ] You've added required license files and/or file headers (explaining where the code came from with proper attribution), where code is copied from StackOverflow, a blog, or OSS.
