### PR TITLE
Fix broken heapdump tests for OSX

### DIFF
--- a/src/Management/src/Endpoint/HeapDump/ConfigureHeapDumpEndpointOptions.cs
+++ b/src/Management/src/Endpoint/HeapDump/ConfigureHeapDumpEndpointOptions.cs
@@ -3,16 +3,33 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Steeltoe.Common;
 using Steeltoe.Management.Endpoint.Options;
 
 namespace Steeltoe.Management.Endpoint.HeapDump;
 
 internal sealed class ConfigureHeapDumpEndpointOptions : ConfigureEndpointOptions<HeapDumpEndpointOptions>
 {
+    private readonly ILogger<ConfigureHeapDumpEndpointOptions> _logger;
     private const string ManagementInfoPrefix = "management:endpoints:heapdump";
 
-    public ConfigureHeapDumpEndpointOptions(IConfiguration configuration)
+
+    public ConfigureHeapDumpEndpointOptions(IConfiguration configuration, ILogger<ConfigureHeapDumpEndpointOptions> logger)
         : base(configuration, ManagementInfoPrefix, "heapdump")
     {
+        _logger = logger;
+    }
+
+    public override void Configure(HeapDumpEndpointOptions options)
+    {
+        base.Configure(options);
+
+        // Full dumps are broken on Osx, so default to gcdump
+        if (Platform.IsOSX)
+        {
+            _logger.LogInformation("Full dumps are not supported on OSX, defaulting to gcdump.");
+            options.HeapDumpType = "gcdump";
+        }
     }
 }

--- a/src/Management/test/Endpoint.Test/ActuatorRouteBuilderExtensionsTest.cs
+++ b/src/Management/test/Endpoint.Test/ActuatorRouteBuilderExtensionsTest.cs
@@ -20,18 +20,31 @@ namespace Steeltoe.Management.Endpoint.Test;
 
 public sealed class ActuatorRouteBuilderExtensionsTest
 {
-    [Fact]
-    public async Task MapTestAuthSuccess()
+
+    public static IEnumerable<object[]> ActuatorOptions
+
+    {
+        get
+        {
+            IHostBuilder hostBuilder = GetHostBuilder(policy => policy.RequireClaim("scope", "actuators.read"));
+            return hostBuilder.Build().Services.GetServices<EndpointOptions>().Select(options => new object[]{options});
+        }
+    }
+    [Theory]
+    [MemberData(nameof(ActuatorOptions))]
+
+    public async Task MapTestAuthSuccess(EndpointOptions options)
     {
         IHostBuilder hostBuilder = GetHostBuilder(policy => policy.RequireClaim("scope", "actuators.read"));
-        await ActAndAssertAsync(hostBuilder, true);
+        await ActAndAssertAsync(hostBuilder, options, true);
     }
 
-    [Fact]
-    public async Task MapTestAuthFail()
+    [Theory]
+    [MemberData(nameof(ActuatorOptions))]
+    public async Task MapTestAuthFail(EndpointOptions options)
     {
         IHostBuilder hostBuilder = GetHostBuilder(policy => policy.RequireClaim("scope", "invalidscope"));
-        await ActAndAssertAsync(hostBuilder, false);
+        await ActAndAssertAsync(hostBuilder, options, false);
     }
 
     private static IHostBuilder GetHostBuilder(Action<AuthorizationPolicyBuilder> policyAction)
@@ -64,32 +77,27 @@ public sealed class ActuatorRouteBuilderExtensionsTest
         }).ConfigureAppConfiguration(configure => configure.AddInMemoryCollection(appSettings));
     }
 
