### PR TITLE
Health: Fixed error handling and incorrect volume on linux/macOS

### DIFF
--- a/src/Management/test/Endpoint.Test/Health/Contributor/DiskSpaceContributorTest.cs
+++ b/src/Management/test/Endpoint.Test/Health/Contributor/DiskSpaceContributorTest.cs
@@ -2,8 +2,10 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
+using FluentAssertions;
 using Microsoft.Extensions.Options;
 using Steeltoe.Common.HealthChecks;
+using Steeltoe.Common.TestResources;
 using Steeltoe.Management.Endpoint.Health.Contributor;
 using Xunit;
 
@@ -33,5 +35,81 @@ public sealed class DiskSpaceContributorTest : BaseTest
         Assert.True(result.Details.ContainsKey("free"));
         Assert.True(result.Details.ContainsKey("threshold"));
         Assert.True(result.Details.ContainsKey("status"));
+    }
+
+    [Fact]
+    public void Health_UnknownDirectory_ReportsError()
+    {
+        var optionsMonitor = new TestOptionsMonitor<DiskSpaceContributorOptions>(new DiskSpaceContributorOptions
+        {
+            Path = OperatingSystem.IsWindows() ? "C:\\does-not-exist" : "/does/not/exist"
+        });
+
+        var contributor = new DiskSpaceContributor(optionsMonitor);
+
+        HealthCheckResult? result = contributor.Health();
+
+        result.Should().NotBeNull();
+        result!.Status.Should().Be(HealthStatus.Unknown);
+        result.Description.Should().Be("Failed to determine free disk space.");
+        result.Details.Should().Contain("error", "The configured path is invalid or does not exist.");
+        result.Details.Should().Contain("status", "UNKNOWN");
+    }
+
+    [Theory]
+    [InlineData("C:\\", "C:\\", PlatformID.Win32NT)]
+    [InlineData("C:\\Windows\\System32", "C:\\", PlatformID.Win32NT)]
+    [InlineData("C:\\Windows\\System32\\", "C:\\", PlatformID.Win32NT)]
+    [InlineData("c:\\WINDOWS\\SYSTEM32\\", "C:\\", PlatformID.Win32NT)]
+    [InlineData("/", "/", PlatformID.Unix, PlatformID.MacOSX)]
+    [InlineData("/dev", "/dev", PlatformID.Unix, PlatformID.MacOSX)]
+    [InlineData("/dev/", "/dev", PlatformID.Unix, PlatformID.MacOSX)]
+    [InlineData("/dev/shm", "/dev/shm", PlatformID.Unix, PlatformID.MacOSX)]
+    [InlineData("/dev/shm/", "/dev/shm", PlatformID.Unix, PlatformID.MacOSX)]
+    [InlineData("/dev/shm/data", "/dev/shm", PlatformID.Unix, PlatformID.MacOSX)]
+    [InlineData("/dev/shm-some", "/dev", PlatformID.Unix, PlatformID.MacOSX)]
+    [InlineData("/dev/SHM", "/dev", PlatformID.Unix)]
+    [InlineData("/dev/SHM", "/dev/shm", PlatformID.MacOSX)]
+    public void Selects_correct_volume(string path, string? expected, params PlatformID[] platforms)
+    {
+        if (OperatingSystem.IsWindows() && !platforms.Contains(PlatformID.Win32NT))
+        {
+            return;
+        }
+
+        if (OperatingSystem.IsLinux() && !platforms.Contains(PlatformID.Unix))
+        {
+            return;
+        }
+
+        if (OperatingSystem.IsMacOS() && !platforms.Contains(PlatformID.MacOSX))
+        {
+            return;
+        }
+
+        DriveInfo[] systemDrives = OperatingSystem.IsWindows()
+            ? new[]
+            {
+                new DriveInfo("C:\\"),
+                new DriveInfo("D:\\")
+            }
+            : new[]
+            {
+                new DriveInfo("/"),
+                new DriveInfo("/dev"),
+                new DriveInfo("/dev/shm")
+            };
+
+        DriveInfo? drive = DiskSpaceContributor.FindVolume(path, systemDrives);
+
+        if (expected == null)
+        {
+            drive.Should().BeNull();
+        }
+        else
+        {
+            drive.Should().NotBeNull();
+            drive!.RootDirectory.FullName.Should().Be(expected);
+        }
     }
 }


### PR DESCRIPTION
## Description

Fixes in the disk-space contributor for management health checks.

Fixes #1175
Fixes #1176

## Quality checklist

- [x] Your code complies with our [Coding Style](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-code-style.md).
- [x] You've updated unit and/or integration tests for your change, where applicable.
- [ ] You've updated documentation for your change, where applicable.
      If your change affects other repositories, such as [Documentation](https://github.com/SteeltoeOSS/Documentation), [Samples](https://github.com/SteeltoeOSS/Samples) and/or [MainSite](https://github.com/SteeltoeOSS/MainSite), add linked PRs here.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
- [x] You've added required license files and/or file headers (explaining where the code came from with proper attribution), where code is copied from StackOverflow, a blog, or OSS.
