### PR TITLE
Restrict Otel versions to those supported

### DIFF
--- a/versions.props
+++ b/versions.props
@@ -41,8 +41,8 @@
     <MockHttpVersion>6.0.0</MockHttpVersion>
     <MoqVersion>4.13.1</MoqVersion>
     
-    <OpenTelemetryVersion>1.2.0</OpenTelemetryVersion>
-    <OpenTelemetryInstrumentationVersion>1.0.0-rc9.2</OpenTelemetryInstrumentationVersion>
+    <OpenTelemetryVersion>[1.2.0,1.3.2]</OpenTelemetryVersion>
+    <OpenTelemetryInstrumentationVersion>[1.0.0-rc9.2,1.0.0-rc9.9]</OpenTelemetryInstrumentationVersion>
     <WavefrontSdkVersion>1.8.0-beta</WavefrontSdkVersion>
     
     <RabbitClientVersion>5.0.1</RabbitClientVersion>


### PR DESCRIPTION

## Description

We typically use minimum versions in our upstream dependencies, but consumers of Steeltoe may add a later version causing runtime errors. This will make it a compiler error if dependency limits are violated.  


## Quality checklist

<!-- Please run through the checklist below to ensure a smooth review and merge process for your PR. -->

- [x] Your code complies with our [Coding Style](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-code-style.md).
- [ ] You've updated unit and/or integration tests for your change, where applicable.
- [ ] You've updated documentation for your change, where applicable.
      If your change affects other repositories, such as [Documentation](https://github.com/SteeltoeOSS/Documentation), [Samples](https://github.com/SteeltoeOSS/Samples) and/or [MainSite](https://github.com/SteeltoeOSS/MainSite), add linked PRs here.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
- [ ] You've added required license files and/or file headers (explaining where the code came from with proper attribution), where code is copied from StackOverflow, a blog, or OSS.