-    private async Task ActAndAssertAsync(IHostBuilder hostBuilder, bool expectedSuccess)
+    private async Task ActAndAssertAsync(IHostBuilder hostBuilder, EndpointOptions options, bool expectedSuccess)
     {
         using IHost host = await hostBuilder.StartAsync();
         using TestServer server = host.GetTestServer();
 
-        IEnumerable<EndpointOptions> optionsCollection = host.Services.GetServices<EndpointOptions>();
+        ManagementOptions managementOptions = host.Services.GetRequiredService<IOptionsMonitor<ManagementOptions>>().CurrentValue;
+        string path = options.GetPathMatchPattern(managementOptions, managementOptions.Path);
+        path = path.Replace("metrics/{**_}", "metrics", StringComparison.Ordinal);
+        Assert.NotNull(path);
+        HttpResponseMessage response;
 
-        foreach (EndpointOptions options in optionsCollection)
+        if (options.AllowedVerbs.Contains("Get"))
         {
-            ManagementOptions managementOptions = host.Services.GetRequiredService<IOptionsMonitor<ManagementOptions>>().CurrentValue;
-            string path = options.GetPathMatchPattern(managementOptions, managementOptions.Path);
-            path = path.Replace("metrics/{**_}", "metrics", StringComparison.Ordinal);
-            Assert.NotNull(path);
-            HttpResponseMessage response;
-
-            if (options.AllowedVerbs.Contains("Get"))
-            {
-                response = await server.CreateClient().GetAsync(new Uri(path, UriKind.RelativeOrAbsolute));
-            }
-            else
-            {
-                response = await server.CreateClient().PostAsync(new Uri(path, UriKind.RelativeOrAbsolute), null);
-            }
-
-            Assert.True(expectedSuccess == response.IsSuccessStatusCode,
-                $"Expected {(expectedSuccess ? "success" : "failure")}, but got {response.StatusCode} for {path} and type {options}");
+            response = await server.CreateClient().GetAsync(new Uri(path, UriKind.RelativeOrAbsolute));
         }
+        else
+        {
+            response = await server.CreateClient().PostAsync(new Uri(path, UriKind.RelativeOrAbsolute), null);
+        }
+
+        Assert.True(expectedSuccess == response.IsSuccessStatusCode,
+            $"Expected {(expectedSuccess ? "success" : "failure")}, but got {response.StatusCode} for {path} and type {options}");
     }
 }

--- a/src/Management/test/Endpoint.Test/BaseTest.cs
+++ b/src/Management/test/Endpoint.Test/BaseTest.cs
@@ -111,6 +111,7 @@ public abstract class BaseTest : IDisposable
         services.AddSingleton<IConfiguration>(configurationRoot);
         services.AddSingleton<IApplicationInstanceInfo>(new ApplicationInstanceInfo(configurationRoot, string.Empty));
         services.ConfigureOptions(configureOptionsType);
+        services.AddLogging();
 
         ServiceProvider provider = services.BuildServiceProvider();
         return provider.GetRequiredService<IOptionsMonitor<TOptions>>();

--- a/src/Management/test/Endpoint.Test/HeapDump/HeapDumpEndpointOptionsTest.cs
+++ b/src/Management/test/Endpoint.Test/HeapDump/HeapDumpEndpointOptionsTest.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
+using Steeltoe.Common;
 using Steeltoe.Management.Endpoint.CloudFoundry;
 using Steeltoe.Management.Endpoint.HeapDump;
 using Xunit;
@@ -43,5 +44,14 @@ public sealed class HeapDumpEndpointOptionsTest : BaseTest
         Assert.True(heapDumpEndpointOptions.Enabled);
         Assert.Equal("heapdump", heapDumpEndpointOptions.Id);
         Assert.Equal("heapdump", heapDumpEndpointOptions.Path);
+
+        if (Platform.IsOSX)
+        {
+            Assert.Equal("gcdump", heapDumpEndpointOptions.HeapDumpType);
+        }
+        else
+        {
+            Assert.Null(heapDumpEndpointOptions.HeapDumpType);
+        }
     }
 }


### PR DESCRIPTION
## Description

Running the full dump in OSX appears to be broken even outside Steeltoe using dotnet dump. Running actuators in OSX server side appears unlikely, yet to support developers working on a Mac, we want to provide some functionality here. Instead of disabling the heap dump actuator entirely, we are configuring it to return a gcdump instead which appears to work fine. 



## Quality checklist

<!-- Please run through the checklist below to ensure a smooth review and merge process for your PR. -->

- [x] Your code complies with our [Coding Style](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-code-style.md).
- [x] You've updated unit and/or integration tests for your change, where applicable.
- [ ] You've updated documentation for your change, where applicable.
      If your change affects other repositories, such as [Documentation](https://github.com/SteeltoeOSS/Documentation), [Samples](https://github.com/SteeltoeOSS/Samples) and/or [MainSite](https://github.com/SteeltoeOSS/MainSite), add linked PRs here.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
- [ ] You've added required license files and/or file headers (explaining where the code came from with proper attribution), where code is copied from StackOverflow, a blog, or OSS.
