### PR TITLE
Consul - Add support for metadata in a backwards compatible way

### DIFF
--- a/src/Discovery/src/Consul/Discovery/ConsulDiscoveryOptions.cs
+++ b/src/Discovery/src/Consul/Discovery/ConsulDiscoveryOptions.cs
@@ -53,12 +53,12 @@ public class ConsulDiscoveryOptions
     public IList<string> Tags { get; set; }
 
     /// <summary>
-    /// Gets or sets Metadata to use when registering service.
+    /// Gets or sets Metadata to use when registering service
     /// </summary>
     public IDictionary<string, string> Metadata { get; set; }
 
     /// <summary>
-    /// Gets or sets a  value indicating whether use tags as metadata, defaults to true.
+    /// Gets or sets a  value indicating whether use tags as metadata, defaults to true
     /// </summary>
     public bool TagsAsMetadata { get; set; } = true;
 

--- a/src/Discovery/src/Consul/Discovery/ConsulDiscoveryOptions.cs
+++ b/src/Discovery/src/Consul/Discovery/ConsulDiscoveryOptions.cs
@@ -52,6 +52,16 @@ public class ConsulDiscoveryOptions
     /// </summary>
     public IList<string> Tags { get; set; }
 
+    /// <summary>
+    /// Gets or sets Metadata to use when registering service.
+    /// </summary>
+    public IDictionary<string, string> Metadata { get; set; }
+
+    /// <summary>
+    /// Gets or sets a  value indicating whether use tags as metadata, defaults to true.
+    /// </summary>
+    public bool TagsAsMetadata { get; set; } = true;
+
     public bool UseNetUtils { get; set; }
 
     public InetUtils NetUtils { get; set; }

--- a/src/Discovery/src/Consul/Registry/ConsulRegistration.cs
+++ b/src/Discovery/src/Consul/Registry/ConsulRegistration.cs
@@ -157,6 +157,7 @@ public class ConsulRegistration : IConsulRegistration
             service.Tags = options.Tags.ToArray();
             service.Meta = CreateMetadata(options);
         }
+
         if (options.Port != 0)
         {
             service.Port = options.Port;

--- a/src/Discovery/src/Consul/Registry/ConsulRegistration.cs
+++ b/src/Discovery/src/Consul/Registry/ConsulRegistration.cs
@@ -9,6 +9,8 @@ using Steeltoe.Discovery.Consul.Discovery;
 using Steeltoe.Discovery.Consul.Util;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
 using System.Text;
 
 namespace Steeltoe.Discovery.Consul.Registry;
@@ -45,7 +47,7 @@ public class ConsulRegistration : IConsulRegistration
         Service = agentServiceRegistration ?? throw new ArgumentNullException(nameof(agentServiceRegistration));
         _options = options ?? throw new ArgumentNullException(nameof(options));
 
-        Initialize(agentServiceRegistration);
+        Initialize(agentServiceRegistration, options);
     }
 
     /// <summary>
@@ -58,7 +60,7 @@ public class ConsulRegistration : IConsulRegistration
         Service = agentServiceRegistration ?? throw new ArgumentNullException(nameof(agentServiceRegistration));
         _optionsMonitor = optionsMonitor ?? throw new ArgumentNullException(nameof(optionsMonitor));
 
-        Initialize(agentServiceRegistration);
+        Initialize(agentServiceRegistration, optionsMonitor.CurrentValue);
     }
 
     // For testing
@@ -66,13 +68,22 @@ public class ConsulRegistration : IConsulRegistration
     {
     }
 
-    internal void Initialize(AgentServiceRegistration agentServiceRegistration)
+    internal void Initialize(AgentServiceRegistration agentServiceRegistration, ConsulDiscoveryOptions options)
     {
         InstanceId = agentServiceRegistration.ID;
         ServiceId = agentServiceRegistration.Name;
         Host = agentServiceRegistration.Address;
         Port = agentServiceRegistration.Port;
-        Metadata = ConsulServerUtils.GetMetadata(agentServiceRegistration.Tags);
+
+        if (options.TagsAsMetadata)
+        {
+            Metadata = ConsulServerUtils.GetMetadata(agentServiceRegistration.Tags);
+        }
+        else
+        {
+            Tags = agentServiceRegistration.Tags;
+            Metadata = agentServiceRegistration.Meta;
+        }
     }
 
     /// <inheritdoc/>
