### PR TITLE
Fix infinite recursion, caused by competing configuration providers

### DIFF
--- a/src/Bootstrap/test/AutoConfiguration.Test/HostBuilderExtensionsTest.cs
+++ b/src/Bootstrap/test/AutoConfiguration.Test/HostBuilderExtensionsTest.cs
@@ -27,6 +27,7 @@ using Steeltoe.Common;
 using Steeltoe.Common.Options;
 using Steeltoe.Common.Security;
 using Steeltoe.Common.TestResources;
+using Steeltoe.Configuration;
 using Steeltoe.Configuration.CloudFoundry;
 using Steeltoe.Configuration.CloudFoundry.ServiceBinding;
 using Steeltoe.Configuration.ConfigServer;
@@ -69,10 +70,10 @@ public sealed class HostBuilderExtensionsTest
         IHostBuilder hostBuilder = new HostBuilder().ConfigureAppConfiguration(builder => builder.AddInMemoryCollection(TestHelpers.FastTestsConfiguration));
 
         IHost host = hostBuilder.AddSteeltoe(exclusions).Build();
-        var configurationRoot = (IConfigurationRoot)host.Services.GetRequiredService<IConfiguration>();
+        var configuration = host.Services.GetRequiredService<IConfiguration>();
 
-        Assert.Single(configurationRoot.Providers.OfType<CloudFoundryConfigurationProvider>());
-        Assert.Single(configurationRoot.Providers.OfType<ConfigServerConfigurationProvider>());
+        Assert.NotNull(configuration.FindConfigurationProvider<CloudFoundryConfigurationProvider>());
+        Assert.NotNull(configuration.FindConfigurationProvider<ConfigServerConfigurationProvider>());
     }
 
     [Fact]

--- a/src/Bootstrap/test/AutoConfiguration.Test/WebHostBuilderExtensionsTest.cs
+++ b/src/Bootstrap/test/AutoConfiguration.Test/WebHostBuilderExtensionsTest.cs
@@ -27,6 +27,7 @@ using Steeltoe.Common;
 using Steeltoe.Common.Options;
 using Steeltoe.Common.Security;
 using Steeltoe.Common.TestResources;
+using Steeltoe.Configuration;
 using Steeltoe.Configuration.CloudFoundry;
 using Steeltoe.Configuration.CloudFoundry.ServiceBinding;
 using Steeltoe.Configuration.ConfigServer;
@@ -72,10 +73,10 @@ public sealed class WebHostBuilderExtensionsTest
             });
 
         IWebHost host = hostBuilder.AddSteeltoe(exclusions).Build();
-        var configurationRoot = (IConfigurationRoot)host.Services.GetRequiredService<IConfiguration>();
+        var configuration = host.Services.GetRequiredService<IConfiguration>();
 
-        Assert.Single(configurationRoot.Providers.OfType<CloudFoundryConfigurationProvider>());
-        Assert.Single(configurationRoot.Providers.OfType<ConfigServerConfigurationProvider>());
+        Assert.NotNull(configuration.FindConfigurationProvider<CloudFoundryConfigurationProvider>());
+        Assert.NotNull(configuration.FindConfigurationProvider<ConfigServerConfigurationProvider>());
     }
 
     [Fact]

