### PR TITLE
Correct nullability in Steeltoe.Configuration

### DIFF
--- a/src/Configuration/src/Abstractions/ConfigurationDictionaryExtensions.cs
+++ b/src/Configuration/src/Abstractions/ConfigurationDictionaryExtensions.cs
@@ -2,17 +2,19 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using Microsoft.Extensions.Configuration;
 
 namespace Steeltoe.Configuration;
 
 internal static class ConfigurationDictionaryExtensions
 {
-    public static IEnumerable<string> Filter(this IDictionary<string, string> configurationData, string keyPrefix, string keySuffix, string keyValue)
+    public static IEnumerable<string> Filter(this IDictionary<string, string?> configurationData, string keyPrefix, string keySuffix, string keyValue)
     {
         var results = new List<string>();
 
-        foreach ((string key, string value) in configurationData)
+        foreach ((string key, string? value) in configurationData)
         {
             if (key.StartsWith(keyPrefix, StringComparison.OrdinalIgnoreCase) && key.EndsWith(keySuffix, StringComparison.OrdinalIgnoreCase) &&
                 value == keyValue)
@@ -22,21 +24,5 @@ internal static class ConfigurationDictionaryExtensions
         }
 
         return results;
-    }
-
-    public static IEnumerable<string> Filter(this IDictionary<string, string> configurationData, string keyPrefix)
-    {
-        return
-            from pair in configurationData
-            where pair.Key.StartsWith(keyPrefix, StringComparison.OrdinalIgnoreCase)
-            select ConfigurationPath.GetParentPath(pair.Key);
-    }
-
-    public static void ForEach(this IEnumerable<string> keys, Action<string> mapping)
-    {
-        foreach (string key in keys)
-        {
-            mapping(key);
-        }
     }
 }

--- a/src/Configuration/src/Abstractions/ConfigurationDictionaryMapper.cs
+++ b/src/Configuration/src/Abstractions/ConfigurationDictionaryMapper.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using Microsoft.Extensions.Configuration;
 
 namespace Steeltoe.Configuration;
