### PR TITLE
Replace hardcoded package versions with variable

### DIFF
--- a/src/Configuration/src/Encryption/Steeltoe.Configuration.Encryption.csproj
+++ b/src/Configuration/src/Encryption/Steeltoe.Configuration.Encryption.csproj
@@ -13,8 +13,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="BouncyCastle.NetCore" Version="1.9.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="7.0.2" />
+    <PackageReference Include="BouncyCastle.NetCore" Version="$(BouncyCastleVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="$(AspNetCoreVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Configuration/test/Encryption.Test/Steeltoe.Configuration.Encryption.Test.csproj
+++ b/src/Configuration/test/Encryption.Test/Steeltoe.Configuration.Encryption.Test.csproj
@@ -5,18 +5,14 @@
 
   <Import Project="..\..\..\..\shared.props" />
 
-  
-
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="$(ExtensionsVersion)" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Xml" Version="$(ExtensionsVersion)" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Ini" Version="$(ExtensionsVersion)" />
     <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="$(ExtensionsVersion)" />
-    <PackageReference Include="Moq" Version="4.18.4" />
+    <PackageReference Include="Moq" Version="$(MoqVersion)" />
   </ItemGroup>
-
-  
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\Common\src\Common.Utils\Steeltoe.Common.Utils.csproj" />

--- a/src/Management/src/Prometheus/Steeltoe.Management.Prometheus.csproj
+++ b/src/Management/src/Prometheus/Steeltoe.Management.Prometheus.csproj
@@ -10,11 +10,11 @@
   <Import Project="..\..\..\..\shared.props" />
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
-    <PackageReference Include="OpenTelemetry" Version="1.4.0-rc.3" />
-    <PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.4.0-rc.3" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.4.0-rc.3" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="$(ExtensionsVersion)" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(ExtensionsVersion)" />
+    <PackageReference Include="OpenTelemetry" Version="$(OpenTelemetryVersion)" />
+    <PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="$(OpenTelemetryVersion)" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="$(OpenTelemetryVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Management/src/Wavefront/Steeltoe.Management.Wavefront.csproj
+++ b/src/Management/src/Wavefront/Steeltoe.Management.Wavefront.csproj
@@ -10,10 +10,10 @@
   <Import Project="..\..\..\..\shared.props" />
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />
-    <PackageReference Include="OpenTelemetry" Version="1.4.0-rc.3" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.4.0-rc.3" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(ExtensionsVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="$(ExtensionsVersion)" />
+    <PackageReference Include="OpenTelemetry" Version="$(OpenTelemetryVersion)" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="$(OpenTelemetryVersion)" />
     <PackageReference Include="Wavefront.SDK.CSharp" Version="$(WavefrontSdkVersion)" />
   </ItemGroup>
 

--- a/versions.props
+++ b/versions.props
@@ -73,5 +73,6 @@
     <EFCoreVersion>6.0.*</EFCoreVersion>
     <LightweightEmitVersion>4.7.*</LightweightEmitVersion>
     <AspNetCoreVersion>6.0.*</AspNetCoreVersion>
+    <OpenTelemetryVersion>1.4.0-rc.3</OpenTelemetryVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
## Description

Replace hardcoded package versions with variables. Found these while trying to run on .NET 8 preview.

## Quality checklist

- [x] Your code complies with our [Coding Style](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-code-style.md).
- [ ] You've updated unit and/or integration tests for your change, where applicable.
- [ ] You've updated documentation for your change, where applicable.
      If your change affects other repositories, such as [Documentation](https://github.com/SteeltoeOSS/Documentation), [Samples](https://github.com/SteeltoeOSS/Samples) and/or [MainSite](https://github.com/SteeltoeOSS/MainSite), add linked PRs here.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
- [ ] You've added required license files and/or file headers (explaining where the code came from with proper attribution), where code is copied from StackOverflow, a blog, or OSS.
