### PR TITLE
Reproduce CleanupCode hang

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "jetbrains.resharper.globaltools": {
-      "version": "2022.2.2",
+      "version": "2023.2.0",
       "commands": [
         "jb"
       ]

--- a/build/verify-code-style.yml
+++ b/build/verify-code-style.yml
@@ -10,9 +10,21 @@ jobs:
     DOTNET_NOLOGO: true
     DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
     DOTNET_CLI_TELEMETRY_OPTOUT: 1
+  strategy:
+    matrix:
+      linux:
+        imageName: 'ubuntu-latest'
+      mac:
+        imageName: 'macOS-latest'
+      windows:
+        imageName: 'windows-latest'
   pool:
-    vmImage: windows-latest
+    vmImage: $(imageName)
   steps:
+  - task: UseDotNet@2
+    displayName: Install .NET 6
+    inputs:
+      version: 6.0.x
   - checkout: self
     persistCredentials: true
     fetchDepth: 0
@@ -23,11 +35,11 @@ jobs:
       script: |
         dotnet tool restore
   - task: PowerShell@2
-    displayName: Restore packages
+    displayName: Build
     inputs:
       targetType: 'inline'
       script: |
-        dotnet restore src
+        dotnet build src -c Release
   - task: PowerShell@2
     displayName: Verify code style
     inputs:

--- a/build/verify-code-style.yml
+++ b/build/verify-code-style.yml
@@ -47,7 +47,7 @@ jobs:
       script: |
         if (-not $env:SYSTEM_PULLREQUEST_TARGETBRANCH) {
           Write-Output "Running code cleanup on all files in branch."
-          dotnet regitlint -s src/Steeltoe.All.sln --print-command --skip-tool-check --jb-profile="Steeltoe Full Cleanup" --jb --properties:Configuration=Release --jb --verbosity=WARN --fail-on-diff --print-diff
+          dotnet regitlint -s src/Steeltoe.All.sln --print-command --skip-tool-check --jb-profile="Steeltoe Full Cleanup" --jb --properties:Configuration=Release --jb --verbosity=TRACE --jb --LogFolder=$env:BUILD_ARTIFACTSTAGINGDIRECTORY/cleanup-logs --jb --debug --fail-on-diff --print-diff
         }
         else {
           # We are in detached head (the merge result), so there's no need to account for an out-of-date PR.
@@ -58,5 +58,18 @@ jobs:
           if ($LastExitCode -ne 0) { throw "Command 'git rev-parse (2)' failed with exit code $LastExitCode." }
   
           Write-Output "Running code cleanup on commit range $baseCommitHash..$headCommitHash in pull request."
-          dotnet regitlint -s src/Steeltoe.All.sln --print-command --skip-tool-check --jb-profile="Steeltoe Full Cleanup" --jb --properties:Configuration=Release --jb --verbosity=WARN --fail-on-diff --print-diff -f commits -a $headCommitHash -b $baseCommitHash
+          dotnet regitlint -s src/Steeltoe.All.sln --print-command --skip-tool-check --jb-profile="Steeltoe Full Cleanup" --jb --properties:Configuration=Release --jb --verbosity=TRACE --jb --LogFolder=$env:BUILD_ARTIFACTSTAGINGDIRECTORY/cleanup-logs --jb --debug --fail-on-diff --print-diff -f commits -a $headCommitHash -b $baseCommitHash
         }
+  - task: PowerShell@2
+    condition: always()
+    displayName: Kill hanging processes
+    inputs:
+      targetType: 'inline'
+      script: |
+        Get-Process | Where-Object {$_.ProcessName -eq 'dotnet'} | Stop-Process -Force
+        Get-Process | Where-Object {$_.ProcessName -eq 'msbuild'} | Stop-Process -Force
+        Get-Process | Where-Object {$_.ProcessName -eq 'VBCSCompiler'} | Stop-Process -Force
+  - publish: $(Build.ArtifactStagingDirectory)/cleanup-logs
+    condition: always()
+    displayName: Publish cleanup logs
+    artifact: cleanup-logs_$(imageName)


### PR DESCRIPTION
Reproduce hang in the latest version of Resharper CleanupCode, tracked at https://youtrack.jetbrains.com/issue/RSRP-491800/2023.1.0-eap10-CleanupCode-never-completes.