@@ -10,34 +12,30 @@ internal abstract class ConfigurationDictionaryMapper
 {
     protected string BindingKey { get; }
     protected string ToPrefix { get; }
-    protected IDictionary<string, string> ConfigurationData { get; }
+    protected IDictionary<string, string?> ConfigurationData { get; }
 
-    protected ConfigurationDictionaryMapper(IDictionary<string, string> configurationData, string bindingKey, params string[] toPrefix)
+    protected ConfigurationDictionaryMapper(IDictionary<string, string?> configurationData, string bindingKey, params string[] toPrefix)
     {
         ConfigurationData = configurationData;
         BindingKey = !string.IsNullOrEmpty(bindingKey) ? bindingKey + ConfigurationPath.KeyDelimiter : string.Empty;
-
-        if (toPrefix.Length > 0)
-        {
-            ToPrefix = string.Join(ConfigurationPath.KeyDelimiter, toPrefix) + ConfigurationPath.KeyDelimiter;
-        }
+        ToPrefix = toPrefix.Length > 0 ? string.Join(ConfigurationPath.KeyDelimiter, toPrefix) + ConfigurationPath.KeyDelimiter : string.Empty;
     }
 
-    public string MapFromTo(string fromKey, string toKey)
+    public string? MapFromTo(string fromKey, string toKey)
     {
-        string value = GetFromValue(fromKey);
+        string? value = GetFromValue(fromKey);
         SetToValue(toKey, value);
 
         return value;
     }
 
-    public string MapFromAppendTo(string fromKey, string appendToKey, string separator)
+    public string? MapFromAppendTo(string fromKey, string appendToKey, string separator)
     {
-        string valueToAppend = GetFromValue(fromKey);
+        string? valueToAppend = GetFromValue(fromKey);
 
         if (valueToAppend != null)
         {
-            string existingValue = GetToValue(appendToKey);
+            string? existingValue = GetToValue(appendToKey);
 
             if (existingValue != null)
             {
@@ -51,9 +49,9 @@ internal abstract class ConfigurationDictionaryMapper
         return null;
     }
 
-    public string MapFromToFile(string fromKey, string toKey)
+    public string? MapFromToFile(string fromKey, string toKey)
     {
-        string value = GetFromValue(fromKey);
+        string? value = GetFromValue(fromKey);
 
         if (value == null)
         {
@@ -72,21 +70,21 @@ internal abstract class ConfigurationDictionaryMapper
         return tempPath;
     }
 
-    public void SetToValue(string toKey, string value)
+    public void SetToValue(string toKey, string? value)
     {
         string key = $"{ToPrefix}{toKey}";
         ConfigurationData[key] = value;
     }
 
-    public string GetFromValue(string fromKey)
+    public string? GetFromValue(string fromKey)
     {
         string key = $"{BindingKey}{fromKey}";
-        return ConfigurationData.TryGetValue(key, out string value) ? value : null;
+        return ConfigurationData.TryGetValue(key, out string? value) ? value : null;
     }
 
-    private string GetToValue(string toKey)
+    private string? GetToValue(string toKey)
     {
         string key = $"{ToPrefix}{toKey}";
-        return ConfigurationData.TryGetValue(key, out string value) ? value : null;
+        return ConfigurationData.TryGetValue(key, out string? value) ? value : null;
     }
 }

--- a/src/Configuration/src/Abstractions/IConfigurationPostProcessor.cs
+++ b/src/Configuration/src/Abstractions/IConfigurationPostProcessor.cs
@@ -2,9 +2,11 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 namespace Steeltoe.Configuration;
 
 internal interface IConfigurationPostProcessor
 {
-    void PostProcessConfiguration(PostProcessorConfigurationProvider provider, IDictionary<string, string> configurationData);
+    void PostProcessConfiguration(PostProcessorConfigurationProvider provider, IDictionary<string, string?> configurationData);
 }

--- a/src/Configuration/src/Abstractions/PostProcessorConfigurationSource.cs
+++ b/src/Configuration/src/Abstractions/PostProcessorConfigurationSource.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using Microsoft.Extensions.Configuration;
 using Steeltoe.Common;
 
@@ -10,7 +12,7 @@ namespace Steeltoe.Configuration;
 internal abstract class PostProcessorConfigurationSource
 {
     private readonly List<IConfigurationPostProcessor> _postProcessors = new();
-    private IConfigurationBuilder _capturedConfigurationBuilder;
+    private IConfigurationBuilder? _capturedConfigurationBuilder;
 
     public IReadOnlyList<IConfigurationPostProcessor> PostProcessors => _postProcessors.AsReadOnly();
     public Predicate<string> IgnoreKeyPredicate { get; set; } = _ => false;

--- a/src/Configuration/src/CloudFoundry.ServiceBinding/CloudFoundryServiceBindingConfigurationProvider.cs
+++ b/src/Configuration/src/CloudFoundry.ServiceBinding/CloudFoundryServiceBindingConfigurationProvider.cs
@@ -24,7 +24,7 @@ internal sealed class CloudFoundryServiceBindingConfigurationProvider : PostProc
 
     public override void Load()
     {
-        var data = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        var data = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
         string? json = _serviceBindingsReader.GetServiceBindingsJson();
 
         if (!string.IsNullOrEmpty(json))
@@ -59,7 +59,7 @@ internal sealed class CloudFoundryServiceBindingConfigurationProvider : PostProc
         return stream;
     }
 
-    private void LoadSections(string prefix, IEnumerable<IConfigurationSection> sections, IDictionary<string, string> data)
+    private void LoadSections(string prefix, IEnumerable<IConfigurationSection> sections, IDictionary<string, string?> data)
     {
         foreach (IConfigurationSection section in sections)
         {
@@ -68,7 +68,7 @@ internal sealed class CloudFoundryServiceBindingConfigurationProvider : PostProc
         }
     }
 
-    private void LoadSection(string prefix, IConfigurationSection section, IDictionary<string, string> data)
+    private void LoadSection(string prefix, IConfigurationSection section, IDictionary<string, string?> data)
     {
         if (string.IsNullOrEmpty(section.Value))
         {

--- a/src/Configuration/src/CloudFoundry.ServiceBinding/PostProcessors/CloudFoundryPostProcessor.cs
+++ b/src/Configuration/src/CloudFoundry.ServiceBinding/PostProcessors/CloudFoundryPostProcessor.cs
@@ -11,18 +11,27 @@ internal abstract class CloudFoundryPostProcessor : IConfigurationPostProcessor
 {
     private static readonly Regex TagsConfigurationKeyRegex = new(@"^vcap:services:[^:]+:[0-9]+:tags:[0-9]+", RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
-    public abstract void PostProcessConfiguration(PostProcessorConfigurationProvider provider, IDictionary<string, string> configurationData);
+    public abstract void PostProcessConfiguration(PostProcessorConfigurationProvider provider, IDictionary<string, string?> configurationData);
 
-    protected IEnumerable<string> FilterKeys(IDictionary<string, string> configurationData, string tagValueToFind)
+    protected IEnumerable<string> FilterKeys(IDictionary<string, string?> configurationData, string tagValueToFind)
     {
         List<string> keys = new();
 
-        foreach ((string key, string value) in configurationData)
+        foreach ((string key, string? value) in configurationData)
         {
             if (TagsConfigurationKeyRegex.IsMatch(key) && string.Equals(value, tagValueToFind, StringComparison.OrdinalIgnoreCase))
             {
-                string serviceBindingKey = ConfigurationPath.GetParentPath(ConfigurationPath.GetParentPath(key));
-                keys.Add(serviceBindingKey);
+                string? parentKey = ConfigurationPath.GetParentPath(key);
+
+                if (parentKey != null)
+                {
+                    string? serviceBindingKey = ConfigurationPath.GetParentPath(parentKey);
+
+                    if (serviceBindingKey != null)
+                    {
+                        keys.Add(serviceBindingKey);
+                    }
+                }
             }
         }
 

--- a/src/Configuration/src/CloudFoundry.ServiceBinding/PostProcessors/CosmosDbCloudFoundryPostProcessor.cs
+++ b/src/Configuration/src/CloudFoundry.ServiceBinding/PostProcessors/CosmosDbCloudFoundryPostProcessor.cs
@@ -8,7 +8,7 @@ internal sealed class CosmosDbCloudFoundryPostProcessor : CloudFoundryPostProces
 {
     internal const string BindingType = "cosmosdb";
 
-    public override void PostProcessConfiguration(PostProcessorConfigurationProvider provider, IDictionary<string, string> configurationData)
+    public override void PostProcessConfiguration(PostProcessorConfigurationProvider provider, IDictionary<string, string?> configurationData)
     {
         foreach (string key in FilterKeys(configurationData, BindingType))
         {

--- a/src/Configuration/src/CloudFoundry.ServiceBinding/PostProcessors/MongoDbCloudFoundryPostProcessor.cs
+++ b/src/Configuration/src/CloudFoundry.ServiceBinding/PostProcessors/MongoDbCloudFoundryPostProcessor.cs
@@ -8,7 +8,7 @@ internal sealed class MongoDbCloudFoundryPostProcessor : CloudFoundryPostProcess
 {
     internal const string BindingType = "mongodb";
 
-    public override void PostProcessConfiguration(PostProcessorConfigurationProvider provider, IDictionary<string, string> configurationData)
+    public override void PostProcessConfiguration(PostProcessorConfigurationProvider provider, IDictionary<string, string?> configurationData)
     {
         foreach (string key in FilterKeys(configurationData, BindingType))
         {
@@ -24,11 +24,15 @@ internal sealed class MongoDbCloudFoundryPostProcessor : CloudFoundryPostProcess
             {
                 // The MongoDB Azure Service Broker solely provides an url, which contains the authentication database.
                 // We extract this and expose it as the database used for application data as well.
-                string url = mapper.GetFromValue("credentials:uri");
-                var uri = new Uri(url);
-                string database = uri.GetComponents(UriComponents.Path, UriFormat.Unescaped);
+                string? url = mapper.GetFromValue("credentials:uri");
 
-                mapper.SetToValue("database", database);
+                if (!string.IsNullOrEmpty(url))
+                {
+                    var uri = new Uri(url);
+                    string database = uri.GetComponents(UriComponents.Path, UriFormat.Unescaped);
+
+                    mapper.SetToValue("database", database);
+                }
             }
         }
     }

--- a/src/Configuration/src/CloudFoundry.ServiceBinding/PostProcessors/MySqlCloudFoundryPostProcessor.cs
+++ b/src/Configuration/src/CloudFoundry.ServiceBinding/PostProcessors/MySqlCloudFoundryPostProcessor.cs
@@ -8,7 +8,7 @@ internal sealed class MySqlCloudFoundryPostProcessor : CloudFoundryPostProcessor
 {
     internal const string BindingType = "mysql";
 
-    public override void PostProcessConfiguration(PostProcessorConfigurationProvider provider, IDictionary<string, string> configurationData)
+    public override void PostProcessConfiguration(PostProcessorConfigurationProvider provider, IDictionary<string, string?> configurationData)
     {
         foreach (string key in FilterKeys(configurationData, BindingType))
         {

--- a/src/Configuration/src/CloudFoundry.ServiceBinding/PostProcessors/PostgreSqlCloudFoundryPostProcessor.cs
+++ b/src/Configuration/src/CloudFoundry.ServiceBinding/PostProcessors/PostgreSqlCloudFoundryPostProcessor.cs
@@ -8,7 +8,7 @@ internal sealed class PostgreSqlCloudFoundryPostProcessor : CloudFoundryPostProc
 {
     internal const string BindingType = "postgresql";
 
-    public override void PostProcessConfiguration(PostProcessorConfigurationProvider provider, IDictionary<string, string> configurationData)
+    public override void PostProcessConfiguration(PostProcessorConfigurationProvider provider, IDictionary<string, string?> configurationData)
     {
         foreach (string key in FilterKeys(configurationData, BindingType))
         {

--- a/src/Configuration/src/CloudFoundry.ServiceBinding/PostProcessors/RabbitMQCloudFoundryPostProcessor.cs
+++ b/src/Configuration/src/CloudFoundry.ServiceBinding/PostProcessors/RabbitMQCloudFoundryPostProcessor.cs
@@ -8,7 +8,7 @@ internal sealed class RabbitMQCloudFoundryPostProcessor : CloudFoundryPostProces
 {
     internal const string BindingType = "rabbitmq";
 
-    public override void PostProcessConfiguration(PostProcessorConfigurationProvider provider, IDictionary<string, string> configurationData)
+    public override void PostProcessConfiguration(PostProcessorConfigurationProvider provider, IDictionary<string, string?> configurationData)
     {
         foreach (string key in FilterKeys(configurationData, BindingType))
         {
@@ -18,7 +18,7 @@ internal sealed class RabbitMQCloudFoundryPostProcessor : CloudFoundryPostProces
             // The available credentials are documented at:
             // - VMware Broker: https://docs.vmware.com/en/VMware-RabbitMQ-for-Tanzu-Application-Service/2.2/tanzu-rmq/GUID-reference.html#vcapservices-0
 
-            string useTlsValue = mapper.MapFromTo("credentials:ssl", "useTls");
+            string? useTlsValue = mapper.MapFromTo("credentials:ssl", "useTls");
             string fromProtocol = bool.TryParse(useTlsValue, out bool useTls) && useTls ? "amqp+ssl" : "amqp";
 
             mapper.MapFromTo($"credentials:protocols:{fromProtocol}:host", "host");

--- a/src/Configuration/src/CloudFoundry.ServiceBinding/PostProcessors/RedisCloudFoundryPostProcessor.cs
+++ b/src/Configuration/src/CloudFoundry.ServiceBinding/PostProcessors/RedisCloudFoundryPostProcessor.cs
@@ -8,7 +8,7 @@ internal sealed class RedisCloudFoundryPostProcessor : CloudFoundryPostProcessor
 {
     internal const string BindingType = "redis";
 
-    public override void PostProcessConfiguration(PostProcessorConfigurationProvider provider, IDictionary<string, string> configurationData)
+    public override void PostProcessConfiguration(PostProcessorConfigurationProvider provider, IDictionary<string, string?> configurationData)
     {
         foreach (string key in FilterKeys(configurationData, BindingType))
         {

--- a/src/Configuration/src/CloudFoundry.ServiceBinding/PostProcessors/SqlServerCloudFoundryPostProcessor.cs
+++ b/src/Configuration/src/CloudFoundry.ServiceBinding/PostProcessors/SqlServerCloudFoundryPostProcessor.cs
@@ -8,7 +8,7 @@ internal sealed class SqlServerCloudFoundryPostProcessor : CloudFoundryPostProce
 {
     internal const string BindingType = "sqlserver";
 
-    public override void PostProcessConfiguration(PostProcessorConfigurationProvider provider, IDictionary<string, string> configurationData)
+    public override void PostProcessConfiguration(PostProcessorConfigurationProvider provider, IDictionary<string, string?> configurationData)
     {
         foreach (string key in FilterKeys(configurationData, BindingType))
         {

--- a/src/Configuration/src/CloudFoundry.ServiceBinding/ServiceBindingMapper.cs
+++ b/src/Configuration/src/CloudFoundry.ServiceBinding/ServiceBindingMapper.cs
@@ -13,7 +13,7 @@ internal sealed class ServiceBindingMapper : ConfigurationDictionaryMapper
     public string BindingName { get; }
     public string BindingType { get; }
 
-    private ServiceBindingMapper(IDictionary<string, string> configurationData, string bindingKey, string bindingType, string bindingProvider,
+    private ServiceBindingMapper(IDictionary<string, string?> configurationData, string bindingKey, string bindingType, string bindingProvider,
         string bindingName, string[] toPrefix)
         : base(configurationData, bindingKey, toPrefix)
     {
@@ -22,14 +22,14 @@ internal sealed class ServiceBindingMapper : ConfigurationDictionaryMapper
         BindingType = bindingType;
     }
 
-    public static ServiceBindingMapper Create(IDictionary<string, string> configurationData, string bindingKey, string bindingType)
+    public static ServiceBindingMapper Create(IDictionary<string, string?> configurationData, string bindingKey, string bindingType)
     {
         ArgumentGuard.NotNull(bindingType);
         ArgumentGuard.NotNull(bindingKey);
         ArgumentGuard.NotNull(configurationData);
 
-        string bindingName = configurationData[ConfigurationPath.Combine(bindingKey, "name")];
-        string bindingProvider = ConfigurationPath.GetSectionKey(ConfigurationPath.GetParentPath(bindingKey));
+        string bindingName = configurationData[ConfigurationPath.Combine(bindingKey, "name")] ?? string.Empty;
+        string bindingProvider = ConfigurationPath.GetSectionKey(ConfigurationPath.GetParentPath(bindingKey)) ?? string.Empty;
 
         List<string> toPrefix = CloudFoundryServiceBindingConfigurationProvider.ToKeyPrefix.Split(ConfigurationPath.KeyDelimiter).ToList();
         toPrefix.Add(bindingType);

--- a/src/Configuration/src/Kubernetes.ServiceBinding/KubernetesServiceBindingConfigurationProvider.cs
+++ b/src/Configuration/src/Kubernetes.ServiceBinding/KubernetesServiceBindingConfigurationProvider.cs
@@ -41,7 +41,7 @@ internal sealed class KubernetesServiceBindingConfigurationProvider : PostProces
 
     private void Load(bool reload)
     {
-        var data = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        var data = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
 
         if (_source.FileProvider == null)
         {
@@ -80,7 +80,7 @@ internal sealed class KubernetesServiceBindingConfigurationProvider : PostProces
             AddBindingType(binding, data);
             AddBindingProvider(binding, data);
 
-            foreach (KeyValuePair<string, string> secretEntry in binding.Secrets)
+            foreach (KeyValuePair<string, string?> secretEntry in binding.Secrets)
             {
                 AddBindingSecret(binding, secretEntry, data);
             }
@@ -96,7 +96,7 @@ internal sealed class KubernetesServiceBindingConfigurationProvider : PostProces
         _changeToken?.Dispose();
     }
 
-    private void AddBindingType(ServiceBinding binding, Dictionary<string, string> data)
+    private void AddBindingType(ServiceBinding binding, Dictionary<string, string?> data)
     {
         string typeKey = ConfigurationPath.Combine(FromKeyPrefix, binding.Name, TypeKey);
 
@@ -106,7 +106,7 @@ internal sealed class KubernetesServiceBindingConfigurationProvider : PostProces
         }
     }
 
-    private void AddBindingProvider(ServiceBinding binding, Dictionary<string, string> data)
+    private void AddBindingProvider(ServiceBinding binding, Dictionary<string, string?> data)
     {
         if (!string.IsNullOrEmpty(binding.Provider))
         {
@@ -119,7 +119,7 @@ internal sealed class KubernetesServiceBindingConfigurationProvider : PostProces
         }
     }
 
-    private void AddBindingSecret(ServiceBinding binding, KeyValuePair<string, string> secretEntry, Dictionary<string, string> data)
+    private void AddBindingSecret(ServiceBinding binding, KeyValuePair<string, string?> secretEntry, Dictionary<string, string?> data)
     {
         string secretKey = ConfigurationPath.Combine(FromKeyPrefix, binding.Name, secretEntry.Key);
 
@@ -131,12 +131,12 @@ internal sealed class KubernetesServiceBindingConfigurationProvider : PostProces
 
     internal sealed class ServiceBinding
     {
-        private readonly Dictionary<string, string> _secrets;
+        private readonly Dictionary<string, string?> _secrets;
 
         public string Name { get; }
         public string Path { get; }
         public string? Provider { get; }
-        public IDictionary<string, string> Secrets => new ReadOnlyDictionary<string, string>(_secrets);
+        public IDictionary<string, string?> Secrets => new ReadOnlyDictionary<string, string?>(_secrets);
         public string Type { get; }
 
         // Creates a new Binding instance using the specified file system directory
@@ -146,17 +146,17 @@ internal sealed class KubernetesServiceBindingConfigurationProvider : PostProces
         }
 
         // Creates a new Binding instance using the specified content
-        private ServiceBinding(string name, string path, IDictionary<string, string> secrets)
+        private ServiceBinding(string name, string path, IDictionary<string, string?> secrets)
         {
             Name = name ?? throw new ArgumentException("Binding has no name and is not a valid binding");
             Path = path ?? throw new ArgumentException("Binding has no path and is not a valid binding");
 
-            _secrets = new Dictionary<string, string>();
+            _secrets = new Dictionary<string, string?>();
 
             string? type = null;
             string? provider = null;
 
-            foreach ((string secretName, string secretValue) in secrets)
+            foreach ((string secretName, string? secretValue) in secrets)
             {
                 switch (secretName)
                 {
@@ -176,17 +176,17 @@ internal sealed class KubernetesServiceBindingConfigurationProvider : PostProces
             Provider = provider;
         }
 
-        private static IDictionary<string, string> CreateSecrets(string path, IFileProvider fileProvider)
+        private static IDictionary<string, string?> CreateSecrets(string path, IFileProvider fileProvider)
         {
             return CreateFilePerEntry(path, fileProvider);
         }
 
-        private static IDictionary<string, string> CreateFilePerEntry(string path, IFileProvider fileProvider)
+        private static IDictionary<string, string?> CreateFilePerEntry(string path, IFileProvider fileProvider)
         {
             try
             {
                 IDirectoryContents directoryContents = fileProvider.GetDirectoryContents(path);
-                var result = new Dictionary<string, string>();
+                var result = new Dictionary<string, string?>();
 
                 foreach (IFileInfo fileInfo in directoryContents.Where(element => !element.IsDirectory))
                 {

--- a/src/Configuration/src/Kubernetes.ServiceBinding/PostProcessors/MongoDbKubernetesPostProcessor.cs
+++ b/src/Configuration/src/Kubernetes.ServiceBinding/PostProcessors/MongoDbKubernetesPostProcessor.cs
@@ -10,7 +10,7 @@ internal sealed class MongoDbKubernetesPostProcessor : IConfigurationPostProcess
 {
     internal const string BindingType = "mongodb";
 
-    public void PostProcessConfiguration(PostProcessorConfigurationProvider provider, IDictionary<string, string> configurationData)
+    public void PostProcessConfiguration(PostProcessorConfigurationProvider provider, IDictionary<string, string?> configurationData)
     {
         foreach (string bindingKey in configurationData.Filter(KubernetesServiceBindingConfigurationProvider.FromKeyPrefix,
             KubernetesServiceBindingConfigurationProvider.TypeKey, BindingType))

--- a/src/Configuration/src/Kubernetes.ServiceBinding/PostProcessors/MySqlKubernetesPostProcessor.cs
+++ b/src/Configuration/src/Kubernetes.ServiceBinding/PostProcessors/MySqlKubernetesPostProcessor.cs
@@ -10,7 +10,7 @@ internal sealed class MySqlKubernetesPostProcessor : IConfigurationPostProcessor
 {
     internal const string BindingType = "mysql";
 
-    public void PostProcessConfiguration(PostProcessorConfigurationProvider provider, IDictionary<string, string> configurationData)
+    public void PostProcessConfiguration(PostProcessorConfigurationProvider provider, IDictionary<string, string?> configurationData)
     {
         foreach (string bindingKey in configurationData.Filter(KubernetesServiceBindingConfigurationProvider.FromKeyPrefix,
             KubernetesServiceBindingConfigurationProvider.TypeKey, BindingType))

--- a/src/Configuration/src/Kubernetes.ServiceBinding/PostProcessors/PostgreSqlKubernetesPostProcessor.cs
+++ b/src/Configuration/src/Kubernetes.ServiceBinding/PostProcessors/PostgreSqlKubernetesPostProcessor.cs
@@ -10,7 +10,7 @@ internal sealed class PostgreSqlKubernetesPostProcessor : IConfigurationPostProc
 {
     internal const string BindingType = "postgresql";
 
-    public void PostProcessConfiguration(PostProcessorConfigurationProvider provider, IDictionary<string, string> configurationData)
+    public void PostProcessConfiguration(PostProcessorConfigurationProvider provider, IDictionary<string, string?> configurationData)
     {
         foreach (string bindingKey in configurationData.Filter(KubernetesServiceBindingConfigurationProvider.FromKeyPrefix,
             KubernetesServiceBindingConfigurationProvider.TypeKey, BindingType))

--- a/src/Configuration/src/Kubernetes.ServiceBinding/PostProcessors/RabbitMQKubernetesPostProcessor.cs
+++ b/src/Configuration/src/Kubernetes.ServiceBinding/PostProcessors/RabbitMQKubernetesPostProcessor.cs
@@ -10,7 +10,7 @@ internal sealed class RabbitMQKubernetesPostProcessor : IConfigurationPostProces
 {
     internal const string BindingType = "rabbitmq";
 
-    public void PostProcessConfiguration(PostProcessorConfigurationProvider provider, IDictionary<string, string> configurationData)
+    public void PostProcessConfiguration(PostProcessorConfigurationProvider provider, IDictionary<string, string?> configurationData)
     {
         foreach (string bindingKey in configurationData.Filter(KubernetesServiceBindingConfigurationProvider.FromKeyPrefix,
             KubernetesServiceBindingConfigurationProvider.TypeKey, BindingType))

--- a/src/Configuration/src/Kubernetes.ServiceBinding/PostProcessors/RedisKubernetesPostProcessor.cs
+++ b/src/Configuration/src/Kubernetes.ServiceBinding/PostProcessors/RedisKubernetesPostProcessor.cs
@@ -10,7 +10,7 @@ internal sealed class RedisKubernetesPostProcessor : IConfigurationPostProcessor
 {
     internal const string BindingType = "redis";
 
-    public void PostProcessConfiguration(PostProcessorConfigurationProvider provider, IDictionary<string, string> configurationData)
+    public void PostProcessConfiguration(PostProcessorConfigurationProvider provider, IDictionary<string, string?> configurationData)
     {
         foreach (string bindingKey in configurationData.Filter(KubernetesServiceBindingConfigurationProvider.FromKeyPrefix,
             KubernetesServiceBindingConfigurationProvider.TypeKey, BindingType))

--- a/src/Configuration/src/Kubernetes.ServiceBinding/ServiceBindingMapper.cs
+++ b/src/Configuration/src/Kubernetes.ServiceBinding/ServiceBindingMapper.cs
@@ -12,7 +12,7 @@ internal sealed class ServiceBindingMapper : ConfigurationDictionaryMapper
     public string BindingName { get; }
     public string BindingType { get; }
 
-    public ServiceBindingMapper(IDictionary<string, string> configurationData, string bindingKey, params string[] toPrefix)
+    public ServiceBindingMapper(IDictionary<string, string?> configurationData, string bindingKey, params string[] toPrefix)
         : base(configurationData, bindingKey, toPrefix)
     {
         BindingProvider = GetBindingProvider($"{BindingKey}provider");
@@ -22,11 +22,11 @@ internal sealed class ServiceBindingMapper : ConfigurationDictionaryMapper
 
     private string GetBindingProvider(string providerKey)
     {
-        return ConfigurationData.TryGetValue(providerKey, out string? result) ? result : string.Empty;
+        return !ConfigurationData.TryGetValue(providerKey, out string? result) || result == null ? string.Empty : result;
     }
 
     private string GetBindingType(string typeKey)
     {
-        return ConfigurationData.TryGetValue(typeKey, out string? result) ? result : string.Empty;
+        return !ConfigurationData.TryGetValue(typeKey, out string? result) || result == null ? string.Empty : result;
     }
 }

--- a/src/Configuration/test/CloudFoundry.ServiceBinding.Test/BasePostProcessorsTest.cs
+++ b/src/Configuration/test/CloudFoundry.ServiceBinding.Test/BasePostProcessorsTest.cs
@@ -11,10 +11,10 @@ public abstract class BasePostProcessorsTest
     protected const string TestBindingName = "test-name";
     protected const string TestProviderName = "test-provider";
 
-    protected Dictionary<string, string> GetConfigurationData(string bindingType, string bindingProvider, string bindingName,
+    protected Dictionary<string, string?> GetConfigurationData(string bindingType, string bindingProvider, string bindingName,
         params Tuple<string, string>[] secrets)
     {
-        var dictionary = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        var dictionary = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase)
         {
             [$"vcap:services:{bindingProvider}:0:tags:0"] = bindingType,
             [$"vcap:services:{bindingProvider}:0:name"] = bindingName
@@ -47,9 +47,9 @@ public abstract class BasePostProcessorsTest
         return new TestPostProcessorConfigurationProvider(source);
     }
 
-    protected string? GetFileContentAtKey(Dictionary<string, string> configurationData, string key)
+    protected string? GetFileContentAtKey(Dictionary<string, string?> configurationData, string key)
     {
-        if (configurationData.TryGetValue(key, out string? value))
+        if (configurationData.TryGetValue(key, out string? value) && value != null)
         {
             return File.ReadAllText(value);
         }

--- a/src/Configuration/test/CloudFoundry.ServiceBinding.Test/CloudFoundryServiceBindingConfigurationProviderTest.cs
+++ b/src/Configuration/test/CloudFoundry.ServiceBinding.Test/CloudFoundryServiceBindingConfigurationProviderTest.cs
@@ -104,7 +104,7 @@ public sealed class CloudFoundryServiceBindingConfigurationProviderTest
         var builder = new ConfigurationBuilder();
         builder.Add(source);
 
-        builder.AddInMemoryCollection(new Dictionary<string, string>
+        builder.AddInMemoryCollection(new Dictionary<string, string?>
         {
             { "some:value:in:configuration:path", "true" }
         });
@@ -142,7 +142,7 @@ public sealed class CloudFoundryServiceBindingConfigurationProviderTest
     {
         public bool PostProcessorCalled { get; private set; }
 
-        public void PostProcessConfiguration(PostProcessorConfigurationProvider provider, IDictionary<string, string> configurationData)
+        public void PostProcessConfiguration(PostProcessorConfigurationProvider provider, IDictionary<string, string?> configurationData)
         {
             PostProcessorCalled = true;
         }

--- a/src/Configuration/test/CloudFoundry.ServiceBinding.Test/PostProcessorsTest.cs
+++ b/src/Configuration/test/CloudFoundry.ServiceBinding.Test/PostProcessorsTest.cs
@@ -24,7 +24,7 @@ public sealed class PostProcessorsTest : BasePostProcessorsTest
             Tuple.Create("credentials:password", "test-password")
         };
 
-        Dictionary<string, string> configurationData =
+        Dictionary<string, string?> configurationData =
             GetConfigurationData(MySqlCloudFoundryPostProcessor.BindingType, TestProviderName, TestBindingName, secrets);
 
         PostProcessorConfigurationProvider provider = GetConfigurationProvider(postProcessor);
@@ -56,7 +56,7 @@ public sealed class PostProcessorsTest : BasePostProcessorsTest
             Tuple.Create("credentials:sslrootcert", "test-ssl-root-cert")
         };
 
-        Dictionary<string, string> configurationData =
+        Dictionary<string, string?> configurationData =
             GetConfigurationData(PostgreSqlCloudFoundryPostProcessor.BindingType, TestProviderName, TestBindingName, secrets);
 
         PostProcessorConfigurationProvider provider = GetConfigurationProvider(postProcessor);
@@ -89,7 +89,7 @@ public sealed class PostProcessorsTest : BasePostProcessorsTest
             Tuple.Create("credentials:protocols:amqp:vhost", "test-vhost")
         };
 
-        Dictionary<string, string> configurationData =
+        Dictionary<string, string?> configurationData =
             GetConfigurationData(RabbitMQCloudFoundryPostProcessor.BindingType, TestProviderName, TestBindingName, secrets);
 
         PostProcessorConfigurationProvider provider = GetConfigurationProvider(postProcessor);
@@ -117,7 +117,7 @@ public sealed class PostProcessorsTest : BasePostProcessorsTest
             Tuple.Create("credentials:password", "test-password")
         };
 
-        Dictionary<string, string> configurationData =
+        Dictionary<string, string?> configurationData =
             GetConfigurationData(RedisCloudFoundryPostProcessor.BindingType, TestProviderName, TestBindingName, secrets);
 
         PostProcessorConfigurationProvider provider = GetConfigurationProvider(postProcessor);
@@ -142,7 +142,7 @@ public sealed class PostProcessorsTest : BasePostProcessorsTest
             Tuple.Create("credentials:password", "test-password")
         };
 
-        Dictionary<string, string> configurationData =
+        Dictionary<string, string?> configurationData =
             GetConfigurationData(RedisCloudFoundryPostProcessor.BindingType, TestProviderName, TestBindingName, secrets);
 
         PostProcessorConfigurationProvider provider = GetConfigurationProvider(postProcessor);
@@ -170,7 +170,7 @@ public sealed class PostProcessorsTest : BasePostProcessorsTest
             Tuple.Create("credentials:password", "test-password")
         };
 
-        Dictionary<string, string> configurationData =
+        Dictionary<string, string?> configurationData =
             GetConfigurationData(SqlServerCloudFoundryPostProcessor.BindingType, TestProviderName, TestBindingName, secrets);
 
         PostProcessorConfigurationProvider provider = GetConfigurationProvider(postProcessor);
@@ -194,7 +194,7 @@ public sealed class PostProcessorsTest : BasePostProcessorsTest
             Tuple.Create("credentials:uri", "mongodb://localhost:27017/auth-db?appname=sample")
         };
 
-        Dictionary<string, string> configurationData =
+        Dictionary<string, string?> configurationData =
             GetConfigurationData(MongoDbCloudFoundryPostProcessor.BindingType, "csb-azure-mongodb", TestBindingName, secrets);
 
         PostProcessorConfigurationProvider provider = GetConfigurationProvider(postProcessor);
@@ -218,7 +218,7 @@ public sealed class PostProcessorsTest : BasePostProcessorsTest
             Tuple.Create("credentials:cosmosdb_database_id", "test-database")
         };
 
-        Dictionary<string, string> configurationData =
+        Dictionary<string, string?> configurationData =
             GetConfigurationData(CosmosDbCloudFoundryPostProcessor.BindingType, TestProviderName, TestBindingName, secrets);
 
         PostProcessorConfigurationProvider provider = GetConfigurationProvider(postProcessor);

--- a/src/Configuration/test/Kubernetes.ServiceBinding.Test/BasePostProcessorsTest.cs
+++ b/src/Configuration/test/Kubernetes.ServiceBinding.Test/BasePostProcessorsTest.cs
@@ -9,54 +9,27 @@ namespace Steeltoe.Configuration.Kubernetes.ServiceBinding.Test;
 public abstract class BasePostProcessorsTest
 {
     protected const string TestBindingName = "test-name";
-    protected const string TestBindingName1 = "test-name-1";
-    protected const string TestBindingName2 = "test-name-2";
-    protected const string TestBindingName3 = "test-name-3";
-    protected const string TestMissingProvider = "test-missing-provider";
 
-    protected Dictionary<string, string> GetConfigurationData(string bindingName, string bindingType, params Tuple<string, string>[] secrets)
+    protected Dictionary<string, string?> GetConfigurationData(string bindingName, string bindingType, params Tuple<string, string>[] secrets)
     {
-        var dictionary = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-        AddConfigurationData(dictionary, bindingName, bindingType, secrets);
-        return dictionary;
-    }
+        var dictionary = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
 
-    protected Dictionary<string, string> GetConfigurationData(string bindingName, string bindingType, string bindingProvider,
-        params Tuple<string, string>[] secrets)
-    {
-        var dictionary = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-        AddConfigurationData(dictionary, bindingName, bindingType, bindingProvider, secrets);
-        return dictionary;
-    }
+        string typeKey = MakeTypeKey(bindingName);
+        dictionary.Add(typeKey, bindingType);
 
-    protected void AddConfigurationData(Dictionary<string, string> dictionary, string bindingName, string bindingType, string bindingProvider,
-        params Tuple<string, string>[] secrets)
-    {
-        AddConfigurationData(dictionary, bindingName, bindingType, secrets);
-
-        dictionary.Add(MakeProviderKey(bindingName), bindingProvider);
-    }
-
-    protected void AddConfigurationData(Dictionary<string, string> dictionary, string bindingName, string bindingType, params Tuple<string, string>[] secrets)
-    {
-        foreach (Tuple<string, string> kv in secrets)
+        foreach ((string name, string? value) in secrets)
         {
-            dictionary.Add(MakeSecretKey(bindingName, kv.Item1), kv.Item2);
+            string secretKey = MakeSecretKey(bindingName, name);
+            dictionary.Add(secretKey, value);
         }
 
-        dictionary.Add(MakeTypeKey(bindingName), bindingType);
+        return dictionary;
     }
 
     private string MakeTypeKey(string bindingName)
     {
         return ConfigurationPath.Combine(KubernetesServiceBindingConfigurationProvider.FromKeyPrefix, bindingName,
             KubernetesServiceBindingConfigurationProvider.TypeKey);
-    }
-
-    private string MakeProviderKey(string bindingName)
-    {
-        return ConfigurationPath.Combine(KubernetesServiceBindingConfigurationProvider.FromKeyPrefix, bindingName,
-            KubernetesServiceBindingConfigurationProvider.ProviderKey);
     }
 
     private string MakeSecretKey(string bindingName, string key)

--- a/src/Configuration/test/Kubernetes.ServiceBinding.Test/KubernetesServiceBindingConfigurationProviderTest.cs
+++ b/src/Configuration/test/Kubernetes.ServiceBinding.Test/KubernetesServiceBindingConfigurationProviderTest.cs
@@ -66,7 +66,7 @@ public sealed class KubernetesServiceBindingConfigurationProviderTest
         var provider = new KubernetesServiceBindingConfigurationProvider(source);
         provider.Load();
 
-        provider.TryGet("k8s:bindings:test-name-1:type", out string value).Should().BeTrue();
+        provider.TryGet("k8s:bindings:test-name-1:type", out string? value).Should().BeTrue();
         value.Should().Be("test-type-1");
         provider.TryGet("k8s:bindings:test-name-1:provider", out value).Should().BeTrue();
         value.Should().Be("test-provider-1");
@@ -127,7 +127,7 @@ public sealed class KubernetesServiceBindingConfigurationProviderTest
     {
         public bool PostProcessorCalled { get; set; }
 
-        public void PostProcessConfiguration(PostProcessorConfigurationProvider provider, IDictionary<string, string> configurationData)
+        public void PostProcessConfiguration(PostProcessorConfigurationProvider provider, IDictionary<string, string?> configurationData)
         {
             PostProcessorCalled = true;
         }

--- a/src/Configuration/test/Kubernetes.ServiceBinding.Test/KubernetesServiceBindingConfigurationSourceTest.cs
+++ b/src/Configuration/test/Kubernetes.ServiceBinding.Test/KubernetesServiceBindingConfigurationSourceTest.cs
@@ -46,7 +46,7 @@ public sealed class KubernetesServiceBindingConfigurationSourceTest
         var builder = new ConfigurationBuilder();
         builder.Add(source);
 
-        builder.AddInMemoryCollection(new Dictionary<string, string>
+        builder.AddInMemoryCollection(new Dictionary<string, string?>
         {
             { "some:value:in:configuration:path", "true" }
         });

--- a/src/Configuration/test/Kubernetes.ServiceBinding.Test/PostProcessorsTest.cs
+++ b/src/Configuration/test/Kubernetes.ServiceBinding.Test/PostProcessorsTest.cs
@@ -24,7 +24,7 @@ public sealed class PostProcessorsTest : BasePostProcessorsTest
             Tuple.Create("password", "test-password")
         };
 
-        Dictionary<string, string> configurationData = GetConfigurationData(TestBindingName, MySqlKubernetesPostProcessor.BindingType, secrets);
+        Dictionary<string, string?> configurationData = GetConfigurationData(TestBindingName, MySqlKubernetesPostProcessor.BindingType, secrets);
         PostProcessorConfigurationProvider provider = GetConfigurationProvider(postProcessor);
 
         postProcessor.PostProcessConfiguration(provider, configurationData);
@@ -51,7 +51,7 @@ public sealed class PostProcessorsTest : BasePostProcessorsTest
             Tuple.Create("password", "test-password")
         };
 
-        Dictionary<string, string> configurationData = GetConfigurationData(TestBindingName, PostgreSqlKubernetesPostProcessor.BindingType, secrets);
+        Dictionary<string, string?> configurationData = GetConfigurationData(TestBindingName, PostgreSqlKubernetesPostProcessor.BindingType, secrets);
         PostProcessorConfigurationProvider provider = GetConfigurationProvider(postProcessor);
 
         postProcessor.PostProcessConfiguration(provider, configurationData);
@@ -78,7 +78,7 @@ public sealed class PostProcessorsTest : BasePostProcessorsTest
             Tuple.Create("password", "test-password")
         };
 
-        Dictionary<string, string> configurationData = GetConfigurationData(TestBindingName, MongoDbKubernetesPostProcessor.BindingType, secrets);
+        Dictionary<string, string?> configurationData = GetConfigurationData(TestBindingName, MongoDbKubernetesPostProcessor.BindingType, secrets);
         PostProcessorConfigurationProvider provider = GetConfigurationProvider(postProcessor);
 
         postProcessor.PostProcessConfiguration(provider, configurationData);
@@ -106,7 +106,7 @@ public sealed class PostProcessorsTest : BasePostProcessorsTest
             Tuple.Create("virtual-host", "test-virtual-host")
         };
 
-        Dictionary<string, string> configurationData = GetConfigurationData(TestBindingName, RabbitMQKubernetesPostProcessor.BindingType, secrets);
+        Dictionary<string, string?> configurationData = GetConfigurationData(TestBindingName, RabbitMQKubernetesPostProcessor.BindingType, secrets);
         PostProcessorConfigurationProvider provider = GetConfigurationProvider(postProcessor);
 
         postProcessor.PostProcessConfiguration(provider, configurationData);
@@ -134,7 +134,7 @@ public sealed class PostProcessorsTest : BasePostProcessorsTest
             Tuple.Create("client-name", "test-client-name")
         };
 
-        Dictionary<string, string> configurationData = GetConfigurationData(TestBindingName, RedisKubernetesPostProcessor.BindingType, secrets);
+        Dictionary<string, string?> configurationData = GetConfigurationData(TestBindingName, RedisKubernetesPostProcessor.BindingType, secrets);
         PostProcessorConfigurationProvider provider = GetConfigurationProvider(postProcessor);
 
         postProcessor.PostProcessConfiguration(provider, configurationData);

--- a/src/Configuration/test/Kubernetes.ServiceBinding.Test/ServiceBindingMapperTest.cs
+++ b/src/Configuration/test/Kubernetes.ServiceBinding.Test/ServiceBindingMapperTest.cs
@@ -12,7 +12,7 @@ public sealed class ServiceBindingMapperTest
     [Fact]
     public void MapFromTo_Present()
     {
-        var source = new Dictionary<string, string>
+        var source = new Dictionary<string, string?>
         {
             { "test-source-key", "test-source-value" }
         };
@@ -27,7 +27,7 @@ public sealed class ServiceBindingMapperTest
     [Fact]
     public void MapFromTo_NotPresent_SetNull()
     {
-        var source = new Dictionary<string, string>();
+        var source = new Dictionary<string, string?>();
         var mapper = new ServiceBindingMapper(source, string.Empty, Array.Empty<string>());
         string? newValue = mapper.MapFromTo("test-source-key", "test-destination-key");
 
@@ -38,7 +38,7 @@ public sealed class ServiceBindingMapperTest
     [Fact]
     public void MapFromTo_OverwritesExisting()
     {
-        var source = new Dictionary<string, string>
+        var source = new Dictionary<string, string?>
         {
             { "test-source-key-1", "test-source-value-1" },
             { "test-source-key-2", "test-source-value-2" },
@@ -56,7 +56,7 @@ public sealed class ServiceBindingMapperTest
     [Fact]
     public void MapFromAppendTo_Present()
     {
-        var source = new Dictionary<string, string>
+        var source = new Dictionary<string, string?>
         {
             { "test-destination-key", "test-source-value-1" },
             { "test-source-key", "test-source-value-2" }
@@ -72,7 +72,7 @@ public sealed class ServiceBindingMapperTest
     [Fact]
     public void MapFromAppendTo_FromKeyNotPresent_DoesNothing()
     {
-        var source = new Dictionary<string, string>
+        var source = new Dictionary<string, string?>
         {
             { "test-destination-key", "test-source-value" }
         };
@@ -87,7 +87,7 @@ public sealed class ServiceBindingMapperTest
     [Fact]
     public void MapFromAppendTo_AppendToKeyNotPresent_DoesNothing()
     {
-        var source = new Dictionary<string, string>
+        var source = new Dictionary<string, string?>
         {
             { "test-source-key", "test-source-value" }
         };
@@ -102,27 +102,27 @@ public sealed class ServiceBindingMapperTest
     [Fact]
     public void MapFromToFile_Present()
     {
-        var source = new Dictionary<string, string>
+        var source = new Dictionary<string, string?>
         {
             { "test-source-key", "test-source-value" }
         };
 
         var mapper = new ServiceBindingMapper(source, string.Empty, Array.Empty<string>());
-        string tempPath = mapper.MapFromToFile("test-source-key", "test-destination-key");
+        string? tempPath = mapper.MapFromToFile("test-source-key", "test-destination-key");
 
         tempPath.Should().NotBeNull();
         source["test-destination-key"].Should().Be(tempPath);
-        File.ReadAllText(tempPath).Should().Be("test-source-value");
+        File.ReadAllText(tempPath!).Should().Be("test-source-value");
 
-        File.Delete(tempPath);
+        File.Delete(tempPath!);
     }
 
     [Fact]
     public void MapFromToFile_NotPresent_SetNull()
     {
-        var source = new Dictionary<string, string>();
+        var source = new Dictionary<string, string?>();
         var mapper = new ServiceBindingMapper(source, string.Empty, Array.Empty<string>());
-        string tempPath = mapper.MapFromToFile("test-source-key", "test-destination-key");
+        string? tempPath = mapper.MapFromToFile("test-source-key", "test-destination-key");
 
         tempPath.Should().BeNull();
         source["test-destination-key"].Should().BeNull();

--- a/src/Connectors/src/Connectors/ConnectionStringPostProcessor.cs
+++ b/src/Connectors/src/Connectors/ConnectionStringPostProcessor.cs
@@ -27,7 +27,7 @@ internal abstract class ConnectionStringPostProcessor : IConfigurationPostProces
         return new DbConnectionStringBuilderWrapper(new DbConnectionStringBuilder());
     }
 
-    public void PostProcessConfiguration(PostProcessorConfigurationProvider provider, IDictionary<string, string> configurationData)
+    public void PostProcessConfiguration(PostProcessorConfigurationProvider provider, IDictionary<string, string?> configurationData)
     {
         IConfigurationRoot parentConfiguration = provider.Source.GetParentConfiguration();
 
@@ -122,9 +122,9 @@ internal abstract class ConnectionStringPostProcessor : IConfigurationPostProces
         }
     }
 
-    private void SetConnectionString(IDictionary<string, string> configurationData, string bindingName, BindingInfo bindingInfo)
+    private void SetConnectionString(IDictionary<string, string?> configurationData, string bindingName, BindingInfo bindingInfo)
     {
-        Dictionary<string, string> separateSecrets = new(StringComparer.OrdinalIgnoreCase);
+        Dictionary<string, string?> separateSecrets = new(StringComparer.OrdinalIgnoreCase);
         IConnectionStringBuilder connectionStringBuilder = CreateConnectionStringBuilder();
 
         if (bindingInfo.ClientBindingSection != null)
@@ -132,9 +132,9 @@ internal abstract class ConnectionStringPostProcessor : IConfigurationPostProces
             foreach (IConfigurationSection secretSection in bindingInfo.ClientBindingSection.GetChildren())
             {
                 string secretName = secretSection.Key;
-                string secretValue = secretSection.Value;
+                string? secretValue = secretSection.Value;
 
-                if (string.Equals(secretName, ConnectionStringName, StringComparison.OrdinalIgnoreCase) && !string.IsNullOrEmpty(secretValue))
+                if (string.Equals(secretName, ConnectionStringName, StringComparison.OrdinalIgnoreCase))
                 {
                     // Take the connection string from appsettings.json as baseline, then merge cloud-provided secrets into it.
                     connectionStringBuilder.ConnectionString = secretValue;
@@ -156,7 +156,7 @@ internal abstract class ConnectionStringPostProcessor : IConfigurationPostProces
             foreach (IConfigurationSection secretSection in bindingInfo.ServerBindingSection.GetChildren())
             {
                 string secretName = secretSection.Key;
-                string secretValue = secretSection.Value;
+                string? secretValue = secretSection.Value;
 
                 if (IsPartOfConnectionString(secretName))
                 {
@@ -172,7 +172,7 @@ internal abstract class ConnectionStringPostProcessor : IConfigurationPostProces
         string connectionStringKey = ConfigurationPath.Combine(ServiceBindingsConfigurationKey, BindingType, bindingName, ConnectionStringName);
         configurationData[connectionStringKey] = connectionStringBuilder.ConnectionString;
 
-        foreach ((string secretName, string secretValue) in separateSecrets)
+        foreach ((string secretName, string? secretValue) in separateSecrets)
         {
             string key = ConfigurationPath.Combine(ServiceBindingsConfigurationKey, BindingType, bindingName, secretName);
             configurationData[key] = secretValue;

--- a/src/Connectors/test/Connectors.Test/CosmosDb/CosmosDbConnectorTests.cs
+++ b/src/Connectors/test/Connectors.Test/CosmosDb/CosmosDbConnectorTests.cs
@@ -113,7 +113,7 @@ public sealed class CosmosDbConnectorTests
     {
         WebApplicationBuilder builder = WebApplication.CreateBuilder();
 
-        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string>
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
         {
             ["Steeltoe:Client:CosmosDb:myCosmosDbServiceOne:ConnectionString"] =
                 "AccountEndpoint=https://host-1:8081;AccountKey=C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==",
@@ -149,7 +149,7 @@ public sealed class CosmosDbConnectorTests
         WebApplicationBuilder builder = WebApplication.CreateBuilder();
         builder.Configuration.AddCloudFoundryServiceBindings(new StringServiceBindingsReader(MultiVcapServicesJson));
 
-        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string>
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
         {
             ["Steeltoe:Client:CosmosDb:myCosmosDbServiceOne:ConnectionString"] =
                 "AccountEndpoint=https://localhost:8081;AccountKey=C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==",
@@ -181,7 +181,7 @@ public sealed class CosmosDbConnectorTests
     {
         WebApplicationBuilder builder = WebApplication.CreateBuilder();
 
-        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string>
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
         {
             ["Steeltoe:Client:CosmosDb:myCosmosDbServiceOne:ConnectionString"] =
                 "AccountEndpoint=https://host-1:8081;AccountKey=C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==",
@@ -231,7 +231,7 @@ public sealed class CosmosDbConnectorTests
     {
         WebApplicationBuilder builder = WebApplication.CreateBuilder();
 
-        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string>
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
         {
             ["Steeltoe:Client:CosmosDb:myCosmosDbServiceOne:ConnectionString"] =
                 "AccountEndpoint=https://host-1:8081;AccountKey=C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==",
@@ -288,7 +288,7 @@ public sealed class CosmosDbConnectorTests
     {
         WebApplicationBuilder builder = WebApplication.CreateBuilder();
 
-        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string>
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
         {
             ["Steeltoe:Client:CosmosDb:Default:ConnectionString"] =
                 "AccountEndpoint=https://localhost:8081;AccountKey=C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==",

--- a/src/Connectors/test/Connectors.Test/MongoDb/MongoDbConnectorTests.cs
+++ b/src/Connectors/test/Connectors.Test/MongoDb/MongoDbConnectorTests.cs
@@ -102,7 +102,7 @@ public sealed class MongoDbConnectorTests
     {
         WebApplicationBuilder builder = WebApplication.CreateBuilder();
 
-        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string>
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
         {
             ["Steeltoe:Client:MongoDb:myMongoDbServiceOne:ConnectionString"] = "mongodb://localhost:27017/auth-db?connectTimeoutMS=5000",
             ["Steeltoe:Client:MongoDb:myMongoDbServiceOne:Database"] = "db1",
@@ -140,7 +140,7 @@ public sealed class MongoDbConnectorTests
         WebApplicationBuilder builder = WebApplication.CreateBuilder();
         builder.Configuration.AddCloudFoundryServiceBindings(new StringServiceBindingsReader(MultiVcapServicesJson));
 
-        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string>
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
         {
             ["Steeltoe:Client:MongoDb:myMongoDbServiceOne:ConnectionString"] = "mongodb://localhost:27017/auth-db?connectTimeoutMS=5000",
             ["Steeltoe:Client:MongoDb:myMongoDbServiceOne:Database"] = "db1"
@@ -184,7 +184,7 @@ public sealed class MongoDbConnectorTests
         var reader = new KubernetesMemoryServiceBindingsReader(fileProvider);
         builder.Configuration.AddKubernetesServiceBindings(false, true, _ => false, reader);
 
-        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string>
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
         {
             ["Steeltoe:Client:MongoDb:db:ConnectionString"] = "mongodb://localhost:27017/auth-db?connectTimeoutMS=5000",
             ["Steeltoe:Client:MongoDb:db:Database"] = "db1"
@@ -208,7 +208,7 @@ public sealed class MongoDbConnectorTests
     {
         WebApplicationBuilder builder = WebApplication.CreateBuilder();
 
-        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string>
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
         {
             ["Steeltoe:Client:MongoDb:myMongoDbServiceOne:ConnectionString"] = "mongodb://localhost:27017",
             ["Steeltoe:Client:MongoDb:myMongoDbServiceTwo:ConnectionString"] = "mongodb://user:pass@localhost:27018"
@@ -241,7 +241,7 @@ public sealed class MongoDbConnectorTests
     {
         WebApplicationBuilder builder = WebApplication.CreateBuilder();
 
-        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string>
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
         {
             ["Steeltoe:Client:MongoDb:myMongoDbServiceOne:ConnectionString"] = "mongodb://localhost:27017/auth-db",
             ["Steeltoe:Client:MongoDb:myMongoDbServiceTwo:ConnectionString"] = "mongodb://user:pass@localhost:27018/auth-db"
@@ -296,7 +296,7 @@ public sealed class MongoDbConnectorTests
     {
         WebApplicationBuilder builder = WebApplication.CreateBuilder();
 
-        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string>
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
         {
             ["Steeltoe:Client:MongoDb:Default:ConnectionString"] = "mongodb://localhost:27017/auth-db",
             ["Steeltoe:Client:MongoDb:Default:Database"] = "db"

--- a/src/Connectors/test/Connectors.Test/MySql/MySqlConnector/MySqlConnectorTests.cs
+++ b/src/Connectors/test/Connectors.Test/MySql/MySqlConnector/MySqlConnectorTests.cs
@@ -106,7 +106,7 @@ public sealed class MySqlConnectorTests
     {
         WebApplicationBuilder builder = WebApplication.CreateBuilder();
 
-        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string>
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
         {
             ["Steeltoe:Client:MySql:myMySqlServiceOne:ConnectionString"] = "SERVER=localhost;Database=db1;UID=user1;PWD=pass1",
             ["Steeltoe:Client:MySql:myMySqlServiceTwo:ConnectionString"] = "SERVER=localhost;Database=db2;UID=user2;PWD=pass2"
@@ -146,7 +146,7 @@ public sealed class MySqlConnectorTests
         WebApplicationBuilder builder = WebApplication.CreateBuilder();
         builder.Configuration.AddCloudFoundryServiceBindings(new StringServiceBindingsReader(MultiVcapServicesJson));
 
-        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string>
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
         {
             ["Steeltoe:Client:MySql:myMySqlServiceOne:ConnectionString"] = "Connection Timeout=15;host=localhost"
         });
@@ -198,7 +198,7 @@ public sealed class MySqlConnectorTests
         var reader = new KubernetesMemoryServiceBindingsReader(fileProvider);
         builder.Configuration.AddKubernetesServiceBindings(false, true, _ => false, reader);
 
-        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string>
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
         {
             ["Steeltoe:Client:MySql:db:ConnectionString"] = "Connection Timeout=15;host=localhost"
         });
@@ -226,7 +226,7 @@ public sealed class MySqlConnectorTests
     {
         WebApplicationBuilder builder = WebApplication.CreateBuilder();
 
-        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string>
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
         {
             ["Steeltoe:Client:MySql:myMySqlServiceOne:ConnectionString"] = "SERVER=localhost;Database=db1;UID=user1;PWD=pass1",
             ["Steeltoe:Client:MySql:myMySqlServiceTwo:ConnectionString"] = "SERVER=localhost;Database=db2;UID=user2;PWD=pass2"
@@ -254,7 +254,7 @@ public sealed class MySqlConnectorTests
     {
         WebApplicationBuilder builder = WebApplication.CreateBuilder();
 
-        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string>
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
         {
             ["Steeltoe:Client:MySql:myMySqlServiceOne:ConnectionString"] = "SERVER=localhost;Database=db1;UID=user1;PWD=pass1",
             ["Steeltoe:Client:MySql:myMySqlServiceTwo:ConnectionString"] = "SERVER=localhost;Database=db2;UID=user2;PWD=pass2"
@@ -307,7 +307,7 @@ public sealed class MySqlConnectorTests
     {
         WebApplicationBuilder builder = WebApplication.CreateBuilder();
 
-        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string>
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
         {
             ["Steeltoe:Client:MySql:Default:ConnectionString"] = "SERVER=localhost;Database=myDb;UID=myUser;PWD=myPass"
         });

--- a/src/Connectors/test/Connectors.Test/MySql/Oracle/MySqlConnectorTests.cs
+++ b/src/Connectors/test/Connectors.Test/MySql/Oracle/MySqlConnectorTests.cs
@@ -106,7 +106,7 @@ public sealed class MySqlConnectorTests
     {
         WebApplicationBuilder builder = WebApplication.CreateBuilder();
 
-        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string>
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
         {
             ["Steeltoe:Client:MySql:myMySqlServiceOne:ConnectionString"] = "SERVER=localhost;Database=db1;UID=user1;PWD=pass1",
             ["Steeltoe:Client:MySql:myMySqlServiceTwo:ConnectionString"] = "SERVER=localhost;Database=db2;UID=user2;PWD=pass2"
@@ -146,7 +146,7 @@ public sealed class MySqlConnectorTests
         WebApplicationBuilder builder = WebApplication.CreateBuilder();
         builder.Configuration.AddCloudFoundryServiceBindings(new StringServiceBindingsReader(MultiVcapServicesJson));
 
-        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string>
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
         {
             ["Steeltoe:Client:MySql:myMySqlServiceOne:ConnectionString"] = "Connection Timeout=15;host=localhost"
         });
@@ -198,7 +198,7 @@ public sealed class MySqlConnectorTests
         var reader = new KubernetesMemoryServiceBindingsReader(fileProvider);
         builder.Configuration.AddKubernetesServiceBindings(false, true, _ => false, reader);
 
-        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string>
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
         {
             ["Steeltoe:Client:MySql:db:ConnectionString"] = "Connection Timeout=15;host=localhost"
         });
@@ -226,7 +226,7 @@ public sealed class MySqlConnectorTests
     {
         WebApplicationBuilder builder = WebApplication.CreateBuilder();
 
-        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string>
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
         {
             ["Steeltoe:Client:MySql:myMySqlServiceOne:ConnectionString"] = "SERVER=localhost;Database=db1;UID=user1;PWD=pass1",
             ["Steeltoe:Client:MySql:myMySqlServiceTwo:ConnectionString"] = "SERVER=localhost;Database=db2;UID=user2;PWD=pass2"
@@ -254,7 +254,7 @@ public sealed class MySqlConnectorTests
     {
         WebApplicationBuilder builder = WebApplication.CreateBuilder();
 
-        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string>
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
         {
             ["Steeltoe:Client:MySql:myMySqlServiceOne:ConnectionString"] = "SERVER=localhost;Database=db1;UID=user1;PWD=pass1",
             ["Steeltoe:Client:MySql:myMySqlServiceTwo:ConnectionString"] = "SERVER=localhost;Database=db2;UID=user2;PWD=pass2"
@@ -307,7 +307,7 @@ public sealed class MySqlConnectorTests
     {
         WebApplicationBuilder builder = WebApplication.CreateBuilder();
 
-        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string>
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
         {
             ["Steeltoe:Client:MySql:Default:ConnectionString"] = "SERVER=localhost;Database=myDb;UID=myUser;PWD=myPass"
         });

--- a/src/Connectors/test/Connectors.Test/PostgreSql/PostgreSqlConnectorTests.cs
+++ b/src/Connectors/test/Connectors.Test/PostgreSql/PostgreSqlConnectorTests.cs
@@ -185,7 +185,7 @@ public sealed class PostgreSqlConnectorTests
     {
         WebApplicationBuilder builder = WebApplication.CreateBuilder();
 
-        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string>
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
         {
             ["Steeltoe:Client:PostgreSql:myPostgreSqlServiceOne:ConnectionString"] = "SERVER=localhost;DB=db1;UID=user1;PWD=pass1",
             ["Steeltoe:Client:PostgreSql:myPostgreSqlServiceTwo:ConnectionString"] = "SERVER=localhost;DB=db2;UID=user2;PWD=pass2"
@@ -225,7 +225,7 @@ public sealed class PostgreSqlConnectorTests
         WebApplicationBuilder builder = WebApplication.CreateBuilder();
         builder.Configuration.AddCloudFoundryServiceBindings(new StringServiceBindingsReader(MultiVcapServicesJson));
 
-        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string>
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
         {
             ["Steeltoe:Client:PostgreSql:myPostgreSqlServiceAzureOne:ConnectionString"] = "Include Error Detail=true;Log Parameters=true;host=localhost"
         });
@@ -361,7 +361,7 @@ bR1Bjw0NBrcC7/tryf5kzKVdYs3FAHOR3qCFIaVGg97okwhOiMP6e6j0fBENDj8f
         var reader = new KubernetesMemoryServiceBindingsReader(fileProvider);
         builder.Configuration.AddKubernetesServiceBindings(false, true, _ => false, reader);
 
-        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string>
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
         {
             ["Steeltoe:Client:PostgreSql:db:ConnectionString"] = "Host=ignored;Database=ignored;Include Error Detail=true;Log Parameters=true;host=localhost"
         });
@@ -390,7 +390,7 @@ bR1Bjw0NBrcC7/tryf5kzKVdYs3FAHOR3qCFIaVGg97okwhOiMP6e6j0fBENDj8f
     {
         WebApplicationBuilder builder = WebApplication.CreateBuilder();
 
-        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string>
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
         {
             ["Steeltoe:Client:PostgreSql:myPostgreSqlServiceOne:ConnectionString"] = "SERVER=localhost;DB=db1;UID=user1;PWD=pass1",
             ["Steeltoe:Client:PostgreSql:myPostgreSqlServiceTwo:ConnectionString"] = "SERVER=localhost;DB=db2;UID=user2;PWD=pass2"
@@ -418,7 +418,7 @@ bR1Bjw0NBrcC7/tryf5kzKVdYs3FAHOR3qCFIaVGg97okwhOiMP6e6j0fBENDj8f
     {
         WebApplicationBuilder builder = WebApplication.CreateBuilder();
 
-        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string>
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
         {
             ["Steeltoe:Client:PostgreSql:myPostgreSqlServiceOne:ConnectionString"] = "SERVER=localhost;DB=db1;UID=user1;PWD=pass1",
             ["Steeltoe:Client:PostgreSql:myPostgreSqlServiceTwo:ConnectionString"] = "SERVER=localhost;DB=db2;UID=user2;PWD=pass2"
@@ -446,7 +446,7 @@ bR1Bjw0NBrcC7/tryf5kzKVdYs3FAHOR3qCFIaVGg97okwhOiMP6e6j0fBENDj8f
     {
         WebApplicationBuilder builder = WebApplication.CreateBuilder();
 
-        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string>
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
         {
             ["Steeltoe:Client:PostgreSql:myPostgreSqlServiceOne:ConnectionString"] = "SERVER=localhost;DB=db1;UID=user1;PWD=pass1",
             ["Steeltoe:Client:PostgreSql:myPostgreSqlServiceTwo:ConnectionString"] = "SERVER=localhost;DB=db2;UID=user2;PWD=pass2"
@@ -467,7 +467,7 @@ bR1Bjw0NBrcC7/tryf5kzKVdYs3FAHOR3qCFIaVGg97okwhOiMP6e6j0fBENDj8f
     {
         WebApplicationBuilder builder = WebApplication.CreateBuilder();
 
-        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string>
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
         {
             ["Steeltoe:Client:PostgreSql:myPostgreSqlServiceOne:ConnectionString"] = "SERVER=localhost;DB=db1;UID=user1;PWD=pass1",
             ["Steeltoe:Client:PostgreSql:myPostgreSqlServiceTwo:ConnectionString"] = "SERVER=localhost;DB=db2;UID=user2;PWD=pass2"
@@ -490,7 +490,7 @@ bR1Bjw0NBrcC7/tryf5kzKVdYs3FAHOR3qCFIaVGg97okwhOiMP6e6j0fBENDj8f
         WebApplicationBuilder builder = WebApplication.CreateBuilder();
         builder.Configuration.AddCloudFoundryServiceBindings(new StringServiceBindingsReader(SingleVcapServicesJson));
 
-        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string>
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
         {
             ["Steeltoe:Client:PostgreSql:Default:ConnectionString"] = "SERVER=localhost;DB=myDb;UID=myUser;PWD=myPass;Log Parameters=True"
         });
@@ -553,7 +553,7 @@ bR1Bjw0NBrcC7/tryf5kzKVdYs3FAHOR3qCFIaVGg97okwhOiMP6e6j0fBENDj8f
     {
         WebApplicationBuilder builder = WebApplication.CreateBuilder();
 
-        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string>
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
         {
             ["Steeltoe:Client:PostgreSql:Default:ConnectionString"] = "SERVER=localhost;DB=myDb;UID=myUser;PWD=myPass"
         });
@@ -578,7 +578,7 @@ bR1Bjw0NBrcC7/tryf5kzKVdYs3FAHOR3qCFIaVGg97okwhOiMP6e6j0fBENDj8f
     {
         WebApplicationBuilder builder = WebApplication.CreateBuilder();
 
-        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string>
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
         {
             ["Steeltoe:Client:PostgreSql:myPostgreSqlServiceAzureOne:ConnectionString"] = "host=localhost"
         });
@@ -603,7 +603,7 @@ bR1Bjw0NBrcC7/tryf5kzKVdYs3FAHOR3qCFIaVGg97okwhOiMP6e6j0fBENDj8f
     {
         WebApplicationBuilder builder = WebApplication.CreateBuilder();
 
-        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string>
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
         {
             ["Steeltoe:Client:PostgreSql:myPostgreSqlServiceAzureOne:ConnectionString"] = "host=localhost",
             ["Steeltoe:Client:PostgreSql:Default:ConnectionString"] = "host=ignored"
@@ -630,7 +630,7 @@ bR1Bjw0NBrcC7/tryf5kzKVdYs3FAHOR3qCFIaVGg97okwhOiMP6e6j0fBENDj8f
         WebApplicationBuilder builder = WebApplication.CreateBuilder();
         builder.Configuration.AddCloudFoundryServiceBindings(new StringServiceBindingsReader(MultiVcapServicesJson));
 
-        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string>
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
         {
             ["Steeltoe:Client:PostgreSql:Default:ConnectionString"] = "host=ignored"
         });
@@ -658,7 +658,7 @@ bR1Bjw0NBrcC7/tryf5kzKVdYs3FAHOR3qCFIaVGg97okwhOiMP6e6j0fBENDj8f
         WebApplicationBuilder builder = WebApplication.CreateBuilder();
         builder.Configuration.AddCloudFoundryServiceBindings(new StringServiceBindingsReader(SingleVcapServicesJson));
 
-        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string>
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
         {
             ["Steeltoe:Client:PostgreSql:myPostgreSqlServiceAzureOne:ConnectionString"] = "host=localhost",
             ["Steeltoe:Client:PostgreSql:Default:ConnectionString"] = "host=ignored"
@@ -685,7 +685,7 @@ bR1Bjw0NBrcC7/tryf5kzKVdYs3FAHOR3qCFIaVGg97okwhOiMP6e6j0fBENDj8f
         WebApplicationBuilder builder = WebApplication.CreateBuilder();
         builder.Configuration.AddCloudFoundryServiceBindings(new StringServiceBindingsReader(SingleVcapServicesJson));
 
-        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string>
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
         {
             ["Steeltoe:Client:PostgreSql:alternatePostgreSqlService:ConnectionString"] = "host=localhost",
             ["Steeltoe:Client:PostgreSql:Default:ConnectionString"] = "host=ignored"
@@ -715,7 +715,7 @@ bR1Bjw0NBrcC7/tryf5kzKVdYs3FAHOR3qCFIaVGg97okwhOiMP6e6j0fBENDj8f
     {
         WebApplicationBuilder builder = WebApplication.CreateBuilder();
 
-        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string>
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
         {
             ["Steeltoe:Client:PostgreSql:myPostgreSqlServiceAzureOne:ConnectionString"] = "Include Error Detail=true;Log Parameters=true;host=localhost"
         });

--- a/src/Connectors/test/Connectors.Test/RabbitMQ/RabbitMQConnectorTests.cs
+++ b/src/Connectors/test/Connectors.Test/RabbitMQ/RabbitMQConnectorTests.cs
@@ -187,7 +187,7 @@ public sealed class RabbitMQConnectorTests
     {
         WebApplicationBuilder builder = WebApplication.CreateBuilder();
 
-        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string>
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
         {
             ["Steeltoe:Client:RabbitMQ:myRabbitMQServiceOne:ConnectionString"] = "amqp://user1:pass1@host1:5672/virtual-host-1",
             ["Steeltoe:Client:RabbitMQ:myRabbitMQServiceTwo:ConnectionString"] = "amqps://user2:pass2@host2:5672/virtual-host-2"
@@ -211,7 +211,7 @@ public sealed class RabbitMQConnectorTests
         WebApplicationBuilder builder = WebApplication.CreateBuilder();
         builder.Configuration.AddCloudFoundryServiceBindings(new StringServiceBindingsReader(MultiVcapServicesJson));
 
-        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string>
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
         {
             ["Steeltoe:Client:RabbitMQ:myRabbitMQServiceOne:ConnectionString"] = "amqps://user:pass@localhost:5672"
         });
@@ -249,7 +249,7 @@ public sealed class RabbitMQConnectorTests
         var reader = new KubernetesMemoryServiceBindingsReader(fileProvider);
         builder.Configuration.AddKubernetesServiceBindings(false, true, _ => false, reader);
 
-        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string>
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
         {
             ["Steeltoe:Client:RabbitMQ:db:ConnectionString"] = "amqps://user:pass@localhost:5672/extra-virtual-host"
         });
@@ -269,7 +269,7 @@ public sealed class RabbitMQConnectorTests
     {
         WebApplicationBuilder builder = WebApplication.CreateBuilder();
 
-        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string>
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
         {
             ["Steeltoe:Client:RabbitMQ:myRabbitMQServiceOne:ConnectionString"] = "amqp://user1:pass1@host1:5672/virtual-host-1",
             ["Steeltoe:Client:RabbitMQ:myRabbitMQServiceTwo:ConnectionString"] = "amqps://user2:pass2@host2:5672/virtual-host-2"
@@ -309,7 +309,7 @@ public sealed class RabbitMQConnectorTests
     {
         WebApplicationBuilder builder = WebApplication.CreateBuilder();
 
-        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string>
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
         {
             ["Steeltoe:Client:RabbitMQ:myRabbitMQServiceOne:ConnectionString"] = "amqp://user1:pass1@host1:5672/virtual-host-1",
             ["Steeltoe:Client:RabbitMQ:myRabbitMQServiceTwo:ConnectionString"] = "amqps://user2:pass2@host2:5672/virtual-host-2"
@@ -380,7 +380,7 @@ public sealed class RabbitMQConnectorTests
     {
         WebApplicationBuilder builder = WebApplication.CreateBuilder();
 
-        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string>
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
         {
             ["Steeltoe:Client:RabbitMQ:Default:ConnectionString"] = "amqp://localhost:5672/my-virtual-host"
         });

--- a/src/Connectors/test/Connectors.Test/Redis/RedisConnectorTests.cs
+++ b/src/Connectors/test/Connectors.Test/Redis/RedisConnectorTests.cs
@@ -100,7 +100,7 @@ public sealed class RedisConnectorTests
     {
         WebApplicationBuilder builder = WebApplication.CreateBuilder();
 
-        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string>
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
         {
             ["Steeltoe:Client:Redis:myRedisServiceOne:ConnectionString"] = "server1:6380,keepAlive=30",
             ["Steeltoe:Client:Redis:myRedisServiceTwo:ConnectionString"] = "server2:6380,allowAdmin=true"
@@ -124,7 +124,7 @@ public sealed class RedisConnectorTests
         WebApplicationBuilder builder = WebApplication.CreateBuilder();
         builder.Configuration.AddCloudFoundryServiceBindings(new StringServiceBindingsReader(MultiVcapServicesJson));
 
-        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string>
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
         {
             ["Steeltoe:Client:Redis:myRedisServiceOne:ConnectionString"] = "localhost:12345,keepAlive=30,user=admin"
         });
@@ -157,7 +157,7 @@ public sealed class RedisConnectorTests
         var reader = new KubernetesMemoryServiceBindingsReader(fileProvider);
         builder.Configuration.AddKubernetesServiceBindings(false, true, _ => false, reader);
 
-        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string>
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
         {
             ["Steeltoe:Client:Redis:db:ConnectionString"] = "localhost:12345,keepAlive=30,user=admin"
         });
@@ -177,7 +177,7 @@ public sealed class RedisConnectorTests
     {
         WebApplicationBuilder builder = WebApplication.CreateBuilder();
 
-        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string>
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
         {
             ["Steeltoe:Client:Redis:myRedisServiceOne:ConnectionString"] = "server1:6380,keepAlive=30",
             ["Steeltoe:Client:Redis:myRedisServiceTwo:ConnectionString"] = "server2:6380,allowAdmin=true"
@@ -217,7 +217,7 @@ public sealed class RedisConnectorTests
     {
         WebApplicationBuilder builder = WebApplication.CreateBuilder();
 
-        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string>
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
         {
             ["Steeltoe:Client:Redis:myRedisServiceOne:ConnectionString"] = "server1:6380,keepAlive=30",
             ["Steeltoe:Client:Redis:myRedisServiceTwo:ConnectionString"] = "server2:6380,allowAdmin=true"
@@ -259,7 +259,7 @@ public sealed class RedisConnectorTests
     {
         WebApplicationBuilder builder = WebApplication.CreateBuilder();
 
-        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string>
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
         {
             ["Steeltoe:Client:Redis:myRedisServiceOne:ConnectionString"] = "server1:6380,keepAlive=30",
             ["Steeltoe:Client:Redis:myRedisServiceTwo:ConnectionString"] = "server2:6380,allowAdmin=true"
@@ -330,7 +330,7 @@ public sealed class RedisConnectorTests
     {
         WebApplicationBuilder builder = WebApplication.CreateBuilder();
 
-        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string>
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
         {
             ["Steeltoe:Client:Redis:Default:ConnectionString"] = "server1:6380,keepAlive=30"
         });

--- a/src/Connectors/test/Connectors.Test/SqlServer/MicrosoftData/SqlServerConnectorTests.cs
+++ b/src/Connectors/test/Connectors.Test/SqlServer/MicrosoftData/SqlServerConnectorTests.cs
@@ -138,7 +138,7 @@ public sealed class SqlServerConnectorTests
     {
         WebApplicationBuilder builder = WebApplication.CreateBuilder();
 
-        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string>
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
         {
             ["Steeltoe:Client:SqlServer:mySqlServerServiceOne:ConnectionString"] = "Data Source=localhost;Initial Catalog=db1;UID=user1;PWD=pass1",
             ["Steeltoe:Client:SqlServer:mySqlServerServiceTwo:ConnectionString"] = "Server=localhost;Database=db2;UID=user2;PWD=pass2"
@@ -178,7 +178,7 @@ public sealed class SqlServerConnectorTests
         WebApplicationBuilder builder = WebApplication.CreateBuilder();
         builder.Configuration.AddCloudFoundryServiceBindings(new StringServiceBindingsReader(MultiVcapServicesJson));
 
-        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string>
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
         {
             ["Steeltoe:Client:SqlServer:mySqlServerServiceOne:ConnectionString"] = "Data Source=localhost;Max Pool Size=50"
         });
@@ -215,7 +215,7 @@ public sealed class SqlServerConnectorTests
     {
         WebApplicationBuilder builder = WebApplication.CreateBuilder();
 
-        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string>
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
         {
             ["Steeltoe:Client:SqlServer:mySqlServerServiceOne:ConnectionString"] = "SERVER=localhost;Database=db1;UID=user1;PWD=pass1",
             ["Steeltoe:Client:SqlServer:mySqlServerServiceTwo:ConnectionString"] = "SERVER=localhost;Database=db2;UID=user2;PWD=pass2"
@@ -243,7 +243,7 @@ public sealed class SqlServerConnectorTests
     {
         WebApplicationBuilder builder = WebApplication.CreateBuilder();
 
-        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string>
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
         {
             ["Steeltoe:Client:SqlServer:mySqlServerServiceOne:ConnectionString"] = "SERVER=localhost;Database=db1;UID=user1;PWD=pass1",
             ["Steeltoe:Client:SqlServer:mySqlServerServiceTwo:ConnectionString"] = "SERVER=localhost;Database=db2;UID=user2;PWD=pass2"
@@ -296,7 +296,7 @@ public sealed class SqlServerConnectorTests
     {
         WebApplicationBuilder builder = WebApplication.CreateBuilder();
 
-        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string>
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
         {
             ["Steeltoe:Client:SqlServer:Default:ConnectionString"] = "SERVER=localhost;Database=myDb;UID=myUser;PWD=myPass"
         });

--- a/src/Connectors/test/Connectors.Test/SqlServer/SystemData/SqlServerConnectorTests.cs
+++ b/src/Connectors/test/Connectors.Test/SqlServer/SystemData/SqlServerConnectorTests.cs
@@ -138,7 +138,7 @@ public sealed class SqlServerConnectorTests
     {
         WebApplicationBuilder builder = WebApplication.CreateBuilder();
 
-        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string>
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
         {
             ["Steeltoe:Client:SqlServer:mySqlServerServiceOne:ConnectionString"] = "Data Source=localhost;Initial Catalog=db1;UID=user1;PWD=pass1",
             ["Steeltoe:Client:SqlServer:mySqlServerServiceTwo:ConnectionString"] = "Server=localhost;Database=db2;UID=user2;PWD=pass2"
@@ -178,7 +178,7 @@ public sealed class SqlServerConnectorTests
         WebApplicationBuilder builder = WebApplication.CreateBuilder();
         builder.Configuration.AddCloudFoundryServiceBindings(new StringServiceBindingsReader(MultiVcapServicesJson));
 
-        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string>
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
         {
             ["Steeltoe:Client:SqlServer:mySqlServerServiceOne:ConnectionString"] = "Data Source=localhost;Max Pool Size=50"
         });
@@ -215,7 +215,7 @@ public sealed class SqlServerConnectorTests
     {
         WebApplicationBuilder builder = WebApplication.CreateBuilder();
 
-        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string>
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
         {
             ["Steeltoe:Client:SqlServer:mySqlServerServiceOne:ConnectionString"] = "SERVER=localhost;Database=db1;UID=user1;PWD=pass1",
             ["Steeltoe:Client:SqlServer:mySqlServerServiceTwo:ConnectionString"] = "SERVER=localhost;Database=db2;UID=user2;PWD=pass2"
@@ -243,7 +243,7 @@ public sealed class SqlServerConnectorTests
     {
         WebApplicationBuilder builder = WebApplication.CreateBuilder();
 
-        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string>
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
         {
             ["Steeltoe:Client:SqlServer:mySqlServerServiceOne:ConnectionString"] = "SERVER=localhost;Database=db1;UID=user1;PWD=pass1",
             ["Steeltoe:Client:SqlServer:mySqlServerServiceTwo:ConnectionString"] = "SERVER=localhost;Database=db2;UID=user2;PWD=pass2"
@@ -296,7 +296,7 @@ public sealed class SqlServerConnectorTests
     {
         WebApplicationBuilder builder = WebApplication.CreateBuilder();
 
-        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string>
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
         {
             ["Steeltoe:Client:SqlServer:Default:ConnectionString"] = "SERVER=localhost;Database=myDb;UID=myUser;PWD=myPass"
         });

--- a/src/Connectors/test/EntityFrameworkCore.Test/MySql/Oracle/MySqlDbContextOptionsBuilderExtensionsTest.cs
+++ b/src/Connectors/test/EntityFrameworkCore.Test/MySql/Oracle/MySqlDbContextOptionsBuilderExtensionsTest.cs
@@ -22,7 +22,7 @@ public sealed class MySqlDbContextOptionsBuilderExtensionsTest
     {
         WebApplicationBuilder builder = WebApplication.CreateBuilder();
 
-        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string>
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
         {
             ["Steeltoe:Client:MySql:Default:ConnectionString"] = "SERVER=localhost;database=myDb;UID=steeltoe;PWD=steeltoe;connect timeout=15"
         });
@@ -46,7 +46,7 @@ public sealed class MySqlDbContextOptionsBuilderExtensionsTest
     {
         WebApplicationBuilder builder = WebApplication.CreateBuilder();
 
-        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string>
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
         {
             ["Steeltoe:Client:MySql:myMySqlService:ConnectionString"] = "SERVER=localhost;database=myDb;UID=steeltoe;PWD=steeltoe;connect timeout=15"
         });

--- a/src/Connectors/test/EntityFrameworkCore.Test/MySql/Pomelo/MySqlDbContextOptionsBuilderExtensionsTest.cs
+++ b/src/Connectors/test/EntityFrameworkCore.Test/MySql/Pomelo/MySqlDbContextOptionsBuilderExtensionsTest.cs
@@ -22,7 +22,7 @@ public sealed class MySqlDbContextOptionsBuilderExtensionsTest
     {
         WebApplicationBuilder builder = WebApplication.CreateBuilder();
 
-        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string>
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
         {
             ["Steeltoe:Client:MySql:Default:ConnectionString"] = "SERVER=localhost;database=myDb;UID=steeltoe;PWD=steeltoe;connect timeout=15"
         });
@@ -47,7 +47,7 @@ public sealed class MySqlDbContextOptionsBuilderExtensionsTest
     {
         WebApplicationBuilder builder = WebApplication.CreateBuilder();
 
-        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string>
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
         {
             ["Steeltoe:Client:MySql:myMySqlService:ConnectionString"] = "SERVER=localhost;database=myDb;UID=steeltoe;PWD=steeltoe;connect timeout=15"
         });

--- a/src/Connectors/test/EntityFrameworkCore.Test/PostgreSql/PostgreSqlDbContextOptionsBuilderExtensionsTest.cs
+++ b/src/Connectors/test/EntityFrameworkCore.Test/PostgreSql/PostgreSqlDbContextOptionsBuilderExtensionsTest.cs
@@ -20,7 +20,7 @@ public sealed class PostgreSqlDbContextOptionsBuilderExtensionsTest
     {
         WebApplicationBuilder builder = WebApplication.CreateBuilder();
 
-        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string>
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
         {
             ["Steeltoe:Client:PostgreSql:Default:ConnectionString"] = "SERVER=localhost;DB=myDb;UID=myUser;PWD=myPass;Log Parameters=True"
         });
@@ -42,7 +42,7 @@ public sealed class PostgreSqlDbContextOptionsBuilderExtensionsTest
     {
         WebApplicationBuilder builder = WebApplication.CreateBuilder();
 
-        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string>
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
         {
             ["Steeltoe:Client:PostgreSql:myPostgreSqlService:ConnectionString"] = "SERVER=localhost;DB=myDb;UID=myUser;PWD=myPass;Log Parameters=True"
         });

--- a/src/Connectors/test/EntityFrameworkCore.Test/SqlServer/SqlServerDbContextOptionsBuilderExtensionsTest.cs
+++ b/src/Connectors/test/EntityFrameworkCore.Test/SqlServer/SqlServerDbContextOptionsBuilderExtensionsTest.cs
@@ -21,7 +21,7 @@ public sealed class SqlServerDbContextOptionsBuilderExtensionsTest
     {
         WebApplicationBuilder builder = WebApplication.CreateBuilder();
 
-        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string>
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
         {
             ["Steeltoe:Client:SqlServer:Default:ConnectionString"] = "SERVER=localhost;database=myDb;UID=steeltoe;PWD=steeltoe;Max Pool Size=50"
         });
@@ -44,7 +44,7 @@ public sealed class SqlServerDbContextOptionsBuilderExtensionsTest
     {
         WebApplicationBuilder builder = WebApplication.CreateBuilder();
 
-        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string>
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
         {
             ["Steeltoe:Client:SqlServer:mySqlServerService:ConnectionString"] = "SERVER=localhost;database=myDb;UID=steeltoe;PWD=steeltoe;Max Pool Size=50"
         });

--- a/src/Discovery/test/Kubernetes.Test/KubernetesDiscoveryClientExtensionTest.cs
+++ b/src/Discovery/test/Kubernetes.Test/KubernetesDiscoveryClientExtensionTest.cs
@@ -30,7 +30,7 @@ public sealed class KubernetesDiscoveryClientExtensionTest
     {
         var services = new ServiceCollection();
 
-        var appSettings = new Dictionary<string, string>
+        var appSettings = new Dictionary<string, string?>
         {
             { "spring:cloud:discovery:enabled", "false" }
         };
@@ -49,7 +49,7 @@ public sealed class KubernetesDiscoveryClientExtensionTest
     {
         var services = new ServiceCollection();
 
-        var appSettings = new Dictionary<string, string>
+        var appSettings = new Dictionary<string, string?>
         {
             { "spring:cloud:discovery:enabled", "false" },
             { "spring:cloud:kubernetes:discovery:enabled", "true" }

--- a/src/Management/src/Abstractions/Info/ConfigurationContributor.cs
+++ b/src/Management/src/Abstractions/Info/ConfigurationContributor.cs
@@ -53,7 +53,7 @@ internal abstract class ConfigurationContributor
         foreach (IConfigurationSection section in sections)
         {
             string key = section.Key;
-            string value = section.Value;
+            string? value = section.Value;
 
             if (value == null)
             {


### PR DESCRIPTION
## Description

Correct the nullability annotations in Steeltoe.Configuration, based on .NET 7/8. The related annotations in the BCL didn't yet exist in .NET 6, so we didn't get warnings on them before. Getting them right makes it easier to sync the Steeltoe codebase with .NET 7/8.

## Quality checklist

- [x] Your code complies with our [Coding Style](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-code-style.md).
- [x] You've updated unit and/or integration tests for your change, where applicable.
- [ ] You've updated documentation for your change, where applicable.
      If your change affects other repositories, such as [Documentation](https://github.com/SteeltoeOSS/Documentation), [Samples](https://github.com/SteeltoeOSS/Samples) and/or [MainSite](https://github.com/SteeltoeOSS/MainSite), add linked PRs here.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
- [x] You've added required license files and/or file headers (explaining where the code came from with proper attribution), where code is copied from StackOverflow, a blog, or OSS.