@@ -108,6 +119,8 @@ public class ConsulRegistration : IConsulRegistration
         }
     }
 
+    public string[] Tags { get; private set; }
+
     /// <inheritdoc/>
     public IDictionary<string, string> Metadata { get; private set; }
 
@@ -135,7 +148,15 @@ public class ConsulRegistration : IConsulRegistration
 
         var appName = applicationInfo.ApplicationNameInContext(SteeltoeComponent.Discovery, ConsulDiscoveryOptions.CONSUL_DISCOVERY_CONFIGURATION_PREFIX + ":serviceName");
         service.Name = NormalizeForConsul(appName);
-        service.Tags = CreateTags(options);
+        if (options.TagsAsMetadata)
+        {
+            service.Tags = CreateTags(options);
+        }
+        else
+        {
+            service.Tags = options.Tags.ToArray();
+            service.Meta = CreateMetadata(options);
+        }
         if (options.Port != 0)
         {
             service.Port = options.Port;
@@ -143,6 +164,36 @@ public class ConsulRegistration : IConsulRegistration
         }
 
         return new ConsulRegistration(service, options);
+    }
+
+    internal static IDictionary<string, string> CreateMetadata(ConsulDiscoveryOptions options)
+    {
+        var metadata = new Dictionary<string, string>();
+
+        if (options.Metadata != null && options.Metadata.Any())
+        {
+            foreach (KeyValuePair<string, string> m in options.Metadata)
+            {
+                metadata.Add(m.Key, m.Value);
+            }
+        }
+
+        if (!string.IsNullOrEmpty(options.InstanceZone))
+        {
+            metadata.Add(options.DefaultZoneMetadataName, options.InstanceZone);
+        }
+
+        if (!string.IsNullOrEmpty(options.InstanceGroup))
+        {
+            metadata.Add("group", options.InstanceGroup);
+        }
+
+        // store the secure flag in the metadata so that clients will be able to figure out whether to use http or https automatically
+#pragma warning disable S4040 // Strings should be normalized to uppercase
+        metadata.Add("secure", (options.Scheme == "https").ToString(CultureInfo.InvariantCulture).ToLowerInvariant());
+#pragma warning restore S4040 // Strings should be normalized to uppercase
+
+        return metadata;
     }
 
     internal static string[] CreateTags(ConsulDiscoveryOptions options)

--- a/src/Discovery/test/Consul.Test/Discovery/ConsulServiceInstanceTest.cs
+++ b/src/Discovery/test/Consul.Test/Discovery/ConsulServiceInstanceTest.cs
@@ -4,6 +4,7 @@
 
 using Consul;
 using System;
+using System.Collections.Generic;
 using Xunit;
 
 namespace Steeltoe.Discovery.Consul.Discovery.Test;
@@ -34,6 +35,42 @@ public class ConsulServiceInstanceTest
         Assert.Contains("secure", si.Metadata.Keys);
         Assert.Contains("bar", si.Metadata.Values);
         Assert.Contains("true", si.Metadata.Values);
+        Assert.Equal(new Uri("https://foo.bar.com:1234"), si.Uri);
+    }
+
+    [Fact]
+    public void ConstructorWithMeta_Initializes()
+    {
+        var healthService = new ServiceEntry()
+        {
+            Service = new AgentService()
+            {
+                Service = "ServiceId",
+                Address = "foo.bar.com",
+                Port = 1234,
+                Meta = new Dictionary<string, string>
+                {
+                    ["foo"] = "bar",
+                    ["secure"] = "true"
+                },
+                Tags = new[] { "tag1", "tag2", "tag3" }
+            }
+        };
+
+        var si = new ConsulServiceInstance(healthService);
+        Assert.Equal("foo.bar.com", si.Host);
+        Assert.Equal("ServiceId", si.ServiceId);
+        Assert.True(si.IsSecure);
+        Assert.Equal(1234, si.Port);
+        Assert.Equal(2, si.Metadata.Count);
+        Assert.Contains("foo", si.Metadata.Keys);
+        Assert.Contains("secure", si.Metadata.Keys);
+        Assert.Contains("bar", si.Metadata.Values);
+        Assert.Contains("true", si.Metadata.Values);
+        Assert.Equal(3, si.Tags.Length);
+        Assert.Contains("tag1", si.Tags);
+        Assert.Contains("tag2", si.Tags);
+        Assert.Contains("tag3", si.Tags);
         Assert.Equal(new Uri("https://foo.bar.com:1234"), si.Uri);
     }
 }