--- a/src/Configuration/src/Abstractions/ConfigurationExtensions.cs
+++ b/src/Configuration/src/Abstractions/ConfigurationExtensions.cs
@@ -1,0 +1,90 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+#nullable enable
+
+using System.Reflection;
+using Microsoft.Extensions.Configuration;
+using Steeltoe.Common;
+
+namespace Steeltoe.Configuration;
+
+internal static class ConfigurationExtensions
+{
+    /// <summary>
+    /// Finds the first configuration provider of the specified type, scanning through any <see cref="IPlaceholderResolverProvider" /> and
+    /// <see cref="ChainedConfigurationProvider" /> composite providers.
+    /// </summary>
+    /// <typeparam name="TProvider">
+    /// The type of <see cref="IConfigurationProvider" /> to find.
+    /// </typeparam>
+    /// <param name="configuration">
+    /// The configuration to search in.
+    /// </param>
+    public static TProvider? FindConfigurationProvider<TProvider>(this IConfiguration configuration)
+        where TProvider : class, IConfigurationProvider
+    {
+        ArgumentGuard.NotNull(configuration);
+
+        if (configuration is IConfigurationRoot root)
+        {
+            return FindConfigurationProvider<TProvider>(root.Providers);
+        }
+
+        return null;
+    }
+
+    private static TProvider? FindConfigurationProvider<TProvider>(IEnumerable<IConfigurationProvider> providers)
+        where TProvider : class, IConfigurationProvider
+    {
+        foreach (IConfigurationProvider provider in providers)
+        {
+            if (provider is TProvider matchingProvider)
+            {
+                return matchingProvider;
+            }
+
+            if (provider is IPlaceholderResolverProvider placeholder)
+            {
+                var nextProvider = FindConfigurationProvider<TProvider>(placeholder.Providers);
+
+                if (nextProvider != null)
+                {
+                    return nextProvider;
+                }
+            }
+
+            if (provider is ChainedConfigurationProvider chained)
+            {
+                var nextProvider = FindConfigurationProvider<TProvider>(chained);
+
+                if (nextProvider != null)
+                {
+                    return nextProvider;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private static TProvider? FindConfigurationProvider<TProvider>(ChainedConfigurationProvider provider)
+        where TProvider : class, IConfigurationProvider
+    {
+        // ChainedConfigurationProvider.Configuration is publicly exposed in .NET 8.
+        FieldInfo? field = typeof(ChainedConfigurationProvider).GetField("_config", BindingFlags.Instance | BindingFlags.NonPublic);
+
+        if (field != null)
+        {
+            var configuration = (IConfiguration?)field.GetValue(provider);
+
+            if (configuration != null)
+            {
+                return FindConfigurationProvider<TProvider>(configuration);
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Configuration/src/Abstractions/Properties/AssemblyInfo.cs
+++ b/src/Configuration/src/Abstractions/Properties/AssemblyInfo.cs
@@ -4,8 +4,12 @@
 
 using System.Runtime.CompilerServices;
 
+[assembly: InternalsVisibleTo("Steeltoe.Bootstrap.AutoConfiguration.Test")]
 [assembly: InternalsVisibleTo("Steeltoe.Configuration.CloudFoundry.ServiceBinding")]
 [assembly: InternalsVisibleTo("Steeltoe.Configuration.CloudFoundry.ServiceBinding.Test")]
+[assembly: InternalsVisibleTo("Steeltoe.Configuration.ConfigServer")]
+[assembly: InternalsVisibleTo("Steeltoe.Configuration.ConfigServer.Test")]
 [assembly: InternalsVisibleTo("Steeltoe.Configuration.Kubernetes.ServiceBinding")]
 [assembly: InternalsVisibleTo("Steeltoe.Configuration.Kubernetes.ServiceBinding.Test")]
 [assembly: InternalsVisibleTo("Steeltoe.Connectors")]
+[assembly: InternalsVisibleTo("Steeltoe.Management.Endpoint")]

--- a/src/Configuration/src/ConfigServer/ConfigServerConfigurationBuilderExtensions.cs
+++ b/src/Configuration/src/ConfigServer/ConfigServerConfigurationBuilderExtensions.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Steeltoe.Common;
 using Steeltoe.Configuration.CloudFoundry;
+using Steeltoe.Configuration.Placeholder;
 
 namespace Steeltoe.Configuration.ConfigServer;
 
@@ -89,6 +90,11 @@ public static class ConfigServerConfigurationBuilderExtensions
         if (configurationBuilder.Sources.All(source => source is not CloudFoundryConfigurationSource))
         {
             configurationBuilder.Add(new CloudFoundryConfigurationSource());
+        }
+
+        if (configurationBuilder.Sources.All(source => source is not PlaceholderResolverSource))
+        {
+            configurationBuilder.AddPlaceholderResolver(loggerFactory);
         }
 
         if (configurationBuilder is IConfiguration configuration)

--- a/src/Configuration/src/ConfigServer/ConfigServerConfigurationProvider.cs
+++ b/src/Configuration/src/ConfigServer/ConfigServerConfigurationProvider.cs
@@ -17,7 +17,6 @@ using Steeltoe.Common;
 using Steeltoe.Common.Discovery;
 using Steeltoe.Common.Http;
 using Steeltoe.Common.Logging;
-using Steeltoe.Configuration.Placeholder;
 using Steeltoe.Discovery;
 
 namespace Steeltoe.Configuration.ConfigServer;
@@ -124,9 +123,9 @@ internal class ConfigServerConfigurationProvider : ConfigurationProvider
         ArgumentGuard.NotNull(source);
 
         ConfigServerClientSettings newSettings = source.DefaultSettings;
-        IConfiguration configuration = WrapWithPlaceholderResolver(source.Configuration, loggerFactory);
+
         loggerFactory ??= BootstrapLoggerFactory.Instance;
-        Initialize(newSettings, configuration, null, loggerFactory);
+        Initialize(newSettings, source.Configuration, null, loggerFactory);
     }
 
     private void Initialize(ConfigServerClientSettings settings, IConfiguration configuration, HttpClient httpClient, ILoggerFactory loggerFactory)
@@ -849,21 +848,6 @@ internal class ConfigServerConfigurationProvider : ConfigurationProvider
         }
 
         return client;
-    }
-
-    private IConfiguration WrapWithPlaceholderResolver(IConfiguration configuration, ILoggerFactory loggerFactory)
-    {
-        var root = (IConfigurationRoot)configuration;
-
-        if (root.Providers.LastOrDefault() is PlaceholderResolverProvider)
-        {
-            return configuration;
-        }
-
-        return new ConfigurationRoot(new List<IConfigurationProvider>
-        {
-            new PlaceholderResolverProvider(root.Providers.ToList(), loggerFactory)
-        });
     }
 
     private bool IsContinueExceptionType(Exception exception)

--- a/src/Configuration/src/ConfigServer/ConfigServerConfigurationSource.cs
+++ b/src/Configuration/src/ConfigServer/ConfigServerConfigurationSource.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Steeltoe.Common;
 using Steeltoe.Common.Options;
+using Steeltoe.Configuration.Placeholder;
 
 namespace Steeltoe.Configuration.ConfigServer;
 
@@ -121,12 +122,12 @@ internal sealed class ConfigServerConfigurationSource : IConfigurationSource
             Configuration = configurationBuilder.Build();
         }
 
-        IConfigurationSource certificateSource = Sources.FirstOrDefault(cSource => cSource is ICertificateSource);
+        var certificateSource = Sources.FindConfigurationSource<ICertificateSource>();
 
         if (certificateSource != null && DefaultSettings.ClientCertificate == null)
         {
             var certificateConfigurer =
-                (IConfigureNamedOptions<CertificateOptions>)Activator.CreateInstance(((ICertificateSource)certificateSource).OptionsConfigurer, Configuration)!;
+                (IConfigureNamedOptions<CertificateOptions>)Activator.CreateInstance(certificateSource.OptionsConfigurer, Configuration)!;
 
             var options = new CertificateOptions();
             certificateConfigurer.Configure(options);

--- a/src/Configuration/src/Placeholder/ConfigurationBuilderExtensions.cs
+++ b/src/Configuration/src/Placeholder/ConfigurationBuilderExtensions.cs
@@ -1,0 +1,90 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+#nullable enable
+
+using Microsoft.Extensions.Configuration;
+using Steeltoe.Common;
+
+namespace Steeltoe.Configuration.Placeholder;
+
+internal static class ConfigurationBuilderExtensions
+{
+    /// <summary>
+    /// Finds the first configuration source of the specified type, scanning through any <see cref="PlaceholderResolverSource" /> composite sources.
+    /// </summary>
+    /// <typeparam name="TSource">
+    /// The type of <see cref="IConfigurationSource" /> to find.
+    /// </typeparam>
+    /// <param name="builder">
+    /// The configuration builder to search in.
+    /// </param>
+    public static TSource? FindConfigurationSource<TSource>(this IConfigurationBuilder builder)
+        where TSource : class, IConfigurationSource
+    {
+        ArgumentGuard.NotNull(builder);
+
+        return FindConfigurationSource<TSource>(builder.Sources);
+    }
+
+    public static TSource? FindConfigurationSource<TSource>(this IEnumerable<IConfigurationSource> sources)
+        where TSource : class, IConfigurationSource
+    {
+        foreach (IConfigurationSource source in sources)
+        {
+            if (source is TSource matchingSource)
+            {
+                return matchingSource;
+            }
+
+            if (source is PlaceholderResolverSource placeholder)
+            {
+                var nextSource = FindConfigurationSource<TSource>(placeholder.Sources);
+
+                if (nextSource != null)
+                {
+                    return nextSource;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Gets all configuration sources of the specified type, scanning through any <see cref="PlaceholderResolverSource" /> composite sources.
+    /// </summary>
+    /// <typeparam name="TSource">
+    /// The type of <see cref="IConfigurationSource" /> to find.
+    /// </typeparam>
+    /// <param name="builder">
+    /// The configuration builder to search in.
+    /// </param>
+    public static IEnumerable<TSource> GetConfigurationSources<TSource>(this IConfigurationBuilder builder)
+        where TSource : class, IConfigurationSource
+    {
+        ArgumentGuard.NotNull(builder);
+
+        var sources = new List<TSource>();
+        AddConfigurationSources(builder.Sources, sources);
+        return sources;
+    }
+
+    private static void AddConfigurationSources<TSource>(IEnumerable<IConfigurationSource> sourcesToScan, List<TSource> foundSources)
+        where TSource : class, IConfigurationSource
+    {
+        foreach (IConfigurationSource source in sourcesToScan)
+        {
+            if (source is TSource matchingSource)
+            {
+                foundSources.Add(matchingSource);
+            }
+
+            if (source is PlaceholderResolverSource placeholder)
+            {
+                AddConfigurationSources(placeholder.Sources, foundSources);
+            }
+        }
+    }
+}

--- a/src/Configuration/test/ConfigServer.Test/ConfigServerConfigurationBuilderExtensionsTest.cs
+++ b/src/Configuration/test/ConfigServer.Test/ConfigServerConfigurationBuilderExtensionsTest.cs
@@ -8,6 +8,7 @@ using Steeltoe.Common.Security;
 using Steeltoe.Common.TestResources;
 using Steeltoe.Common.Utils.IO;
 using Steeltoe.Configuration.CloudFoundry;
+using Steeltoe.Configuration.Placeholder;
 using Xunit;
 
 namespace Steeltoe.Configuration.ConfigServer.Test;
@@ -144,9 +145,9 @@ public sealed class ConfigServerConfigurationBuilderExtensionsTest
         configurationBuilder.AddPemFiles("instance.crt", "instance.key").AddConfigServer(settings);
         configurationBuilder.Build();
 
-        ConfigServerConfigurationSource configServerSource = configurationBuilder.Sources.OfType<ConfigServerConfigurationSource>().SingleOrDefault();
-        Assert.NotNull(configServerSource);
-        Assert.NotNull(configServerSource.DefaultSettings.ClientCertificate);
+        var source = configurationBuilder.FindConfigurationSource<ConfigServerConfigurationSource>();
+        Assert.NotNull(source);
+        Assert.NotNull(source.DefaultSettings.ClientCertificate);
     }
 
     [Fact]
@@ -491,7 +492,8 @@ public sealed class ConfigServerConfigurationBuilderExtensionsTest
 
         configurationBuilder.AddConfigServer();
 
-        Assert.Single(configurationBuilder.Sources.OfType<CloudFoundryConfigurationSource>());
+        var source = configurationBuilder.FindConfigurationSource<CloudFoundryConfigurationSource>();
+        Assert.NotNull(source);
     }
 
     [Fact]
@@ -502,6 +504,6 @@ public sealed class ConfigServerConfigurationBuilderExtensionsTest
         configurationBuilder.AddCloudFoundry(new CustomCloudFoundrySettingsReader());
         configurationBuilder.AddConfigServer();
 
-        Assert.Single(configurationBuilder.Sources.Where(source => source is CloudFoundryConfigurationSource));
+        Assert.Single(configurationBuilder.GetConfigurationSources<CloudFoundryConfigurationSource>());
     }
 }

--- a/src/Configuration/test/ConfigServer.Test/ConfigServerHealthContributorTest.cs
+++ b/src/Configuration/test/ConfigServer.Test/ConfigServerHealthContributorTest.cs
@@ -60,7 +60,7 @@ public sealed class ConfigServerHealthContributorTest
         IConfigurationRoot configurationRoot = builder.Build();
 
         var contributor = new ConfigServerHealthContributor(configurationRoot, NullLogger<ConfigServerHealthContributor>.Instance);
-        Assert.NotNull(contributor.FindProvider(configurationRoot));
+        Assert.NotNull(contributor.Provider);
     }
 
     [Fact]

--- a/src/Configuration/test/ConfigServer.Test/ConfigServerHostBuilderExtensionsTest.cs
+++ b/src/Configuration/test/ConfigServer.Test/ConfigServerHostBuilderExtensionsTest.cs
@@ -19,40 +19,45 @@ public sealed class ConfigServerHostBuilderExtensionsTest
     [Fact]
     public void AddConfigServer_DefaultWebHost_AddsConfigServer()
     {
-        IWebHostBuilder hostBuilder = WebHost.CreateDefaultBuilder()
-            .ConfigureAppConfiguration(builder => builder.AddInMemoryCollection(TestHelpers.FastTestsConfiguration)).UseStartup<TestConfigServerStartup>();
-
+        IWebHostBuilder hostBuilder = WebHost.CreateDefaultBuilder();
+        hostBuilder.ConfigureAppConfiguration(builder => builder.AddInMemoryCollection(TestHelpers.FastTestsConfiguration));
+        hostBuilder.UseStartup<TestConfigServerStartup>();
         hostBuilder.AddConfigServer();
-        var configurationRoot = hostBuilder.Build().Services.GetServices<IConfiguration>().SingleOrDefault() as ConfigurationRoot;
 
-        Assert.Single(configurationRoot.Providers.OfType<CloudFoundryConfigurationProvider>());
-        Assert.Single(configurationRoot.Providers.OfType<ConfigServerConfigurationProvider>());
+        IWebHost host = hostBuilder.Build();
+        var configuration = host.Services.GetRequiredService<IConfiguration>();
+
+        Assert.NotNull(configuration.FindConfigurationProvider<CloudFoundryConfigurationProvider>());
+        Assert.NotNull(configuration.FindConfigurationProvider<ConfigServerConfigurationProvider>());
     }
 
     [Fact]
     public void AddConfigServer_New_WebHostBuilder_AddsConfigServer()
     {
-        IWebHostBuilder hostBuilder = new WebHostBuilder()
-            .ConfigureAppConfiguration(builder => builder.AddInMemoryCollection(TestHelpers.FastTestsConfiguration)).UseStartup<TestConfigServerStartup>();
-
+        IWebHostBuilder hostBuilder = new WebHostBuilder();
+        hostBuilder.ConfigureAppConfiguration(builder => builder.AddInMemoryCollection(TestHelpers.FastTestsConfiguration));
+        hostBuilder.UseStartup<TestConfigServerStartup>();
         hostBuilder.AddConfigServer();
-        var configurationRoot = hostBuilder.Build().Services.GetServices<IConfiguration>().SingleOrDefault() as ConfigurationRoot;
 
-        Assert.Single(configurationRoot.Providers.OfType<CloudFoundryConfigurationProvider>());
-        Assert.Single(configurationRoot.Providers.OfType<ConfigServerConfigurationProvider>());
+        IWebHost host = hostBuilder.Build();
+        var configuration = host.Services.GetRequiredService<IConfiguration>();
+
+        Assert.NotNull(configuration.FindConfigurationProvider<CloudFoundryConfigurationProvider>());
+        Assert.NotNull(configuration.FindConfigurationProvider<ConfigServerConfigurationProvider>());
     }
 
     [Fact]
     public void AddConfigServer_IHostBuilder_AddsConfigServer()
     {
-        IHostBuilder hostBuilder = new HostBuilder().ConfigureAppConfiguration(builder => builder.AddInMemoryCollection(TestHelpers.FastTestsConfiguration))
-            .AddConfigServer();
+        IHostBuilder hostBuilder = new HostBuilder();
+        hostBuilder.ConfigureAppConfiguration(builder => builder.AddInMemoryCollection(TestHelpers.FastTestsConfiguration));
+        hostBuilder.AddConfigServer();
 
         IHost host = hostBuilder.Build();
-        var configurationRoot = host.Services.GetServices<IConfiguration>().SingleOrDefault() as ConfigurationRoot;
+        var configuration = host.Services.GetRequiredService<IConfiguration>();
 
-        Assert.Single(configurationRoot.Providers.OfType<CloudFoundryConfigurationProvider>());
-        Assert.Single(configurationRoot.Providers.OfType<ConfigServerConfigurationProvider>());
+        Assert.NotNull(configuration.FindConfigurationProvider<CloudFoundryConfigurationProvider>());
+        Assert.NotNull(configuration.FindConfigurationProvider<ConfigServerConfigurationProvider>());
     }
 
     [Fact]
@@ -60,10 +65,11 @@ public sealed class ConfigServerHostBuilderExtensionsTest
     {
         WebApplicationBuilder hostBuilder = TestHelpers.GetTestWebApplicationBuilder();
         hostBuilder.AddConfigServer();
-        WebApplication host = hostBuilder.Build();
 
-        var configurationRoot = host.Services.GetService<IConfiguration>() as IConfigurationRoot;
-        Assert.Single(configurationRoot.Providers.OfType<CloudFoundryConfigurationProvider>());
-        Assert.Single(configurationRoot.Providers.OfType<ConfigServerConfigurationProvider>());
+        WebApplication host = hostBuilder.Build();
+        var configuration = host.Services.GetRequiredService<IConfiguration>();
+
+        Assert.NotNull(configuration.FindConfigurationProvider<CloudFoundryConfigurationProvider>());
+        Assert.NotNull(configuration.FindConfigurationProvider<ConfigServerConfigurationProvider>());
     }
 }


### PR DESCRIPTION
## Description

Adding the ConfigServer configuration provider to the configuration builder adds the Placeholder configuration provider as a side-effect (see the `WrapWithPlaceholderResolver()` call). This looks harmless, but `WebApplicationManager` loads a provider immediately when its source gets added.

A Placeholder provider loads its children during load, whereas a Postprocessor provider loads its parents during load. Depending on the order of setup, this results in either a `StackOverflowException` (endless recursion) or a hang (providers trigger the change tokens of each other, so they never complete).

The fix is to add the Placeholder resolver not as a side-effect, but in the regular way. An observable change is that the Placeholder and ConfigServer providers now become siblings, instead of nested. This broke several tests, therefore utility extension methods were added to find a configuration provider/source in the configuration subtree by scanning through composites.

Fixes #1182

## Quality checklist

- [x] Your code complies with our [Coding Style](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-code-style.md).
- [x] You've updated unit and/or integration tests for your change, where applicable.
- [ ] You've updated documentation for your change, where applicable.
      If your change affects other repositories, such as [Documentation](https://github.com/SteeltoeOSS/Documentation), [Samples](https://github.com/SteeltoeOSS/Samples) and/or [MainSite](https://github.com/SteeltoeOSS/MainSite), add linked PRs here.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
- [x] You've added required license files and/or file headers (explaining where the code came from with proper attribution), where code is copied from StackOverflow, a blog, or OSS.