--- a/src/Discovery/test/Consul.Test/Discovery/ThisServiceInstanceTest.cs
+++ b/src/Discovery/test/Consul.Test/Discovery/ThisServiceInstanceTest.cs
@@ -5,6 +5,7 @@
 using Consul;
 using Steeltoe.Discovery.Consul.Registry;
 using System;
+using System.Collections.Generic;
 using Xunit;
 
 namespace Steeltoe.Discovery.Consul.Discovery.Test;
@@ -23,6 +24,36 @@ public class ThisServiceInstanceTest
             Tags = new string[] { "foo=bar" }
         };
         var opts = new ConsulDiscoveryOptions();
+        var registration = new ConsulRegistration(serviceRegistration, opts);
+        var thiz = new ThisServiceInstance(registration);
+        Assert.Equal("test.foo.bar", thiz.Host);
+        Assert.Equal("foobar", thiz.ServiceId);
+        Assert.False(thiz.IsSecure);
+        Assert.Equal(1234, thiz.Port);
+        Assert.Single(thiz.Metadata);
+        Assert.Contains("foo", thiz.Metadata.Keys);
+        Assert.Contains("bar", thiz.Metadata.Values);
+        Assert.Equal(new Uri("http://test.foo.bar:1234"), thiz.Uri);
+    }
+
+    [Fact]
+    public void Constructor_WhenTagsAsMetadataSetToFalse_Initializes()
+    {
+        var serviceRegistration = new AgentServiceRegistration()
+        {
+            ID = "ID",
+            Name = "foobar",
+            Address = "test.foo.bar",
+            Port = 1234,
+            Meta = new Dictionary<string, string>
+            {
+                ["foo"] = "bar"
+            }
+        };
+        var opts = new ConsulDiscoveryOptions
+        {
+            TagsAsMetadata = false
+        };
         var registration = new ConsulRegistration(serviceRegistration, opts);
         var thiz = new ThisServiceInstance(registration);
         Assert.Equal("test.foo.bar", thiz.Host);


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->

<!-- If this is your first PR in this repo, please read our [Contributing Guidelines (https://github.com/SteeltoeOSS/.github/blob/master/CONTRIBUTING.md) and remember to sign the [Contributor License Agreement](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-license.md). Our bot will notify you shortly after the PR has been created. -->

## Description

This PR backports #1167 to `3.x`

I'd like to open a discussion on some details regarding implementation before completing it and adding tests.

I tried to get some inspiration from [Spring Cloud Consul implementation](https://github.com/spring-cloud/spring-cloud-consul/blob/bbdff2365a491d2e371e5a1e469f7dafc30493bf/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/discovery/ConsulDiscoveryProperties.java#L62C18-L62C33):

- Added `TagsAsMetadata` (defaults to `true`)
- This setting controls whether we fallback to Metadata creation from Tags (default) or we use the real Metadata
- Both approaches add default metadata

Let me know if this is what you had in mind. I will add unit tests then. 
Documentation changes will follow.

## Quality checklist

<!-- Please run through the checklist below to ensure a smooth review and merge process for your PR. -->

- [x] Your code complies with our [Coding Style](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-code-style.md).
- [x] You've updated unit and/or integration tests for your change, where applicable.
- [ ] You've updated documentation for your change, where applicable.
      If your change affects other repositories, such as [Documentation](https://github.com/SteeltoeOSS/Documentation), [Samples](https://github.com/SteeltoeOSS/Samples) and/or [MainSite](https://github.com/SteeltoeOSS/MainSite), add linked PRs here.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
- [x] You've added required license files and/or file headers (explaining where the code came from with proper attribution), where code is copied from StackOverflow, a blog, or OSS.
