### PR TITLE
Make health contributors async

### DIFF
--- a/src/Common/src/Abstractions/Discovery/IServiceInstanceProvider.cs
+++ b/src/Common/src/Abstractions/Discovery/IServiceInstanceProvider.cs
@@ -7,23 +7,32 @@ namespace Steeltoe.Common.Discovery;
 public interface IServiceInstanceProvider
 {
     /// <summary>
-    /// Gets a human readable description of the implementation.
+    /// Gets a human-readable description of this provider.
     /// </summary>
     string Description { get; }
 
     /// <summary>
-    /// Gets all known service Ids.
+    /// Gets all known service IDs.
     /// </summary>
-    IList<string> Services { get; }
-
-    /// <summary>
-    /// Get all ServiceInstances associated with a particular serviceId.
-    /// </summary>
-    /// <param name="serviceId">
-    /// the serviceId to lookup.
+    /// <param name="cancellationToken">
+    /// The token to monitor for cancellation requests.
     /// </param>
     /// <returns>
-    /// List of service instances.
+    /// The service IDs.
     /// </returns>
-    IList<IServiceInstance> GetInstances(string serviceId);
+    Task<IList<string>> GetServicesAsync(CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Gets all service instances associated with the specified service ID.
+    /// </summary>
+    /// <param name="serviceId">
+    /// The ID of the service to lookup.
+    /// </param>
+    /// <param name="cancellationToken">
+    /// The token to monitor for cancellation requests.
+    /// </param>
+    /// <returns>
+    /// The list of service instances.
+    /// </returns>
+    Task<IList<IServiceInstance>> GetInstancesAsync(string serviceId, CancellationToken cancellationToken);
 }

--- a/src/Common/src/Abstractions/DynamicTypeAccess/TaskShim.cs
+++ b/src/Common/src/Abstractions/DynamicTypeAccess/TaskShim.cs
@@ -1,0 +1,37 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+#nullable enable
+namespace Steeltoe.Common.DynamicTypeAccess;
+
+/// <summary>
+/// Provides a shim for a compiler-generated type that behaves like a <see cref="Task{TResult}" />, but is not assignable to it. For example:
+/// <code><![CDATA[AsyncTaskMethodBuilder<T>.AsyncStateMachineBox<T>]]></code>.
+/// </summary>
+/// <typeparam name="TResult">
+/// The type of the result produced by the underlying task.
+/// </typeparam>
+internal sealed class TaskShim<TResult> : Shim, IDisposable
+{
+    public override Task Instance => (Task)base.Instance;
+
+    public TResult Result => InstanceAccessor.GetPropertyValue<TResult>("Result");
+
+    public TaskShim(object instance)
+        : base(Wrap(instance))
+    {
+    }
+
+    private static InstanceAccessor Wrap(object instance)
+    {
+        Type taskLikeType = instance.GetType();
+        var typeAccessor = new TypeAccessor(taskLikeType);
+        return new InstanceAccessor(typeAccessor, instance);
+    }
+
+    public void Dispose()
+    {
+        Instance.Dispose();
+    }
+}

--- a/src/Common/src/Abstractions/ExceptionExtensions.cs
+++ b/src/Common/src/Abstractions/ExceptionExtensions.cs
@@ -8,8 +8,18 @@ using System.Reflection;
 
 namespace Steeltoe.Common;
 
-internal static class ExceptionExtensions
+public static class ExceptionExtensions
 {
+    /// <summary>
+    /// Unwraps a potential tree of nested exceptions, returning the deepest one. Exceptions of type <see cref="TargetInvocationException" /> and
+    /// <see cref="AggregateException" /> with a single inner exception are unwrapped.
+    /// </summary>
+    /// <param name="exception">
+    /// The exception to unwrap.
+    /// </param>
+    /// <returns>
+    /// The deepest exception, or the original <paramref name="exception" /> is there's nothing to unwrap.
+    /// </returns>
     public static Exception UnwrapAll(this Exception exception)
     {
         ArgumentGuard.NotNull(exception);
@@ -33,5 +43,22 @@ internal static class ExceptionExtensions
         }
 
         return exception;
+    }
+
+    /// <summary>
+    /// Determines whether the thrown exception results from incoming request cancellation.
+    /// </summary>
+    /// <param name="exception">
+    /// The caught exception to inspect.
+    /// </param>
+    public static bool IsCancellation(this Exception? exception)
+    {
+        // See note in remarks at https://learn.microsoft.com/en-us/dotnet/api/system.net.http.httpclient.sendasync.
+        if (exception is OperationCanceledException && exception.InnerException?.GetType() != typeof(TimeoutException))
+        {
+            return true;
+        }
+
+        return false;
     }
 }

--- a/src/Common/src/Abstractions/ExceptionExtensions.cs
+++ b/src/Common/src/Abstractions/ExceptionExtensions.cs
@@ -1,0 +1,37 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+#nullable enable
+
+using System.Reflection;
+
+namespace Steeltoe.Common;
+
+internal static class ExceptionExtensions
+{
+    public static Exception UnwrapAll(this Exception exception)
+    {
+        ArgumentGuard.NotNull(exception);
+
+        bool hasChanges = true;
+
+        while (hasChanges)
+        {
+            hasChanges = false;
+
+            if (exception is TargetInvocationException && exception.InnerException != null)
+            {
+                exception = exception.InnerException;
+                hasChanges = true;
+            }
+            else if (exception is AggregateException aggregateException && aggregateException.InnerExceptions.Count == 1)
+            {
+                exception = aggregateException.InnerExceptions[0];
+                hasChanges = true;
+            }
+        }
+
+        return exception;
+    }
+}

--- a/src/Common/src/Abstractions/HealthChecks/IHealthAggregator.cs
+++ b/src/Common/src/Abstractions/HealthChecks/IHealthAggregator.cs
@@ -6,5 +6,5 @@ namespace Steeltoe.Common.HealthChecks;
 
 public interface IHealthAggregator
 {
-    HealthCheckResult Aggregate(ICollection<IHealthContributor> contributors, CancellationToken cancellationToken);
+    Task<HealthCheckResult> AggregateAsync(ICollection<IHealthContributor> contributors, CancellationToken cancellationToken);
 }

--- a/src/Common/src/Abstractions/HealthChecks/IHealthContributor.cs
+++ b/src/Common/src/Abstractions/HealthChecks/IHealthContributor.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 namespace Steeltoe.Common.HealthChecks;
 
 /// <summary>
@@ -15,10 +17,10 @@ public interface IHealthContributor
     string Id { get; }
 
     /// <summary>
-    /// Check the health of a resource.
+    /// Performs a health check.
     /// </summary>
     /// <returns>
-    /// The result of checking the health of a resource, or <c>null</c> if this health check is currently disabled.
+    /// The result of the health check, or <c>null</c> if this health check is currently disabled.
     /// </returns>
-    HealthCheckResult Health();
+    Task<HealthCheckResult?> HealthAsync(CancellationToken cancellationToken);
 }

--- a/src/Common/src/Abstractions/HealthChecks/IHealthContributor.cs
+++ b/src/Common/src/Abstractions/HealthChecks/IHealthContributor.cs
@@ -19,8 +19,11 @@ public interface IHealthContributor
     /// <summary>
     /// Performs a health check.
     /// </summary>
+    /// <param name="cancellationToken">
+    /// The token to monitor for cancellation requests.
+    /// </param>
     /// <returns>
     /// The result of the health check, or <c>null</c> if this health check is currently disabled.
     /// </returns>
-    Task<HealthCheckResult?> HealthAsync(CancellationToken cancellationToken);
+    Task<HealthCheckResult?> CheckHealthAsync(CancellationToken cancellationToken);
 }

--- a/src/Common/src/Abstractions/LoadBalancer/ILoadBalancer.cs
+++ b/src/Common/src/Abstractions/LoadBalancer/ILoadBalancer.cs
@@ -12,10 +12,13 @@ public interface ILoadBalancer
     /// <param name="request">
     /// A URI containing a service name that can be resolved into one or more service instances.
     /// </param>
+    /// <param name="cancellationToken">
+    /// The token to monitor for cancellation requests.
+    /// </param>
     /// <returns>
     /// The original URI, with serviceName replaced by the host:port of a service instance.
     /// </returns>
-    Task<Uri> ResolveServiceInstanceAsync(Uri request);
+    Task<Uri> ResolveServiceInstanceAsync(Uri request, CancellationToken cancellationToken);
 
     /// <summary>
     /// A mechanism for tracking statistics for service instances.
@@ -30,8 +33,10 @@ public interface ILoadBalancer
     /// The amount of time taken for a remote call to complete.
     /// </param>
     /// <param name="exception">
-    /// Any exception called during calls to a resolved service instance.
+    /// Any exception thrown during calls to a resolved service instance.
     /// </param>
-    /// <returns>A task.</returns>
-    Task UpdateStatsAsync(Uri originalUri, Uri resolvedUri, TimeSpan responseTime, Exception exception);
+    /// <param name="cancellationToken">
+    /// The token to monitor for cancellation requests.
+    /// </param>
+    Task UpdateStatsAsync(Uri originalUri, Uri resolvedUri, TimeSpan responseTime, Exception exception, CancellationToken cancellationToken);
 }

--- a/src/Common/src/Common.Http/Discovery/DiscoveryHttpClientHandler.cs
+++ b/src/Common/src/Common.Http/Discovery/DiscoveryHttpClientHandler.cs
@@ -44,7 +44,7 @@ public class DiscoveryHttpClientHandler : HttpClientHandler
             request.RequestUri = await _discoveryBase.LookupServiceAsync(current, cancellationToken);
             return await base.SendAsync(request, cancellationToken);
         }
-        catch (Exception exception) when (exception is not OperationCanceledException)
+        catch (Exception exception) when (!exception.IsCancellation())
         {
             _logger?.LogDebug(exception, "Exception during SendAsync()");
             throw;

--- a/src/Common/src/Common.Http/Discovery/DiscoveryHttpClientHandler.cs
+++ b/src/Common/src/Common.Http/Discovery/DiscoveryHttpClientHandler.cs
@@ -41,12 +41,12 @@ public class DiscoveryHttpClientHandler : HttpClientHandler
 
         try
         {
-            request.RequestUri = await _discoveryBase.LookupServiceAsync(current);
+            request.RequestUri = await _discoveryBase.LookupServiceAsync(current, cancellationToken);
             return await base.SendAsync(request, cancellationToken);
         }
-        catch (Exception e)
+        catch (Exception exception) when (exception is not OperationCanceledException)
         {
-            _logger?.LogDebug(e, "Exception during SendAsync()");
+            _logger?.LogDebug(exception, "Exception during SendAsync()");
             throw;
         }
         finally

--- a/src/Common/src/Common.Http/Discovery/DiscoveryHttpClientHandlerBase.cs
+++ b/src/Common/src/Common.Http/Discovery/DiscoveryHttpClientHandlerBase.cs
@@ -23,7 +23,7 @@ public class DiscoveryHttpClientHandlerBase
         this.logger = logger;
     }
 
-    public virtual Uri LookupService(Uri current)
+    public virtual async Task<Uri> LookupServiceAsync(Uri current, CancellationToken cancellationToken)
     {
         logger?.LogDebug("LookupService({uri})", current);
 
@@ -32,18 +32,6 @@ public class DiscoveryHttpClientHandlerBase
             return current;
         }
 
-        return loadBalancer.ResolveServiceInstanceAsync(current).GetAwaiter().GetResult();
-    }
-
-    public virtual async Task<Uri> LookupServiceAsync(Uri current)
-    {
-        logger?.LogDebug("LookupService({uri})", current);
-
-        if (!current.IsDefaultPort)
-        {
-            return current;
-        }
-
-        return await loadBalancer.ResolveServiceInstanceAsync(current);
+        return await loadBalancer.ResolveServiceInstanceAsync(current, cancellationToken);
     }
 }

--- a/src/Common/src/Common.Http/Discovery/DiscoveryHttpMessageHandler.cs
+++ b/src/Common/src/Common.Http/Discovery/DiscoveryHttpMessageHandler.cs
@@ -41,12 +41,12 @@ public class DiscoveryHttpMessageHandler : DelegatingHandler
 
         try
         {
-            request.RequestUri = await _discoveryBase.LookupServiceAsync(current);
+            request.RequestUri = await _discoveryBase.LookupServiceAsync(current, cancellationToken);
             return await base.SendAsync(request, cancellationToken);
         }
-        catch (Exception e)
+        catch (Exception exception) when (exception is not OperationCanceledException)
         {
-            _logger?.LogDebug(e, "Exception during SendAsync()");
+            _logger?.LogDebug(exception, "Exception during SendAsync()");
             throw;
         }
         finally

--- a/src/Common/src/Common.Http/Discovery/DiscoveryHttpMessageHandler.cs
+++ b/src/Common/src/Common.Http/Discovery/DiscoveryHttpMessageHandler.cs
@@ -44,7 +44,7 @@ public class DiscoveryHttpMessageHandler : DelegatingHandler
             request.RequestUri = await _discoveryBase.LookupServiceAsync(current, cancellationToken);
             return await base.SendAsync(request, cancellationToken);
         }
-        catch (Exception exception) when (exception is not OperationCanceledException)
+        catch (Exception exception) when (!exception.IsCancellation())
         {
             _logger?.LogDebug(exception, "Exception during SendAsync()");
             throw;

--- a/src/Common/src/Common.Http/HttpClientHelper.cs
+++ b/src/Common/src/Common.Http/HttpClientHelper.cs
@@ -219,7 +219,7 @@ public static class HttpClientHelper
 
             return token.ToString();
         }
-        catch (Exception exception) when (exception is not OperationCanceledException)
+        catch (Exception exception) when (!exception.IsCancellation())
         {
             logger?.LogError(exception, "GetAccessTokenAsync exception obtaining access token from: {uri}",
                 WebUtility.UrlEncode(accessTokenUri.OriginalString));

--- a/src/Common/src/Common.Http/LoadBalancer/LoadBalancerDelegatingHandler.cs
+++ b/src/Common/src/Common.Http/LoadBalancer/LoadBalancerDelegatingHandler.cs
@@ -36,7 +36,7 @@ public class LoadBalancerDelegatingHandler : DelegatingHandler
         Uri originalUri = request.RequestUri;
 
         // look up a service instance and update the request
-        Uri resolvedUri = await _loadBalancer.ResolveServiceInstanceAsync(request.RequestUri);
+        Uri resolvedUri = await _loadBalancer.ResolveServiceInstanceAsync(request.RequestUri, cancellationToken);
         request.RequestUri = resolvedUri;
 
         // allow other handlers to operate and the request to continue
@@ -59,7 +59,7 @@ public class LoadBalancerDelegatingHandler : DelegatingHandler
             request.RequestUri = originalUri;
 
             // track stats
-            await _loadBalancer.UpdateStatsAsync(originalUri, resolvedUri, DateTime.UtcNow - startTime, exception);
+            await _loadBalancer.UpdateStatsAsync(originalUri, resolvedUri, DateTime.UtcNow - startTime, exception, cancellationToken);
         }
     }
 }

--- a/src/Common/src/Common.Http/LoadBalancer/LoadBalancerHttpClientHandler.cs
+++ b/src/Common/src/Common.Http/LoadBalancer/LoadBalancerHttpClientHandler.cs
@@ -35,7 +35,7 @@ public class LoadBalancerHttpClientHandler : HttpClientHandler
         Uri originalUri = request.RequestUri;
 
         // look up a service instance and update the request
-        Uri resolvedUri = await _loadBalancer.ResolveServiceInstanceAsync(request.RequestUri);
+        Uri resolvedUri = await _loadBalancer.ResolveServiceInstanceAsync(request.RequestUri, cancellationToken);
         request.RequestUri = resolvedUri;
 
         // allow other handlers to operate and the request to continue
@@ -58,7 +58,7 @@ public class LoadBalancerHttpClientHandler : HttpClientHandler
             request.RequestUri = originalUri;
 
             // track stats
-            await _loadBalancer.UpdateStatsAsync(originalUri, resolvedUri, DateTime.UtcNow - startTime, exception);
+            await _loadBalancer.UpdateStatsAsync(originalUri, resolvedUri, DateTime.UtcNow - startTime, exception, cancellationToken);
         }
     }
 }

--- a/src/Common/src/Common.Kubernetes/PodUtilities.cs
+++ b/src/Common/src/Common.Kubernetes/PodUtilities.cs
@@ -37,7 +37,7 @@ public sealed class PodUtilities
 
             return response.Body.Items?.FirstOrDefault(p => p.Metadata.Name == hostname);
         }
-        catch (Exception exception) when (exception is not OperationCanceledException)
+        catch (Exception exception) when (!exception.IsCancellation())
         {
             _logger.LogError(exception, "Failed to retrieve information about the current pod.");
 

--- a/src/Common/src/Common.Kubernetes/PodUtilities.cs
+++ b/src/Common/src/Common.Kubernetes/PodUtilities.cs
@@ -37,9 +37,10 @@ public sealed class PodUtilities
 
             return response.Body.Items?.FirstOrDefault(p => p.Metadata.Name == hostname);
         }
-        catch (Exception exception)
+        catch (Exception exception) when (exception is not OperationCanceledException)
         {
             _logger.LogError(exception, "Failed to retrieve information about the current pod.");
+
             return null;
         }
     }

--- a/src/Common/src/Common/Availability/AvailabilityHealthContributor.cs
+++ b/src/Common/src/Common/Availability/AvailabilityHealthContributor.cs
@@ -22,7 +22,7 @@ public abstract class AvailabilityHealthContributor : IHealthContributor
         _logger = logger;
     }
 
-    public Task<HealthCheckResult> HealthAsync(CancellationToken cancellationToken)
+    public Task<HealthCheckResult> CheckHealthAsync(CancellationToken cancellationToken)
     {
         HealthCheckResult result = Health();
         return Task.FromResult(result);

--- a/src/Common/src/Common/Availability/AvailabilityHealthContributor.cs
+++ b/src/Common/src/Common/Availability/AvailabilityHealthContributor.cs
@@ -22,7 +22,13 @@ public abstract class AvailabilityHealthContributor : IHealthContributor
         _logger = logger;
     }
 
-    public HealthCheckResult Health()
+    public Task<HealthCheckResult> HealthAsync(CancellationToken cancellationToken)
+    {
+        HealthCheckResult result = Health();
+        return Task.FromResult(result);
+    }
+
+    private HealthCheckResult Health()
     {
         var health = new HealthCheckResult();
         IAvailabilityState currentHealth = GetState();

--- a/src/Common/src/Common/Discovery/ConfigurationServiceInstanceProvider.cs
+++ b/src/Common/src/Common/Discovery/ConfigurationServiceInstanceProvider.cs
@@ -12,20 +12,22 @@ public class ConfigurationServiceInstanceProvider : IServiceInstanceProvider
 
     public string Description => "A service instance provider that returns services from app configuration";
 
-    public IList<string> Services => GetServices();
-
     public ConfigurationServiceInstanceProvider(IOptionsMonitor<List<ConfigurationServiceInstance>> serviceInstances)
     {
         _serviceInstances = serviceInstances;
     }
 
-    public IList<IServiceInstance> GetInstances(string serviceId)
+    public Task<IList<string>> GetServicesAsync(CancellationToken cancellationToken)
     {
-        return new List<IServiceInstance>(_serviceInstances.CurrentValue.Where(si => si.ServiceId.Equals(serviceId, StringComparison.OrdinalIgnoreCase)));
+        IList<string> services = _serviceInstances.CurrentValue.Select(si => si.ServiceId).Distinct().ToList();
+        return Task.FromResult(services);
     }
 
-    internal IList<string> GetServices()
+    public Task<IList<IServiceInstance>> GetInstancesAsync(string serviceId, CancellationToken cancellationToken)
     {
-        return _serviceInstances.CurrentValue.Select(si => si.ServiceId).Distinct().ToList();
+        IList<IServiceInstance> instances = _serviceInstances.CurrentValue.Cast<IServiceInstance>().Where(instance =>
+            instance.ServiceId.Equals(serviceId, StringComparison.OrdinalIgnoreCase)).ToList();
+
+        return Task.FromResult(instances);
     }
 }

--- a/src/Common/src/Common/LoadBalancer/RandomLoadBalancer.cs
+++ b/src/Common/src/Common/LoadBalancer/RandomLoadBalancer.cs
@@ -42,12 +42,12 @@ public class RandomLoadBalancer : ILoadBalancer
         _logger = logger;
     }
 
-    public virtual async Task<Uri> ResolveServiceInstanceAsync(Uri request)
+    public virtual async Task<Uri> ResolveServiceInstanceAsync(Uri request, CancellationToken cancellationToken)
     {
         _logger?.LogTrace("ResolveServiceInstance {serviceInstance}", request.Host);
 
         IList<IServiceInstance> availableServiceInstances =
-            await _serviceInstanceProvider.GetInstancesWithCacheAsync(request.Host, _distributedCache, _cacheOptions);
+            await _serviceInstanceProvider.GetInstancesWithCacheAsync(request.Host, cancellationToken, _distributedCache, _cacheOptions);
 
         if (availableServiceInstances.Count > 0)
         {
@@ -61,7 +61,7 @@ public class RandomLoadBalancer : ILoadBalancer
         return request;
     }
 
-    public virtual Task UpdateStatsAsync(Uri originalUri, Uri resolvedUri, TimeSpan responseTime, Exception exception)
+    public virtual Task UpdateStatsAsync(Uri originalUri, Uri resolvedUri, TimeSpan responseTime, Exception exception, CancellationToken cancellationToken)
     {
         return Task.CompletedTask;
     }

--- a/src/Common/test/Common.Http.Test/Discovery/DiscoveryHttpClientHandlerBaseTest.cs
+++ b/src/Common/test/Common.Http.Test/Discovery/DiscoveryHttpClientHandlerBaseTest.cs
@@ -20,46 +20,13 @@ public sealed class DiscoveryHttpClientHandlerBaseTest
     }
 
     [Fact]
-    public void LookupService_NonDefaultPort_ReturnsOriginalURI()
-    {
-        IDiscoveryClient client = new TestDiscoveryClient();
-        var handler = new DiscoveryHttpClientHandlerBase(client);
-        var uri = new Uri("https://foo:8080/test");
-
-        Uri result = handler.LookupService(uri);
-        Assert.Equal(uri, result);
-    }
-
-    [Fact]
-    public void LookupService_DoesNotFindService_ReturnsOriginalURI()
-    {
-        IDiscoveryClient client = new TestDiscoveryClient();
-        var handler = new DiscoveryHttpClientHandlerBase(client);
-        var uri = new Uri("https://foo/test");
-
-        Uri result = handler.LookupService(uri);
-        Assert.Equal(uri, result);
-    }
-
-    [Fact]
-    public void LookupService_FindsService_ReturnsURI()
-    {
-        IDiscoveryClient client = new TestDiscoveryClient(new TestServiceInstance(new Uri("https://foundit:5555")));
-        var handler = new DiscoveryHttpClientHandlerBase(client);
-        var uri = new Uri("https://foo/test/bar/foo?test=1&test2=2");
-
-        Uri result = handler.LookupService(uri);
-        Assert.Equal(new Uri("https://foundit:5555/test/bar/foo?test=1&test2=2"), result);
-    }
-
-    [Fact]
     public async Task LookupServiceAsync_NonDefaultPort_ReturnsOriginalURI()
     {
         IDiscoveryClient client = new TestDiscoveryClient();
         var handler = new DiscoveryHttpClientHandlerBase(client);
         var uri = new Uri("https://foo:8080/test");
 
-        Uri result = await handler.LookupServiceAsync(uri);
+        Uri result = await handler.LookupServiceAsync(uri, CancellationToken.None);
         Assert.Equal(uri, result);
     }
 
@@ -70,7 +37,7 @@ public sealed class DiscoveryHttpClientHandlerBaseTest
         var handler = new DiscoveryHttpClientHandlerBase(client);
         var uri = new Uri("https://foo/test");
 
-        Uri result = await handler.LookupServiceAsync(uri);
+        Uri result = await handler.LookupServiceAsync(uri, CancellationToken.None);
         Assert.Equal(uri, result);
     }
 
@@ -81,7 +48,7 @@ public sealed class DiscoveryHttpClientHandlerBaseTest
         var handler = new DiscoveryHttpClientHandlerBase(client);
         var uri = new Uri("https://foo/test/bar/foo?test=1&test2=2");
 
-        Uri result = await handler.LookupServiceAsync(uri);
+        Uri result = await handler.LookupServiceAsync(uri, CancellationToken.None);
         Assert.Equal(new Uri("https://foundit:5555/test/bar/foo?test=1&test2=2"), result);
     }
 }

--- a/src/Common/test/Common.Http.Test/Discovery/TestDiscoveryClient.cs
+++ b/src/Common/test/Common.Http.Test/Discovery/TestDiscoveryClient.cs
@@ -13,32 +13,34 @@ internal sealed class TestDiscoveryClient : IDiscoveryClient
 
     public string Description => throw new NotImplementedException();
 
-    public IList<string> Services => throw new NotImplementedException();
-
     public TestDiscoveryClient(IServiceInstance instance = null)
     {
         _instance = instance;
     }
 
-    public IList<IServiceInstance> GetInstances(string serviceId)
-    {
-        if (_instance != null)
-        {
-            return new List<IServiceInstance>
-            {
-                _instance
-            };
-        }
-
-        return new List<IServiceInstance>();
-    }
-
-    public IServiceInstance GetLocalServiceInstance()
+    public Task<IList<string>> GetServicesAsync(CancellationToken cancellationToken)
     {
         throw new NotImplementedException();
     }
 
-    public Task ShutdownAsync()
+    public Task<IList<IServiceInstance>> GetInstancesAsync(string serviceId, CancellationToken cancellationToken)
+    {
+        IList<IServiceInstance> instances = new List<IServiceInstance>();
+
+        if (_instance != null)
+        {
+            instances.Add(_instance);
+        }
+
+        return Task.FromResult(instances);
+    }
+
+    public Task<IServiceInstance> GetLocalServiceInstanceAsync(CancellationToken cancellationToken)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task ShutdownAsync(CancellationToken cancellationToken)
     {
         throw new NotImplementedException();
     }

--- a/src/Common/test/Common.Http.Test/HttpClientHelperTest.cs
+++ b/src/Common/test/Common.Http.Test/HttpClientHelperTest.cs
@@ -51,7 +51,7 @@ public sealed class HttpClientHelperTest
         HttpRequestMessage message = HttpClientHelper.GetRequestMessage(HttpMethod.Put, new Uri("https://localhost/foobar"), null, null);
         Assert.NotNull(message);
         Assert.Equal(HttpMethod.Put, message.Method);
-        Assert.Equal("https://localhost/foobar", message.RequestUri.ToString());
+        Assert.Equal("https://localhost/foobar", message.RequestUri?.ToString());
         Assert.Null(message.Headers.Authorization);
     }
 
@@ -61,7 +61,7 @@ public sealed class HttpClientHelperTest
         HttpRequestMessage message = HttpClientHelper.GetRequestMessage(HttpMethod.Put, new Uri("https://localhost/foobar"), "foo", "bar");
         Assert.NotNull(message);
         Assert.Equal(HttpMethod.Put, message.Method);
-        Assert.Equal("https://localhost/foobar", message.RequestUri.ToString());
+        Assert.Equal("https://localhost/foobar", message.RequestUri?.ToString());
         Assert.NotNull(message.Headers.Authorization);
         string bytes = Convert.ToBase64String(Encoding.ASCII.GetBytes("foo" + ":" + "bar"));
         Assert.Equal("Basic", message.Headers.Authorization.Scheme);
@@ -69,11 +69,16 @@ public sealed class HttpClientHelperTest
     }
 
     [Fact]
-    public void GetAccessToken_ThrowsNulls()
+    public async Task GetAccessToken_ThrowsNulls()
     {
-        Assert.ThrowsAsync<ArgumentException>(() => HttpClientHelper.GetAccessTokenAsync(string.Empty, null, null));
-        Assert.ThrowsAsync<ArgumentException>(() => HttpClientHelper.GetAccessTokenAsync("https://foo/bar", null, null));
-        Assert.ThrowsAsync<ArgumentException>(() => HttpClientHelper.GetAccessTokenAsync("https://foo/bar", "clientid", null));
+        await Assert.ThrowsAsync<ArgumentNullException>(async () => await HttpClientHelper.GetAccessTokenAsync(string.Empty, null, null,
+            HttpClientHelper.DefaultGetAccessTokenTimeout, HttpClientHelper.DefaultValidateCertificates, null, null, CancellationToken.None));
+
+        await Assert.ThrowsAsync<ArgumentNullException>(async () => await HttpClientHelper.GetAccessTokenAsync("https://foo/bar", null, null,
+            HttpClientHelper.DefaultGetAccessTokenTimeout, HttpClientHelper.DefaultValidateCertificates, null, null, CancellationToken.None));
+
+        await Assert.ThrowsAsync<ArgumentNullException>(async () => await HttpClientHelper.GetAccessTokenAsync("https://foo/bar", "clientid", null,
+            HttpClientHelper.DefaultGetAccessTokenTimeout, HttpClientHelper.DefaultValidateCertificates, null, null, CancellationToken.None));
     }
 
     [Fact]

--- a/src/Common/test/Common.Http.Test/LoadBalancer/BrokenLoadBalancer.cs
+++ b/src/Common/test/Common.Http.Test/LoadBalancer/BrokenLoadBalancer.cs
@@ -13,12 +13,12 @@ internal sealed class BrokenLoadBalancer : ILoadBalancer
     /// <summary>
     /// Throws exceptions when you try to resolve services.
     /// </summary>
-    public Task<Uri> ResolveServiceInstanceAsync(Uri request)
+    public Task<Uri> ResolveServiceInstanceAsync(Uri request, CancellationToken cancellationToken)
     {
         throw new Exception("(╯°□°）╯︵ ┻━┻");
     }
 
-    public Task UpdateStatsAsync(Uri originalUri, Uri resolvedUri, TimeSpan responseTime, Exception exception)
+    public Task UpdateStatsAsync(Uri originalUri, Uri resolvedUri, TimeSpan responseTime, Exception exception, CancellationToken cancellationToken)
     {
         Stats.Add(new Tuple<Uri, Uri, TimeSpan, Exception>(originalUri, resolvedUri, responseTime, exception));
         return Task.CompletedTask;

--- a/src/Common/test/Common.Http.Test/LoadBalancer/FakeLoadBalancer.cs
+++ b/src/Common/test/Common.Http.Test/LoadBalancer/FakeLoadBalancer.cs
@@ -13,12 +13,12 @@ internal sealed class FakeLoadBalancer : ILoadBalancer
 {
     internal List<Tuple<Uri, Uri, TimeSpan, Exception>> Stats { get; } = new();
 
-    public Task<Uri> ResolveServiceInstanceAsync(Uri request)
+    public Task<Uri> ResolveServiceInstanceAsync(Uri request, CancellationToken cancellationToken)
     {
         return Task.FromResult(new Uri(request.AbsoluteUri.Replace("replaceme", "someresolvedhost", StringComparison.Ordinal)));
     }
 
-    public Task UpdateStatsAsync(Uri originalUri, Uri resolvedUri, TimeSpan responseTime, Exception exception)
+    public Task UpdateStatsAsync(Uri originalUri, Uri resolvedUri, TimeSpan responseTime, Exception exception, CancellationToken cancellationToken)
     {
         Stats.Add(new Tuple<Uri, Uri, TimeSpan, Exception>(originalUri, resolvedUri, responseTime, exception));
         return Task.CompletedTask;

--- a/src/Common/test/Common.Test/Availability/LivenessHealthContributorTest.cs
+++ b/src/Common/test/Common.Test/Availability/LivenessHealthContributorTest.cs
@@ -17,7 +17,7 @@ public sealed class LivenessHealthContributorTest
     {
         var contributor = new LivenessHealthContributor(_availability);
 
-        HealthCheckResult result = await contributor.HealthAsync(CancellationToken.None);
+        HealthCheckResult result = await contributor.CheckHealthAsync(CancellationToken.None);
 
         Assert.Equal(HealthStatus.Unknown, result.Status);
     }
@@ -28,7 +28,7 @@ public sealed class LivenessHealthContributorTest
         _availability.SetAvailabilityState(ApplicationAvailability.LivenessKey, LivenessState.Correct, "tests");
         var contributor = new LivenessHealthContributor(_availability);
 
-        HealthCheckResult result = await contributor.HealthAsync(CancellationToken.None);
+        HealthCheckResult result = await contributor.CheckHealthAsync(CancellationToken.None);
 
         Assert.Equal(HealthStatus.Up, result.Status);
     }
@@ -39,7 +39,7 @@ public sealed class LivenessHealthContributorTest
         _availability.SetAvailabilityState(ApplicationAvailability.LivenessKey, LivenessState.Broken, "tests");
         var contributor = new LivenessHealthContributor(_availability);
 
-        HealthCheckResult result = await contributor.HealthAsync(CancellationToken.None);
+        HealthCheckResult result = await contributor.CheckHealthAsync(CancellationToken.None);
 
         Assert.Equal(HealthStatus.Down, result.Status);
     }

--- a/src/Common/test/Common.Test/Availability/LivenessHealthContributorTest.cs
+++ b/src/Common/test/Common.Test/Availability/LivenessHealthContributorTest.cs
@@ -13,33 +13,33 @@ public sealed class LivenessHealthContributorTest
     private readonly ApplicationAvailability _availability = new();
 
     [Fact]
-    public void HandlesUnknown()
+    public async Task HandlesUnknown()
     {
         var contributor = new LivenessHealthContributor(_availability);
 
-        HealthCheckResult result = contributor.Health();
+        HealthCheckResult result = await contributor.HealthAsync(CancellationToken.None);
 
         Assert.Equal(HealthStatus.Unknown, result.Status);
     }
 
     [Fact]
-    public void HandlesCorrect()
+    public async Task HandlesCorrect()
     {
         _availability.SetAvailabilityState(ApplicationAvailability.LivenessKey, LivenessState.Correct, "tests");
         var contributor = new LivenessHealthContributor(_availability);
 
-        HealthCheckResult result = contributor.Health();
+        HealthCheckResult result = await contributor.HealthAsync(CancellationToken.None);
 
         Assert.Equal(HealthStatus.Up, result.Status);
     }
 
     [Fact]
-    public void HandlesBroken()
+    public async Task HandlesBroken()
     {
         _availability.SetAvailabilityState(ApplicationAvailability.LivenessKey, LivenessState.Broken, "tests");
         var contributor = new LivenessHealthContributor(_availability);
 
-        HealthCheckResult result = contributor.Health();
+        HealthCheckResult result = await contributor.HealthAsync(CancellationToken.None);
 
         Assert.Equal(HealthStatus.Down, result.Status);
     }

--- a/src/Common/test/Common.Test/Availability/ReadinessHealthContributorTest.cs
+++ b/src/Common/test/Common.Test/Availability/ReadinessHealthContributorTest.cs
@@ -13,33 +13,33 @@ public sealed class ReadinessHealthContributorTest
     private readonly ApplicationAvailability _availability = new();
 
     [Fact]
-    public void HandlesUnknown()
+    public async Task HandlesUnknown()
     {
         var contributor = new ReadinessHealthContributor(_availability);
 
-        HealthCheckResult result = contributor.Health();
+        HealthCheckResult result = await contributor.HealthAsync(CancellationToken.None);
 
         Assert.Equal(HealthStatus.Unknown, result.Status);
     }
 
     [Fact]
-    public void HandlesAccepting()
+    public async Task HandlesAccepting()
     {
         _availability.SetAvailabilityState(ApplicationAvailability.ReadinessKey, ReadinessState.AcceptingTraffic, "tests");
         var contributor = new ReadinessHealthContributor(_availability);
 
-        HealthCheckResult result = contributor.Health();
+        HealthCheckResult result = await contributor.HealthAsync(CancellationToken.None);
 
         Assert.Equal(HealthStatus.Up, result.Status);
     }
 
     [Fact]
-    public void HandlesRefusing()
+    public async Task HandlesRefusing()
     {
         _availability.SetAvailabilityState(ApplicationAvailability.ReadinessKey, ReadinessState.RefusingTraffic, "tests");
         var contributor = new ReadinessHealthContributor(_availability);
 
-        HealthCheckResult result = contributor.Health();
+        HealthCheckResult result = await contributor.HealthAsync(CancellationToken.None);
 
         Assert.Equal(HealthStatus.OutOfService, result.Status);
     }

--- a/src/Common/test/Common.Test/Availability/ReadinessHealthContributorTest.cs
+++ b/src/Common/test/Common.Test/Availability/ReadinessHealthContributorTest.cs
@@ -17,7 +17,7 @@ public sealed class ReadinessHealthContributorTest
     {
         var contributor = new ReadinessHealthContributor(_availability);
 
-        HealthCheckResult result = await contributor.HealthAsync(CancellationToken.None);
+        HealthCheckResult result = await contributor.CheckHealthAsync(CancellationToken.None);
 
         Assert.Equal(HealthStatus.Unknown, result.Status);
     }
@@ -28,7 +28,7 @@ public sealed class ReadinessHealthContributorTest
         _availability.SetAvailabilityState(ApplicationAvailability.ReadinessKey, ReadinessState.AcceptingTraffic, "tests");
         var contributor = new ReadinessHealthContributor(_availability);
 
-        HealthCheckResult result = await contributor.HealthAsync(CancellationToken.None);
+        HealthCheckResult result = await contributor.CheckHealthAsync(CancellationToken.None);
 
         Assert.Equal(HealthStatus.Up, result.Status);
     }
@@ -39,7 +39,7 @@ public sealed class ReadinessHealthContributorTest
         _availability.SetAvailabilityState(ApplicationAvailability.ReadinessKey, ReadinessState.RefusingTraffic, "tests");
         var contributor = new ReadinessHealthContributor(_availability);
 
-        HealthCheckResult result = await contributor.HealthAsync(CancellationToken.None);
+        HealthCheckResult result = await contributor.CheckHealthAsync(CancellationToken.None);
 
         Assert.Equal(HealthStatus.OutOfService, result.Status);
     }

--- a/src/Common/test/Common.Test/Discovery/ConfigurationServiceInstanceProviderServiceCollectionExtensionsTest.cs
+++ b/src/Common/test/Common.Test/Discovery/ConfigurationServiceInstanceProviderServiceCollectionExtensionsTest.cs
@@ -13,7 +13,7 @@ namespace Steeltoe.Common.Test.Discovery;
 public sealed class ConfigurationServiceInstanceProviderServiceCollectionExtensionsTest
 {
     [Fact]
-    public void AddConfigurationDiscoveryClient_AddsClientWithOptions()
+    public async Task AddConfigurationDiscoveryClient_AddsClientWithOptions()
     {
         const string appsettings = @"
 {
@@ -44,8 +44,14 @@ public sealed class ConfigurationServiceInstanceProviderServiceCollectionExtensi
 
         Assert.NotNull(serviceInstanceProvider);
         Assert.IsType<ConfigurationServiceInstanceProvider>(serviceInstanceProvider);
-        Assert.Equal(2, serviceInstanceProvider.Services.Count);
-        Assert.Equal(2, serviceInstanceProvider.GetInstances("fruitService").Count);
-        Assert.Equal(2, serviceInstanceProvider.GetInstances("vegetableService").Count);
+
+        IList<string> servicesIds = await serviceInstanceProvider.GetServicesAsync(CancellationToken.None);
+        Assert.Equal(2, servicesIds.Count);
+
+        IList<IServiceInstance> fruitInstances = await serviceInstanceProvider.GetInstancesAsync("fruitService", CancellationToken.None);
+        Assert.Equal(2, fruitInstances.Count);
+
+        IList<IServiceInstance> vegetableInstances = await serviceInstanceProvider.GetInstancesAsync("vegetableService", CancellationToken.None);
+        Assert.Equal(2, vegetableInstances.Count);
     }
 }

--- a/src/Common/test/Common.Test/Discovery/ConfigurationServiceInstanceProviderTest.cs
+++ b/src/Common/test/Common.Test/Discovery/ConfigurationServiceInstanceProviderTest.cs
@@ -11,7 +11,7 @@ namespace Steeltoe.Common.Test.Discovery;
 public sealed class ConfigurationServiceInstanceProviderTest
 {
     [Fact]
-    public void Returns_ConfiguredServices()
+    public async Task Returns_ConfiguredServices()
     {
         var services = new List<ConfigurationServiceInstance>
         {
@@ -59,13 +59,18 @@ public sealed class ConfigurationServiceInstanceProviderTest
 
         var provider = new ConfigurationServiceInstanceProvider(serviceOptions);
 
-        Assert.Equal(3, provider.GetInstances("fruitService").Count);
-        Assert.Equal(3, provider.GetInstances("vegetableService").Count);
-        Assert.Equal(2, provider.Services.Count);
+        IList<IServiceInstance> fruitInstances = await provider.GetInstancesAsync("fruitService", CancellationToken.None);
+        Assert.Equal(3, fruitInstances.Count);
+
+        IList<IServiceInstance> vegetableInstances = await provider.GetInstancesAsync("vegetableService", CancellationToken.None);
+        Assert.Equal(3, vegetableInstances.Count);
+
+        IList<string> servicesIds = await provider.GetServicesAsync(CancellationToken.None);
+        Assert.Equal(2, servicesIds.Count);
     }
 
     [Fact]
-    public void ReceivesUpdatesTo_ConfiguredServices()
+    public async Task ReceivesUpdatesTo_ConfiguredServices()
     {
         var services = new List<ConfigurationServiceInstance>
         {
@@ -80,11 +85,14 @@ public sealed class ConfigurationServiceInstanceProviderTest
 
         var serviceOptions = new TestOptionsMonitor<List<ConfigurationServiceInstance>>(services);
         var provider = new ConfigurationServiceInstanceProvider(serviceOptions);
-        Assert.Single(provider.GetInstances("fruitService"));
-        Assert.Equal("fruitball", provider.GetInstances("fruitService").First().Host);
+
+        IList<IServiceInstance> fruitInstances = await provider.GetInstancesAsync("fruitService", CancellationToken.None);
+
+        Assert.Single(fruitInstances);
+        Assert.Equal("fruitball", fruitInstances.First().Host);
 
         services.First().Host = "updatedValue";
 
-        Assert.Equal("updatedValue", provider.GetInstances("fruitService").First().Host);
+        Assert.Equal("updatedValue", fruitInstances.First().Host);
     }
 }

--- a/src/Common/test/Common.Test/LoadBalancer/RoundRobinLoadBalancerTest.cs
+++ b/src/Common/test/Common.Test/LoadBalancer/RoundRobinLoadBalancerTest.cs
@@ -71,9 +71,10 @@ public sealed class RoundRobinLoadBalancerTest
 
         Assert.Throws<KeyNotFoundException>(() => loadBalancer.NextIndexForService[$"{RoundRobinLoadBalancer.IndexKeyPrefix}fruitService"]);
         Assert.Throws<KeyNotFoundException>(() => loadBalancer.NextIndexForService[$"{RoundRobinLoadBalancer.IndexKeyPrefix}vegetableService"]);
-        Uri fruitResult = await loadBalancer.ResolveServiceInstanceAsync(new Uri("https://fruitservice/api"));
-        await loadBalancer.ResolveServiceInstanceAsync(new Uri("https://vegetableservice/api"));
-        Uri vegResult = await loadBalancer.ResolveServiceInstanceAsync(new Uri("https://vegetableservice/api"));
+
+        Uri fruitResult = await loadBalancer.ResolveServiceInstanceAsync(new Uri("https://fruitservice/api"), CancellationToken.None);
+        await loadBalancer.ResolveServiceInstanceAsync(new Uri("https://vegetableservice/api"), CancellationToken.None);
+        Uri vegResult = await loadBalancer.ResolveServiceInstanceAsync(new Uri("https://vegetableservice/api"), CancellationToken.None);
 
         Assert.Equal(1, loadBalancer.NextIndexForService[$"{RoundRobinLoadBalancer.IndexKeyPrefix}fruitservice"]);
         Assert.Equal(8000, fruitResult.Port);
@@ -130,9 +131,9 @@ public sealed class RoundRobinLoadBalancerTest
         var provider = new ConfigurationServiceInstanceProvider(serviceOptions);
         var loadBalancer = new RoundRobinLoadBalancer(provider, GetCache());
 
-        Uri fruitResult = await loadBalancer.ResolveServiceInstanceAsync(new Uri("https://fruitservice/api"));
-        await loadBalancer.ResolveServiceInstanceAsync(new Uri("https://vegetableservice/api"));
-        Uri vegResult = await loadBalancer.ResolveServiceInstanceAsync(new Uri("https://vegetableservice/api"));
+        Uri fruitResult = await loadBalancer.ResolveServiceInstanceAsync(new Uri("https://fruitservice/api"), CancellationToken.None);
+        await loadBalancer.ResolveServiceInstanceAsync(new Uri("https://vegetableservice/api"), CancellationToken.None);
+        Uri vegResult = await loadBalancer.ResolveServiceInstanceAsync(new Uri("https://vegetableservice/api"), CancellationToken.None);
 
         Assert.Equal(8000, fruitResult.Port);
         Assert.Equal(8011, vegResult.Port);

--- a/src/Common/test/Common.TestResources/HostingHelpers.cs
+++ b/src/Common/test/Common.TestResources/HostingHelpers.cs
@@ -9,6 +9,8 @@ namespace Steeltoe.Common.TestResources;
 
 public static class HostingHelpers
 {
+    public const string TestAppName = "TestApp";
+
     public static IHostEnvironment GetHostingEnvironment()
     {
         return GetHostingEnvironment("EnvironmentName");
@@ -18,7 +20,8 @@ public static class HostingHelpers
     {
         return new HostingEnvironment
         {
-            EnvironmentName = environmentName
+            EnvironmentName = environmentName,
+            ApplicationName = TestAppName
         };
     }
 }

--- a/src/Common/test/Common.TestResources/IgnoreLineEndingsComparer.cs
+++ b/src/Common/test/Common.TestResources/IgnoreLineEndingsComparer.cs
@@ -1,0 +1,40 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+namespace Steeltoe.Common.TestResources;
+
+public sealed class IgnoreLineEndingsComparer : IEqualityComparer<string>
+{
+    private static readonly string[] LineSeparators =
+    {
+        "\r\n",
+        "\r",
+        "\n"
+    };
+
+    public static readonly IgnoreLineEndingsComparer Instance = new();
+
+    public bool Equals(string x, string y)
+    {
+        if (x == y)
+        {
+            return true;
+        }
+
+        if (x == null || y == null)
+        {
+            return false;
+        }
+
+        string[] xLines = x.Split(LineSeparators, StringSplitOptions.None);
+        string[] yLines = y.Split(LineSeparators, StringSplitOptions.None);
+
+        return xLines.SequenceEqual(yLines);
+    }
+
+    public int GetHashCode(string obj)
+    {
+        return obj.GetHashCode();
+    }
+}

--- a/src/Common/test/Common.Utils.Test/Diagnostics/CommandExecutorTest.cs
+++ b/src/Common/test/Common.Utils.Test/Diagnostics/CommandExecutorTest.cs
@@ -52,6 +52,6 @@ public sealed class CommandExecutorTest
             await executor.ExecuteAsync("no-such-command");
         };
 
-        await act.Should().ThrowAsync<CommandException>().WithMessage("'no-such-command' failed to start*");
+        await act.Should().ThrowExactlyAsync<CommandException>().WithMessage("'no-such-command' failed to start*");
     }
 }

--- a/src/Configuration/src/ConfigServer/ConfigServerConfigurationProvider.cs
+++ b/src/Configuration/src/ConfigServer/ConfigServerConfigurationProvider.cs
@@ -166,7 +166,7 @@ internal class ConfigServerConfigurationProvider : ConfigurationProvider
         }
         else if (_refreshTimer == null)
         {
-            _refreshTimer = new Timer(_ => DoLoad(), null, TimeSpan.Zero, Settings.PollingInterval);
+            _refreshTimer = new Timer(_ => DoLoadAsync(true, CancellationToken.None).GetAwaiter().GetResult(), null, TimeSpan.Zero, Settings.PollingInterval);
         }
         else if (existingPollingInterval != Settings.PollingInterval)
         {
@@ -179,10 +179,10 @@ internal class ConfigServerConfigurationProvider : ConfigurationProvider
     /// </summary>
     public override void Load()
     {
-        LoadInternal();
+        LoadInternalAsync(true, CancellationToken.None).GetAwaiter().GetResult();
     }
 
-    internal ConfigEnvironment LoadInternal(bool updateDictionary = true)
+    internal async Task<ConfigEnvironment> LoadInternalAsync(bool updateDictionary, CancellationToken cancellationToken)
     {
         if (!Settings.Enabled)
         {
@@ -193,7 +193,7 @@ internal class ConfigServerConfigurationProvider : ConfigurationProvider
         if (IsDiscoveryFirstEnabled())
         {
             _configServerDiscoveryService ??= new ConfigServerDiscoveryService(_configuration, Settings, _loggerFactory);
-            DiscoverServerInstances();
+            await DiscoverServerInstancesAsync(cancellationToken);
         }
 
         // Adds client settings (e.g spring:cloud:config:uri, etc) to the Data dictionary
@@ -210,7 +210,7 @@ internal class ConfigServerConfigurationProvider : ConfigurationProvider
 
                 try
                 {
-                    return DoLoad(updateDictionary);
+                    return await DoLoadAsync(updateDictionary, cancellationToken);
                 }
                 catch (ConfigServerException e)
                 {
@@ -233,10 +233,10 @@ internal class ConfigServerConfigurationProvider : ConfigurationProvider
         }
 
         Logger.LogInformation("Fetching configuration from server at: {uri}", Settings.Uri);
-        return DoLoad(updateDictionary);
+        return await DoLoadAsync(updateDictionary, cancellationToken);
     }
 
-    internal ConfigEnvironment DoLoad(bool updateDictionary = true)
+    internal async Task<ConfigEnvironment> DoLoadAsync(bool updateDictionary, CancellationToken cancellationToken)
     {
         Exception error = null;
 
@@ -253,10 +253,7 @@ internal class ConfigServerConfigurationProvider : ConfigurationProvider
                 }
 
                 // Invoke Config Servers
-                Task<ConfigEnvironment> task = RemoteLoadAsync(uris, label);
-
-                // Wait for results from server
-                ConfigEnvironment env = task.GetAwaiter().GetResult();
+                ConfigEnvironment env = await RemoteLoadAsync(uris, label, cancellationToken);
 
                 // Update configuration Data dictionary with any results
                 if (env != null)
@@ -311,12 +308,15 @@ internal class ConfigServerConfigurationProvider : ConfigurationProvider
                 }
             }
         }
-        catch (Exception e)
+        catch (Exception exception)
         {
-            error = e;
+            error = exception;
         }
 
-        Logger.LogWarning(error, "Could not locate PropertySource");
+        if (error is not OperationCanceledException)
+        {
+            Logger.LogWarning(error, "Could not locate PropertySource");
+        }
 
         if (Settings.FailFast)
         {
@@ -336,9 +336,9 @@ internal class ConfigServerConfigurationProvider : ConfigurationProvider
         return Settings.Label.Split(CommaDelimiter, StringSplitOptions.RemoveEmptyEntries);
     }
 
-    private void DiscoverServerInstances()
+    private async Task DiscoverServerInstancesAsync(CancellationToken cancellationToken)
     {
-        IServiceInstance[] instances = _configServerDiscoveryService.GetConfigServerInstances().ToArray();
+        IServiceInstance[] instances = (await _configServerDiscoveryService.GetConfigServerInstancesAsync(cancellationToken)).ToArray();
 
         if (!instances.Any())
         {
@@ -394,19 +394,19 @@ internal class ConfigServerConfigurationProvider : ConfigurationProvider
         }
     }
 
-    internal async Task ProvideRuntimeReplacementsAsync(IDiscoveryClient discoveryClientFromDi)
+    internal async Task ProvideRuntimeReplacementsAsync(IDiscoveryClient discoveryClientFromDi, CancellationToken cancellationToken)
     {
         if (_configServerDiscoveryService is not null)
         {
-            await _configServerDiscoveryService.ProvideRuntimeReplacementsAsync(discoveryClientFromDi);
+            await _configServerDiscoveryService.ProvideRuntimeReplacementsAsync(discoveryClientFromDi, cancellationToken);
         }
     }
 
-    internal async Task ShutdownAsync()
+    internal async Task ShutdownAsync(CancellationToken cancellationToken)
     {
         if (_configServerDiscoveryService is not null)
         {
-            await _configServerDiscoveryService.ShutdownAsync();
+            await _configServerDiscoveryService.ShutdownAsync(cancellationToken);
         }
     }
 
@@ -422,14 +422,17 @@ internal class ConfigServerConfigurationProvider : ConfigurationProvider
     /// <param name="password">
     /// Password to use if required.
     /// </param>
+    /// <param name="cancellationToken">
+    /// The token to monitor for cancellation requests.
+    /// </param>
     /// <returns>
     /// The HttpRequestMessage built from the path.
     /// </returns>
-    protected internal HttpRequestMessage GetRequestMessage(Uri requestUri, string username, string password)
+    internal async Task<HttpRequestMessage> GetRequestMessageAsync(Uri requestUri, string username, string password, CancellationToken cancellationToken)
     {
         HttpRequestMessage request = string.IsNullOrEmpty(Settings.AccessTokenUri)
             ? HttpClientHelper.GetRequestMessage(HttpMethod.Get, requestUri, username, password)
-            : HttpClientHelper.GetRequestMessage(HttpMethod.Get, requestUri, () => FetchAccessTokenAsync().GetAwaiter().GetResult());
+            : await HttpClientHelper.GetRequestMessageAsync(HttpMethod.Get, requestUri, FetchAccessTokenAsync, cancellationToken);
 
         if (!string.IsNullOrEmpty(Settings.Token) && !ConfigServerClientSettings.IsMultiServerConfiguration(Settings.Uri))
         {
@@ -498,7 +501,7 @@ internal class ConfigServerConfigurationProvider : ConfigurationProvider
         data["spring:cloud:config:health:timeToLive"] = Settings.HealthTimeToLive.ToString(culture);
     }
 
-    protected internal async Task<ConfigEnvironment> RemoteLoadAsync(IEnumerable<string> requestUris, string label)
+    protected internal async Task<ConfigEnvironment> RemoteLoadAsync(IEnumerable<string> requestUris, string label, CancellationToken cancellationToken)
     {
         ArgumentGuard.NotNull(requestUris);
 
@@ -519,12 +522,12 @@ internal class ConfigServerConfigurationProvider : ConfigurationProvider
             var uri = new Uri(GetConfigServerUri(serverUri, label), UriKind.RelativeOrAbsolute);
 
             // Get the request message
-            HttpRequestMessage request = GetRequestMessage(uri, username, password);
+            HttpRequestMessage request = await GetRequestMessageAsync(uri, username, password, cancellationToken);
 
             // Invoke Config Server
             try
             {
-                using HttpResponseMessage response = await HttpClient.SendAsync(request);
+                using HttpResponseMessage response = await HttpClient.SendAsync(request, cancellationToken);
 
                 Logger.LogInformation("Config Server returned status: {statusCode} invoking path: {requestUri}", response.StatusCode,
                     WebUtility.UrlEncode(requestUri));
@@ -547,12 +550,16 @@ internal class ConfigServerConfigurationProvider : ConfigurationProvider
                     return null;
                 }
 
-                return await response.Content.ReadFromJsonAsync<ConfigEnvironment>(SerializerOptions);
+                return await response.Content.ReadFromJsonAsync<ConfigEnvironment>(SerializerOptions, cancellationToken);
             }
             catch (Exception exception)
             {
                 error = exception;
-                Logger.LogError(exception, "Config Server exception, path: {requestUri}", WebUtility.UrlEncode(requestUri));
+
+                if (exception is not OperationCanceledException)
+                {
+                    Logger.LogError(exception, "Config Server exception, path: {requestUri}", WebUtility.UrlEncode(requestUri));
+                }
 
                 if (IsContinueExceptionType(exception))
                 {
@@ -729,7 +736,7 @@ internal class ConfigServerConfigurationProvider : ConfigurationProvider
 
     private void RenewToken()
     {
-        _ = new Timer(_ => RefreshVaultTokenAsync().GetAwaiter().GetResult(), null, TimeSpan.FromMilliseconds(Settings.TokenRenewRate),
+        _ = new Timer(_ => RefreshVaultTokenAsync(CancellationToken.None).GetAwaiter().GetResult(), null, TimeSpan.FromMilliseconds(Settings.TokenRenewRate),
             TimeSpan.FromMilliseconds(Settings.TokenRenewRate));
     }
 
@@ -739,7 +746,7 @@ internal class ConfigServerConfigurationProvider : ConfigurationProvider
     /// <returns>
     /// The task object representing asynchronous operation.
     /// </returns>
-    private async Task<string> FetchAccessTokenAsync()
+    private async Task<string> FetchAccessTokenAsync(CancellationToken cancellationToken)
     {
         if (string.IsNullOrEmpty(Settings.AccessTokenUri))
         {
@@ -747,11 +754,11 @@ internal class ConfigServerConfigurationProvider : ConfigurationProvider
         }
 
         return await HttpClientHelper.GetAccessTokenAsync(Settings.AccessTokenUri, Settings.ClientId, Settings.ClientSecret, Settings.Timeout,
-            Settings.ValidateCertificates, HttpClient, Logger);
+            Settings.ValidateCertificates, HttpClient, Logger, cancellationToken);
     }
 
     // fire and forget
-    private async Task RefreshVaultTokenAsync()
+    private async Task RefreshVaultTokenAsync(CancellationToken cancellationToken)
     {
         if (string.IsNullOrEmpty(Settings.Token))
         {
@@ -765,18 +772,18 @@ internal class ConfigServerConfigurationProvider : ConfigurationProvider
             HttpClient ??= GetConfiguredHttpClient(Settings);
 
             Uri uri = GetVaultRenewUri();
-            HttpRequestMessage message = GetVaultRenewMessage(uri);
+            HttpRequestMessage message = await GetVaultRenewMessageAsync(uri, cancellationToken);
 
             Logger.LogInformation("Renewing Vault token {token} for {ttl} milliseconds at Uri {uri}", obscuredToken, Settings.TokenTtl, uri);
 
-            using HttpResponseMessage response = await HttpClient.SendAsync(message);
+            using HttpResponseMessage response = await HttpClient.SendAsync(message, cancellationToken);
 
             if (response.StatusCode != HttpStatusCode.OK)
             {
                 Logger.LogWarning("Renewing Vault token {token} returned status: {status}", obscuredToken, response.StatusCode);
             }
         }
-        catch (Exception exception)
+        catch (Exception exception) when (exception is not OperationCanceledException)
         {
             Logger.LogError(exception, "Unable to renew Vault token {token}. Is the token invalid or expired?", obscuredToken);
         }
@@ -794,9 +801,9 @@ internal class ConfigServerConfigurationProvider : ConfigurationProvider
         return new Uri(rawUri + VaultRenewPath, UriKind.RelativeOrAbsolute);
     }
 
-    private HttpRequestMessage GetVaultRenewMessage(Uri requestUri)
+    private async Task<HttpRequestMessage> GetVaultRenewMessageAsync(Uri requestUri, CancellationToken cancellationToken)
     {
-        HttpRequestMessage request = HttpClientHelper.GetRequestMessage(HttpMethod.Post, requestUri, () => FetchAccessTokenAsync().GetAwaiter().GetResult());
+        HttpRequestMessage request = await HttpClientHelper.GetRequestMessageAsync(HttpMethod.Post, requestUri, FetchAccessTokenAsync, cancellationToken);
 
         if (!string.IsNullOrEmpty(Settings.Token))
         {
@@ -852,7 +859,7 @@ internal class ConfigServerConfigurationProvider : ConfigurationProvider
 
     private bool IsContinueExceptionType(Exception exception)
     {
-        if (exception is TaskCanceledException)
+        if (exception is OperationCanceledException)
         {
             return true;
         }

--- a/src/Configuration/src/ConfigServer/ConfigServerDiscoveryService.cs
+++ b/src/Configuration/src/ConfigServer/ConfigServerDiscoveryService.cs
@@ -60,22 +60,23 @@ internal sealed class ConfigServerDiscoveryService
         _logger.LogDebug("Found Discovery Client of type {DiscoveryClientType}", DiscoveryClient.GetType());
     }
 
-    internal IEnumerable<IServiceInstance> GetConfigServerInstances()
+    internal async Task<IEnumerable<IServiceInstance>> GetConfigServerInstancesAsync(CancellationToken cancellationToken)
     {
         int attempts = 0;
         int backOff = _settings.RetryInitialInterval;
-        List<IServiceInstance> instances;
+        IList<IServiceInstance> instances;
 
         do
         {
             try
             {
                 _logger.LogDebug("Locating configserver {serviceId} via discovery", _settings.DiscoveryServiceId);
-                instances = DiscoveryClient.GetInstances(_settings.DiscoveryServiceId).ToList();
+                instances = await DiscoveryClient.GetInstancesAsync(_settings.DiscoveryServiceId, cancellationToken);
             }
-            catch (Exception exception)
+            catch (Exception exception) when (exception is not OperationCanceledException)
             {
                 _logger.LogError(exception, "Exception invoking GetInstances() during config server lookup");
+
                 instances = new List<IServiceInstance>();
             }
 
@@ -102,22 +103,22 @@ internal sealed class ConfigServerDiscoveryService
         return instances;
     }
 
-    internal async Task ProvideRuntimeReplacementsAsync(IDiscoveryClient discoveryClientFromDI)
+    internal async Task ProvideRuntimeReplacementsAsync(IDiscoveryClient discoveryClientFromDI, CancellationToken cancellationToken)
     {
         if (discoveryClientFromDI is not null)
         {
             _logger.LogInformation("Replacing the IDiscoveryClient built at startup with one for runtime");
-            await DiscoveryClient.ShutdownAsync();
+            await DiscoveryClient.ShutdownAsync(cancellationToken);
             DiscoveryClient = discoveryClientFromDI;
             _usingInitialDiscoveryClient = false;
         }
     }
 
-    internal async Task ShutdownAsync()
+    internal async Task ShutdownAsync(CancellationToken cancellationToken)
     {
         if (_usingInitialDiscoveryClient)
         {
-            await DiscoveryClient.ShutdownAsync();
+            await DiscoveryClient.ShutdownAsync(cancellationToken);
         }
     }
 }

--- a/src/Configuration/src/ConfigServer/ConfigServerDiscoveryService.cs
+++ b/src/Configuration/src/ConfigServer/ConfigServerDiscoveryService.cs
@@ -73,7 +73,7 @@ internal sealed class ConfigServerDiscoveryService
                 _logger.LogDebug("Locating configserver {serviceId} via discovery", _settings.DiscoveryServiceId);
                 instances = await DiscoveryClient.GetInstancesAsync(_settings.DiscoveryServiceId, cancellationToken);
             }
-            catch (Exception exception) when (exception is not OperationCanceledException)
+            catch (Exception exception) when (!exception.IsCancellation())
             {
                 _logger.LogError(exception, "Exception invoking GetInstances() during config server lookup");
 

--- a/src/Configuration/src/ConfigServer/ConfigServerHealthContributor.cs
+++ b/src/Configuration/src/ConfigServer/ConfigServerHealthContributor.cs
@@ -52,7 +52,7 @@ internal sealed class ConfigServerHealthContributor : IHealthContributor
             return health;
         }
 
-        IList<PropertySource> sources = GetPropertySources();
+        IList<PropertySource> sources = GetPropertySourcesAsync(CancellationToken.None).GetAwaiter().GetResult();
 
         if (sources == null || sources.Count == 0)
         {
@@ -82,7 +82,7 @@ internal sealed class ConfigServerHealthContributor : IHealthContributor
         health.Details.Add("propertySources", names);
     }
 
-    internal IList<PropertySource> GetPropertySources()
+    internal async Task<IList<PropertySource>> GetPropertySourcesAsync(CancellationToken cancellationToken)
     {
         long currentTime = DateTimeOffset.Now.ToUnixTimeMilliseconds();
 
@@ -90,7 +90,7 @@ internal sealed class ConfigServerHealthContributor : IHealthContributor
         {
             LastAccess = currentTime;
             _logger.LogDebug("Cache stale, fetching config server health");
-            Cached = Provider.LoadInternal(false);
+            Cached = await Provider.LoadInternalAsync(false, cancellationToken);
         }
 
         return Cached?.PropertySources;

--- a/src/Configuration/src/ConfigServer/ConfigServerHealthContributor.cs
+++ b/src/Configuration/src/ConfigServer/ConfigServerHealthContributor.cs
@@ -32,7 +32,7 @@ internal sealed class ConfigServerHealthContributor : IHealthContributor
         }
     }
 
-    public async Task<HealthCheckResult> HealthAsync(CancellationToken cancellationToken)
+    public async Task<HealthCheckResult> CheckHealthAsync(CancellationToken cancellationToken)
     {
         var health = new HealthCheckResult();
 

--- a/src/Configuration/src/ConfigServer/ConfigServerHealthContributor.cs
+++ b/src/Configuration/src/ConfigServer/ConfigServerHealthContributor.cs
@@ -32,7 +32,7 @@ internal sealed class ConfigServerHealthContributor : IHealthContributor
         }
     }
 
-    public HealthCheckResult Health()
+    public async Task<HealthCheckResult> HealthAsync(CancellationToken cancellationToken)
     {
         var health = new HealthCheckResult();
 
@@ -52,7 +52,7 @@ internal sealed class ConfigServerHealthContributor : IHealthContributor
             return health;
         }
 
-        IList<PropertySource> sources = GetPropertySourcesAsync(CancellationToken.None).GetAwaiter().GetResult();
+        IList<PropertySource> sources = await GetPropertySourcesAsync(cancellationToken);
 
         if (sources == null || sources.Count == 0)
         {

--- a/src/Configuration/src/ConfigServer/ConfigServerHostedService.cs
+++ b/src/Configuration/src/ConfigServer/ConfigServerHostedService.cs
@@ -43,11 +43,11 @@ internal sealed class ConfigServerHostedService : IHostedService
 
     public async Task StartAsync(CancellationToken cancellationToken)
     {
-        await _configuration.ProvideRuntimeReplacementsAsync(_discoveryClient);
+        await _configuration.ProvideRuntimeReplacementsAsync(_discoveryClient, cancellationToken);
     }
 
     public async Task StopAsync(CancellationToken cancellationToken)
     {
-        await _configuration.ShutdownAsync();
+        await _configuration.ShutdownAsync(cancellationToken);
     }
 }

--- a/src/Configuration/test/CloudFoundry.Test/CloudfoundryConfigurationProviderTest.cs
+++ b/src/Configuration/test/CloudFoundry.Test/CloudfoundryConfigurationProviderTest.cs
@@ -204,7 +204,7 @@ public sealed class CloudFoundryConfigurationProviderTest
             }
         }
 
-        _ = Task.Run(ReloadLoop);
+        _ = Task.Run(ReloadLoop, cts.Token);
 
         while (!cts.IsCancellationRequested)
         {

--- a/src/Configuration/test/ConfigServer.Integration.Test/HomeController.cs
+++ b/src/Configuration/test/ConfigServer.Integration.Test/HomeController.cs
@@ -36,7 +36,7 @@ public sealed class HomeController : Controller
     {
         if (_healthContributor != null)
         {
-            HealthCheckResult health = await _healthContributor.HealthAsync(HttpContext.RequestAborted);
+            HealthCheckResult health = await _healthContributor.CheckHealthAsync(HttpContext.RequestAborted);
 
             if (health != null)
             {

--- a/src/Configuration/test/ConfigServer.Test/ConfigServerConfigurationProviderTest.cs
+++ b/src/Configuration/test/ConfigServer.Test/ConfigServerConfigurationProviderTest.cs
@@ -322,10 +322,10 @@ public sealed class ConfigServerConfigurationProviderTest
         var settings = new ConfigServerClientSettings();
         var provider = new ConfigServerConfigurationProvider(settings, NullLoggerFactory.Instance);
 
-        await Assert.ThrowsAsync<UriFormatException>(() => provider.RemoteLoadAsync(new[]
+        await Assert.ThrowsAsync<UriFormatException>(async () => await provider.RemoteLoadAsync(new[]
         {
             "foobar\\foobar\\"
-        }, null));
+        }, null, CancellationToken.None));
     }
 
     [Fact]
@@ -340,19 +340,19 @@ public sealed class ConfigServerConfigurationProviderTest
 
         try
         {
-            await Assert.ThrowsAsync<HttpRequestException>(() => provider.RemoteLoadAsync(new[]
+            await Assert.ThrowsAsync<HttpRequestException>(async () => await provider.RemoteLoadAsync(new[]
             {
                 "http://localhost:9999/app/profile"
-            }, null));
+            }, null, CancellationToken.None));
         }
         catch (ThrowsException e)
         {
-            if (e.InnerException is TaskCanceledException)
+            if (e.InnerException is OperationCanceledException)
             {
                 return;
             }
 
-            Assert.True(false, "Request didn't timeout or throw TaskCanceledException");
+            Assert.True(false, "Request didn't timeout or throw OperationCanceledException");
         }
     }
 
@@ -368,16 +368,14 @@ public sealed class ConfigServerConfigurationProviderTest
 
         IWebHostBuilder builder = new WebHostBuilder().UseStartup<TestConfigServerStartup>().UseEnvironment("testing");
 
-        using var server = new TestServer(builder)
-        {
-            BaseAddress = new Uri(ConfigServerClientSettings.DefaultUri)
-        };
+        using var server = new TestServer(builder);
+        server.BaseAddress = new Uri(ConfigServerClientSettings.DefaultUri);
 
         ConfigServerClientSettings settings = _commonSettings;
         using HttpClient client = server.CreateClient();
         var provider = new ConfigServerConfigurationProvider(settings, client, NullLoggerFactory.Instance);
 
-        await Assert.ThrowsAsync<HttpRequestException>(() => provider.RemoteLoadAsync(settings.GetUris(), null));
+        await Assert.ThrowsAsync<HttpRequestException>(async () => await provider.RemoteLoadAsync(settings.GetUris(), null, CancellationToken.None));
 
         Assert.NotNull(TestConfigServerStartup.LastRequest);
         Assert.Equal($"/{settings.Name}/{settings.Environment}", TestConfigServerStartup.LastRequest.Path.Value);
@@ -396,16 +394,14 @@ public sealed class ConfigServerConfigurationProviderTest
 
         IWebHostBuilder builder = new WebHostBuilder().UseStartup<TestConfigServerStartup>().UseEnvironment(environment.EnvironmentName);
 
-        using var server = new TestServer(builder)
-        {
-            BaseAddress = new Uri(ConfigServerClientSettings.DefaultUri)
-        };
+        using var server = new TestServer(builder);
+        server.BaseAddress = new Uri(ConfigServerClientSettings.DefaultUri);
 
         ConfigServerClientSettings settings = _commonSettings;
         using HttpClient client = server.CreateClient();
         var provider = new ConfigServerConfigurationProvider(settings, client, NullLoggerFactory.Instance);
 
-        ConfigEnvironment result = await provider.RemoteLoadAsync(settings.RawUris, null);
+        ConfigEnvironment result = await provider.RemoteLoadAsync(settings.RawUris, null, CancellationToken.None);
 
         Assert.NotNull(TestConfigServerStartup.LastRequest);
         Assert.Equal($"/{settings.Name}/{settings.Environment}", TestConfigServerStartup.LastRequest.Path.Value);
@@ -434,10 +430,8 @@ public sealed class ConfigServerConfigurationProviderTest
         TestConfigServerStartup.Label = "testlabel";
         IWebHostBuilder builder = new WebHostBuilder().UseStartup<TestConfigServerStartup>().UseEnvironment(hostEnvironment.EnvironmentName);
 
-        using var server = new TestServer(builder)
-        {
-            BaseAddress = new Uri(ConfigServerClientSettings.DefaultUri)
-        };
+        using var server = new TestServer(builder);
+        server.BaseAddress = new Uri(ConfigServerClientSettings.DefaultUri);
 
         var settings = new ConfigServerClientSettings
         {
@@ -458,7 +452,7 @@ public sealed class ConfigServerConfigurationProviderTest
     }
 
     [Fact]
-    public void DoLoad_MultipleLabels_ChecksAllLabels()
+    public async Task DoLoad_MultipleLabels_ChecksAllLabels()
     {
         const string environment = @"
                 {
@@ -490,17 +484,15 @@ public sealed class ConfigServerConfigurationProviderTest
         TestConfigServerStartup.Label = "testlabel";
         IWebHostBuilder builder = new WebHostBuilder().UseStartup<TestConfigServerStartup>().UseEnvironment(hostEnvironment.EnvironmentName);
 
-        using var server = new TestServer(builder)
-        {
-            BaseAddress = new Uri(ConfigServerClientSettings.DefaultUri)
-        };
+        using var server = new TestServer(builder);
+        server.BaseAddress = new Uri(ConfigServerClientSettings.DefaultUri);
 
         ConfigServerClientSettings settings = _commonSettings;
         settings.Label = "label,testlabel";
         using HttpClient client = server.CreateClient();
         var provider = new ConfigServerConfigurationProvider(settings, client, NullLoggerFactory.Instance);
 
-        provider.DoLoad();
+        await provider.DoLoadAsync(true, CancellationToken.None);
 
         Assert.NotNull(TestConfigServerStartup.LastRequest);
         Assert.Equal(2, TestConfigServerStartup.RequestCount);
@@ -532,16 +524,14 @@ public sealed class ConfigServerConfigurationProviderTest
         TestConfigServerStartup.Response = environment;
         IWebHostBuilder builder = new WebHostBuilder().UseStartup<TestConfigServerStartup>().UseEnvironment(hostEnvironment.EnvironmentName);
 
-        using var server = new TestServer(builder)
-        {
-            BaseAddress = new Uri(ConfigServerClientSettings.DefaultUri)
-        };
+        using var server = new TestServer(builder);
+        server.BaseAddress = new Uri(ConfigServerClientSettings.DefaultUri);
 
         ConfigServerClientSettings settings = _commonSettings;
         using HttpClient client = server.CreateClient();
         var provider = new ConfigServerConfigurationProvider(settings, client, NullLoggerFactory.Instance);
 
-        ConfigEnvironment env = await provider.RemoteLoadAsync(settings.GetUris(), null);
+        ConfigEnvironment env = await provider.RemoteLoadAsync(settings.GetUris(), null, CancellationToken.None);
         Assert.NotNull(TestConfigServerStartup.LastRequest);
         Assert.Equal($"/{settings.Name}/{settings.Environment}", TestConfigServerStartup.LastRequest.Path.Value);
         Assert.NotNull(env);
@@ -560,7 +550,7 @@ public sealed class ConfigServerConfigurationProviderTest
     }
 
     [Fact]
-    public void Load_MultipleConfigServers_ReturnsGreaterThanEqualBadRequest_StopsChecking()
+    public async Task Load_MultipleConfigServers_ReturnsGreaterThanEqualBadRequest_StopsChecking()
     {
         IHostEnvironment environment = HostingHelpers.GetHostingEnvironment();
         TestConfigServerStartup.Reset();
@@ -573,24 +563,22 @@ public sealed class ConfigServerConfigurationProviderTest
 
         IWebHostBuilder builder = new WebHostBuilder().UseStartup<TestConfigServerStartup>().UseEnvironment(environment.EnvironmentName);
 
-        using var server = new TestServer(builder)
-        {
-            BaseAddress = new Uri(ConfigServerClientSettings.DefaultUri)
-        };
+        using var server = new TestServer(builder);
+        server.BaseAddress = new Uri(ConfigServerClientSettings.DefaultUri);
 
         ConfigServerClientSettings settings = _commonSettings;
         settings.Uri = "http://localhost:8888, http://localhost:8888";
         using HttpClient client = server.CreateClient();
         var provider = new ConfigServerConfigurationProvider(settings, client, NullLoggerFactory.Instance);
 
-        provider.LoadInternal();
+        await provider.LoadInternalAsync(true, CancellationToken.None);
         Assert.NotNull(TestConfigServerStartup.LastRequest);
         Assert.Equal($"/{settings.Name}/{settings.Environment}", TestConfigServerStartup.LastRequest.Path.Value);
         Assert.Equal(1, TestConfigServerStartup.RequestCount);
     }
 
     [Fact]
-    public void Load_MultipleConfigServers_ReturnsNotFoundStatus_DoesNotContinueChecking()
+    public async Task Load_MultipleConfigServers_ReturnsNotFoundStatus_DoesNotContinueChecking()
     {
         IHostEnvironment environment = HostingHelpers.GetHostingEnvironment();
         TestConfigServerStartup.Reset();
@@ -603,24 +591,22 @@ public sealed class ConfigServerConfigurationProviderTest
 
         IWebHostBuilder builder = new WebHostBuilder().UseStartup<TestConfigServerStartup>().UseEnvironment(environment.EnvironmentName);
 
-        using var server = new TestServer(builder)
-        {
-            BaseAddress = new Uri(ConfigServerClientSettings.DefaultUri)
-        };
+        using var server = new TestServer(builder);
+        server.BaseAddress = new Uri(ConfigServerClientSettings.DefaultUri);
 
         ConfigServerClientSettings settings = _commonSettings;
         settings.Uri = "http://localhost:8888, http://localhost:8888";
         using HttpClient client = server.CreateClient();
         var provider = new ConfigServerConfigurationProvider(settings, client, NullLoggerFactory.Instance);
 
-        provider.LoadInternal();
+        await provider.LoadInternalAsync(true, CancellationToken.None);
         Assert.NotNull(TestConfigServerStartup.LastRequest);
         Assert.Equal($"/{settings.Name}/{settings.Environment}", TestConfigServerStartup.LastRequest.Path.Value);
         Assert.Equal(1, TestConfigServerStartup.RequestCount);
     }
 
     [Fact]
-    public void Load_ConfigServerReturnsNotFoundStatus()
+    public async Task Load_ConfigServerReturnsNotFoundStatus()
     {
         IHostEnvironment environment = HostingHelpers.GetHostingEnvironment();
         TestConfigServerStartup.Reset();
@@ -632,23 +618,21 @@ public sealed class ConfigServerConfigurationProviderTest
 
         IWebHostBuilder builder = new WebHostBuilder().UseStartup<TestConfigServerStartup>().UseEnvironment(environment.EnvironmentName);
 
-        using var server = new TestServer(builder)
-        {
-            BaseAddress = new Uri(ConfigServerClientSettings.DefaultUri)
-        };
+        using var server = new TestServer(builder);
+        server.BaseAddress = new Uri(ConfigServerClientSettings.DefaultUri);
 
         ConfigServerClientSettings settings = _commonSettings;
         using HttpClient client = server.CreateClient();
         var provider = new ConfigServerConfigurationProvider(settings, client, NullLoggerFactory.Instance);
 
-        provider.LoadInternal();
+        await provider.LoadInternalAsync(true, CancellationToken.None);
         Assert.NotNull(TestConfigServerStartup.LastRequest);
         Assert.Equal($"/{settings.Name}/{settings.Environment}", TestConfigServerStartup.LastRequest.Path.Value);
         Assert.Equal(26, provider.Properties.Count);
     }
 
     [Fact]
-    public void Load_ConfigServerReturnsNotFoundStatus_FailFastEnabled()
+    public async Task Load_ConfigServerReturnsNotFoundStatus_FailFastEnabled()
     {
         IHostEnvironment environment = HostingHelpers.GetHostingEnvironment();
         TestConfigServerStartup.Reset();
@@ -660,21 +644,19 @@ public sealed class ConfigServerConfigurationProviderTest
 
         IWebHostBuilder builder = new WebHostBuilder().UseStartup<TestConfigServerStartup>().UseEnvironment(environment.EnvironmentName);
 
-        using var server = new TestServer(builder)
-        {
-            BaseAddress = new Uri(ConfigServerClientSettings.DefaultUri)
-        };
+        using var server = new TestServer(builder);
+        server.BaseAddress = new Uri(ConfigServerClientSettings.DefaultUri);
 
         ConfigServerClientSettings settings = _commonSettings;
         settings.FailFast = true;
         using HttpClient client = server.CreateClient();
         var provider = new ConfigServerConfigurationProvider(settings, client, NullLoggerFactory.Instance);
 
-        Assert.Throws<ConfigServerException>(() => provider.LoadInternal());
+        await Assert.ThrowsAsync<ConfigServerException>(async () => await provider.LoadInternalAsync(true, CancellationToken.None));
     }
 
     [Fact]
-    public void Load_MultipleConfigServers_ReturnsNotFoundStatus__DoesNotContinueChecking_FailFastEnabled()
+    public async Task Load_MultipleConfigServers_ReturnsNotFoundStatus__DoesNotContinueChecking_FailFastEnabled()
     {
         ConfigServerClientSettings settings = _commonSettings;
         settings.FailFast = true;
@@ -682,10 +664,8 @@ public sealed class ConfigServerConfigurationProviderTest
         IHostEnvironment environment = HostingHelpers.GetHostingEnvironment();
         IWebHostBuilder builder = new WebHostBuilder().UseStartup<TestConfigServerStartup>().UseEnvironment(environment.EnvironmentName);
 
-        using var server = new TestServer(builder)
-        {
-            BaseAddress = new Uri(ConfigServerClientSettings.DefaultUri)
-        };
+        using var server = new TestServer(builder);
+        server.BaseAddress = new Uri(ConfigServerClientSettings.DefaultUri);
 
         using HttpClient client = server.CreateClient();
         var provider = new ConfigServerConfigurationProvider(settings, client, NullLoggerFactory.Instance);
@@ -697,12 +677,12 @@ public sealed class ConfigServerConfigurationProviderTest
             200
         };
 
-        Assert.Throws<ConfigServerException>(() => provider.LoadInternal());
+        await Assert.ThrowsAsync<ConfigServerException>(async () => await provider.LoadInternalAsync(true, CancellationToken.None));
         Assert.Equal(1, TestConfigServerStartup.RequestCount);
     }
 
     [Fact]
-    public void Load_ConfigServerReturnsBadStatus_FailFastEnabled()
+    public async Task Load_ConfigServerReturnsBadStatus_FailFastEnabled()
     {
         IHostEnvironment environment = HostingHelpers.GetHostingEnvironment();
         TestConfigServerStartup.Reset();
@@ -714,21 +694,19 @@ public sealed class ConfigServerConfigurationProviderTest
 
         IWebHostBuilder builder = new WebHostBuilder().UseStartup<TestConfigServerStartup>().UseEnvironment(environment.EnvironmentName);
 
-        using var server = new TestServer(builder)
-        {
-            BaseAddress = new Uri(ConfigServerClientSettings.DefaultUri)
-        };
+        using var server = new TestServer(builder);
+        server.BaseAddress = new Uri(ConfigServerClientSettings.DefaultUri);
 
         ConfigServerClientSettings settings = _commonSettings;
         settings.FailFast = true;
         using HttpClient client = server.CreateClient();
         var provider = new ConfigServerConfigurationProvider(settings, client, NullLoggerFactory.Instance);
 
-        Assert.Throws<ConfigServerException>(() => provider.LoadInternal());
+        await Assert.ThrowsAsync<ConfigServerException>(async () => await provider.LoadInternalAsync(true, CancellationToken.None));
     }
 
     [Fact]
-    public void Load_MultipleConfigServers_ReturnsBadStatus_StopsChecking_FailFastEnabled()
+    public async Task Load_MultipleConfigServers_ReturnsBadStatus_StopsChecking_FailFastEnabled()
     {
         IHostEnvironment environment = HostingHelpers.GetHostingEnvironment();
         TestConfigServerStartup.Reset();
@@ -742,10 +720,8 @@ public sealed class ConfigServerConfigurationProviderTest
 
         IWebHostBuilder builder = new WebHostBuilder().UseStartup<TestConfigServerStartup>().UseEnvironment(environment.EnvironmentName);
 
-        using var server = new TestServer(builder)
-        {
-            BaseAddress = new Uri(ConfigServerClientSettings.DefaultUri)
-        };
+        using var server = new TestServer(builder);
+        server.BaseAddress = new Uri(ConfigServerClientSettings.DefaultUri);
 
         ConfigServerClientSettings settings = _commonSettings;
         settings.FailFast = true;
@@ -753,12 +729,12 @@ public sealed class ConfigServerConfigurationProviderTest
         using HttpClient client = server.CreateClient();
         var provider = new ConfigServerConfigurationProvider(settings, client, NullLoggerFactory.Instance);
 
-        Assert.Throws<ConfigServerException>(() => provider.LoadInternal());
+        await Assert.ThrowsAsync<ConfigServerException>(async () => await provider.LoadInternalAsync(true, CancellationToken.None));
         Assert.Equal(1, TestConfigServerStartup.RequestCount);
     }
 
     [Fact]
-    public void Load_ConfigServerReturnsBadStatus_FailFastEnabled_RetryEnabled()
+    public async Task Load_ConfigServerReturnsBadStatus_FailFastEnabled_RetryEnabled()
     {
         IHostEnvironment environment = HostingHelpers.GetHostingEnvironment();
         TestConfigServerStartup.Reset();
@@ -775,10 +751,8 @@ public sealed class ConfigServerConfigurationProviderTest
 
         IWebHostBuilder builder = new WebHostBuilder().UseStartup<TestConfigServerStartup>().UseEnvironment(environment.EnvironmentName);
 
-        using var server = new TestServer(builder)
-        {
-            BaseAddress = new Uri(ConfigServerClientSettings.DefaultUri)
-        };
+        using var server = new TestServer(builder);
+        server.BaseAddress = new Uri(ConfigServerClientSettings.DefaultUri);
 
         var settings = new ConfigServerClientSettings
         {
@@ -792,12 +766,12 @@ public sealed class ConfigServerConfigurationProviderTest
         using HttpClient client = server.CreateClient();
         var provider = new ConfigServerConfigurationProvider(settings, client, NullLoggerFactory.Instance);
 
-        Assert.Throws<ConfigServerException>(() => provider.LoadInternal());
+        await Assert.ThrowsAsync<ConfigServerException>(async () => await provider.LoadInternalAsync(true, CancellationToken.None));
         Assert.Equal(6, TestConfigServerStartup.RequestCount);
     }
 
     [Fact]
-    public void Load_ChangesDataDictionary()
+    public async Task Load_ChangesDataDictionary()
     {
         const string environment = @"
                 {
@@ -821,16 +795,14 @@ public sealed class ConfigServerConfigurationProviderTest
         TestConfigServerStartup.Response = environment;
         IWebHostBuilder builder = new WebHostBuilder().UseStartup<TestConfigServerStartup>().UseEnvironment(hostEnvironment.EnvironmentName);
 
-        using var server = new TestServer(builder)
-        {
-            BaseAddress = new Uri(ConfigServerClientSettings.DefaultUri)
-        };
+        using var server = new TestServer(builder);
+        server.BaseAddress = new Uri(ConfigServerClientSettings.DefaultUri);
 
         ConfigServerClientSettings settings = _commonSettings;
         using HttpClient client = server.CreateClient();
         var provider = new ConfigServerConfigurationProvider(settings, client, NullLoggerFactory.Instance);
 
-        provider.LoadInternal();
+        await provider.LoadInternalAsync(true, CancellationToken.None);
         Assert.NotNull(TestConfigServerStartup.LastRequest);
         Assert.Equal($"/{settings.Name}/{settings.Environment}", TestConfigServerStartup.LastRequest.Path.Value);
 
@@ -867,10 +839,8 @@ public sealed class ConfigServerConfigurationProviderTest
         TestConfigServerStartup.Response = environment;
         IWebHostBuilder builder = new WebHostBuilder().UseStartup<TestConfigServerStartup>().UseEnvironment(hostEnvironment.EnvironmentName);
 
-        using var server = new TestServer(builder)
-        {
-            BaseAddress = new Uri(ConfigServerClientSettings.DefaultUri)
-        };
+        using var server = new TestServer(builder);
+        server.BaseAddress = new Uri(ConfigServerClientSettings.DefaultUri);
 
         ConfigServerClientSettings settings = _commonSettings;
         using HttpClient client = server.CreateClient();
@@ -1070,7 +1040,7 @@ public sealed class ConfigServerConfigurationProviderTest
     }
 
     [Fact]
-    public void GetRequestMessage_AddsBasicAuthIfPassword()
+    public async Task GetRequestMessage_AddsBasicAuthIfPassword()
     {
         var settings = new ConfigServerClientSettings
         {
@@ -1082,7 +1052,7 @@ public sealed class ConfigServerConfigurationProviderTest
         var provider = new ConfigServerConfigurationProvider(settings, NullLoggerFactory.Instance);
 
         var requestUri = new Uri(provider.GetConfigServerUri(settings.RawUris[0], null));
-        HttpRequestMessage request = provider.GetRequestMessage(requestUri, "user", "password");
+        HttpRequestMessage request = await provider.GetRequestMessageAsync(requestUri, "user", "password", CancellationToken.None);
 
         Assert.Equal(HttpMethod.Get, request.Method);
         Assert.Equal(requestUri, request.RequestUri);
@@ -1092,7 +1062,7 @@ public sealed class ConfigServerConfigurationProviderTest
     }
 
     [Fact]
-    public void GetRequestMessage_AddsVaultToken_IfNeeded()
+    public async Task GetRequestMessage_AddsVaultToken_IfNeeded()
     {
         var settings = new ConfigServerClientSettings
         {
@@ -1104,7 +1074,7 @@ public sealed class ConfigServerConfigurationProviderTest
         var provider = new ConfigServerConfigurationProvider(settings, NullLoggerFactory.Instance);
 
         var requestUri = new Uri(provider.GetConfigServerUri(settings.RawUris[0], null));
-        HttpRequestMessage request = provider.GetRequestMessage(requestUri, null, null);
+        HttpRequestMessage request = await provider.GetRequestMessageAsync(requestUri, null, null, CancellationToken.None);
 
         Assert.Equal(HttpMethod.Get, request.Method);
         Assert.Equal(requestUri, request.RequestUri);
@@ -1216,7 +1186,7 @@ public sealed class ConfigServerConfigurationProviderTest
     }
 
     [Fact]
-    public void DiscoverServerInstances_FailsFast()
+    public async Task DiscoverServerInstances_FailsFast()
     {
         var values = new Dictionary<string, string>
         {
@@ -1237,7 +1207,7 @@ public sealed class ConfigServerConfigurationProviderTest
         var source = new ConfigServerConfigurationSource(settings, configuration, NullLoggerFactory.Instance);
         var provider = new ConfigServerConfigurationProvider(source, NullLoggerFactory.Instance);
 
-        var exception = Assert.Throws<ConfigServerException>(() => provider.LoadInternal());
+        var exception = await Assert.ThrowsAsync<ConfigServerException>(async () => await provider.LoadInternalAsync(true, CancellationToken.None));
         Assert.StartsWith("Could not locate Config Server via discovery", exception.Message, StringComparison.Ordinal);
     }
 
@@ -1268,10 +1238,8 @@ public sealed class ConfigServerConfigurationProviderTest
 
         ConfigServerClientSettings settings = _commonSettings;
 
-        using var server = new TestServer(hostBuilder)
-        {
-            BaseAddress = new Uri(settings.Uri)
-        };
+        using var server = new TestServer(hostBuilder);
+        server.BaseAddress = new Uri(settings.Uri);
 
         using HttpClient client = server.CreateClient();
         var provider = new ConfigServerConfigurationProvider(settings, client, NullLoggerFactory.Instance);
@@ -1294,7 +1262,7 @@ public sealed class ConfigServerConfigurationProviderTest
             }
         }
 
-        _ = Task.Run(ReloadLoop);
+        _ = Task.Run(ReloadLoop, cts.Token);
 
         while (!cts.IsCancellationRequested)
         {

--- a/src/Configuration/test/ConfigServer.Test/ConfigServerDiscoveryServiceTest.cs
+++ b/src/Configuration/test/ConfigServer.Test/ConfigServerDiscoveryServiceTest.cs
@@ -41,7 +41,7 @@ public sealed class ConfigServerDiscoveryServiceTest
     }
 
     [Fact]
-    public void InvokeGetInstances_ReturnsExpected()
+    public async Task InvokeGetInstances_ReturnsExpected()
     {
         var values = new Dictionary<string, string>
         {
@@ -55,12 +55,12 @@ public sealed class ConfigServerDiscoveryServiceTest
         var settings = new ConfigServerClientSettings();
 
         var service = new ConfigServerDiscoveryService(configurationRoot, settings, null);
-        IEnumerable<IServiceInstance> result = service.GetConfigServerInstances();
+        IEnumerable<IServiceInstance> result = await service.GetConfigServerInstancesAsync(CancellationToken.None);
         Assert.Empty(result);
     }
 
     [Fact]
-    public void InvokeGetInstances_RetryEnabled_ReturnsExpected()
+    public async Task InvokeGetInstances_RetryEnabled_ReturnsExpected()
     {
         var values = new Dictionary<string, string>
         {
@@ -78,12 +78,12 @@ public sealed class ConfigServerDiscoveryServiceTest
         };
 
         var service = new ConfigServerDiscoveryService(configurationRoot, settings, null);
-        IEnumerable<IServiceInstance> result = service.GetConfigServerInstances();
+        IEnumerable<IServiceInstance> result = await service.GetConfigServerInstancesAsync(CancellationToken.None);
         Assert.Empty(result);
     }
 
     [Fact]
-    public void GetConfigServerInstances_ReturnsExpected()
+    public async Task GetConfigServerInstances_ReturnsExpected()
     {
         var values = new Dictionary<string, string>
         {
@@ -102,12 +102,12 @@ public sealed class ConfigServerDiscoveryServiceTest
         };
 
         var service = new ConfigServerDiscoveryService(configurationRoot, settings, null);
-        IEnumerable<IServiceInstance> result = service.GetConfigServerInstances();
+        IEnumerable<IServiceInstance> result = await service.GetConfigServerInstancesAsync(CancellationToken.None);
         Assert.Empty(result);
     }
 
     [Fact]
-    public void GetConfigServerInstancesCatchesDiscoveryExceptions()
+    public async Task GetConfigServerInstancesCatchesDiscoveryExceptions()
     {
         var appSettings = new Dictionary<string, string>
         {
@@ -118,7 +118,7 @@ public sealed class ConfigServerDiscoveryServiceTest
         var service = new ConfigServerDiscoveryService(configurationRoot, new ConfigServerClientSettings(), null);
 
         // act - the test discovery client throws on GetInstances()
-        IEnumerable<IServiceInstance> result = service.GetConfigServerInstances();
+        IEnumerable<IServiceInstance> result = await service.GetConfigServerInstancesAsync(CancellationToken.None);
 
         Assert.Empty(result);
     }
@@ -138,7 +138,7 @@ public sealed class ConfigServerDiscoveryServiceTest
         Assert.IsType<EurekaDiscoveryClient>(service.DiscoveryClient);
 
         // replace the bootstrapped eureka client with a test client
-        await service.ProvideRuntimeReplacementsAsync(testDiscoveryClient);
+        await service.ProvideRuntimeReplacementsAsync(testDiscoveryClient, CancellationToken.None);
         service.DiscoveryClient.Should().Be(testDiscoveryClient);
         service.LoggerFactory.Should().NotBeNull();
     }
@@ -156,10 +156,10 @@ public sealed class ConfigServerDiscoveryServiceTest
 
         IConfigurationRoot configurationRoot = new ConfigurationBuilder().AddInMemoryCollection(appSettings).Build();
         var service = new ConfigServerDiscoveryService(configurationRoot, new ConfigServerClientSettings(), null);
-        var originalClient = service.DiscoveryClient as TestDiscoveryClient;
+        var originalClient = (TestDiscoveryClient)service.DiscoveryClient;
 
         // replace the bootstrapped eureka client with a test client
-        await service.ProvideRuntimeReplacementsAsync(replacementDiscoveryClient);
+        await service.ProvideRuntimeReplacementsAsync(replacementDiscoveryClient, CancellationToken.None);
 
         Assert.True(originalClient.HasShutdown, "ShutdownAsync() called on original discovery client.");
         Assert.False(replacementDiscoveryClient.HasShutdown, "ShutdownAsync() NOT called on replacement discovery client.");
@@ -176,10 +176,10 @@ public sealed class ConfigServerDiscoveryServiceTest
 
         IConfigurationRoot configurationRoot = new ConfigurationBuilder().AddInMemoryCollection(appSettings).Build();
         var service = new ConfigServerDiscoveryService(configurationRoot, new ConfigServerClientSettings(), null);
-        var originalClient = service.DiscoveryClient as TestDiscoveryClient;
+        var originalClient = (TestDiscoveryClient)service.DiscoveryClient;
 
         // replace the bootstrapped eureka client with a test client
-        await service.ShutdownAsync();
+        await service.ShutdownAsync(CancellationToken.None);
 
         Assert.True(originalClient.HasShutdown, "ShutdownAsync() called on original discovery client.");
     }

--- a/src/Configuration/test/ConfigServer.Test/ConfigServerHealthContributorTest.cs
+++ b/src/Configuration/test/ConfigServer.Test/ConfigServerHealthContributorTest.cs
@@ -168,7 +168,7 @@ public sealed class ConfigServerHealthContributorTest
     }
 
     [Fact]
-    public void Health_NoProvider_ReturnsExpected()
+    public async Task Health_NoProvider_ReturnsExpected()
     {
         var values = new Dictionary<string, string>
         {
@@ -186,14 +186,14 @@ public sealed class ConfigServerHealthContributorTest
 
         var contributor = new ConfigServerHealthContributor(configurationRoot, NullLogger<ConfigServerHealthContributor>.Instance);
         Assert.Null(contributor.Provider);
-        HealthCheckResult health = contributor.Health();
+        HealthCheckResult health = await contributor.HealthAsync(CancellationToken.None);
         Assert.NotNull(health);
         Assert.Equal(HealthStatus.Unknown, health.Status);
         Assert.True(health.Details.ContainsKey("error"));
     }
 
     [Fact]
-    public void Health_NotEnabled_ReturnsExpected()
+    public async Task Health_NotEnabled_ReturnsExpected()
     {
         var values = new Dictionary<string, string>(TestHelpers.FastTestsConfiguration)
         {
@@ -212,13 +212,13 @@ public sealed class ConfigServerHealthContributorTest
 
         var contributor = new ConfigServerHealthContributor(configurationRoot, NullLogger<ConfigServerHealthContributor>.Instance);
         Assert.NotNull(contributor.Provider);
-        HealthCheckResult health = contributor.Health();
+        HealthCheckResult health = await contributor.HealthAsync(CancellationToken.None);
         Assert.NotNull(health);
         Assert.Equal(HealthStatus.Unknown, health.Status);
     }
 
     [Fact]
-    public void Health_NoPropertySources_ReturnsExpected()
+    public async Task Health_NoPropertySources_ReturnsExpected()
     {
         // this test does NOT expect to find a running Config Server
         var values = new Dictionary<string, string>(TestHelpers.FastTestsConfiguration)
@@ -238,7 +238,7 @@ public sealed class ConfigServerHealthContributorTest
 
         var contributor = new ConfigServerHealthContributor(configurationRoot, NullLogger<ConfigServerHealthContributor>.Instance);
         Assert.NotNull(contributor.Provider);
-        HealthCheckResult health = contributor.Health();
+        HealthCheckResult health = await contributor.HealthAsync(CancellationToken.None);
         Assert.NotNull(health);
         Assert.Equal(HealthStatus.Unknown, health.Status);
         Assert.True(health.Details.ContainsKey("error"));

--- a/src/Configuration/test/ConfigServer.Test/ConfigServerHealthContributorTest.cs
+++ b/src/Configuration/test/ConfigServer.Test/ConfigServerHealthContributorTest.cs
@@ -135,7 +135,7 @@ public sealed class ConfigServerHealthContributorTest
     }
 
     [Fact]
-    public void GetPropertySources_ReturnsExpected()
+    public async Task GetPropertySources_ReturnsExpected()
     {
         // this test does NOT expect to find a running Config Server
         var values = new Dictionary<string, string>(TestHelpers.FastTestsConfiguration)
@@ -160,7 +160,7 @@ public sealed class ConfigServerHealthContributorTest
         };
 
         long lastAccess = contributor.LastAccess = DateTimeOffset.Now.ToUnixTimeMilliseconds() - 100;
-        IList<PropertySource> sources = contributor.GetPropertySources();
+        IList<PropertySource> sources = await contributor.GetPropertySourcesAsync(CancellationToken.None);
 
         Assert.NotEqual(lastAccess, contributor.LastAccess);
         Assert.Null(sources);

--- a/src/Configuration/test/ConfigServer.Test/ConfigServerHealthContributorTest.cs
+++ b/src/Configuration/test/ConfigServer.Test/ConfigServerHealthContributorTest.cs
@@ -186,7 +186,7 @@ public sealed class ConfigServerHealthContributorTest
 
         var contributor = new ConfigServerHealthContributor(configurationRoot, NullLogger<ConfigServerHealthContributor>.Instance);
         Assert.Null(contributor.Provider);
-        HealthCheckResult health = await contributor.HealthAsync(CancellationToken.None);
+        HealthCheckResult health = await contributor.CheckHealthAsync(CancellationToken.None);
         Assert.NotNull(health);
         Assert.Equal(HealthStatus.Unknown, health.Status);
         Assert.True(health.Details.ContainsKey("error"));
@@ -212,7 +212,7 @@ public sealed class ConfigServerHealthContributorTest
 
         var contributor = new ConfigServerHealthContributor(configurationRoot, NullLogger<ConfigServerHealthContributor>.Instance);
         Assert.NotNull(contributor.Provider);
-        HealthCheckResult health = await contributor.HealthAsync(CancellationToken.None);
+        HealthCheckResult health = await contributor.CheckHealthAsync(CancellationToken.None);
         Assert.NotNull(health);
         Assert.Equal(HealthStatus.Unknown, health.Status);
     }
@@ -238,7 +238,7 @@ public sealed class ConfigServerHealthContributorTest
 
         var contributor = new ConfigServerHealthContributor(configurationRoot, NullLogger<ConfigServerHealthContributor>.Instance);
         Assert.NotNull(contributor.Provider);
-        HealthCheckResult health = await contributor.HealthAsync(CancellationToken.None);
+        HealthCheckResult health = await contributor.CheckHealthAsync(CancellationToken.None);
         Assert.NotNull(health);
         Assert.Equal(HealthStatus.Unknown, health.Status);
         Assert.True(health.Details.ContainsKey("error"));

--- a/src/Configuration/test/ConfigServer.Test/ConfigServerServiceCollectionExtensionsTest.cs
+++ b/src/Configuration/test/ConfigServer.Test/ConfigServerServiceCollectionExtensionsTest.cs
@@ -28,7 +28,7 @@ public sealed class ConfigServerServiceCollectionExtensionsTest
         var services = new ServiceCollection();
         IHostEnvironment environment = HostingHelpers.GetHostingEnvironment("Production");
 
-        IConfigurationBuilder builder = new ConfigurationBuilder().AddConfigServer(environment.EnvironmentName);
+        IConfigurationBuilder builder = new ConfigurationBuilder().AddConfigServer(environment);
         IConfigurationRoot configurationRoot = builder.Build();
         services.AddSingleton<IConfiguration>(configurationRoot);
         services.ConfigureConfigServerClientOptions();

--- a/src/Configuration/test/ConfigServer.Test/TestDiscoveryClient.cs
+++ b/src/Configuration/test/ConfigServer.Test/TestDiscoveryClient.cs
@@ -13,19 +13,22 @@ internal sealed class TestDiscoveryClient : IDiscoveryClient
 
     public string Description => throw new NotImplementedException();
 
-    public IList<string> Services => throw new NotImplementedException();
-
-    public IList<IServiceInstance> GetInstances(string serviceId)
+    public Task<IList<string>> GetServicesAsync(CancellationToken cancellationToken)
     {
         throw new NotImplementedException();
     }
 
-    public IServiceInstance GetLocalServiceInstance()
+    public Task<IList<IServiceInstance>> GetInstancesAsync(string serviceId, CancellationToken cancellationToken)
     {
         throw new NotImplementedException();
     }
 
-    public Task ShutdownAsync()
+    public Task<IServiceInstance> GetLocalServiceInstanceAsync(CancellationToken cancellationToken)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task ShutdownAsync(CancellationToken cancellationToken)
     {
         HasShutdown = true;
         return Task.CompletedTask;

--- a/src/Configuration/test/ConfigServer.Test/TestHelper.cs
+++ b/src/Configuration/test/ConfigServer.Test/TestHelper.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-using System.Reflection;
+using Steeltoe.Common.TestResources;
 using Xunit;
 
 namespace Steeltoe.Configuration.ConfigServer.Test;
@@ -32,13 +32,9 @@ public static class TestHelper
         Assert.Equal(ConfigServerClientSettings.DefaultHealthEnabled, settings.HealthEnabled);
         Assert.Equal(ConfigServerClientSettings.DefaultHealthTimeToLive, settings.HealthTimeToLive);
 
-        try
+        if (settings.Name != null)
         {
-            Assert.Null(settings.Name);
-        }
-        catch
-        {
-            Assert.Equal(Assembly.GetEntryAssembly().GetName().Name, settings.Name);
+            Assert.Equal(HostingHelpers.TestAppName, settings.Name);
         }
 
         Assert.Null(settings.Label);

--- a/src/Connectors/src/Connectors/CosmosDb/CosmosDbHealthContributor.cs
+++ b/src/Connectors/src/Connectors/CosmosDb/CosmosDbHealthContributor.cs
@@ -34,7 +34,7 @@ internal sealed class CosmosDbHealthContributor : IHealthContributor, IDisposabl
         _logger = logger;
     }
 
-    public async Task<HealthCheckResult?> HealthAsync(CancellationToken cancellationToken)
+    public async Task<HealthCheckResult?> CheckHealthAsync(CancellationToken cancellationToken)
     {
         _logger.LogTrace("Checking {DbConnection} health at {Host}", Id, Host);
 

--- a/src/Connectors/src/Connectors/CosmosDb/CosmosDbHealthContributor.cs
+++ b/src/Connectors/src/Connectors/CosmosDb/CosmosDbHealthContributor.cs
@@ -65,7 +65,7 @@ internal sealed class CosmosDbHealthContributor : IHealthContributor, IDisposabl
         {
             exception = exception.UnwrapAll();
 
-            if (exception is OperationCanceledException)
+            if (exception.IsCancellation())
             {
                 ExceptionDispatchInfo.Capture(exception).Throw();
             }

--- a/src/Connectors/src/Connectors/CosmosDb/DynamicTypeAccess/CosmosClientShim.cs
+++ b/src/Connectors/src/Connectors/CosmosDb/DynamicTypeAccess/CosmosClientShim.cs
@@ -29,9 +29,9 @@ internal sealed class CosmosClientShim : Shim, IDisposable
         return new CosmosClientShim(instanceAccessor);
     }
 
-    public Task ReadAccountAsync()
+    public async Task ReadAccountAsync()
     {
-        return (Task)InstanceAccessor.InvokeMethod("ReadAccountAsync", true)!;
+        await (Task)InstanceAccessor.InvokeMethod("ReadAccountAsync", true)!;
     }
 
     public void Dispose()

--- a/src/Connectors/src/Connectors/MongoDb/DynamicTypeAccess/MongoClientInterfaceShim.cs
+++ b/src/Connectors/src/Connectors/MongoDb/DynamicTypeAccess/MongoClientInterfaceShim.cs
@@ -13,11 +13,16 @@ internal sealed class MongoClientInterfaceShim : Shim
     {
     }
 
-    public IDisposable ListDatabaseNames(CancellationToken cancellationToken)
+    public async Task<IDisposable> ListDatabaseNamesAsync(CancellationToken cancellationToken)
     {
-        return (IDisposable)InstanceAccessor.InvokeMethodOverload("ListDatabaseNames", true, new[]
+        var task = (Task)InstanceAccessor.InvokeMethodOverload("ListDatabaseNamesAsync", true, new[]
         {
             typeof(CancellationToken)
         }, cancellationToken)!;
+
+        await task;
+
+        using var taskShim = new TaskShim<IDisposable>(task);
+        return taskShim.Result;
     }
 }

--- a/src/Connectors/src/Connectors/MongoDb/MongoDbHealthContributor.cs
+++ b/src/Connectors/src/Connectors/MongoDb/MongoDbHealthContributor.cs
@@ -31,7 +31,7 @@ internal sealed class MongoDbHealthContributor : IHealthContributor
         _logger = logger;
     }
 
-    public async Task<HealthCheckResult?> HealthAsync(CancellationToken cancellationToken)
+    public async Task<HealthCheckResult?> CheckHealthAsync(CancellationToken cancellationToken)
     {
         _logger.LogTrace("Checking {DbConnection} health at {Host}", Id, Host);
 

--- a/src/Connectors/src/Connectors/MongoDb/MongoDbHealthContributor.cs
+++ b/src/Connectors/src/Connectors/MongoDb/MongoDbHealthContributor.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-using System.Reflection;
+using System.Runtime.ExceptionServices;
 using Microsoft.Extensions.Logging;
 using Steeltoe.Common;
 using Steeltoe.Common.HealthChecks;
@@ -31,7 +31,7 @@ internal sealed class MongoDbHealthContributor : IHealthContributor
         _logger = logger;
     }
 
-    public HealthCheckResult Health()
+    public async Task<HealthCheckResult?> HealthAsync(CancellationToken cancellationToken)
     {
         _logger.LogTrace("Checking {DbConnection} health at {Host}", Id, Host);
 
@@ -50,7 +50,7 @@ internal sealed class MongoDbHealthContributor : IHealthContributor
 
         try
         {
-            _ = _mongoClientShim.ListDatabaseNames(CancellationToken.None);
+            using IDisposable cursor = await _mongoClientShim.ListDatabaseNamesAsync(cancellationToken);
 
             result.Status = HealthStatus.Up;
             result.Details.Add("status", HealthStatus.Up.ToSnakeCaseString(SnakeCaseStyle.AllCaps));
@@ -59,9 +59,11 @@ internal sealed class MongoDbHealthContributor : IHealthContributor
         }
         catch (Exception exception)
         {
-            if (exception is TargetInvocationException)
+            exception = exception.UnwrapAll();
+
+            if (exception is OperationCanceledException)
             {
-                exception = exception.InnerException ?? exception;
+                ExceptionDispatchInfo.Capture(exception).Throw();
             }
 
             _logger.LogError(exception, "{DbConnection} at {Host} is down!", Id, Host);

--- a/src/Connectors/src/Connectors/MongoDb/MongoDbHealthContributor.cs
+++ b/src/Connectors/src/Connectors/MongoDb/MongoDbHealthContributor.cs
@@ -61,7 +61,7 @@ internal sealed class MongoDbHealthContributor : IHealthContributor
         {
             exception = exception.UnwrapAll();
 
-            if (exception is OperationCanceledException)
+            if (exception.IsCancellation())
             {
                 ExceptionDispatchInfo.Capture(exception).Throw();
             }

--- a/src/Connectors/src/Connectors/RabbitMQ/RabbitMQHealthContributor.cs
+++ b/src/Connectors/src/Connectors/RabbitMQ/RabbitMQHealthContributor.cs
@@ -76,7 +76,7 @@ internal sealed class RabbitMQHealthContributor : IHealthContributor, IDisposabl
         {
             exception = exception.UnwrapAll();
 
-            if (exception is OperationCanceledException)
+            if (exception.IsCancellation())
             {
                 ExceptionDispatchInfo.Capture(exception).Throw();
             }

--- a/src/Connectors/src/Connectors/RabbitMQ/RabbitMQHealthContributor.cs
+++ b/src/Connectors/src/Connectors/RabbitMQ/RabbitMQHealthContributor.cs
@@ -33,7 +33,7 @@ internal sealed class RabbitMQHealthContributor : IHealthContributor, IDisposabl
         _logger = logger;
     }
 
-    public Task<HealthCheckResult?> HealthAsync(CancellationToken cancellationToken)
+    public Task<HealthCheckResult?> CheckHealthAsync(CancellationToken cancellationToken)
     {
         _logger.LogTrace("Checking {DbConnection} health at {Host}", Id, Host);
 

--- a/src/Connectors/src/Connectors/Redis/DynamicTypeAccess/ConnectionMultiplexerShim.cs
+++ b/src/Connectors/src/Connectors/Redis/DynamicTypeAccess/ConnectionMultiplexerShim.cs
@@ -29,6 +29,22 @@ internal sealed class ConnectionMultiplexerShim : Shim, IDisposable
         return new ConnectionMultiplexerInterfaceShim(packageResolver, instance);
     }
 
+    public static async Task<ConnectionMultiplexerInterfaceShim> ConnectAsync(StackExchangeRedisPackageResolver packageResolver, string configuration)
+    {
+        ArgumentGuard.NotNull(packageResolver);
+
+        var task = (Task)packageResolver.ConnectionMultiplexerClass.InvokeMethodOverload("ConnectAsync", true, new[]
+        {
+            typeof(string),
+            typeof(TextWriter)
+        }, configuration, null)!;
+
+        await task;
+
+        using var taskShim = new TaskShim<IDisposable>(task);
+        return new ConnectionMultiplexerInterfaceShim(packageResolver, taskShim.Result);
+    }
+
     public void Dispose()
     {
         Instance.Dispose();

--- a/src/Connectors/src/Connectors/Redis/DynamicTypeAccess/DatabaseInterfaceShim.cs
+++ b/src/Connectors/src/Connectors/Redis/DynamicTypeAccess/DatabaseInterfaceShim.cs
@@ -13,9 +13,14 @@ internal sealed class DatabaseInterfaceShim : Shim
     {
     }
 
-    public TimeSpan Ping()
+    public async Task<TimeSpan> PingAsync()
     {
         InstanceAccessor runtimeInstanceAccessor = InstanceAccessor.AsRuntimeType();
-        return (TimeSpan)runtimeInstanceAccessor.InvokeMethod("Ping", true, 0)!;
+        var task = (Task)runtimeInstanceAccessor.InvokeMethod("PingAsync", true, 0)!;
+
+        await task;
+
+        using var taskShim = new TaskShim<TimeSpan>(task);
+        return taskShim.Result;
     }
 }

--- a/src/Connectors/src/Connectors/Redis/RedisHealthContributor.cs
+++ b/src/Connectors/src/Connectors/Redis/RedisHealthContributor.cs
@@ -48,7 +48,7 @@ internal sealed class RedisHealthContributor : IHealthContributor, IDisposable
         _connectionMultiplexerInterfaceShim = new ConnectionMultiplexerInterfaceShim(StackExchangeRedisPackageResolver.Default, connectionMultiplexer);
     }
 
-    public async Task<HealthCheckResult?> HealthAsync(CancellationToken cancellationToken)
+    public async Task<HealthCheckResult?> CheckHealthAsync(CancellationToken cancellationToken)
     {
         _logger.LogTrace("Checking {DbConnection} health at {Host}", Id, Host);
 

--- a/src/Connectors/src/Connectors/Redis/RedisHealthContributor.cs
+++ b/src/Connectors/src/Connectors/Redis/RedisHealthContributor.cs
@@ -83,7 +83,7 @@ internal sealed class RedisHealthContributor : IHealthContributor, IDisposable
         {
             exception = exception.UnwrapAll();
 
-            if (exception is OperationCanceledException)
+            if (exception.IsCancellation())
             {
                 ExceptionDispatchInfo.Capture(exception).Throw();
             }

--- a/src/Connectors/src/Connectors/RelationalDatabaseHealthContributor.cs
+++ b/src/Connectors/src/Connectors/RelationalDatabaseHealthContributor.cs
@@ -65,7 +65,7 @@ internal sealed class RelationalDatabaseHealthContributor : IHealthContributor, 
         {
             exception = exception.UnwrapAll();
 
-            if (exception is OperationCanceledException)
+            if (exception.IsCancellation())
             {
                 ExceptionDispatchInfo.Capture(exception).Throw();
             }

--- a/src/Connectors/src/Connectors/RelationalDatabaseHealthContributor.cs
+++ b/src/Connectors/src/Connectors/RelationalDatabaseHealthContributor.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Data.Common;
+using System.Runtime.ExceptionServices;
 using Microsoft.Extensions.Logging;
 using Steeltoe.Common;
 using Steeltoe.Common.HealthChecks;
@@ -31,7 +32,7 @@ internal sealed class RelationalDatabaseHealthContributor : IHealthContributor, 
         Id = GetDatabaseType(connection);
     }
 
-    public HealthCheckResult Health()
+    public async Task<HealthCheckResult?> HealthAsync(CancellationToken cancellationToken)
     {
         _logger.LogTrace("Checking {DbConnection} health at {Host}", Id, Host);
 
@@ -50,10 +51,10 @@ internal sealed class RelationalDatabaseHealthContributor : IHealthContributor, 
 
         try
         {
-            _connection.Open();
+            await _connection.OpenAsync(cancellationToken);
             DbCommand command = _connection.CreateCommand();
             command.CommandText = "SELECT 1;";
-            command.ExecuteScalar();
+            await command.ExecuteScalarAsync(cancellationToken);
 
             result.Status = HealthStatus.Up;
             result.Details.Add("status", HealthStatus.Up.ToSnakeCaseString(SnakeCaseStyle.AllCaps));
@@ -62,6 +63,13 @@ internal sealed class RelationalDatabaseHealthContributor : IHealthContributor, 
         }
         catch (Exception exception)
         {
+            exception = exception.UnwrapAll();
+
+            if (exception is OperationCanceledException)
+            {
+                ExceptionDispatchInfo.Capture(exception).Throw();
+            }
+
             _logger.LogError(exception, "{DbConnection} at {Host} is down!", Id, Host);
 
             result.Status = HealthStatus.Down;
@@ -71,7 +79,7 @@ internal sealed class RelationalDatabaseHealthContributor : IHealthContributor, 
         }
         finally
         {
-            _connection.Close();
+            await _connection.CloseAsync();
         }
 
         return result;

--- a/src/Connectors/src/Connectors/RelationalDatabaseHealthContributor.cs
+++ b/src/Connectors/src/Connectors/RelationalDatabaseHealthContributor.cs
@@ -32,7 +32,7 @@ internal sealed class RelationalDatabaseHealthContributor : IHealthContributor, 
         Id = GetDatabaseType(connection);
     }
 
-    public async Task<HealthCheckResult?> HealthAsync(CancellationToken cancellationToken)
+    public async Task<HealthCheckResult?> CheckHealthAsync(CancellationToken cancellationToken)
     {
         _logger.LogTrace("Checking {DbConnection} health at {Host}", Id, Host);
 

--- a/src/Connectors/test/Connectors.Test/CosmosDb/CosmosDbHealthContributorTest.cs
+++ b/src/Connectors/test/Connectors.Test/CosmosDb/CosmosDbHealthContributorTest.cs
@@ -36,7 +36,7 @@ public sealed class CosmosDbHealthContributorTest
             ServiceName = "Example"
         };
 
-        HealthCheckResult? status = await healthContributor.HealthAsync(CancellationToken.None);
+        HealthCheckResult? status = await healthContributor.CheckHealthAsync(CancellationToken.None);
 
         status.Should().NotBeNull();
         status!.Status.Should().Be(HealthStatus.Down);
@@ -56,7 +56,7 @@ public sealed class CosmosDbHealthContributorTest
         healthContributor.ServiceName = "Example";
         healthContributor.Timeout = 1.Milliseconds();
 
-        HealthCheckResult? status = await healthContributor.HealthAsync(CancellationToken.None);
+        HealthCheckResult? status = await healthContributor.CheckHealthAsync(CancellationToken.None);
 
         status.Should().NotBeNull();
         status!.Status.Should().Be(HealthStatus.Down);
@@ -77,7 +77,7 @@ public sealed class CosmosDbHealthContributorTest
             ServiceName = "Example"
         };
 
-        HealthCheckResult? status = await healthContributor.HealthAsync(CancellationToken.None);
+        HealthCheckResult? status = await healthContributor.CheckHealthAsync(CancellationToken.None);
 
         status.Should().NotBeNull();
         status!.Status.Should().Be(HealthStatus.Up);
@@ -103,7 +103,7 @@ public sealed class CosmosDbHealthContributorTest
         using var source = new CancellationTokenSource();
         source.Cancel();
 
-        Func<Task> action = async () => await healthContributor.HealthAsync(source.Token);
+        Func<Task> action = async () => await healthContributor.CheckHealthAsync(source.Token);
 
         await action.Should().ThrowExactlyAsync<TaskCanceledException>();
     }
@@ -119,7 +119,7 @@ public sealed class CosmosDbHealthContributorTest
             ServiceName = "Example"
         };
 
-        HealthCheckResult? status = await healthContributor.HealthAsync(CancellationToken.None);
+        HealthCheckResult? status = await healthContributor.CheckHealthAsync(CancellationToken.None);
 
         status.Should().NotBeNull();
         status!.Status.Should().Be(HealthStatus.Up);

--- a/src/Connectors/test/Connectors.Test/CosmosDb/CosmosDbHealthContributorTest.cs
+++ b/src/Connectors/test/Connectors.Test/CosmosDb/CosmosDbHealthContributorTest.cs
@@ -51,11 +51,9 @@ public sealed class CosmosDbHealthContributorTest
     {
         var cosmosClient = new CosmosClient("AccountEndpoint=https://localhost:8081;AccountKey=IA==");
 
-        using var healthContributor = new CosmosDbHealthContributor(cosmosClient, "localhost", NullLogger<CosmosDbHealthContributor>.Instance)
-        {
-            ServiceName = "Example",
-            Timeout = 1.Milliseconds()
-        };
+        using var healthContributor = new CosmosDbHealthContributor(cosmosClient, "localhost", NullLogger<CosmosDbHealthContributor>.Instance);
+        healthContributor.ServiceName = "Example";
+        healthContributor.Timeout = 1.Milliseconds();
 
         HealthCheckResult status = healthContributor.Health();
 

--- a/src/Connectors/test/Connectors.Test/CosmosDb/CosmosDbHealthContributorTest.cs
+++ b/src/Connectors/test/Connectors.Test/CosmosDb/CosmosDbHealthContributorTest.cs
@@ -17,7 +17,7 @@ namespace Steeltoe.Connectors.Test.CosmosDb;
 public sealed class CosmosDbHealthContributorTest
 {
     [Fact]
-    public void Not_Connected_Returns_Down_Status()
+    public async Task Not_Connected_Returns_Down_Status()
     {
         var httpMessageHandlerMock = new Mock<HttpMessageHandler>();
 
@@ -36,9 +36,10 @@ public sealed class CosmosDbHealthContributorTest
             ServiceName = "Example"
         };
 
-        HealthCheckResult status = healthContributor.Health();
+        HealthCheckResult? status = await healthContributor.HealthAsync(CancellationToken.None);
 
-        status.Status.Should().Be(HealthStatus.Down);
+        status.Should().NotBeNull();
+        status!.Status.Should().Be(HealthStatus.Down);
         status.Description.Should().Be("CosmosDB health check failed");
         status.Details.Should().Contain("host", "localhost");
         status.Details.Should().Contain("service", "Example");
@@ -47,7 +48,7 @@ public sealed class CosmosDbHealthContributorTest
     }
 
     [Fact]
-    public void Not_Connected_With_Timeout_Returns_Down_Status()
+    public async Task Not_Connected_With_Timeout_Returns_Down_Status()
     {
         var cosmosClient = new CosmosClient("AccountEndpoint=https://localhost:8081;AccountKey=IA==");
 
@@ -55,9 +56,10 @@ public sealed class CosmosDbHealthContributorTest
         healthContributor.ServiceName = "Example";
         healthContributor.Timeout = 1.Milliseconds();
 
-        HealthCheckResult status = healthContributor.Health();
+        HealthCheckResult? status = await healthContributor.HealthAsync(CancellationToken.None);
 
-        status.Status.Should().Be(HealthStatus.Down);
+        status.Should().NotBeNull();
+        status!.Status.Should().Be(HealthStatus.Down);
         status.Description.Should().Be("CosmosDB health check failed");
         status.Details.Should().Contain("host", "localhost");
         status.Details.Should().Contain("service", "Example");
@@ -66,27 +68,48 @@ public sealed class CosmosDbHealthContributorTest
     }
 
     [Fact]
-    public void Is_Connected_Returns_Up_Status()
+    public async Task Is_Connected_Returns_Up_Status()
     {
         var cosmosClientMock = new Mock<CosmosClient>();
-        cosmosClientMock.Setup(client => client.ReadAccountAsync()).Returns(Task.FromResult(new Mock<AccountProperties>().Object));
 
         using var healthContributor = new CosmosDbHealthContributor(cosmosClientMock.Object, "localhost", NullLogger<CosmosDbHealthContributor>.Instance)
         {
             ServiceName = "Example"
         };
 
-        HealthCheckResult status = healthContributor.Health();
+        HealthCheckResult? status = await healthContributor.HealthAsync(CancellationToken.None);
 
-        status.Status.Should().Be(HealthStatus.Up);
+        status.Should().NotBeNull();
+        status!.Status.Should().Be(HealthStatus.Up);
         status.Details.Should().Contain("host", "localhost");
         status.Details.Should().Contain("service", "Example");
         status.Details.Should().NotContainKey("error");
         status.Details.Should().Contain("status", "UP");
     }
 
+    [Fact]
+    public async Task Canceled_Throws()
+    {
+        var cosmosClientMock = new Mock<CosmosClient>();
+
+        cosmosClientMock.Setup(client => client.ReadAccountAsync()).Returns(async () =>
+        {
+            await Task.Delay(3.Seconds());
+            return null!;
+        });
+
+        using var healthContributor = new CosmosDbHealthContributor(cosmosClientMock.Object, "localhost", NullLogger<CosmosDbHealthContributor>.Instance);
+
+        using var source = new CancellationTokenSource();
+        source.Cancel();
+
+        Func<Task> action = async () => await healthContributor.HealthAsync(source.Token);
+
+        await action.Should().ThrowExactlyAsync<TaskCanceledException>();
+    }
+
     [Fact(Skip = "Integration test - Requires local CosmosDB emulator")]
-    public void Integration_Is_Connected_Returns_Up_Status()
+    public async Task Integration_Is_Connected_Returns_Up_Status()
     {
         var cosmosClient = new CosmosClient(
             "AccountEndpoint=https://localhost:8081;AccountKey=C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==");
@@ -96,9 +119,10 @@ public sealed class CosmosDbHealthContributorTest
             ServiceName = "Example"
         };
 
-        HealthCheckResult status = healthContributor.Health();
+        HealthCheckResult? status = await healthContributor.HealthAsync(CancellationToken.None);
 
-        status.Status.Should().Be(HealthStatus.Up);
+        status.Should().NotBeNull();
+        status!.Status.Should().Be(HealthStatus.Up);
         status.Details.Should().Contain("host", "localhost");
         status.Details.Should().Contain("service", "Example");
         status.Details.Should().NotContainKey("error");

--- a/src/Connectors/test/Connectors.Test/MongoDb/MongoDbHealthContributorTest.cs
+++ b/src/Connectors/test/Connectors.Test/MongoDb/MongoDbHealthContributorTest.cs
@@ -15,7 +15,7 @@ namespace Steeltoe.Connectors.Test.MongoDb;
 public sealed class MongoDbHealthContributorTest
 {
     [Fact]
-    public void Not_Connected_Returns_Down_Status()
+    public async Task Not_Connected_Returns_Down_Status()
     {
         var settings = new MongoClientSettings
         {
@@ -30,9 +30,10 @@ public sealed class MongoDbHealthContributorTest
             ServiceName = "Example"
         };
 
-        HealthCheckResult status = healthContributor.Health();
+        HealthCheckResult? status = await healthContributor.HealthAsync(CancellationToken.None);
 
-        status.Status.Should().Be(HealthStatus.Down);
+        status.Should().NotBeNull();
+        status!.Status.Should().Be(HealthStatus.Down);
         status.Description.Should().Be("MongoDB health check failed");
         status.Details.Should().Contain("host", "localhost");
         status.Details.Should().Contain("service", "Example");
@@ -41,27 +42,48 @@ public sealed class MongoDbHealthContributorTest
     }
 
     [Fact]
-    public void Is_Connected_Returns_Up_Status()
+    public async Task Is_Connected_Returns_Up_Status()
     {
         var mongoClientMock = new Mock<IMongoClient>();
-        mongoClientMock.Setup(client => client.ListDatabaseNames(It.IsAny<CancellationToken>())).Returns(() => null!);
 
         var healthContributor = new MongoDbHealthContributor(mongoClientMock.Object, "localhost", NullLogger<MongoDbHealthContributor>.Instance)
         {
             ServiceName = "Example"
         };
 
-        HealthCheckResult status = healthContributor.Health();
+        HealthCheckResult? status = await healthContributor.HealthAsync(CancellationToken.None);
 
-        status.Status.Should().Be(HealthStatus.Up);
+        status.Should().NotBeNull();
+        status!.Status.Should().Be(HealthStatus.Up);
         status.Details.Should().Contain("host", "localhost");
         status.Details.Should().Contain("service", "Example");
         status.Details.Should().NotContainKey("error");
         status.Details.Should().Contain("status", "UP");
     }
 
+    [Fact]
+    public async Task Canceled_Throws()
+    {
+        var mongoClientMock = new Mock<IMongoClient>();
+
+        mongoClientMock.Setup(client => client.ListDatabaseNamesAsync(It.IsAny<CancellationToken>())).Returns((CancellationToken cancellationToken) =>
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return null!;
+        });
+
+        var healthContributor = new MongoDbHealthContributor(mongoClientMock.Object, "localhost", NullLogger<MongoDbHealthContributor>.Instance);
+
+        using var source = new CancellationTokenSource();
+        source.Cancel();
+
+        Func<Task> action = async () => await healthContributor.HealthAsync(source.Token);
+
+        await action.Should().ThrowExactlyAsync<OperationCanceledException>();
+    }
+
     [Fact(Skip = "Integration test - Requires local MongoDb server")]
-    public void Integration_Is_Connected_Returns_Up_Status()
+    public async Task Integration_Is_Connected_Returns_Up_Status()
     {
         var settings = new MongoClientSettings
         {
@@ -76,9 +98,10 @@ public sealed class MongoDbHealthContributorTest
             ServiceName = "Example"
         };
 
-        HealthCheckResult status = healthContributor.Health();
+        HealthCheckResult? status = await healthContributor.HealthAsync(CancellationToken.None);
 
-        status.Status.Should().Be(HealthStatus.Up);
+        status.Should().NotBeNull();
+        status!.Status.Should().Be(HealthStatus.Up);
         status.Details.Should().Contain("host", "localhost");
         status.Details.Should().Contain("service", "Example");
         status.Details.Should().NotContainKey("error");

--- a/src/Connectors/test/Connectors.Test/MongoDb/MongoDbHealthContributorTest.cs
+++ b/src/Connectors/test/Connectors.Test/MongoDb/MongoDbHealthContributorTest.cs
@@ -30,7 +30,7 @@ public sealed class MongoDbHealthContributorTest
             ServiceName = "Example"
         };
 
-        HealthCheckResult? status = await healthContributor.HealthAsync(CancellationToken.None);
+        HealthCheckResult? status = await healthContributor.CheckHealthAsync(CancellationToken.None);
 
         status.Should().NotBeNull();
         status!.Status.Should().Be(HealthStatus.Down);
@@ -51,7 +51,7 @@ public sealed class MongoDbHealthContributorTest
             ServiceName = "Example"
         };
 
-        HealthCheckResult? status = await healthContributor.HealthAsync(CancellationToken.None);
+        HealthCheckResult? status = await healthContributor.CheckHealthAsync(CancellationToken.None);
 
         status.Should().NotBeNull();
         status!.Status.Should().Be(HealthStatus.Up);
@@ -77,7 +77,7 @@ public sealed class MongoDbHealthContributorTest
         using var source = new CancellationTokenSource();
         source.Cancel();
 
-        Func<Task> action = async () => await healthContributor.HealthAsync(source.Token);
+        Func<Task> action = async () => await healthContributor.CheckHealthAsync(source.Token);
 
         await action.Should().ThrowExactlyAsync<OperationCanceledException>();
     }
@@ -98,7 +98,7 @@ public sealed class MongoDbHealthContributorTest
             ServiceName = "Example"
         };
 
-        HealthCheckResult? status = await healthContributor.HealthAsync(CancellationToken.None);
+        HealthCheckResult? status = await healthContributor.CheckHealthAsync(CancellationToken.None);
 
         status.Should().NotBeNull();
         status!.Status.Should().Be(HealthStatus.Up);

--- a/src/Connectors/test/Connectors.Test/PostgreSql/PostgreSqlConnectorTests.cs
+++ b/src/Connectors/test/Connectors.Test/PostgreSql/PostgreSqlConnectorTests.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Npgsql;
 using Steeltoe.Common.HealthChecks;
+using Steeltoe.Common.TestResources;
 using Steeltoe.Configuration.CloudFoundry.ServiceBinding;
 using Steeltoe.Configuration.Kubernetes.ServiceBinding;
 using Steeltoe.Connectors.PostgreSql;
@@ -338,7 +339,7 @@ YrSRLwUCgYAURMaw8BXwBsp8hB8cPWJ5G7K+9eyKImSmLUdKdAhV7g9uEKOk0uYg
 bR1Bjw0NBrcC7/tryf5kzKVdYs3FAHOR3qCFIaVGg97okwhOiMP6e6j0fBENDj8f
 7BzaXnC0iPbhCQwsVrdPHU7rwocyR4oBm+BVyLe6FqCb0+LijCgXYQ==
 -----END RSA PRIVATE KEY-----"
-        }, options => options.WithoutStrictOrdering());
+        }, options => options.WithoutStrictOrdering().Using(IgnoreLineEndingsComparer.Instance));
 
         CleanupTempFiles(optionsAzureOne.ConnectionString, optionsAzureTwo.ConnectionString, optionsGoogle.ConnectionString);
     }

--- a/src/Connectors/test/Connectors.Test/RabbitMQ/RabbitMQHealthContributorTest.cs
+++ b/src/Connectors/test/Connectors.Test/RabbitMQ/RabbitMQHealthContributorTest.cs
@@ -30,7 +30,7 @@ public sealed class RabbitMQHealthContributorTest
             ServiceName = "Example"
         };
 
-        HealthCheckResult? status = await healthContributor.HealthAsync(CancellationToken.None);
+        HealthCheckResult? status = await healthContributor.CheckHealthAsync(CancellationToken.None);
 
         status.Should().NotBeNull();
         status!.Status.Should().Be(HealthStatus.Down);
@@ -60,7 +60,7 @@ public sealed class RabbitMQHealthContributorTest
             ServiceName = "Example"
         };
 
-        HealthCheckResult? status = await healthContributor.HealthAsync(CancellationToken.None);
+        HealthCheckResult? status = await healthContributor.CheckHealthAsync(CancellationToken.None);
 
         status.Should().NotBeNull();
         status!.Status.Should().Be(HealthStatus.Up);
@@ -91,11 +91,11 @@ public sealed class RabbitMQHealthContributorTest
         };
 
         // Ensure initial connection is obtained.
-        _ = await healthContributor.HealthAsync(CancellationToken.None);
+        _ = await healthContributor.CheckHealthAsync(CancellationToken.None);
 
         connectionMock.Setup(connection => connection.IsOpen).Returns(false);
 
-        HealthCheckResult? status = await healthContributor.HealthAsync(CancellationToken.None);
+        HealthCheckResult? status = await healthContributor.CheckHealthAsync(CancellationToken.None);
 
         status.Should().NotBeNull();
         status!.Status.Should().Be(HealthStatus.Down);
@@ -115,7 +115,7 @@ public sealed class RabbitMQHealthContributorTest
         using var source = new CancellationTokenSource();
         source.Cancel();
 
-        Func<Task> action = async () => await healthContributor.HealthAsync(source.Token);
+        Func<Task> action = async () => await healthContributor.CheckHealthAsync(source.Token);
 
         await action.Should().ThrowExactlyAsync<OperationCanceledException>();
     }
@@ -133,7 +133,7 @@ public sealed class RabbitMQHealthContributorTest
             ServiceName = "Example"
         };
 
-        HealthCheckResult? status = await healthContributor.HealthAsync(CancellationToken.None);
+        HealthCheckResult? status = await healthContributor.CheckHealthAsync(CancellationToken.None);
 
         status.Should().NotBeNull();
         status!.Status.Should().Be(HealthStatus.Up);

--- a/src/Connectors/test/Connectors.Test/Redis/RedisHealthContributorTest.cs
+++ b/src/Connectors/test/Connectors.Test/Redis/RedisHealthContributorTest.cs
@@ -30,7 +30,7 @@ public sealed class RedisHealthContributorTest
 
         healthContributor.SetConnectionMultiplexer(connectionMultiplexerMock.Object);
 
-        HealthCheckResult? status = await healthContributor.HealthAsync(CancellationToken.None);
+        HealthCheckResult? status = await healthContributor.CheckHealthAsync(CancellationToken.None);
 
         status.Should().NotBeNull();
         status!.Status.Should().Be(HealthStatus.Down);
@@ -59,7 +59,7 @@ public sealed class RedisHealthContributorTest
 
         healthContributor.SetConnectionMultiplexer(connectionMultiplexerMock.Object);
 
-        HealthCheckResult? status = await healthContributor.HealthAsync(CancellationToken.None);
+        HealthCheckResult? status = await healthContributor.CheckHealthAsync(CancellationToken.None);
 
         status.Should().NotBeNull();
         status!.Status.Should().Be(HealthStatus.Up);
@@ -78,7 +78,7 @@ public sealed class RedisHealthContributorTest
         using var source = new CancellationTokenSource();
         source.Cancel();
 
-        Func<Task> action = async () => await healthContributor.HealthAsync(source.Token);
+        Func<Task> action = async () => await healthContributor.CheckHealthAsync(source.Token);
 
         await action.Should().ThrowExactlyAsync<OperationCanceledException>();
     }
@@ -93,7 +93,7 @@ public sealed class RedisHealthContributorTest
             ServiceName = "Example"
         };
 
-        HealthCheckResult? status = await healthContributor.HealthAsync(CancellationToken.None);
+        HealthCheckResult? status = await healthContributor.CheckHealthAsync(CancellationToken.None);
 
         status.Should().NotBeNull();
         status!.Status.Should().Be(HealthStatus.Up);

--- a/src/Connectors/test/Connectors.Test/Redis/RedisHealthContributorTest.cs
+++ b/src/Connectors/test/Connectors.Test/Redis/RedisHealthContributorTest.cs
@@ -16,7 +16,7 @@ namespace Steeltoe.Connectors.Test.Redis;
 public sealed class RedisHealthContributorTest
 {
     [Fact]
-    public void Not_Connected_Returns_Down_Status()
+    public async Task Not_Connected_Returns_Down_Status()
     {
         var connectionMultiplexerMock = new Mock<IConnectionMultiplexer>();
 
@@ -30,9 +30,10 @@ public sealed class RedisHealthContributorTest
 
         healthContributor.SetConnectionMultiplexer(connectionMultiplexerMock.Object);
 
-        HealthCheckResult status = healthContributor.Health();
+        HealthCheckResult? status = await healthContributor.HealthAsync(CancellationToken.None);
 
-        status.Status.Should().Be(HealthStatus.Down);
+        status.Should().NotBeNull();
+        status!.Status.Should().Be(HealthStatus.Down);
         status.Description.Should().Be("Redis health check failed");
         status.Details.Should().Contain("host", "localhost");
         status.Details.Should().Contain("service", "Example");
@@ -41,10 +42,10 @@ public sealed class RedisHealthContributorTest
     }
 
     [Fact]
-    public void Is_Connected_Returns_Up_Status()
+    public async Task Is_Connected_Returns_Up_Status()
     {
         var databaseMock = new Mock<IDatabase>();
-        databaseMock.Setup(database => database.Ping(It.IsAny<CommandFlags>())).Returns(50.Milliseconds());
+        databaseMock.Setup(database => database.PingAsync(It.IsAny<CommandFlags>())).Returns(Task.FromResult(50.Milliseconds()));
 
         var connectionMultiplexerMock = new Mock<IConnectionMultiplexer>();
 
@@ -58,9 +59,10 @@ public sealed class RedisHealthContributorTest
 
         healthContributor.SetConnectionMultiplexer(connectionMultiplexerMock.Object);
 
-        HealthCheckResult status = healthContributor.Health();
+        HealthCheckResult? status = await healthContributor.HealthAsync(CancellationToken.None);
 
-        status.Status.Should().Be(HealthStatus.Up);
+        status.Should().NotBeNull();
+        status!.Status.Should().Be(HealthStatus.Up);
         status.Details.Should().Contain("host", "localhost");
         status.Details.Should().Contain("service", "Example");
         status.Details.Should().NotContainKey("error");
@@ -68,8 +70,21 @@ public sealed class RedisHealthContributorTest
         status.Details.Should().Contain("ping", 50D);
     }
 
+    [Fact]
+    public async Task Canceled_Throws()
+    {
+        using var healthContributor = new RedisHealthContributor("localhost", NullLogger<RedisHealthContributor>.Instance);
+
+        using var source = new CancellationTokenSource();
+        source.Cancel();
+
+        Func<Task> action = async () => await healthContributor.HealthAsync(source.Token);
+
+        await action.Should().ThrowExactlyAsync<OperationCanceledException>();
+    }
+
     [Fact(Skip = "Integration test - Requires local Redis server")]
-    public void Integration_Is_Connected_Returns_Up_Status()
+    public async Task Integration_Is_Connected_Returns_Up_Status()
     {
         const string connectionString = "localhost";
 
@@ -78,9 +93,10 @@ public sealed class RedisHealthContributorTest
             ServiceName = "Example"
         };
 
-        HealthCheckResult status = healthContributor.Health();
+        HealthCheckResult? status = await healthContributor.HealthAsync(CancellationToken.None);
 
-        status.Status.Should().Be(HealthStatus.Up);
+        status.Should().NotBeNull();
+        status!.Status.Should().Be(HealthStatus.Up);
         status.Details.Should().Contain("host", "localhost");
         status.Details.Should().Contain("service", "Example");
         status.Details.Should().NotContainKey("error");

--- a/src/Connectors/test/Connectors.Test/RelationalDatabaseHealthContributorTest.cs
+++ b/src/Connectors/test/Connectors.Test/RelationalDatabaseHealthContributorTest.cs
@@ -27,7 +27,7 @@ public sealed class RelationalDatabaseHealthContributorTest
             ServiceName = "Example"
         };
 
-        HealthCheckResult? status = await healthContributor.HealthAsync(CancellationToken.None);
+        HealthCheckResult? status = await healthContributor.CheckHealthAsync(CancellationToken.None);
 
         status.Should().NotBeNull();
         status!.Status.Should().Be(HealthStatus.Down);
@@ -48,7 +48,7 @@ public sealed class RelationalDatabaseHealthContributorTest
             ServiceName = "Example"
         };
 
-        HealthCheckResult? status = await healthContributor.HealthAsync(CancellationToken.None);
+        HealthCheckResult? status = await healthContributor.CheckHealthAsync(CancellationToken.None);
 
         status.Should().NotBeNull();
         status!.Status.Should().Be(HealthStatus.Up);
@@ -68,7 +68,7 @@ public sealed class RelationalDatabaseHealthContributorTest
             ServiceName = "Example"
         };
 
-        HealthCheckResult? status = await healthContributor.HealthAsync(CancellationToken.None);
+        HealthCheckResult? status = await healthContributor.CheckHealthAsync(CancellationToken.None);
 
         status.Should().NotBeNull();
         status!.Status.Should().Be(HealthStatus.Down);
@@ -89,7 +89,7 @@ public sealed class RelationalDatabaseHealthContributorTest
             ServiceName = "Example"
         };
 
-        HealthCheckResult? status = await healthContributor.HealthAsync(CancellationToken.None);
+        HealthCheckResult? status = await healthContributor.CheckHealthAsync(CancellationToken.None);
 
         status.Should().NotBeNull();
         status!.Status.Should().Be(HealthStatus.Up);
@@ -110,7 +110,7 @@ public sealed class RelationalDatabaseHealthContributorTest
             ServiceName = "Example"
         };
 
-        HealthCheckResult? status = await healthContributor.HealthAsync(CancellationToken.None);
+        HealthCheckResult? status = await healthContributor.CheckHealthAsync(CancellationToken.None);
 
         status.Should().NotBeNull();
         status!.Status.Should().Be(HealthStatus.Down);
@@ -131,7 +131,7 @@ public sealed class RelationalDatabaseHealthContributorTest
             ServiceName = "Example"
         };
 
-        HealthCheckResult? status = await healthContributor.HealthAsync(CancellationToken.None);
+        HealthCheckResult? status = await healthContributor.CheckHealthAsync(CancellationToken.None);
 
         status.Should().NotBeNull();
         status!.Status.Should().Be(HealthStatus.Up);
@@ -157,7 +157,7 @@ public sealed class RelationalDatabaseHealthContributorTest
                 ServiceName = "Example"
             };
 
-        HealthCheckResult? status = await healthContributor.HealthAsync(CancellationToken.None);
+        HealthCheckResult? status = await healthContributor.CheckHealthAsync(CancellationToken.None);
 
         status.Should().NotBeNull();
         status!.Status.Should().Be(HealthStatus.Up);
@@ -184,7 +184,7 @@ public sealed class RelationalDatabaseHealthContributorTest
         using var source = new CancellationTokenSource();
         source.Cancel();
 
-        Func<Task> action = async () => await healthContributor.HealthAsync(source.Token);
+        Func<Task> action = async () => await healthContributor.CheckHealthAsync(source.Token);
 
         await action.Should().ThrowExactlyAsync<OperationCanceledException>();
     }

--- a/src/Connectors/test/Connectors.Test/RelationalDatabaseHealthContributorTest.cs
+++ b/src/Connectors/test/Connectors.Test/RelationalDatabaseHealthContributorTest.cs
@@ -18,7 +18,7 @@ namespace Steeltoe.Connectors.Test;
 public sealed class RelationalDatabaseHealthContributorTest
 {
     [Fact]
-    public void PostgreSQL_Not_Connected_Returns_Down_Status()
+    public async Task PostgreSQL_Not_Connected_Returns_Down_Status()
     {
         DbConnection connection = new NpgsqlConnection("Server=localhost;Port=9999;Timeout=1");
 
@@ -27,9 +27,10 @@ public sealed class RelationalDatabaseHealthContributorTest
             ServiceName = "Example"
         };
 
-        HealthCheckResult status = healthContributor.Health();
+        HealthCheckResult? status = await healthContributor.HealthAsync(CancellationToken.None);
 
-        status.Status.Should().Be(HealthStatus.Down);
+        status.Should().NotBeNull();
+        status!.Status.Should().Be(HealthStatus.Down);
         status.Description.Should().Be("PostgreSQL health check failed");
         status.Details.Should().Contain("host", "localhost");
         status.Details.Should().Contain("service", "Example");
@@ -38,7 +39,7 @@ public sealed class RelationalDatabaseHealthContributorTest
     }
 
     [Fact(Skip = "Integration test - Requires local PostgreSQL server")]
-    public void PostgreSQL_Integration_Is_Connected_Returns_Up_Status()
+    public async Task PostgreSQL_Integration_Is_Connected_Returns_Up_Status()
     {
         DbConnection connection = new NpgsqlConnection("Server=localhost;User ID=steeltoe;Password=steeltoe");
 
@@ -47,9 +48,10 @@ public sealed class RelationalDatabaseHealthContributorTest
             ServiceName = "Example"
         };
 
-        HealthCheckResult status = healthContributor.Health();
+        HealthCheckResult? status = await healthContributor.HealthAsync(CancellationToken.None);
 
-        status.Status.Should().Be(HealthStatus.Up);
+        status.Should().NotBeNull();
+        status!.Status.Should().Be(HealthStatus.Up);
         status.Details.Should().Contain("host", "localhost");
         status.Details.Should().Contain("service", "Example");
         status.Details.Should().NotContainKey("error");
@@ -57,7 +59,7 @@ public sealed class RelationalDatabaseHealthContributorTest
     }
 
     [Fact]
-    public void MySQL_Not_Connected_Returns_Down_Status()
+    public async Task MySQL_Not_Connected_Returns_Down_Status()
     {
         DbConnection connection = new MySqlConnection("Server=localhost;Port=9999;Connect Timeout=1");
 
@@ -66,9 +68,10 @@ public sealed class RelationalDatabaseHealthContributorTest
             ServiceName = "Example"
         };
 
-        HealthCheckResult status = healthContributor.Health();
+        HealthCheckResult? status = await healthContributor.HealthAsync(CancellationToken.None);
 
-        status.Status.Should().Be(HealthStatus.Down);
+        status.Should().NotBeNull();
+        status!.Status.Should().Be(HealthStatus.Down);
         status.Description.Should().Be("MySQL health check failed");
         status.Details.Should().Contain("host", "localhost");
         status.Details.Should().Contain("service", "Example");
@@ -77,7 +80,7 @@ public sealed class RelationalDatabaseHealthContributorTest
     }
 
     [Fact(Skip = "Integration test - Requires local MySQL server")]
-    public void MySQL_Integration_Is_Connected_Returns_Up_Status()
+    public async Task MySQL_Integration_Is_Connected_Returns_Up_Status()
     {
         DbConnection connection = new MySqlConnection("Server=localhost;User ID=steeltoe;Password=steeltoe");
 
@@ -86,9 +89,10 @@ public sealed class RelationalDatabaseHealthContributorTest
             ServiceName = "Example"
         };
 
-        HealthCheckResult status = healthContributor.Health();
+        HealthCheckResult? status = await healthContributor.HealthAsync(CancellationToken.None);
 
-        status.Status.Should().Be(HealthStatus.Up);
+        status.Should().NotBeNull();
+        status!.Status.Should().Be(HealthStatus.Up);
         status.Details.Should().Contain("host", "localhost");
         status.Details.Should().Contain("service", "Example");
         status.Details.Should().NotContainKey("error");
@@ -96,7 +100,7 @@ public sealed class RelationalDatabaseHealthContributorTest
     }
 
     [Fact]
-    public void SQLServer_Not_Connected_Returns_Down_Status()
+    public async Task SQLServer_Not_Connected_Returns_Down_Status()
     {
         // Using a known host/port, so running this test doesn't take 15 seconds (the Connect Timeout only kicks in *after* establishing the socket connection).
         DbConnection connection = new SqlConnection("Server=tcp:www.microsoft.com,80;Connect Timeout=1;Connect Retry Count=0");
@@ -106,9 +110,10 @@ public sealed class RelationalDatabaseHealthContributorTest
             ServiceName = "Example"
         };
 
-        HealthCheckResult status = healthContributor.Health();
+        HealthCheckResult? status = await healthContributor.HealthAsync(CancellationToken.None);
 
-        status.Status.Should().Be(HealthStatus.Down);
+        status.Should().NotBeNull();
+        status!.Status.Should().Be(HealthStatus.Down);
         status.Description.Should().Be("SQL Server health check failed");
         status.Details.Should().Contain("host", "localhost");
         status.Details.Should().Contain("service", "Example");
@@ -117,7 +122,7 @@ public sealed class RelationalDatabaseHealthContributorTest
     }
 
     [Fact(Skip = "Integration test - Requires local SQL Server instance")]
-    public void SQLServer_Integration_Is_Connected_Returns_Up_Status()
+    public async Task SQLServer_Integration_Is_Connected_Returns_Up_Status()
     {
         DbConnection connection = new SqlConnection("Server=(localdb)\\mssqllocaldb");
 
@@ -126,9 +131,10 @@ public sealed class RelationalDatabaseHealthContributorTest
             ServiceName = "Example"
         };
 
-        HealthCheckResult status = healthContributor.Health();
+        HealthCheckResult? status = await healthContributor.HealthAsync(CancellationToken.None);
 
-        status.Status.Should().Be(HealthStatus.Up);
+        status.Should().NotBeNull();
+        status!.Status.Should().Be(HealthStatus.Up);
         status.Details.Should().Contain("host", "localhost");
         status.Details.Should().Contain("service", "Example");
         status.Details.Should().NotContainKey("error");
@@ -136,7 +142,7 @@ public sealed class RelationalDatabaseHealthContributorTest
     }
 
     [Fact]
-    public void Is_Connected_Returns_Up_Status()
+    public async Task Is_Connected_Returns_Up_Status()
     {
         var commandMock = new Mock<DbCommand>();
         commandMock.Setup(command => command.ExecuteScalar()).Returns(1);
@@ -151,12 +157,35 @@ public sealed class RelationalDatabaseHealthContributorTest
                 ServiceName = "Example"
             };
 
-        HealthCheckResult status = healthContributor.Health();
+        HealthCheckResult? status = await healthContributor.HealthAsync(CancellationToken.None);
 
-        status.Status.Should().Be(HealthStatus.Up);
+        status.Should().NotBeNull();
+        status!.Status.Should().Be(HealthStatus.Up);
         status.Details.Should().Contain("host", "localhost");
         status.Details.Should().Contain("service", "Example");
         status.Details.Should().NotContainKey("error");
         status.Details.Should().Contain("status", "UP");
+    }
+
+    [Fact]
+    public async Task Canceled_Throws()
+    {
+        var connectionMock = new Mock<DbConnection>();
+
+        connectionMock.Setup(connection => connection.OpenAsync(It.IsAny<CancellationToken>())).Returns((CancellationToken cancellationToken) =>
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return null!;
+        });
+
+        using var healthContributor =
+            new RelationalDatabaseHealthContributor(connectionMock.Object, "localhost", NullLogger<RelationalDatabaseHealthContributor>.Instance);
+
+        using var source = new CancellationTokenSource();
+        source.Cancel();
+
+        Func<Task> action = async () => await healthContributor.HealthAsync(source.Token);
+
+        await action.Should().ThrowExactlyAsync<OperationCanceledException>();
     }
 }

--- a/src/Discovery/src/Abstractions/IDiscoveryClient.cs
+++ b/src/Discovery/src/Abstractions/IDiscoveryClient.cs
@@ -9,12 +9,15 @@ namespace Steeltoe.Discovery;
 public interface IDiscoveryClient : IServiceInstanceProvider
 {
     /// <summary>
-    /// ServiceInstance with information used to register the local service.
+    /// Gets the local service instance with information used to register the local service.
     /// </summary>
+    /// <param name="cancellationToken">
+    /// The token to monitor for cancellation requests.
+    /// </param>
     /// <returns>
-    /// The IServiceInstance.
+    /// The service instance.
     /// </returns>
-    IServiceInstance GetLocalServiceInstance();
+    Task<IServiceInstance> GetLocalServiceInstanceAsync(CancellationToken cancellationToken);
 
-    Task ShutdownAsync();
+    Task ShutdownAsync(CancellationToken cancellationToken);
 }

--- a/src/Discovery/src/Client/DiscoveryClientService.cs
+++ b/src/Discovery/src/Client/DiscoveryClientService.cs
@@ -22,6 +22,6 @@ internal sealed class DiscoveryClientService : IHostedService
 
     public Task StopAsync(CancellationToken cancellationToken)
     {
-        return _discoveryClient.ShutdownAsync();
+        return _discoveryClient.ShutdownAsync(cancellationToken);
     }
 }

--- a/src/Discovery/src/Client/SimpleClients/ConfigurationDiscoveryClient.cs
+++ b/src/Discovery/src/Client/SimpleClients/ConfigurationDiscoveryClient.cs
@@ -14,12 +14,12 @@ public class ConfigurationDiscoveryClient : ConfigurationServiceInstanceProvider
     {
     }
 
-    public IServiceInstance GetLocalServiceInstance()
+    public Task<IServiceInstance> GetLocalServiceInstanceAsync(CancellationToken cancellationToken)
     {
         throw new NotImplementedException("No known use case for implementing this method");
     }
 
-    public Task ShutdownAsync()
+    public Task ShutdownAsync(CancellationToken cancellationToken)
     {
         return Task.CompletedTask;
     }

--- a/src/Discovery/src/Client/SimpleClients/NoOpDiscoveryClient.cs
+++ b/src/Discovery/src/Client/SimpleClients/NoOpDiscoveryClient.cs
@@ -15,8 +15,6 @@ internal sealed class NoOpDiscoveryClient : IDiscoveryClient
 
     public string Description => "An IDiscoveryClient that passes through to underlying infrastructure";
 
-    public IList<string> Services => new List<string>();
-
     internal NoOpDiscoveryClient(IConfiguration configuration, ILogger<NoOpDiscoveryClient> logger = null)
     {
         logger?.LogWarning("No discovery client has been completely configured, using default no-op discovery client.");
@@ -28,7 +26,12 @@ internal sealed class NoOpDiscoveryClient : IDiscoveryClient
         }
     }
 
-    internal Dictionary<string, string> GetConfiguredClients(IConfiguration configuration)
+    public Task<IList<string>> GetServicesAsync(CancellationToken cancellationToken)
+    {
+        return Task.FromResult<IList<string>>(new List<string>());
+    }
+
+    private Dictionary<string, string> GetConfiguredClients(IConfiguration configuration)
     {
         if (configuration is null)
         {
@@ -64,17 +67,17 @@ internal sealed class NoOpDiscoveryClient : IDiscoveryClient
         return clientsWithConfig;
     }
 
-    public IList<IServiceInstance> GetInstances(string serviceId)
+    public Task<IList<IServiceInstance>> GetInstancesAsync(string serviceId, CancellationToken cancellationToken)
     {
-        return _serviceInstances;
+        return Task.FromResult(_serviceInstances);
     }
 
-    public IServiceInstance GetLocalServiceInstance()
+    public Task<IServiceInstance> GetLocalServiceInstanceAsync(CancellationToken cancellationToken)
     {
         throw new NotImplementedException("No known use case for implementing this method");
     }
 
-    public Task ShutdownAsync()
+    public Task ShutdownAsync(CancellationToken cancellationToken)
     {
         return Task.CompletedTask;
     }

--- a/src/Discovery/src/Consul/Discovery/ConsulHealthContributor.cs
+++ b/src/Discovery/src/Consul/Discovery/ConsulHealthContributor.cs
@@ -78,30 +78,33 @@ public class ConsulHealthContributor : IHealthContributor
     }
 
     /// <summary>
-    /// Compute the health of the Consul server connection.
+    /// Computes the health of the Consul server connection.
     /// </summary>
+    /// <param name="cancellationToken">
+    /// The token to monitor for cancellation requests.
+    /// </param>
     /// <returns>
-    /// the health check result.
+    /// The health check result.
     /// </returns>
-    public HealthCheckResult Health()
+    public async Task<HealthCheckResult> HealthAsync(CancellationToken cancellationToken)
     {
         var result = new HealthCheckResult();
-        string leaderStatus = GetLeaderStatusAsync().GetAwaiter().GetResult();
-        Dictionary<string, string[]> services = GetCatalogServicesAsync().GetAwaiter().GetResult();
+        string leaderStatus = await GetLeaderStatusAsync(cancellationToken);
+        Dictionary<string, string[]> services = await GetCatalogServicesAsync(cancellationToken);
         result.Status = HealthStatus.Up;
         result.Details.Add("leader", leaderStatus);
         result.Details.Add("services", services);
         return result;
     }
 
-    internal Task<string> GetLeaderStatusAsync()
+    internal Task<string> GetLeaderStatusAsync(CancellationToken cancellationToken)
     {
-        return _client.Status.Leader();
+        return _client.Status.Leader(cancellationToken);
     }
 
-    internal async Task<Dictionary<string, string[]>> GetCatalogServicesAsync()
+    internal async Task<Dictionary<string, string[]>> GetCatalogServicesAsync(CancellationToken cancellationToken)
     {
-        QueryResult<Dictionary<string, string[]>> result = await _client.Catalog.Services(QueryOptions.Default);
+        QueryResult<Dictionary<string, string[]>> result = await _client.Catalog.Services(QueryOptions.Default, cancellationToken);
         return result.Response;
     }
 }

--- a/src/Discovery/src/Consul/Discovery/ConsulHealthContributor.cs
+++ b/src/Discovery/src/Consul/Discovery/ConsulHealthContributor.cs
@@ -86,7 +86,7 @@ public class ConsulHealthContributor : IHealthContributor
     /// <returns>
     /// The health check result.
     /// </returns>
-    public async Task<HealthCheckResult> HealthAsync(CancellationToken cancellationToken)
+    public async Task<HealthCheckResult> CheckHealthAsync(CancellationToken cancellationToken)
     {
         var result = new HealthCheckResult();
         string leaderStatus = await GetLeaderStatusAsync(cancellationToken);

--- a/src/Discovery/src/Consul/Discovery/IConsulDiscoveryClient.cs
+++ b/src/Discovery/src/Consul/Discovery/IConsulDiscoveryClient.cs
@@ -7,44 +7,50 @@ using Steeltoe.Common.Discovery;
 
 namespace Steeltoe.Discovery.Consul.Discovery;
 
-/// <summary>
-/// A Consul Discovery client.
-/// </summary>
 public interface IConsulDiscoveryClient : IDiscoveryClient, IDisposable
 {
     /// <summary>
-    /// Get all the instances for the given service ID.
+    /// Gets all service instances for the given service ID.
     /// </summary>
     /// <param name="serviceId">
-    /// the service to lookup.
+    /// ID of the service to lookup.
     /// </param>
     /// <param name="queryOptions">
-    /// any Consul query options to use.
+    /// Any Consul query options to use.
+    /// </param>
+    /// <param name="cancellationToken">
+    /// The token to monitor for cancellation requests.
     /// </param>
     /// <returns>
-    /// list of found service instances.
+    /// The list of found service instances.
     /// </returns>
-    IList<IServiceInstance> GetInstances(string serviceId, QueryOptions queryOptions = null);
+    Task<IList<IServiceInstance>> GetInstancesAsync(string serviceId, QueryOptions queryOptions, CancellationToken cancellationToken);
 
     /// <summary>
-    /// Get all the instances from the Consul catalog.
+    /// Gets all service instances from the Consul catalog.
     /// </summary>
     /// <param name="queryOptions">
-    /// any Consul query options to use.
+    /// Any Consul query options to use.
+    /// </param>
+    /// <param name="cancellationToken">
+    /// The token to monitor for cancellation requests.
     /// </param>
     /// <returns>
-    /// list of found service instances.
+    /// The list of found service instances.
     /// </returns>
-    IList<IServiceInstance> GetAllInstances(QueryOptions queryOptions = null);
+    Task<IList<IServiceInstance>> GetAllInstancesAsync(QueryOptions queryOptions, CancellationToken cancellationToken);
 
     /// <summary>
-    /// Get all of the services from the Consul catalog.
+    /// Gets all service names from the Consul catalog.
     /// </summary>
     /// <param name="queryOptions">
-    /// any Consul query options to use.
+    /// Any Consul query options to use.
+    /// </param>
+    /// <param name="cancellationToken">
+    /// The token to monitor for cancellation requests.
     /// </param>
     /// <returns>
-    /// list of found services.
+    /// The list of found service names.
     /// </returns>
-    IList<string> GetServiceNames(QueryOptions queryOptions = null);
+    Task<IList<string>> GetServiceNamesAsync(QueryOptions queryOptions, CancellationToken cancellationToken);
 }

--- a/src/Discovery/src/Consul/Registry/IConsulServiceRegistry.cs
+++ b/src/Discovery/src/Consul/Registry/IConsulServiceRegistry.cs
@@ -17,10 +17,13 @@ public interface IConsulServiceRegistry : IServiceRegistry<IConsulRegistration>
     /// <param name="registration">
     /// the registration to register.
     /// </param>
+    /// <param name="cancellationToken">
+    /// The token to monitor for cancellation requests.
+    /// </param>
     /// <returns>
     /// the task.
     /// </returns>
-    Task RegisterAsync(IConsulRegistration registration);
+    Task RegisterAsync(IConsulRegistration registration, CancellationToken cancellationToken);
 
     /// <summary>
     /// Deregister the provided registration in Consul.
@@ -28,10 +31,13 @@ public interface IConsulServiceRegistry : IServiceRegistry<IConsulRegistration>
     /// <param name="registration">
     /// the registration to register.
     /// </param>
+    /// <param name="cancellationToken">
+    /// The token to monitor for cancellation requests.
+    /// </param>
     /// <returns>
     /// the task.
     /// </returns>
-    Task DeregisterAsync(IConsulRegistration registration);
+    Task DeregisterAsync(IConsulRegistration registration, CancellationToken cancellationToken);
 
     /// <summary>
     /// Set the status of the registration in Consul.
@@ -42,10 +48,13 @@ public interface IConsulServiceRegistry : IServiceRegistry<IConsulRegistration>
     /// <param name="status">
     /// the status value to set.
     /// </param>
+    /// <param name="cancellationToken">
+    /// The token to monitor for cancellation requests.
+    /// </param>
     /// <returns>
     /// the task.
     /// </returns>
-    Task SetStatusAsync(IConsulRegistration registration, string status);
+    Task SetStatusAsync(IConsulRegistration registration, string status, CancellationToken cancellationToken);
 
     /// <summary>
     /// Get the status of the registration in Consul.
@@ -53,8 +62,11 @@ public interface IConsulServiceRegistry : IServiceRegistry<IConsulRegistration>
     /// <param name="registration">
     /// the registration to register.
     /// </param>
+    /// <param name="cancellationToken">
+    /// The token to monitor for cancellation requests.
+    /// </param>
     /// <returns>
     /// the status value.
     /// </returns>
-    Task<object> GetStatusAsync(IConsulRegistration registration);
+    Task<object> GetStatusAsync(IConsulRegistration registration, CancellationToken cancellationToken);
 }

--- a/src/Discovery/src/Eureka/DiscoveryClient.cs
+++ b/src/Discovery/src/Eureka/DiscoveryClient.cs
@@ -300,7 +300,7 @@ public class DiscoveryClient : IEurekaClient
                 fetched = await FetchRegistryDeltaAsync(cancellationToken);
             }
         }
-        catch (Exception exception) when (exception is not OperationCanceledException)
+        catch (Exception exception) when (!exception.IsCancellation())
         {
             logger.LogError(exception, "FetchRegistry Failed for Eureka service urls: {EurekaServerServiceUrls}",
                 new Uri(ClientConfiguration.EurekaServerServiceUrls).ToMaskedString());
@@ -340,7 +340,7 @@ public class DiscoveryClient : IEurekaClient
             logger.LogDebug("Unregister {Application}/{Instance} returned: {StatusCode}", inst.AppName, inst.InstanceId, resp.StatusCode);
             return resp.StatusCode == HttpStatusCode.OK;
         }
-        catch (Exception exception) when (exception is not OperationCanceledException)
+        catch (Exception exception) when (!exception.IsCancellation())
         {
             logger.LogError(exception, "Unregister Failed");
         }
@@ -371,7 +371,7 @@ public class DiscoveryClient : IEurekaClient
 
             return result;
         }
-        catch (Exception exception) when (exception is not OperationCanceledException)
+        catch (Exception exception) when (!exception.IsCancellation())
         {
             logger.LogError(exception, "Register Failed");
         }
@@ -420,7 +420,7 @@ public class DiscoveryClient : IEurekaClient
 
             return result;
         }
-        catch (Exception exception) when (exception is not OperationCanceledException)
+        catch (Exception exception) when (!exception.IsCancellation())
         {
             logger.LogError(exception, "Renew Failed");
         }
@@ -526,7 +526,7 @@ public class DiscoveryClient : IEurekaClient
                 status = await HealthCheckHandler.GetStatusAsync(info.Status, cancellationToken);
                 logger.LogDebug("RefreshInstanceInfo called, returning {status}", status);
             }
-            catch (Exception exception) when (exception is not OperationCanceledException)
+            catch (Exception exception) when (!exception.IsCancellation())
             {
                 logger.LogError(exception, "RefreshInstanceInfo HealthCheck handler. App: {Application}, Instance: {Instance} marked DOWN", info.AppName,
                     info.InstanceId);

--- a/src/Discovery/src/Eureka/DiscoveryClient.cs
+++ b/src/Discovery/src/Eureka/DiscoveryClient.cs
@@ -389,7 +389,7 @@ public class DiscoveryClient : IEurekaClient
             return false;
         }
 
-        RefreshInstanceInfo();
+        await RefreshInstanceInfoAsync(cancellationToken);
 
         if (inst.IsDirty)
         {
@@ -506,7 +506,7 @@ public class DiscoveryClient : IEurekaClient
         return null;
     }
 
-    protected internal void RefreshInstanceInfo()
+    protected internal async Task RefreshInstanceInfoAsync(CancellationToken cancellationToken)
     {
         InstanceInfo info = AppInfoManager.InstanceInfo;
 
@@ -523,12 +523,12 @@ public class DiscoveryClient : IEurekaClient
         {
             try
             {
-                status = HealthCheckHandler.GetStatus(info.Status);
+                status = await HealthCheckHandler.GetStatusAsync(info.Status, cancellationToken);
                 logger.LogDebug("RefreshInstanceInfo called, returning {status}", status);
             }
-            catch (Exception e)
+            catch (Exception exception) when (exception is not OperationCanceledException)
             {
-                logger.LogError(e, "RefreshInstanceInfo HealthCheck handler. App: {Application}, Instance: {Instance} marked DOWN", info.AppName,
+                logger.LogError(exception, "RefreshInstanceInfo HealthCheck handler. App: {Application}, Instance: {Instance} marked DOWN", info.AppName,
                     info.InstanceId);
 
                 status = InstanceStatus.Down;

--- a/src/Discovery/src/Eureka/EurekaApplicationsHealthContributor.cs
+++ b/src/Discovery/src/Eureka/EurekaApplicationsHealthContributor.cs
@@ -25,8 +25,10 @@ public class EurekaApplicationsHealthContributor : IHealthContributor
     {
     }
 
-    public HealthCheckResult Health()
+    public Task<HealthCheckResult> HealthAsync(CancellationToken cancellationToken)
     {
+        cancellationToken.ThrowIfCancellationRequested();
+
         var result = new HealthCheckResult
         {
             Status = HealthStatus.Up,
@@ -47,7 +49,8 @@ public class EurekaApplicationsHealthContributor : IHealthContributor
 
         result.Details.Add("status", result.Status.ToSnakeCaseString(SnakeCaseStyle.AllCaps));
         result.Details.Add("statusDescription", result.Description);
-        return result;
+
+        return Task.FromResult(result);
     }
 
     internal void AddApplicationHealthStatus(string appName, Application app, HealthCheckResult result)
@@ -70,7 +73,7 @@ public class EurekaApplicationsHealthContributor : IHealthContributor
         }
     }
 
-    internal IList<string> GetMonitoredApplications(IEurekaClientConfiguration clientConfiguration)
+    private IList<string> GetMonitoredApplications(IEurekaClientConfiguration clientConfiguration)
     {
         IList<string> configApps = GetApplicationsFromConfig(clientConfiguration);
 

--- a/src/Discovery/src/Eureka/EurekaApplicationsHealthContributor.cs
+++ b/src/Discovery/src/Eureka/EurekaApplicationsHealthContributor.cs
@@ -25,7 +25,7 @@ public class EurekaApplicationsHealthContributor : IHealthContributor
     {
     }
 
-    public Task<HealthCheckResult> HealthAsync(CancellationToken cancellationToken)
+    public Task<HealthCheckResult> CheckHealthAsync(CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
 

--- a/src/Discovery/src/Eureka/EurekaClientService.cs
+++ b/src/Discovery/src/Eureka/EurekaClientService.cs
@@ -25,15 +25,19 @@ public static class EurekaClientService
     /// <param name="logFactory">
     /// optional log factory to use for logging.
     /// </param>
+    /// <param name="cancellationToken">
+    /// The token to monitor for cancellation requests.
+    /// </param>
     /// <returns>
     /// service instances.
     /// </returns>
-    public static IList<IServiceInstance> GetInstances(IConfiguration configuration, string serviceId, ILoggerFactory logFactory = null)
+    public static async Task<IList<IServiceInstance>> GetInstancesAsync(IConfiguration configuration, string serviceId, ILoggerFactory logFactory,
+        CancellationToken cancellationToken)
     {
         EurekaClientOptions options = ConfigureClientOptions(configuration);
         LookupClient client = GetLookupClient(options, logFactory);
         IList<IServiceInstance> result = client.GetInstancesInternal(serviceId);
-        client.ShutdownAsync().GetAwaiter().GetResult();
+        await client.ShutdownAsync(cancellationToken);
         return result;
     }
 
@@ -47,15 +51,18 @@ public static class EurekaClientService
     /// <param name="logFactory">
     /// optional log factory to use for logging.
     /// </param>
+    /// <param name="cancellationToken">
+    /// The token to monitor for cancellation requests.
+    /// </param>
     /// <returns>
     /// all registered services.
     /// </returns>
-    public static IList<string> GetServices(IConfiguration configuration, ILoggerFactory logFactory = null)
+    public static async Task<IList<string>> GetServicesAsync(IConfiguration configuration, ILoggerFactory logFactory, CancellationToken cancellationToken)
     {
         EurekaClientOptions options = ConfigureClientOptions(configuration);
         LookupClient client = GetLookupClient(options, logFactory);
         IList<string> result = client.GetServicesInternal();
-        client.ShutdownAsync().GetAwaiter().GetResult();
+        await client.ShutdownAsync(cancellationToken);
         return result;
     }
 

--- a/src/Discovery/src/Eureka/EurekaHealthCheckHandler.cs
+++ b/src/Discovery/src/Eureka/EurekaHealthCheckHandler.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.Logging;
+using Steeltoe.Common;
 using Steeltoe.Common.HealthChecks;
 using Steeltoe.Discovery.Eureka.AppInfo;
 
@@ -52,7 +53,7 @@ public class EurekaHealthCheckHandler : IHealthCheckHandler
                     results.Add(result);
                 }
             }
-            catch (Exception exception) when (exception is not OperationCanceledException)
+            catch (Exception exception) when (!exception.IsCancellation())
             {
                 _logger?.LogError(exception, "Health Contributor {id} failed, status not included!", contributor.Id);
             }

--- a/src/Discovery/src/Eureka/EurekaHealthCheckHandler.cs
+++ b/src/Discovery/src/Eureka/EurekaHealthCheckHandler.cs
@@ -46,7 +46,7 @@ public class EurekaHealthCheckHandler : IHealthCheckHandler
         {
             try
             {
-                HealthCheckResult result = await contributor.HealthAsync(cancellationToken);
+                HealthCheckResult result = await contributor.CheckHealthAsync(cancellationToken);
 
                 if (result != null)
                 {

--- a/src/Discovery/src/Eureka/EurekaServerHealthContributor.cs
+++ b/src/Discovery/src/Eureka/EurekaServerHealthContributor.cs
@@ -29,7 +29,7 @@ public class EurekaServerHealthContributor : IHealthContributor
     {
     }
 
-    public Task<HealthCheckResult> HealthAsync(CancellationToken cancellationToken)
+    public Task<HealthCheckResult> CheckHealthAsync(CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
 

--- a/src/Discovery/src/Eureka/IEurekaClient.cs
+++ b/src/Discovery/src/Eureka/IEurekaClient.cs
@@ -10,5 +10,5 @@ public interface IEurekaClient : ILookupService
 {
     IList<InstanceInfo> GetInstancesByVipAddress(string vipAddress, bool secure);
 
-    Task ShutdownAsync();
+    Task ShutdownAsync(CancellationToken cancellationToken);
 }

--- a/src/Discovery/src/Eureka/IHealthCheckHandler.cs
+++ b/src/Discovery/src/Eureka/IHealthCheckHandler.cs
@@ -8,5 +8,5 @@ namespace Steeltoe.Discovery.Eureka;
 
 public interface IHealthCheckHandler
 {
-    InstanceStatus GetStatus(InstanceStatus currentStatus);
+    Task<InstanceStatus> GetStatusAsync(InstanceStatus currentStatus, CancellationToken cancellationToken);
 }

--- a/src/Discovery/src/Eureka/Transport/EurekaHttpClient.cs
+++ b/src/Discovery/src/Eureka/Transport/EurekaHttpClient.cs
@@ -87,15 +87,10 @@ public class EurekaHttpClient : IEurekaHttpClient
     {
     }
 
-    public virtual Task<EurekaHttpResponse> RegisterAsync(InstanceInfo info)
+    public virtual async Task<EurekaHttpResponse> RegisterAsync(InstanceInfo info, CancellationToken cancellationToken)
     {
         ArgumentGuard.NotNull(info);
 
-        return RegisterInternalAsync(info);
-    }
-
-    private async Task<EurekaHttpResponse> RegisterInternalAsync(InstanceInfo info)
-    {
         if ((Platform.IsContainerized || Platform.IsCloudHosted) && info.HostName?.Equals("localhost", StringComparison.OrdinalIgnoreCase) == true)
         {
             logger?.LogWarning(
@@ -104,15 +99,14 @@ public class EurekaHttpClient : IEurekaHttpClient
 
         IList<string> candidateServiceUrls = GetServiceUrlCandidates();
         int index = 0;
-        string serviceUrl = null;
         httpClient ??= GetHttpClient(Configuration);
 
         // For retries
         for (int retry = 0; retry < GetRetryCount(Configuration); retry++)
         {
-            serviceUrl = GetServiceUrl(candidateServiceUrls, ref index);
+            string serviceUrl = GetServiceUrl(candidateServiceUrls, ref index);
             Uri requestUri = GetRequestUri($"{serviceUrl}apps/{info.AppName}");
-            HttpRequestMessage request = GetRequestMessage(HttpMethod.Post, requestUri);
+            HttpRequestMessage request = await GetRequestMessageAsync(HttpMethod.Post, requestUri, cancellationToken);
 
             try
             {
@@ -121,7 +115,7 @@ public class EurekaHttpClient : IEurekaHttpClient
                     Instance = info.ToJsonInstance()
                 });
 
-                using HttpResponseMessage response = await httpClient.SendAsync(request);
+                using HttpResponseMessage response = await httpClient.SendAsync(request, cancellationToken);
                 logger?.LogDebug("RegisterAsync {RequestUri}, status: {StatusCode}, retry: {retry}", requestUri.ToMaskedString(), response.StatusCode, retry);
                 int statusCode = (int)response.StatusCode;
 
@@ -137,12 +131,15 @@ public class EurekaHttpClient : IEurekaHttpClient
                     return resp;
                 }
 
-                string jsonError = await response.Content.ReadAsStringAsync();
+                string jsonError = await response.Content.ReadAsStringAsync(cancellationToken);
                 logger?.LogInformation("Failure during RegisterAsync: {jsonError}", jsonError);
             }
-            catch (Exception e)
+            catch (Exception exception)
             {
-                logger?.LogError(e, "RegisterAsync Failed, request was made to {requestUri}, retry: {retry}", requestUri.ToMaskedUri(), retry);
+                if (exception is not OperationCanceledException)
+                {
+                    logger?.LogError(exception, "RegisterAsync Failed, request was made to {requestUri}, retry: {retry}", requestUri.ToMaskedUri(), retry);
+                }
             }
 
             Interlocked.CompareExchange(ref ServiceUrl, null, serviceUrl);
@@ -152,18 +149,13 @@ public class EurekaHttpClient : IEurekaHttpClient
         throw new EurekaTransportException("Retry limit reached; giving up on completing the RegisterAsync request");
     }
 
-    public virtual Task<EurekaHttpResponse<InstanceInfo>> SendHeartBeatAsync(string appName, string id, InstanceInfo info, InstanceStatus overriddenStatus)
+    public virtual async Task<EurekaHttpResponse<InstanceInfo>> SendHeartBeatAsync(string appName, string id, InstanceInfo info,
+        InstanceStatus overriddenStatus, CancellationToken cancellationToken)
     {
-        ArgumentGuard.NotNull(info);
-
         ArgumentGuard.NotNullOrEmpty(appName);
         ArgumentGuard.NotNullOrEmpty(id);
+        ArgumentGuard.NotNull(info);
 
-        return SendHeartBeatInternalAsync(id, info, overriddenStatus);
-    }
-
-    private async Task<EurekaHttpResponse<InstanceInfo>> SendHeartBeatInternalAsync(string id, InstanceInfo info, InstanceStatus overriddenStatus)
-    {
         var queryArgs = new Dictionary<string, string>
         {
             { "status", info.Status.ToSnakeCaseString(SnakeCaseStyle.AllCaps) },
@@ -180,36 +172,35 @@ public class EurekaHttpClient : IEurekaHttpClient
 
         IList<string> candidateServiceUrls = GetServiceUrlCandidates();
         int index = 0;
-        string serviceUrl = null;
         httpClient ??= GetHttpClient(Configuration);
 
         for (int retry = 0; retry < GetRetryCount(Configuration); retry++)
         {
-            serviceUrl = GetServiceUrl(candidateServiceUrls, ref index);
+            string serviceUrl = GetServiceUrl(candidateServiceUrls, ref index);
             Uri requestUri = GetRequestUri($"{serviceUrl}apps/{info.AppName}/{id}", queryArgs);
-            HttpRequestMessage request = GetRequestMessage(HttpMethod.Put, requestUri);
+            HttpRequestMessage request = await GetRequestMessageAsync(HttpMethod.Put, requestUri, cancellationToken);
 
             try
             {
-                using HttpResponseMessage response = await httpClient.SendAsync(request);
+                using HttpResponseMessage response = await httpClient.SendAsync(request, cancellationToken);
                 JsonInstanceInfo instanceInfo = null;
 
                 try
                 {
-                    instanceInfo = await response.Content.ReadFromJsonAsync<JsonInstanceInfo>(JsonSerializerOptions);
+                    instanceInfo = await response.Content.ReadFromJsonAsync<JsonInstanceInfo>(JsonSerializerOptions, cancellationToken);
                 }
-                catch (Exception e)
+                catch (Exception exception)
                 {
-                    string responseBody = await response.Content.ReadAsStringAsync();
+                    string responseBody = await response.Content.ReadAsStringAsync(cancellationToken);
 
                     if (response.IsSuccessStatusCode && string.IsNullOrEmpty(responseBody))
                     {
                         // request was successful but body was empty. This is OK, we don't need a response body
                     }
-                    else
+                    else if (exception is not OperationCanceledException)
                     {
-                        logger?.LogError(e, "Failed to read heartbeat response. Response code: {responseCode}, Body: {responseBody}", response.StatusCode,
-                            responseBody);
+                        logger?.LogError(exception, "Failed to read heartbeat response. Response code: {responseCode}, Body: {responseBody}",
+                            response.StatusCode, responseBody);
                     }
                 }
 
@@ -237,9 +228,9 @@ public class EurekaHttpClient : IEurekaHttpClient
                     return resp;
                 }
             }
-            catch (Exception e)
+            catch (Exception exception) when (exception is not OperationCanceledException)
             {
-                logger?.LogError(e, "SendHeartBeatAsync Failed, request was made to {requestUri}", requestUri.ToMaskedUri());
+                logger?.LogError(exception, "SendHeartBeatAsync Failed, request was made to {requestUri}", requestUri.ToMaskedUri());
             }
 
             Interlocked.CompareExchange(ref ServiceUrl, null, serviceUrl);
@@ -249,66 +240,70 @@ public class EurekaHttpClient : IEurekaHttpClient
         throw new EurekaTransportException("Retry limit reached; giving up on completing the SendHeartBeatAsync request");
     }
 
-    public virtual Task<EurekaHttpResponse<Applications>> GetApplicationsAsync(ISet<string> regions = null)
+    public virtual Task<EurekaHttpResponse<Applications>> GetApplicationsAsync(CancellationToken cancellationToken)
     {
-        return DoGetApplicationsAsync("apps/", regions);
+        return GetApplicationsAsync(null, cancellationToken);
     }
 
-    public virtual Task<EurekaHttpResponse<Applications>> GetDeltaAsync(ISet<string> regions = null)
+    public virtual Task<EurekaHttpResponse<Applications>> GetApplicationsAsync(ISet<string> regions, CancellationToken cancellationToken)
     {
-        return DoGetApplicationsAsync("apps/delta", regions);
+        return DoGetApplicationsAsync("apps/", regions, cancellationToken);
     }
 
-    public virtual Task<EurekaHttpResponse<Applications>> GetVipAsync(string vipAddress, ISet<string> regions = null)
+    public virtual Task<EurekaHttpResponse<Applications>> GetDeltaAsync(CancellationToken cancellationToken)
+    {
+        return GetDeltaAsync(null, cancellationToken);
+    }
+
+    public virtual Task<EurekaHttpResponse<Applications>> GetDeltaAsync(ISet<string> regions, CancellationToken cancellationToken)
+    {
+        return DoGetApplicationsAsync("apps/delta", regions, cancellationToken);
+    }
+
+    public virtual Task<EurekaHttpResponse<Applications>> GetVipAsync(string vipAddress, CancellationToken cancellationToken)
+    {
+        return GetVipAsync(vipAddress, null, cancellationToken);
+    }
+
+    public virtual Task<EurekaHttpResponse<Applications>> GetVipAsync(string vipAddress, ISet<string> regions, CancellationToken cancellationToken)
     {
         ArgumentGuard.NotNullOrEmpty(vipAddress);
 
-        return GetVipInternalAsync(vipAddress, regions);
+        return DoGetApplicationsAsync($"vips/{vipAddress}", regions, cancellationToken);
     }
 
-    private Task<EurekaHttpResponse<Applications>> GetVipInternalAsync(string vipAddress, ISet<string> regions)
+    public virtual Task<EurekaHttpResponse<Applications>> GetSecureVipAsync(string secureVipAddress, CancellationToken cancellationToken)
     {
-        return DoGetApplicationsAsync($"vips/{vipAddress}", regions);
+        return GetSecureVipAsync(secureVipAddress, null, cancellationToken);
     }
 
-    public virtual Task<EurekaHttpResponse<Applications>> GetSecureVipAsync(string secureVipAddress, ISet<string> regions = null)
+    public virtual Task<EurekaHttpResponse<Applications>> GetSecureVipAsync(string secureVipAddress, ISet<string> regions, CancellationToken cancellationToken)
     {
         ArgumentGuard.NotNullOrEmpty(secureVipAddress);
 
-        return GetSecureVipInternalAsync(secureVipAddress, regions);
+        return DoGetApplicationsAsync($"vips/{secureVipAddress}", regions, cancellationToken);
     }
 
-    private Task<EurekaHttpResponse<Applications>> GetSecureVipInternalAsync(string secureVipAddress, ISet<string> regions = null)
-    {
-        return DoGetApplicationsAsync($"vips/{secureVipAddress}", regions);
-    }
-
-    public virtual Task<EurekaHttpResponse<Application>> GetApplicationAsync(string appName)
+    public virtual async Task<EurekaHttpResponse<Application>> GetApplicationAsync(string appName, CancellationToken cancellationToken)
     {
         ArgumentGuard.NotNullOrEmpty(appName);
 
-        return GetApplicationInternalAsync(appName);
-    }
-
-    private async Task<EurekaHttpResponse<Application>> GetApplicationInternalAsync(string appName)
-    {
         IList<string> candidateServiceUrls = GetServiceUrlCandidates();
         int index = 0;
-        string serviceUrl = null;
         httpClient ??= GetHttpClient(Configuration);
 
         // For retries
         for (int retry = 0; retry < GetRetryCount(Configuration); retry++)
         {
-            serviceUrl = GetServiceUrl(candidateServiceUrls, ref index);
+            string serviceUrl = GetServiceUrl(candidateServiceUrls, ref index);
             Uri requestUri = GetRequestUri($"{serviceUrl}apps/{appName}");
-            HttpRequestMessage request = GetRequestMessage(HttpMethod.Get, requestUri);
+            HttpRequestMessage request = await GetRequestMessageAsync(HttpMethod.Get, requestUri, cancellationToken);
 
             try
             {
-                using HttpResponseMessage response = await httpClient.SendAsync(request);
+                using HttpResponseMessage response = await httpClient.SendAsync(request, cancellationToken);
 
-                var applicationRoot = await response.Content.ReadFromJsonAsync<JsonApplicationRoot>(JsonSerializerOptions);
+                var applicationRoot = await response.Content.ReadFromJsonAsync<JsonApplicationRoot>(JsonSerializerOptions, cancellationToken);
 
                 Application appResp = null;
 
@@ -334,9 +329,9 @@ public class EurekaHttpClient : IEurekaHttpClient
                     return resp;
                 }
             }
-            catch (Exception e)
+            catch (Exception exception) when (exception is not OperationCanceledException)
             {
-                logger?.LogError(e, "GetApplicationAsync Failed, request was made to {requestUri}", requestUri.ToMaskedUri());
+                logger?.LogError(exception, "GetApplicationAsync Failed, request was made to {requestUri}", requestUri.ToMaskedUri());
             }
 
             Interlocked.CompareExchange(ref ServiceUrl, null, serviceUrl);
@@ -346,56 +341,40 @@ public class EurekaHttpClient : IEurekaHttpClient
         throw new EurekaTransportException("Retry limit reached; giving up on completing the GetApplicationAsync request");
     }
 
-    public virtual Task<EurekaHttpResponse<InstanceInfo>> GetInstanceAsync(string id)
+    public virtual Task<EurekaHttpResponse<InstanceInfo>> GetInstanceAsync(string id, CancellationToken cancellationToken)
     {
         ArgumentGuard.NotNullOrEmpty(id);
 
-        return GetInstanceInternalAsync(id);
+        return DoGetInstanceAsync($"instances/{id}", cancellationToken);
     }
 
-    public virtual Task<EurekaHttpResponse<InstanceInfo>> GetInstanceAsync(string appName, string id)
+    public virtual Task<EurekaHttpResponse<InstanceInfo>> GetInstanceAsync(string appName, string id, CancellationToken cancellationToken)
     {
         ArgumentGuard.NotNullOrEmpty(appName);
         ArgumentGuard.NotNullOrEmpty(id);
 
-        return GetInstanceInternalAsync(appName, id);
+        return DoGetInstanceAsync($"apps/{appName}/{id}", cancellationToken);
     }
 
-    private Task<EurekaHttpResponse<InstanceInfo>> GetInstanceInternalAsync(string id)
-    {
-        return DoGetInstanceAsync($"instances/{id}");
-    }
-
-    private Task<EurekaHttpResponse<InstanceInfo>> GetInstanceInternalAsync(string appName, string id)
-    {
-        return DoGetInstanceAsync($"apps/{appName}/{id}");
-    }
-
-    public virtual Task<EurekaHttpResponse> CancelAsync(string appName, string id)
+    public virtual async Task<EurekaHttpResponse> CancelAsync(string appName, string id, CancellationToken cancellationToken)
     {
         ArgumentGuard.NotNullOrEmpty(appName);
         ArgumentGuard.NotNullOrEmpty(id);
 
-        return CancelInternalAsync(appName, id);
-    }
-
-    private async Task<EurekaHttpResponse> CancelInternalAsync(string appName, string id)
-    {
         IList<string> candidateServiceUrls = GetServiceUrlCandidates();
         int index = 0;
-        string serviceUrl = null;
         httpClient ??= GetHttpClient(Configuration);
 
         // For retries
         for (int retry = 0; retry < GetRetryCount(Configuration); retry++)
         {
-            serviceUrl = GetServiceUrl(candidateServiceUrls, ref index);
+            string serviceUrl = GetServiceUrl(candidateServiceUrls, ref index);
             Uri requestUri = GetRequestUri($"{serviceUrl}apps/{appName}/{id}");
-            HttpRequestMessage request = GetRequestMessage(HttpMethod.Delete, requestUri);
+            HttpRequestMessage request = await GetRequestMessageAsync(HttpMethod.Delete, requestUri, cancellationToken);
 
             try
             {
-                using HttpResponseMessage response = await httpClient.SendAsync(request);
+                using HttpResponseMessage response = await httpClient.SendAsync(request, cancellationToken);
                 logger?.LogDebug("CancelAsync {RequestUri}, status: {StatusCode}, retry: {retry}", requestUri.ToMaskedString(), response.StatusCode, retry);
                 Interlocked.Exchange(ref ServiceUrl, serviceUrl);
 
@@ -406,9 +385,9 @@ public class EurekaHttpClient : IEurekaHttpClient
 
                 return resp;
             }
-            catch (Exception e)
+            catch (Exception exception) when (exception is not OperationCanceledException)
             {
-                logger?.LogError(e, "CancelAsync Failed, request was made to {requestUri}", requestUri.ToMaskedUri());
+                logger?.LogError(exception, "CancelAsync Failed, request was made to {requestUri}", requestUri.ToMaskedUri());
             }
 
             Interlocked.CompareExchange(ref ServiceUrl, null, serviceUrl);
@@ -418,18 +397,12 @@ public class EurekaHttpClient : IEurekaHttpClient
         throw new EurekaTransportException("Retry limit reached; giving up on completing the CancelAsync request");
     }
 
-    public virtual Task<EurekaHttpResponse> DeleteStatusOverrideAsync(string appName, string id, InstanceInfo info)
+    public virtual async Task<EurekaHttpResponse> DeleteStatusOverrideAsync(string appName, string id, InstanceInfo info, CancellationToken cancellationToken)
     {
         ArgumentGuard.NotNullOrEmpty(appName);
         ArgumentGuard.NotNullOrEmpty(id);
-
         ArgumentGuard.NotNull(info);
 
-        return DeleteStatusOverrideInternalAsync(appName, id, info);
-    }
-
-    private async Task<EurekaHttpResponse> DeleteStatusOverrideInternalAsync(string appName, string id, InstanceInfo info)
-    {
         var queryArgs = new Dictionary<string, string>
         {
             {
@@ -440,19 +413,18 @@ public class EurekaHttpClient : IEurekaHttpClient
 
         IList<string> candidateServiceUrls = GetServiceUrlCandidates();
         int index = 0;
-        string serviceUrl = null;
         httpClient ??= GetHttpClient(Configuration);
 
         // For retries
         for (int retry = 0; retry < GetRetryCount(Configuration); retry++)
         {
-            serviceUrl = GetServiceUrl(candidateServiceUrls, ref index);
+            string serviceUrl = GetServiceUrl(candidateServiceUrls, ref index);
             Uri requestUri = GetRequestUri($"{serviceUrl}apps/{appName}/{id}/status", queryArgs);
-            HttpRequestMessage request = GetRequestMessage(HttpMethod.Delete, requestUri);
+            HttpRequestMessage request = await GetRequestMessageAsync(HttpMethod.Delete, requestUri, cancellationToken);
 
             try
             {
-                using HttpResponseMessage response = await httpClient.SendAsync(request);
+                using HttpResponseMessage response = await httpClient.SendAsync(request, cancellationToken);
 
                 logger?.LogDebug("DeleteStatusOverrideAsync {RequestUri}, status: {StatusCode}, retry: {retry}", requestUri.ToMaskedString(),
                     response.StatusCode, retry);
@@ -471,9 +443,9 @@ public class EurekaHttpClient : IEurekaHttpClient
                     return resp;
                 }
             }
-            catch (Exception e)
+            catch (Exception exception) when (exception is not OperationCanceledException)
             {
-                logger?.LogError(e, "DeleteStatusOverrideAsync Failed, request was made to {requestUri}", requestUri.ToMaskedUri());
+                logger?.LogError(exception, "DeleteStatusOverrideAsync Failed, request was made to {requestUri}", requestUri.ToMaskedUri());
             }
 
             Interlocked.CompareExchange(ref ServiceUrl, null, serviceUrl);
@@ -483,18 +455,13 @@ public class EurekaHttpClient : IEurekaHttpClient
         throw new EurekaTransportException("Retry limit reached; giving up on completing the DeleteStatusOverrideAsync request");
     }
 
-    public virtual Task<EurekaHttpResponse> StatusUpdateAsync(string appName, string id, InstanceStatus newStatus, InstanceInfo info)
+    public virtual async Task<EurekaHttpResponse> StatusUpdateAsync(string appName, string id, InstanceStatus newStatus, InstanceInfo info,
+        CancellationToken cancellationToken)
     {
         ArgumentGuard.NotNullOrEmpty(appName);
         ArgumentGuard.NotNullOrEmpty(id);
-
         ArgumentGuard.NotNull(info);
 
-        return StatusUpdateInternalAsync(appName, id, newStatus, info);
-    }
-
-    private async Task<EurekaHttpResponse> StatusUpdateInternalAsync(string appName, string id, InstanceStatus newStatus, InstanceInfo info)
-    {
         var queryArgs = new Dictionary<string, string>
         {
             { "value", newStatus.ToSnakeCaseString(SnakeCaseStyle.AllCaps) },
@@ -506,19 +473,18 @@ public class EurekaHttpClient : IEurekaHttpClient
 
         IList<string> candidateServiceUrls = GetServiceUrlCandidates();
         int index = 0;
-        string serviceUrl = null;
         httpClient ??= GetHttpClient(Configuration);
 
         // For retries
         for (int retry = 0; retry < GetRetryCount(Configuration); retry++)
         {
-            serviceUrl = GetServiceUrl(candidateServiceUrls, ref index);
+            string serviceUrl = GetServiceUrl(candidateServiceUrls, ref index);
             Uri requestUri = GetRequestUri($"{serviceUrl}apps/{appName}/{id}/status", queryArgs);
-            HttpRequestMessage request = GetRequestMessage(HttpMethod.Put, requestUri);
+            HttpRequestMessage request = await GetRequestMessageAsync(HttpMethod.Put, requestUri, cancellationToken);
 
             try
             {
-                using HttpResponseMessage response = await httpClient.SendAsync(request);
+                using HttpResponseMessage response = await httpClient.SendAsync(request, cancellationToken);
 
                 logger?.LogDebug("StatusUpdateAsync {RequestUri}, status: {StatusCode}, retry: {retry}", requestUri.ToMaskedString(), response.StatusCode,
                     retry);
@@ -537,9 +503,9 @@ public class EurekaHttpClient : IEurekaHttpClient
                     return resp;
                 }
             }
-            catch (Exception e)
+            catch (Exception exception) when (exception is not OperationCanceledException)
             {
-                logger?.LogError(e, "StatusUpdateAsync Failed, request was made to {requestUri}", requestUri.ToMaskedUri());
+                logger?.LogError(exception, "StatusUpdateAsync Failed, request was made to {requestUri}", requestUri.ToMaskedUri());
             }
 
             Interlocked.CompareExchange(ref ServiceUrl, null, serviceUrl);
@@ -549,17 +515,17 @@ public class EurekaHttpClient : IEurekaHttpClient
         throw new EurekaTransportException("Retry limit reached; giving up on completing the StatusUpdateAsync request");
     }
 
-    public virtual void Shutdown()
+    public virtual Task ShutdownAsync(CancellationToken cancellationToken)
     {
+        return Task.CompletedTask;
     }
 
-    internal string FetchAccessToken()
+    private async Task<string> FetchAccessTokenAsync(CancellationToken cancellationToken)
     {
         return Configuration is not EurekaClientOptions options || string.IsNullOrEmpty(options.AccessTokenUri)
             ? null
-            : HttpClientHelper.GetAccessTokenAsync(
-                    options.AccessTokenUri, options.ClientId, options.ClientSecret, DefaultGetAccessTokenTimeout, options.ValidateCertificates).GetAwaiter()
-                .GetResult();
+            : await HttpClientHelper.GetAccessTokenAsync(options.AccessTokenUri, options.ClientId, options.ClientSecret, DefaultGetAccessTokenTimeout,
+                options.ValidateCertificates, null, null, cancellationToken);
     }
 
     internal IList<string> GetServiceUrlCandidates()
@@ -619,7 +585,7 @@ public class EurekaHttpClient : IEurekaHttpClient
         }
     }
 
-    internal string GetServiceUrl(IList<string> candidateServiceUrls, ref int index)
+    private string GetServiceUrl(IList<string> candidateServiceUrls, ref int index)
     {
         string serviceUrl = ServiceUrl;
 
@@ -636,7 +602,7 @@ public class EurekaHttpClient : IEurekaHttpClient
         return serviceUrl;
     }
 
-    protected internal static IList<string> MakeServiceUrls(string serviceUrls)
+    private static IList<string> MakeServiceUrls(string serviceUrls)
     {
         var results = new List<string>();
 
@@ -665,7 +631,7 @@ public class EurekaHttpClient : IEurekaHttpClient
         return url;
     }
 
-    protected internal HttpRequestMessage GetRequestMessage(HttpMethod method, Uri requestUri)
+    protected internal async Task<HttpRequestMessage> GetRequestMessageAsync(HttpMethod method, Uri requestUri, CancellationToken cancellationToken)
     {
         var rawUri = new Uri(requestUri.GetComponents(UriComponents.HttpRequestUrl, UriFormat.Unescaped));
         string rawUserInfo = requestUri.GetComponents(UriComponents.UserInfo, UriFormat.Unescaped);
@@ -682,7 +648,7 @@ public class EurekaHttpClient : IEurekaHttpClient
         }
         else
         {
-            request = HttpClientHelper.GetRequestMessage(method, rawUri, FetchAccessToken);
+            request = await HttpClientHelper.GetRequestMessageAsync(method, rawUri, FetchAccessTokenAsync, cancellationToken);
         }
 
         foreach (KeyValuePair<string, string> header in headers)
@@ -728,24 +694,23 @@ public class EurekaHttpClient : IEurekaHttpClient
         MakeServiceUrls(Configuration.EurekaServerServiceUrls);
     }
 
-    protected virtual async Task<EurekaHttpResponse<InstanceInfo>> DoGetInstanceAsync(string path)
+    protected virtual async Task<EurekaHttpResponse<InstanceInfo>> DoGetInstanceAsync(string path, CancellationToken cancellationToken)
     {
         IList<string> candidateServiceUrls = GetServiceUrlCandidates();
         int index = 0;
-        string serviceUrl = null;
         httpClient ??= GetHttpClient(Configuration);
 
         // For retries
         for (int retry = 0; retry < GetRetryCount(Configuration); retry++)
         {
-            serviceUrl = GetServiceUrl(candidateServiceUrls, ref index);
+            string serviceUrl = GetServiceUrl(candidateServiceUrls, ref index);
             Uri requestUri = GetRequestUri(serviceUrl + path);
-            HttpRequestMessage request = GetRequestMessage(HttpMethod.Get, requestUri);
+            HttpRequestMessage request = await GetRequestMessageAsync(HttpMethod.Get, requestUri, cancellationToken);
 
             try
             {
-                using HttpResponseMessage response = await httpClient.SendAsync(request);
-                var infoRoot = await response.Content.ReadFromJsonAsync<JsonInstanceInfoRoot>(JsonSerializerOptions);
+                using HttpResponseMessage response = await httpClient.SendAsync(request, cancellationToken);
+                var infoRoot = await response.Content.ReadFromJsonAsync<JsonInstanceInfoRoot>(JsonSerializerOptions, cancellationToken);
 
                 InstanceInfo infoResp = null;
 
@@ -771,9 +736,9 @@ public class EurekaHttpClient : IEurekaHttpClient
                     return resp;
                 }
             }
-            catch (Exception e)
+            catch (Exception exception) when (exception is not OperationCanceledException)
             {
-                logger?.LogError(e, "DoGetInstanceAsync Failed, request was made to {requestUri}", requestUri.ToMaskedUri());
+                logger?.LogError(exception, "DoGetInstanceAsync Failed, request was made to {requestUri}", requestUri.ToMaskedUri());
             }
 
             Interlocked.CompareExchange(ref ServiceUrl, null, serviceUrl);
@@ -783,7 +748,8 @@ public class EurekaHttpClient : IEurekaHttpClient
         throw new EurekaTransportException("Retry limit reached; giving up on completing the DoGetInstanceAsync request");
     }
 
-    protected virtual async Task<EurekaHttpResponse<Applications>> DoGetApplicationsAsync(string path, ISet<string> regions)
+    protected virtual async Task<EurekaHttpResponse<Applications>> DoGetApplicationsAsync(string path, ISet<string> regions,
+        CancellationToken cancellationToken)
     {
         string regionParams = CommaDelimit(regions);
 
@@ -796,28 +762,27 @@ public class EurekaHttpClient : IEurekaHttpClient
 
         IList<string> candidateServiceUrls = GetServiceUrlCandidates();
         int index = 0;
-        string serviceUrl = null;
         httpClient ??= GetHttpClient(Configuration);
 
         // For retries
         for (int retry = 0; retry < GetRetryCount(Configuration); retry++)
         {
-            serviceUrl = GetServiceUrl(candidateServiceUrls, ref index);
+            string serviceUrl = GetServiceUrl(candidateServiceUrls, ref index);
             Uri requestUri = GetRequestUri(serviceUrl + path, queryArgs);
-            HttpRequestMessage request = GetRequestMessage(HttpMethod.Get, requestUri);
+            HttpRequestMessage request = await GetRequestMessageAsync(HttpMethod.Get, requestUri, cancellationToken);
 
             try
             {
-                using HttpResponseMessage response = await httpClient.SendAsync(request);
+                using HttpResponseMessage response = await httpClient.SendAsync(request, cancellationToken);
                 JsonApplicationsRoot root = null;
 
                 try
                 {
-                    root = await response.Content.ReadFromJsonAsync<JsonApplicationsRoot>(JsonSerializerOptions);
+                    root = await response.Content.ReadFromJsonAsync<JsonApplicationsRoot>(JsonSerializerOptions, cancellationToken);
                 }
-                catch (Exception e)
+                catch (Exception exception) when (exception is not OperationCanceledException)
                 {
-                    logger?.LogInformation(e, "Failed to deserialize response");
+                    logger?.LogInformation(exception, "Failed to deserialize response");
                 }
 
                 Applications appsResp = null;
@@ -844,9 +809,12 @@ public class EurekaHttpClient : IEurekaHttpClient
                     return resp;
                 }
             }
-            catch (Exception e)
+            catch (Exception exception)
             {
-                logger?.LogError(e, "DoGetApplicationsAsync Failed, request was made to {requestUri}", requestUri.ToMaskedUri());
+                if (exception is not OperationCanceledException)
+                {
+                    logger?.LogError(exception, "DoGetApplicationsAsync Failed, request was made to {requestUri}", requestUri.ToMaskedUri());
+                }
             }
 
             Interlocked.CompareExchange(ref ServiceUrl, null, serviceUrl);

--- a/src/Discovery/src/Eureka/Transport/EurekaHttpClient.cs
+++ b/src/Discovery/src/Eureka/Transport/EurekaHttpClient.cs
@@ -134,12 +134,9 @@ public class EurekaHttpClient : IEurekaHttpClient
                 string jsonError = await response.Content.ReadAsStringAsync(cancellationToken);
                 logger?.LogInformation("Failure during RegisterAsync: {jsonError}", jsonError);
             }
-            catch (Exception exception)
+            catch (Exception exception) when (!exception.IsCancellation())
             {
-                if (exception is not OperationCanceledException)
-                {
-                    logger?.LogError(exception, "RegisterAsync Failed, request was made to {requestUri}, retry: {retry}", requestUri.ToMaskedUri(), retry);
-                }
+                logger?.LogError(exception, "RegisterAsync Failed, request was made to {requestUri}, retry: {retry}", requestUri.ToMaskedUri(), retry);
             }
 
             Interlocked.CompareExchange(ref ServiceUrl, null, serviceUrl);
@@ -189,7 +186,7 @@ public class EurekaHttpClient : IEurekaHttpClient
                 {
                     instanceInfo = await response.Content.ReadFromJsonAsync<JsonInstanceInfo>(JsonSerializerOptions, cancellationToken);
                 }
-                catch (Exception exception)
+                catch (Exception exception) when (!exception.IsCancellation())
                 {
                     string responseBody = await response.Content.ReadAsStringAsync(cancellationToken);
 
@@ -197,11 +194,9 @@ public class EurekaHttpClient : IEurekaHttpClient
                     {
                         // request was successful but body was empty. This is OK, we don't need a response body
                     }
-                    else if (exception is not OperationCanceledException)
-                    {
-                        logger?.LogError(exception, "Failed to read heartbeat response. Response code: {responseCode}, Body: {responseBody}",
-                            response.StatusCode, responseBody);
-                    }
+
+                    logger?.LogError(exception, "Failed to read heartbeat response. Response code: {responseCode}, Body: {responseBody}", response.StatusCode,
+                        responseBody);
                 }
 
                 InstanceInfo infoResp = null;
@@ -228,7 +223,7 @@ public class EurekaHttpClient : IEurekaHttpClient
                     return resp;
                 }
             }
-            catch (Exception exception) when (exception is not OperationCanceledException)
+            catch (Exception exception) when (!exception.IsCancellation())
             {
                 logger?.LogError(exception, "SendHeartBeatAsync Failed, request was made to {requestUri}", requestUri.ToMaskedUri());
             }
@@ -329,7 +324,7 @@ public class EurekaHttpClient : IEurekaHttpClient
                     return resp;
                 }
             }
-            catch (Exception exception) when (exception is not OperationCanceledException)
+            catch (Exception exception) when (!exception.IsCancellation())
             {
                 logger?.LogError(exception, "GetApplicationAsync Failed, request was made to {requestUri}", requestUri.ToMaskedUri());
             }
@@ -385,7 +380,7 @@ public class EurekaHttpClient : IEurekaHttpClient
 
                 return resp;
             }
-            catch (Exception exception) when (exception is not OperationCanceledException)
+            catch (Exception exception) when (!exception.IsCancellation())
             {
                 logger?.LogError(exception, "CancelAsync Failed, request was made to {requestUri}", requestUri.ToMaskedUri());
             }
@@ -443,7 +438,7 @@ public class EurekaHttpClient : IEurekaHttpClient
                     return resp;
                 }
             }
-            catch (Exception exception) when (exception is not OperationCanceledException)
+            catch (Exception exception) when (!exception.IsCancellation())
             {
                 logger?.LogError(exception, "DeleteStatusOverrideAsync Failed, request was made to {requestUri}", requestUri.ToMaskedUri());
             }
@@ -503,7 +498,7 @@ public class EurekaHttpClient : IEurekaHttpClient
                     return resp;
                 }
             }
-            catch (Exception exception) when (exception is not OperationCanceledException)
+            catch (Exception exception) when (!exception.IsCancellation())
             {
                 logger?.LogError(exception, "StatusUpdateAsync Failed, request was made to {requestUri}", requestUri.ToMaskedUri());
             }
@@ -736,7 +731,7 @@ public class EurekaHttpClient : IEurekaHttpClient
                     return resp;
                 }
             }
-            catch (Exception exception) when (exception is not OperationCanceledException)
+            catch (Exception exception) when (!exception.IsCancellation())
             {
                 logger?.LogError(exception, "DoGetInstanceAsync Failed, request was made to {requestUri}", requestUri.ToMaskedUri());
             }
@@ -780,7 +775,7 @@ public class EurekaHttpClient : IEurekaHttpClient
                 {
                     root = await response.Content.ReadFromJsonAsync<JsonApplicationsRoot>(JsonSerializerOptions, cancellationToken);
                 }
-                catch (Exception exception) when (exception is not OperationCanceledException)
+                catch (Exception exception) when (!exception.IsCancellation())
                 {
                     logger?.LogInformation(exception, "Failed to deserialize response");
                 }
@@ -809,12 +804,9 @@ public class EurekaHttpClient : IEurekaHttpClient
                     return resp;
                 }
             }
-            catch (Exception exception)
+            catch (Exception exception) when (!exception.IsCancellation())
             {
-                if (exception is not OperationCanceledException)
-                {
-                    logger?.LogError(exception, "DoGetApplicationsAsync Failed, request was made to {requestUri}", requestUri.ToMaskedUri());
-                }
+                logger?.LogError(exception, "DoGetApplicationsAsync Failed, request was made to {requestUri}", requestUri.ToMaskedUri());
             }
 
             Interlocked.CompareExchange(ref ServiceUrl, null, serviceUrl);

--- a/src/Discovery/src/Eureka/Transport/IEurekaHttpClient.cs
+++ b/src/Discovery/src/Eureka/Transport/IEurekaHttpClient.cs
@@ -8,29 +8,38 @@ namespace Steeltoe.Discovery.Eureka.Transport;
 
 public interface IEurekaHttpClient
 {
-    Task<EurekaHttpResponse> RegisterAsync(InstanceInfo info);
+    Task<EurekaHttpResponse> RegisterAsync(InstanceInfo info, CancellationToken cancellationToken);
 
-    Task<EurekaHttpResponse> CancelAsync(string appName, string id);
+    Task<EurekaHttpResponse> CancelAsync(string appName, string id, CancellationToken cancellationToken);
 
-    Task<EurekaHttpResponse<InstanceInfo>> SendHeartBeatAsync(string appName, string id, InstanceInfo info, InstanceStatus overriddenStatus);
+    Task<EurekaHttpResponse<InstanceInfo>> SendHeartBeatAsync(string appName, string id, InstanceInfo info, InstanceStatus overriddenStatus,
+        CancellationToken cancellationToken);
 
-    Task<EurekaHttpResponse> StatusUpdateAsync(string appName, string id, InstanceStatus newStatus, InstanceInfo info);
+    Task<EurekaHttpResponse> StatusUpdateAsync(string appName, string id, InstanceStatus newStatus, InstanceInfo info, CancellationToken cancellationToken);
 
-    Task<EurekaHttpResponse> DeleteStatusOverrideAsync(string appName, string id, InstanceInfo info);
+    Task<EurekaHttpResponse> DeleteStatusOverrideAsync(string appName, string id, InstanceInfo info, CancellationToken cancellationToken);
 
-    Task<EurekaHttpResponse<Applications>> GetApplicationsAsync(ISet<string> regions = null);
+    Task<EurekaHttpResponse<Applications>> GetApplicationsAsync(CancellationToken cancellationToken);
 
-    Task<EurekaHttpResponse<Applications>> GetDeltaAsync(ISet<string> regions = null);
+    Task<EurekaHttpResponse<Applications>> GetApplicationsAsync(ISet<string> regions, CancellationToken cancellationToken);
 
-    Task<EurekaHttpResponse<Applications>> GetVipAsync(string vipAddress, ISet<string> regions = null);
+    Task<EurekaHttpResponse<Applications>> GetDeltaAsync(CancellationToken cancellationToken);
 
-    Task<EurekaHttpResponse<Applications>> GetSecureVipAsync(string secureVipAddress, ISet<string> regions = null);
+    Task<EurekaHttpResponse<Applications>> GetDeltaAsync(ISet<string> regions, CancellationToken cancellationToken);
 
-    Task<EurekaHttpResponse<Application>> GetApplicationAsync(string appName);
+    Task<EurekaHttpResponse<Applications>> GetVipAsync(string vipAddress, CancellationToken cancellationToken);
 
-    Task<EurekaHttpResponse<InstanceInfo>> GetInstanceAsync(string appName, string id);
+    Task<EurekaHttpResponse<Applications>> GetVipAsync(string vipAddress, ISet<string> regions, CancellationToken cancellationToken);
 
-    Task<EurekaHttpResponse<InstanceInfo>> GetInstanceAsync(string id);
+    Task<EurekaHttpResponse<Applications>> GetSecureVipAsync(string secureVipAddress, CancellationToken cancellationToken);
 
-    void Shutdown();
+    Task<EurekaHttpResponse<Applications>> GetSecureVipAsync(string secureVipAddress, ISet<string> regions, CancellationToken cancellationToken);
+
+    Task<EurekaHttpResponse<Application>> GetApplicationAsync(string appName, CancellationToken cancellationToken);
+
+    Task<EurekaHttpResponse<InstanceInfo>> GetInstanceAsync(string appName, string id, CancellationToken cancellationToken);
+
+    Task<EurekaHttpResponse<InstanceInfo>> GetInstanceAsync(string id, CancellationToken cancellationToken);
+
+    Task ShutdownAsync(CancellationToken cancellationToken);
 }

--- a/src/Discovery/test/Consul.Test/Discovery/ConsulDiscoveryClientTest.cs
+++ b/src/Discovery/test/Consul.Test/Discovery/ConsulDiscoveryClientTest.cs
@@ -68,7 +68,7 @@ public sealed class ConsulDiscoveryClientTest
 
         var dc = new ConsulDiscoveryClient(clientMoq.Object, options);
         var list = new List<IServiceInstance>();
-        await dc.AddInstancesToListAsync(list, "ServiceId", QueryOptions.Default);
+        await dc.AddInstancesToListAsync(list, "ServiceId", QueryOptions.Default, CancellationToken.None);
         Assert.Equal(2, list.Count);
 
         IServiceInstance inst = list[0];
@@ -129,53 +129,14 @@ public sealed class ConsulDiscoveryClientTest
         catMoq.Setup(c => c.Services(QueryOptions.Default, default)).Returns(result);
 
         var dc = new ConsulDiscoveryClient(clientMoq.Object, options);
-        IList<string> services = await dc.GetServiceNamesAsync();
+        IList<string> services = await dc.GetServiceNamesAsync(QueryOptions.Default, CancellationToken.None);
         Assert.Equal(2, services.Count);
         Assert.Contains("foo", services);
         Assert.Contains("bar", services);
     }
 
     [Fact]
-    public void GetServices_ReturnsExpected()
-    {
-        var options = new ConsulDiscoveryOptions();
-
-        var queryResult = new QueryResult<Dictionary<string, string[]>>
-        {
-            Response = new Dictionary<string, string[]>
-            {
-                {
-                    "foo", new[]
-                    {
-                        "I1",
-                        "I2"
-                    }
-                },
-                {
-                    "bar", new[]
-                    {
-                        "I1",
-                        "I2"
-                    }
-                }
-            }
-        };
-
-        Task<QueryResult<Dictionary<string, string[]>>> result = Task.FromResult(queryResult);
-        var clientMoq = new Mock<IConsulClient>();
-        var catMoq = new Mock<ICatalogEndpoint>();
-        clientMoq.Setup(c => c.Catalog).Returns(catMoq.Object);
-        catMoq.Setup(c => c.Services(QueryOptions.Default, default)).Returns(result);
-
-        var dc = new ConsulDiscoveryClient(clientMoq.Object, options);
-        IList<string> services = dc.GetServiceNames();
-        Assert.Equal(2, services.Count);
-        Assert.Contains("foo", services);
-        Assert.Contains("bar", services);
-    }
-
-    [Fact]
-    public void GetAllInstances_ReturnsExpected()
+    public async Task GetAllInstances_ReturnsExpected()
     {
         var options = new ConsulDiscoveryOptions();
 
@@ -242,7 +203,7 @@ public sealed class ConsulDiscoveryClientTest
         healthMoq.Setup(h => h.Service("ServiceId", options.DefaultQueryTag, options.QueryPassing, QueryOptions.Default, default)).Returns(result2);
 
         var dc = new ConsulDiscoveryClient(clientMoq.Object, options);
-        IList<IServiceInstance> list = dc.GetAllInstances(QueryOptions.Default);
+        IList<IServiceInstance> list = await dc.GetAllInstancesAsync(QueryOptions.Default, CancellationToken.None);
 
         Assert.Equal(2, list.Count);
 

--- a/src/Discovery/test/Consul.Test/Discovery/ConsulHealthContributorTest.cs
+++ b/src/Discovery/test/Consul.Test/Discovery/ConsulHealthContributorTest.cs
@@ -108,7 +108,7 @@ public sealed class ConsulHealthContributorTest
         catMoq.Setup(c => c.Services(QueryOptions.Default, default)).Returns(catResult);
 
         var contrib = new ConsulHealthContributor(clientMoq.Object, new ConsulDiscoveryOptions());
-        HealthCheckResult result = await contrib.HealthAsync(CancellationToken.None);
+        HealthCheckResult result = await contrib.CheckHealthAsync(CancellationToken.None);
 
         Assert.Equal(HealthStatus.Up, result.Status);
         Assert.Equal(2, result.Details.Count);

--- a/src/Discovery/test/Consul.Test/Discovery/ConsulHealthContributorTest.cs
+++ b/src/Discovery/test/Consul.Test/Discovery/ConsulHealthContributorTest.cs
@@ -31,7 +31,7 @@ public sealed class ConsulHealthContributorTest
         statusMoq.Setup(s => s.Leader(default)).Returns(statusResult);
 
         var contrib = new ConsulHealthContributor(clientMoq.Object, new ConsulDiscoveryOptions());
-        string result = await contrib.GetLeaderStatusAsync();
+        string result = await contrib.GetLeaderStatusAsync(CancellationToken.None);
         Assert.Equal("thestatus", result);
     }
 
@@ -66,14 +66,14 @@ public sealed class ConsulHealthContributorTest
         catMoq.Setup(c => c.Services(QueryOptions.Default, default)).Returns(catResult);
 
         var contrib = new ConsulHealthContributor(clientMoq.Object, new ConsulDiscoveryOptions());
-        Dictionary<string, string[]> result = await contrib.GetCatalogServicesAsync();
+        Dictionary<string, string[]> result = await contrib.GetCatalogServicesAsync(CancellationToken.None);
         Assert.Equal(2, result.Count);
         Assert.Contains("foo", result.Keys);
         Assert.Contains("bar", result.Keys);
     }
 
     [Fact]
-    public void Health_ReturnsExpected()
+    public async Task Health_ReturnsExpected()
     {
         var queryResult = new QueryResult<Dictionary<string, string[]>>
         {
@@ -108,7 +108,7 @@ public sealed class ConsulHealthContributorTest
         catMoq.Setup(c => c.Services(QueryOptions.Default, default)).Returns(catResult);
 
         var contrib = new ConsulHealthContributor(clientMoq.Object, new ConsulDiscoveryOptions());
-        HealthCheckResult result = contrib.Health();
+        HealthCheckResult result = await contrib.HealthAsync(CancellationToken.None);
 
         Assert.Equal(HealthStatus.Up, result.Status);
         Assert.Equal(2, result.Details.Count);

--- a/src/Discovery/test/Consul.Test/Registry/ConsulServiceRegistryTest.cs
+++ b/src/Discovery/test/Consul.Test/Registry/ConsulServiceRegistryTest.cs
@@ -23,7 +23,7 @@ public sealed class ConsulServiceRegistryTest
     }
 
     [Fact]
-    public void RegisterAsync_ThrowsOnNull()
+    public async Task RegisterAsync_ThrowsOnNull()
     {
         var clientMoq = new Mock<IConsulClient>();
         var agentMoq = new Mock<IAgentEndpoint>();
@@ -34,7 +34,7 @@ public sealed class ConsulServiceRegistryTest
         var sch = new TtlScheduler(opts, clientMoq.Object);
 
         var reg = new ConsulServiceRegistry(clientMoq.Object, opts, sch);
-        Assert.ThrowsAsync<ArgumentNullException>(() => reg.RegisterAsync(null));
+        await Assert.ThrowsAsync<ArgumentNullException>(async () => await reg.RegisterAsync(null, CancellationToken.None));
     }
 
     [Fact]
@@ -57,7 +57,7 @@ public sealed class ConsulServiceRegistryTest
 
         IConfigurationRoot configurationRoot = builder.Build();
         var registration = ConsulRegistration.CreateRegistration(opts, new ApplicationInstanceInfo(configurationRoot));
-        await reg.RegisterAsync(registration);
+        await reg.RegisterAsync(registration, CancellationToken.None);
 
         agentMoq.Verify(a => a.ServiceRegister(registration.Service, default), Times.Once);
 
@@ -67,7 +67,7 @@ public sealed class ConsulServiceRegistryTest
     }
 
     [Fact]
-    public void DeregisterAsync_ThrowsOnNull()
+    public async Task DeregisterAsync_ThrowsOnNull()
     {
         var clientMoq = new Mock<IConsulClient>();
         var agentMoq = new Mock<IAgentEndpoint>();
@@ -78,7 +78,7 @@ public sealed class ConsulServiceRegistryTest
         var sch = new TtlScheduler(opts, clientMoq.Object);
 
         var reg = new ConsulServiceRegistry(clientMoq.Object, opts, sch);
-        Assert.ThrowsAsync<ArgumentNullException>(() => reg.DeregisterAsync(null));
+        await Assert.ThrowsAsync<ArgumentNullException>(async () => await reg.DeregisterAsync(null, CancellationToken.None));
     }
 
     [Fact]
@@ -101,20 +101,20 @@ public sealed class ConsulServiceRegistryTest
 
         IConfigurationRoot configurationRoot = builder.Build();
         var registration = ConsulRegistration.CreateRegistration(opts, new ApplicationInstanceInfo(configurationRoot));
-        await reg.RegisterAsync(registration);
+        await reg.RegisterAsync(registration, CancellationToken.None);
 
         agentMoq.Verify(a => a.ServiceRegister(registration.Service, default), Times.Once);
 
         Assert.Single(sch.ServiceHeartbeats);
         Assert.Contains(registration.InstanceId, sch.ServiceHeartbeats.Keys);
 
-        await reg.DeregisterAsync(registration);
+        await reg.DeregisterAsync(registration, CancellationToken.None);
         agentMoq.Verify(a => a.ServiceDeregister(registration.Service.ID, default), Times.Once);
         Assert.Empty(sch.ServiceHeartbeats);
     }
 
     [Fact]
-    public void SetStatusAsync_ThrowsOnNull()
+    public async Task SetStatusAsync_ThrowsOnNull()
     {
         var clientMoq = new Mock<IConsulClient>();
         var agentMoq = new Mock<IAgentEndpoint>();
@@ -125,11 +125,11 @@ public sealed class ConsulServiceRegistryTest
         var sch = new TtlScheduler(opts, clientMoq.Object);
 
         var reg = new ConsulServiceRegistry(clientMoq.Object, opts, sch);
-        Assert.ThrowsAsync<ArgumentNullException>(() => reg.SetStatusAsync(null, string.Empty));
+        await Assert.ThrowsAsync<ArgumentNullException>(async () => await reg.SetStatusAsync(null, string.Empty, CancellationToken.None));
     }
 
     [Fact]
-    public void SetStatusAsync_ThrowsInvalidStatus()
+    public async Task SetStatusAsync_ThrowsInvalidStatus()
     {
         var clientMoq = new Mock<IConsulClient>();
         var agentMoq = new Mock<IAgentEndpoint>();
@@ -148,7 +148,7 @@ public sealed class ConsulServiceRegistryTest
         var registration = ConsulRegistration.CreateRegistration(opts, new ApplicationInstanceInfo(configurationRoot));
 
         var reg = new ConsulServiceRegistry(clientMoq.Object, opts, sch);
-        Assert.ThrowsAsync<ArgumentException>(() => reg.SetStatusAsync(registration, string.Empty));
+        await Assert.ThrowsAsync<ArgumentException>(async () => await reg.SetStatusAsync(registration, string.Empty, CancellationToken.None));
     }
 
     [Fact]
@@ -171,14 +171,14 @@ public sealed class ConsulServiceRegistryTest
         var registration = ConsulRegistration.CreateRegistration(opts, new ApplicationInstanceInfo(configurationRoot));
 
         var reg = new ConsulServiceRegistry(clientMoq.Object, opts, sch);
-        await reg.SetStatusAsync(registration, "Up");
+        await reg.SetStatusAsync(registration, "Up", CancellationToken.None);
         agentMoq.Verify(a => a.DisableServiceMaintenance(registration.InstanceId, default), Times.Once);
-        await reg.SetStatusAsync(registration, "Out_of_Service");
+        await reg.SetStatusAsync(registration, "Out_of_Service", CancellationToken.None);
         agentMoq.Verify(a => a.EnableServiceMaintenance(registration.InstanceId, "OUT_OF_SERVICE", default), Times.Once);
     }
 
     [Fact]
-    public void GetStatusAsync_ThrowsOnNull()
+    public async Task GetStatusAsync_ThrowsOnNull()
     {
         var clientMoq = new Mock<IConsulClient>();
         var agentMoq = new Mock<IAgentEndpoint>();
@@ -189,7 +189,7 @@ public sealed class ConsulServiceRegistryTest
         var sch = new TtlScheduler(opts, clientMoq.Object);
 
         var reg = new ConsulServiceRegistry(clientMoq.Object, opts, sch);
-        Assert.ThrowsAsync<ArgumentNullException>(() => reg.GetStatusAsync(null));
+        await Assert.ThrowsAsync<ArgumentNullException>(async () => await reg.GetStatusAsync(null, CancellationToken.None));
     }
 
     [Fact]
@@ -233,7 +233,7 @@ public sealed class ConsulServiceRegistryTest
         var sch = new TtlScheduler(opts, clientMoq.Object);
         var reg = new ConsulServiceRegistry(clientMoq.Object, opts, sch);
 
-        object ret = await reg.GetStatusAsync(registration);
+        object ret = await reg.GetStatusAsync(registration, CancellationToken.None);
         Assert.Equal("OUT_OF_SERVICE", ret);
     }
 }

--- a/src/Discovery/test/Eureka.Test/DiscoveryClientTest.cs
+++ b/src/Discovery/test/Eureka.Test/DiscoveryClientTest.cs
@@ -809,7 +809,7 @@ public sealed class DiscoveryClientTest : AbstractBaseTest
     }
 
     [Fact]
-    public void RefreshInstanceInfo_CallsHealthCheckHandler_UpdatesInstanceStatus()
+    public async Task RefreshInstanceInfo_CallsHealthCheckHandler_UpdatesInstanceStatus()
     {
         var configuration = new EurekaClientConfiguration
         {
@@ -824,9 +824,9 @@ public sealed class DiscoveryClientTest : AbstractBaseTest
         var myHandler = new MyHealthCheckHandler(InstanceStatus.Down);
         client.HealthCheckHandler = myHandler;
 
-        client.RefreshInstanceInfo();
+        await client.RefreshInstanceInfoAsync(CancellationToken.None);
 
-        Assert.True(myHandler.Called);
+        Assert.True(myHandler.Awaited);
         Assert.Equal(InstanceStatus.Down, ApplicationInfoManager.Instance.InstanceInfo.Status);
     }
 

--- a/src/Discovery/test/Eureka.Test/DiscoveryClientTest.cs
+++ b/src/Discovery/test/Eureka.Test/DiscoveryClientTest.cs
@@ -124,7 +124,7 @@ public sealed class DiscoveryClientTest : AbstractBaseTest
 
         var httpClient = new EurekaHttpClient(configuration, server.CreateClient());
         var client = new DiscoveryClient(configuration, httpClient);
-        Applications result = await client.FetchFullRegistryAsync();
+        Applications result = await client.FetchFullRegistryAsync(CancellationToken.None);
         Assert.NotNull(result);
         Assert.Equal(1, result.Version);
         Assert.Equal("UP_1_", result.AppsHashCode);
@@ -156,7 +156,7 @@ public sealed class DiscoveryClientTest : AbstractBaseTest
 
         var httpClient = new EurekaHttpClient(configuration, server.CreateClient());
         var client = new DiscoveryClient(configuration, httpClient);
-        Task<Applications> result = client.FetchFullRegistryAsync();
+        Task<Applications> result = client.FetchFullRegistryAsync(CancellationToken.None);
         client.RegistryFetchCounter = 100;
         Applications apps = await result;
         Assert.Null(apps);
@@ -199,7 +199,7 @@ public sealed class DiscoveryClientTest : AbstractBaseTest
         apps.Add(app);
         client.Applications = apps;
 
-        Applications result = await client.FetchRegistryDeltaAsync();
+        Applications result = await client.FetchRegistryDeltaAsync(CancellationToken.None);
         Assert.NotNull(result);
         Assert.Equal(3, result.Version);
         Assert.Equal("UP_1_", result.AppsHashCode);
@@ -232,7 +232,7 @@ public sealed class DiscoveryClientTest : AbstractBaseTest
 
         var httpClient = new EurekaHttpClient(configuration, server.CreateClient());
         var client = new DiscoveryClient(configuration, httpClient);
-        Task<Applications> result = client.FetchRegistryDeltaAsync();
+        Task<Applications> result = client.FetchRegistryDeltaAsync(CancellationToken.None);
         client.RegistryFetchCounter = 100;
         Applications apps = await result;
         Assert.Null(apps);
@@ -270,7 +270,7 @@ public sealed class DiscoveryClientTest : AbstractBaseTest
 
         var httpClient = new EurekaHttpClient(configuration, server.CreateClient());
         var client = new DiscoveryClient(configuration, httpClient);
-        bool result = await client.RegisterAsync();
+        bool result = await client.RegisterAsync(CancellationToken.None);
         Assert.False(result);
 
         // Verify Register done
@@ -312,7 +312,7 @@ public sealed class DiscoveryClientTest : AbstractBaseTest
 
         var httpClient = new EurekaHttpClient(configuration, server.CreateClient());
         var client = new DiscoveryClient(configuration, httpClient);
-        bool result = await client.RegisterAsync();
+        bool result = await client.RegisterAsync(CancellationToken.None);
         Assert.True(result);
 
         // Verify Register done
@@ -354,7 +354,7 @@ public sealed class DiscoveryClientTest : AbstractBaseTest
 
         var httpClient = new EurekaHttpClient(configuration, server.CreateClient());
         var client = new DiscoveryClient(configuration, httpClient);
-        bool result = await client.RenewAsync();
+        bool result = await client.RenewAsync(CancellationToken.None);
 
         // Verify Register done
         Assert.NotNull(TestConfigServerStartup.LastRequest);
@@ -398,7 +398,7 @@ public sealed class DiscoveryClientTest : AbstractBaseTest
 
         var httpClient = new EurekaHttpClient(configuration, server.CreateClient());
         var client = new DiscoveryClient(configuration, httpClient);
-        bool result = await client.RenewAsync();
+        bool result = await client.RenewAsync(CancellationToken.None);
         Assert.True(result);
     }
 
@@ -434,7 +434,7 @@ public sealed class DiscoveryClientTest : AbstractBaseTest
 
         var httpClient = new EurekaHttpClient(configuration, server.CreateClient());
         var client = new DiscoveryClient(configuration, httpClient);
-        bool result = await client.UnregisterAsync();
+        bool result = await client.UnregisterAsync(CancellationToken.None);
         Assert.True(result);
 
         Assert.NotNull(TestConfigServerStartup.LastRequest);
@@ -921,23 +921,23 @@ public sealed class DiscoveryClientTest : AbstractBaseTest
             eventCount++;
         };
 
-        await client.FetchFullRegistryAsync();
+        await client.FetchFullRegistryAsync(CancellationToken.None);
         Assert.Equal(1, eventCount);
 
         TestConfigServerStartup.Response = FooModifiedJson;
 
-        await client.FetchRegistryDeltaAsync();
+        await client.FetchRegistryDeltaAsync(CancellationToken.None);
         Assert.Equal(2, eventCount);
     }
 
     private void TimerFunc()
     {
-        ++_timerFuncCount;
+        Interlocked.Increment(ref _timerFuncCount);
     }
 
     private void TimerFuncThrows()
     {
-        ++_timerFuncCount;
+        Interlocked.Increment(ref _timerFuncCount);
         throw new FormatException();
     }
 }

--- a/src/Discovery/test/Eureka.Test/EurekaClientServiceTest.cs
+++ b/src/Discovery/test/Eureka.Test/EurekaClientServiceTest.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
 using Steeltoe.Common.Discovery;
 using Xunit;
 
@@ -53,7 +54,7 @@ public sealed class EurekaClientServiceTest
     }
 
     [Fact]
-    public void GetInstances_ReturnsExpected()
+    public async Task GetInstances_ReturnsExpected()
     {
         var values = new Dictionary<string, string>
         {
@@ -63,13 +64,16 @@ public sealed class EurekaClientServiceTest
         var builder = new ConfigurationBuilder();
         builder.AddInMemoryCollection(values);
         IConfigurationRoot configurationRoot = builder.Build();
-        IList<IServiceInstance> result = EurekaClientService.GetInstances(configurationRoot, "testService");
+
+        IList<IServiceInstance> result =
+            await EurekaClientService.GetInstancesAsync(configurationRoot, "testService", NullLoggerFactory.Instance, CancellationToken.None);
+
         Assert.NotNull(result);
         Assert.Empty(result);
     }
 
     [Fact]
-    public void GetServices_ReturnsExpected()
+    public async Task GetServices_ReturnsExpected()
     {
         var values = new Dictionary<string, string>
         {
@@ -79,7 +83,7 @@ public sealed class EurekaClientServiceTest
         var builder = new ConfigurationBuilder();
         builder.AddInMemoryCollection(values);
         IConfigurationRoot configurationRoot = builder.Build();
-        IList<string> result = EurekaClientService.GetServices(configurationRoot);
+        IList<string> result = await EurekaClientService.GetServicesAsync(configurationRoot, NullLoggerFactory.Instance, CancellationToken.None);
         Assert.NotNull(result);
         Assert.Empty(result);
     }

--- a/src/Discovery/test/Eureka.Test/EurekaDiscoveryClientTest.cs
+++ b/src/Discovery/test/Eureka.Test/EurekaDiscoveryClientTest.cs
@@ -10,7 +10,7 @@ namespace Steeltoe.Discovery.Eureka.Test;
 public sealed class EurekaDiscoveryClientTest : AbstractBaseTest
 {
     [Fact]
-    public void Constructor_Initializes_Correctly()
+    public async Task Constructor_Initializes_Correctly()
     {
         var clientConfig = new EurekaClientOptions
         {
@@ -30,10 +30,12 @@ public sealed class EurekaDiscoveryClientTest : AbstractBaseTest
         Assert.Equal(clientConfig, client.ClientConfiguration);
         Assert.NotNull(client.HttpClient);
         Assert.NotNull(client.Description);
-        Assert.NotNull(client.Services);
-        Assert.Empty(client.Services);
 
-        IServiceInstance thisService = client.GetLocalServiceInstance();
+        IList<string> services = await client.GetServicesAsync(CancellationToken.None);
+        Assert.NotNull(services);
+        Assert.Empty(services);
+
+        IServiceInstance thisService = await client.GetLocalServiceInstanceAsync(CancellationToken.None);
         Assert.NotNull(thisService);
         Assert.Equal(instanceConfig.ResolveHostName(false), thisService.Host);
         Assert.Equal(instanceConfig.SecurePortEnabled, thisService.IsSecure);

--- a/src/Discovery/test/Eureka.Test/EurekaHealthCheckHandlerTest.cs
+++ b/src/Discovery/test/Eureka.Test/EurekaHealthCheckHandlerTest.cs
@@ -22,16 +22,16 @@ public sealed class EurekaHealthCheckHandlerTest
     }
 
     [Fact]
-    public void DoHealthChecks_ReturnsExpected()
+    public async Task DoHealthChecks_ReturnsExpected()
     {
         var handler = new EurekaHealthCheckHandler();
-        List<HealthCheckResult> result = handler.DoHealthChecks(new List<IHealthContributor>());
+        List<HealthCheckResult> result = await handler.DoHealthChecksAsync(new List<IHealthContributor>(), CancellationToken.None);
         Assert.Empty(result);
 
-        result = handler.DoHealthChecks(new List<IHealthContributor>
+        result = await handler.DoHealthChecksAsync(new List<IHealthContributor>
         {
             new TestContributor()
-        });
+        }, CancellationToken.None);
 
         Assert.Empty(result);
     }
@@ -115,12 +115,13 @@ public sealed class EurekaHealthCheckHandlerTest
         Assert.Equal(HealthStatus.Unknown, handler.AggregateStatus(results));
     }
 
-    public sealed class TestContributor : IHealthContributor
+    private sealed class TestContributor : IHealthContributor
     {
         public string Id => "TestContrib";
 
-        public HealthCheckResult Health()
+        public async Task<HealthCheckResult> HealthAsync(CancellationToken cancellationToken)
         {
+            await Task.Yield();
             throw new NotImplementedException();
         }
     }

--- a/src/Discovery/test/Eureka.Test/EurekaHealthCheckHandlerTest.cs
+++ b/src/Discovery/test/Eureka.Test/EurekaHealthCheckHandlerTest.cs
@@ -119,7 +119,7 @@ public sealed class EurekaHealthCheckHandlerTest
     {
         public string Id => "TestContrib";
 
-        public async Task<HealthCheckResult> HealthAsync(CancellationToken cancellationToken)
+        public async Task<HealthCheckResult> CheckHealthAsync(CancellationToken cancellationToken)
         {
             await Task.Yield();
             throw new NotImplementedException();

--- a/src/Discovery/test/Eureka.Test/MyHealthCheckHandler.cs
+++ b/src/Discovery/test/Eureka.Test/MyHealthCheckHandler.cs
@@ -10,17 +10,19 @@ public sealed class MyHealthCheckHandler : IHealthCheckHandler
 {
     private readonly InstanceStatus _status;
 
-    public bool Called { get; set; }
+    public bool Awaited { get; set; }
 
     public MyHealthCheckHandler(InstanceStatus status)
     {
         _status = status;
-        Called = false;
+        Awaited = false;
     }
 
-    public InstanceStatus GetStatus(InstanceStatus currentStatus)
+    public async Task<InstanceStatus> GetStatusAsync(InstanceStatus currentStatus, CancellationToken cancellationToken)
     {
-        Called = true;
+        await Task.Yield();
+
+        Awaited = true;
         return _status;
     }
 }

--- a/src/Discovery/test/Eureka.Test/Tasks/TimedTaskTest.cs
+++ b/src/Discovery/test/Eureka.Test/Tasks/TimedTaskTest.cs
@@ -25,7 +25,7 @@ public sealed class TimedTaskTest : AbstractBaseTest
 
     private void TimerFunc()
     {
-        ++_timerFuncCount;
+        Interlocked.Increment(ref _timerFuncCount);
         Thread.Sleep(3000);
     }
 }

--- a/src/Discovery/test/Eureka.Test/Transport/EurekaHttpClientTest.cs
+++ b/src/Discovery/test/Eureka.Test/Transport/EurekaHttpClientTest.cs
@@ -49,7 +49,7 @@ public sealed class EurekaHttpClientTest : AbstractBaseTest
     {
         var configuration = new EurekaClientConfiguration();
         var client = new EurekaHttpClient(configuration);
-        var ex = await Assert.ThrowsAsync<ArgumentNullException>(() => client.RegisterAsync(null));
+        var ex = await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.RegisterAsync(null, CancellationToken.None));
         Assert.Contains("info", ex.Message, StringComparison.Ordinal);
     }
 
@@ -63,7 +63,7 @@ public sealed class EurekaHttpClientTest : AbstractBaseTest
         };
 
         var client = new EurekaHttpClient(configuration);
-        await Assert.ThrowsAsync<EurekaTransportException>(() => client.RegisterAsync(new InstanceInfo()));
+        await Assert.ThrowsAsync<EurekaTransportException>(async () => await client.RegisterAsync(new InstanceInfo(), CancellationToken.None));
     }
 
     [Fact]
@@ -87,7 +87,7 @@ public sealed class EurekaHttpClientTest : AbstractBaseTest
 
         var client = new EurekaHttpClient(clientConfig, server.CreateClient());
 
-        EurekaHttpResponse resp = await client.RegisterAsync(info);
+        EurekaHttpResponse resp = await client.RegisterAsync(info, CancellationToken.None);
         Assert.NotNull(resp);
         Assert.Equal(HttpStatusCode.NoContent, resp.StatusCode);
         Assert.NotNull(resp.Headers);
@@ -118,7 +118,7 @@ public sealed class EurekaHttpClientTest : AbstractBaseTest
         };
 
         var client = new EurekaHttpClient(clientConfig, server.CreateClient());
-        await client.RegisterAsync(info);
+        await client.RegisterAsync(info, CancellationToken.None);
 
         Assert.NotNull(TestConfigServerStartup.LastRequest);
         Assert.Equal("POST", TestConfigServerStartup.LastRequest.Method);
@@ -126,15 +126,17 @@ public sealed class EurekaHttpClientTest : AbstractBaseTest
         Assert.Equal("/apps/FOOBAR", TestConfigServerStartup.LastRequest.Path.Value);
 
         // Check JSON payload
-        var receivedJson = JsonSerializer.Deserialize<JsonInstanceInfoRoot>(new StreamReader(TestConfigServerStartup.LastRequest.Body).ReadToEnd());
-        Assert.NotNull(receivedJson);
-        Assert.NotNull(receivedJson.Instance);
+        using var streamReader = new StreamReader(TestConfigServerStartup.LastRequest.Body);
+        string receivedJsonText = await streamReader.ReadToEndAsync();
+        var receivedJsonInstanceRoot = JsonSerializer.Deserialize<JsonInstanceInfoRoot>(receivedJsonText);
+        Assert.NotNull(receivedJsonInstanceRoot);
+        Assert.NotNull(receivedJsonInstanceRoot.Instance);
 
         // Compare a few random values
         JsonInstanceInfo sentJsonObj = info.ToJsonInstance();
-        Assert.Equal(sentJsonObj.ActionType, receivedJson.Instance.ActionType);
-        Assert.Equal(sentJsonObj.AppName, receivedJson.Instance.AppName);
-        Assert.Equal(sentJsonObj.HostName, receivedJson.Instance.HostName);
+        Assert.Equal(sentJsonObj.ActionType, receivedJsonInstanceRoot.Instance.ActionType);
+        Assert.Equal(sentJsonObj.AppName, receivedJsonInstanceRoot.Instance.AppName);
+        Assert.Equal(sentJsonObj.HostName, receivedJsonInstanceRoot.Instance.HostName);
     }
 
     [Fact]
@@ -142,7 +144,10 @@ public sealed class EurekaHttpClientTest : AbstractBaseTest
     {
         var configuration = new EurekaClientConfiguration();
         var client = new EurekaHttpClient(configuration);
-        var ex = await Assert.ThrowsAsync<ArgumentNullException>(() => client.SendHeartBeatAsync(null, "bar", new InstanceInfo(), InstanceStatus.Down));
+
+        var ex = await Assert.ThrowsAsync<ArgumentNullException>(async () =>
+            await client.SendHeartBeatAsync(null, "bar", new InstanceInfo(), InstanceStatus.Down, CancellationToken.None));
+
         Assert.Contains("appName", ex.Message, StringComparison.Ordinal);
     }
 
@@ -151,7 +156,10 @@ public sealed class EurekaHttpClientTest : AbstractBaseTest
     {
         var configuration = new EurekaClientConfiguration();
         var client = new EurekaHttpClient(configuration);
-        var ex = await Assert.ThrowsAsync<ArgumentNullException>(() => client.SendHeartBeatAsync("foo", null, new InstanceInfo(), InstanceStatus.Down));
+
+        var ex = await Assert.ThrowsAsync<ArgumentNullException>(async () =>
+            await client.SendHeartBeatAsync("foo", null, new InstanceInfo(), InstanceStatus.Down, CancellationToken.None));
+
         Assert.Contains("id", ex.Message, StringComparison.Ordinal);
     }
 
@@ -160,7 +168,10 @@ public sealed class EurekaHttpClientTest : AbstractBaseTest
     {
         var configuration = new EurekaClientConfiguration();
         var client = new EurekaHttpClient(configuration);
-        var ex = await Assert.ThrowsAsync<ArgumentNullException>(() => client.SendHeartBeatAsync("foo", "bar", null, InstanceStatus.Down));
+
+        var ex = await Assert.ThrowsAsync<ArgumentNullException>(async () =>
+            await client.SendHeartBeatAsync("foo", "bar", null, InstanceStatus.Down, CancellationToken.None));
+
         Assert.Contains("info", ex.Message, StringComparison.Ordinal);
     }
 
@@ -190,7 +201,7 @@ public sealed class EurekaHttpClientTest : AbstractBaseTest
         };
 
         var client = new EurekaHttpClient(clientConfig, server.CreateClient());
-        EurekaHttpResponse<InstanceInfo> resp = await client.SendHeartBeatAsync("foo", "id1", info, InstanceStatus.Unknown);
+        EurekaHttpResponse<InstanceInfo> resp = await client.SendHeartBeatAsync("foo", "id1", info, InstanceStatus.Unknown, CancellationToken.None);
         Assert.NotNull(resp);
         Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
         Assert.NotNull(resp.Headers);
@@ -253,7 +264,7 @@ public sealed class EurekaHttpClientTest : AbstractBaseTest
         };
 
         var client = new EurekaHttpClient(clientConfig, server.CreateClient());
-        EurekaHttpResponse<Applications> resp = await client.GetApplicationsAsync();
+        EurekaHttpResponse<Applications> resp = await client.GetApplicationsAsync(CancellationToken.None);
         Assert.NotNull(resp);
         Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
         Assert.Equal("GET", TestConfigServerStartup.LastRequest.Method);
@@ -287,7 +298,7 @@ public sealed class EurekaHttpClientTest : AbstractBaseTest
     {
         var configuration = new EurekaClientConfiguration();
         var client = new EurekaHttpClient(configuration);
-        var ex = await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetVipAsync(null));
+        var ex = await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.GetVipAsync(null, CancellationToken.None));
         Assert.Contains("vipAddress", ex.Message, StringComparison.Ordinal);
     }
 
@@ -296,7 +307,7 @@ public sealed class EurekaHttpClientTest : AbstractBaseTest
     {
         var configuration = new EurekaClientConfiguration();
         var client = new EurekaHttpClient(configuration);
-        var ex = await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetSecureVipAsync(null));
+        var ex = await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.GetSecureVipAsync(null, CancellationToken.None));
         Assert.Contains("secureVipAddress", ex.Message, StringComparison.Ordinal);
     }
 
@@ -305,7 +316,7 @@ public sealed class EurekaHttpClientTest : AbstractBaseTest
     {
         var configuration = new EurekaClientConfiguration();
         var client = new EurekaHttpClient(configuration);
-        var ex = await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetApplicationAsync(null));
+        var ex = await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.GetApplicationAsync(null, CancellationToken.None));
         Assert.Contains("appName", ex.Message, StringComparison.Ordinal);
     }
 
@@ -356,7 +367,7 @@ public sealed class EurekaHttpClientTest : AbstractBaseTest
         };
 
         var client = new EurekaHttpClient(clientConfig, server.CreateClient());
-        EurekaHttpResponse<Application> resp = await client.GetApplicationAsync("foo");
+        EurekaHttpResponse<Application> resp = await client.GetApplicationAsync("foo", CancellationToken.None);
         Assert.NotNull(resp);
         Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
         Assert.Equal("GET", TestConfigServerStartup.LastRequest.Method);
@@ -430,7 +441,7 @@ public sealed class EurekaHttpClientTest : AbstractBaseTest
         };
 
         var client = new EurekaHttpClient(clientConfig, server.CreateClient());
-        EurekaHttpResponse<Application> resp = await client.GetApplicationAsync("foo");
+        EurekaHttpResponse<Application> resp = await client.GetApplicationAsync("foo", CancellationToken.None);
         Assert.NotNull(resp);
         Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
         Assert.Equal("GET", TestConfigServerStartup.LastRequest.Method);
@@ -461,7 +472,7 @@ public sealed class EurekaHttpClientTest : AbstractBaseTest
     {
         var configuration = new EurekaClientConfiguration();
         var client = new EurekaHttpClient(configuration);
-        var ex = await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetInstanceAsync(null, "id"));
+        var ex = await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.GetInstanceAsync(null, "id", CancellationToken.None));
         Assert.Contains("appName", ex.Message, StringComparison.Ordinal);
     }
 
@@ -470,7 +481,7 @@ public sealed class EurekaHttpClientTest : AbstractBaseTest
     {
         var configuration = new EurekaClientConfiguration();
         var client = new EurekaHttpClient(configuration);
-        var ex = await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetInstanceAsync("appName", null));
+        var ex = await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.GetInstanceAsync("appName", null, CancellationToken.None));
         Assert.Contains("id", ex.Message, StringComparison.Ordinal);
     }
 
@@ -479,7 +490,7 @@ public sealed class EurekaHttpClientTest : AbstractBaseTest
     {
         var configuration = new EurekaClientConfiguration();
         var client = new EurekaHttpClient(configuration);
-        var ex = await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetInstanceAsync(null));
+        var ex = await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.GetInstanceAsync(null, CancellationToken.None));
         Assert.Contains("id", ex.Message, StringComparison.Ordinal);
     }
 
@@ -532,7 +543,7 @@ public sealed class EurekaHttpClientTest : AbstractBaseTest
         };
 
         var client = new EurekaHttpClient(clientConfig, server.CreateClient());
-        EurekaHttpResponse<InstanceInfo> resp = await client.GetInstanceAsync("DESKTOP-GNQ5SUT");
+        EurekaHttpResponse<InstanceInfo> resp = await client.GetInstanceAsync("DESKTOP-GNQ5SUT", CancellationToken.None);
         Assert.NotNull(resp);
         Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
         Assert.Equal("GET", TestConfigServerStartup.LastRequest.Method);
@@ -599,7 +610,7 @@ public sealed class EurekaHttpClientTest : AbstractBaseTest
         };
 
         var client = new EurekaHttpClient(clientConfig, server.CreateClient());
-        EurekaHttpResponse<InstanceInfo> resp = await client.GetInstanceAsync("DESKTOP-GNQ5SUT");
+        EurekaHttpResponse<InstanceInfo> resp = await client.GetInstanceAsync("DESKTOP-GNQ5SUT", CancellationToken.None);
         Assert.NotNull(resp);
         Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
         Assert.Equal("GET", TestConfigServerStartup.LastRequest.Method);
@@ -621,7 +632,7 @@ public sealed class EurekaHttpClientTest : AbstractBaseTest
     {
         var configuration = new EurekaClientConfiguration();
         var client = new EurekaHttpClient(configuration);
-        var ex = await Assert.ThrowsAsync<ArgumentNullException>(() => client.CancelAsync(null, "id"));
+        var ex = await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.CancelAsync(null, "id", CancellationToken.None));
         Assert.Contains("appName", ex.Message, StringComparison.Ordinal);
     }
 
@@ -630,7 +641,7 @@ public sealed class EurekaHttpClientTest : AbstractBaseTest
     {
         var configuration = new EurekaClientConfiguration();
         var client = new EurekaHttpClient(configuration);
-        var ex = await Assert.ThrowsAsync<ArgumentNullException>(() => client.CancelAsync("appName", null));
+        var ex = await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.CancelAsync("appName", null, CancellationToken.None));
         Assert.Contains("id", ex.Message, StringComparison.Ordinal);
     }
 
@@ -652,7 +663,7 @@ public sealed class EurekaHttpClientTest : AbstractBaseTest
         };
 
         var client = new EurekaHttpClient(clientConfig, server.CreateClient());
-        EurekaHttpResponse resp = await client.CancelAsync("foo", "bar");
+        EurekaHttpResponse resp = await client.CancelAsync("foo", "bar", CancellationToken.None);
         Assert.NotNull(resp);
         Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
         Assert.NotNull(resp.Headers);
@@ -668,7 +679,10 @@ public sealed class EurekaHttpClientTest : AbstractBaseTest
     {
         var configuration = new EurekaClientConfiguration();
         var client = new EurekaHttpClient(configuration);
-        var ex = await Assert.ThrowsAsync<ArgumentNullException>(() => client.StatusUpdateAsync(null, "id", InstanceStatus.Up, null));
+
+        var ex = await Assert.ThrowsAsync<ArgumentNullException>(async () =>
+            await client.StatusUpdateAsync(null, "id", InstanceStatus.Up, null, CancellationToken.None));
+
         Assert.Contains("appName", ex.Message, StringComparison.Ordinal);
     }
 
@@ -677,7 +691,10 @@ public sealed class EurekaHttpClientTest : AbstractBaseTest
     {
         var configuration = new EurekaClientConfiguration();
         var client = new EurekaHttpClient(configuration);
-        var ex = await Assert.ThrowsAsync<ArgumentNullException>(() => client.StatusUpdateAsync("appName", null, InstanceStatus.Up, null));
+
+        var ex = await Assert.ThrowsAsync<ArgumentNullException>(async () =>
+            await client.StatusUpdateAsync("appName", null, InstanceStatus.Up, null, CancellationToken.None));
+
         Assert.Contains("id", ex.Message, StringComparison.Ordinal);
     }
 
@@ -686,7 +703,10 @@ public sealed class EurekaHttpClientTest : AbstractBaseTest
     {
         var configuration = new EurekaClientConfiguration();
         var client = new EurekaHttpClient(configuration);
-        var ex = await Assert.ThrowsAsync<ArgumentNullException>(() => client.StatusUpdateAsync("appName", "bar", InstanceStatus.Up, null));
+
+        var ex = await Assert.ThrowsAsync<ArgumentNullException>(async () =>
+            await client.StatusUpdateAsync("appName", "bar", InstanceStatus.Up, null, CancellationToken.None));
+
         Assert.Contains("info", ex.Message, StringComparison.Ordinal);
     }
 
@@ -714,7 +734,7 @@ public sealed class EurekaHttpClientTest : AbstractBaseTest
         EurekaHttpResponse resp = await client.StatusUpdateAsync("foo", "bar", InstanceStatus.Down, new InstanceInfo
         {
             LastDirtyTimestamp = now
-        });
+        }, CancellationToken.None);
 
         Assert.NotNull(resp);
         Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
@@ -732,7 +752,7 @@ public sealed class EurekaHttpClientTest : AbstractBaseTest
     {
         var configuration = new EurekaClientConfiguration();
         var client = new EurekaHttpClient(configuration);
-        var ex = await Assert.ThrowsAsync<ArgumentNullException>(() => client.DeleteStatusOverrideAsync(null, "id", null));
+        var ex = await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.DeleteStatusOverrideAsync(null, "id", null, CancellationToken.None));
         Assert.Contains("appName", ex.Message, StringComparison.Ordinal);
     }
 
@@ -741,7 +761,10 @@ public sealed class EurekaHttpClientTest : AbstractBaseTest
     {
         var configuration = new EurekaClientConfiguration();
         var client = new EurekaHttpClient(configuration);
-        var ex = await Assert.ThrowsAsync<ArgumentNullException>(() => client.DeleteStatusOverrideAsync("appName", null, null));
+
+        var ex = await Assert.ThrowsAsync<ArgumentNullException>(async () =>
+            await client.DeleteStatusOverrideAsync("appName", null, null, CancellationToken.None));
+
         Assert.Contains("id", ex.Message, StringComparison.Ordinal);
     }
 
@@ -750,7 +773,10 @@ public sealed class EurekaHttpClientTest : AbstractBaseTest
     {
         var configuration = new EurekaClientConfiguration();
         var client = new EurekaHttpClient(configuration);
-        var ex = await Assert.ThrowsAsync<ArgumentNullException>(() => client.DeleteStatusOverrideAsync("appName", "bar", null));
+
+        var ex = await Assert.ThrowsAsync<ArgumentNullException>(async () =>
+            await client.DeleteStatusOverrideAsync("appName", "bar", null, CancellationToken.None));
+
         Assert.Contains("info", ex.Message, StringComparison.Ordinal);
     }
 
@@ -778,7 +804,7 @@ public sealed class EurekaHttpClientTest : AbstractBaseTest
         EurekaHttpResponse resp = await client.DeleteStatusOverrideAsync("foo", "bar", new InstanceInfo
         {
             LastDirtyTimestamp = now
-        });
+        }, CancellationToken.None);
 
         Assert.NotNull(resp);
         Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
@@ -813,7 +839,7 @@ public sealed class EurekaHttpClientTest : AbstractBaseTest
     }
 
     [Fact]
-    public void GetRequestMessage_ReturnsCorrectMessage_WithAdditionalHeaders()
+    public async Task GetRequestMessage_ReturnsCorrectMessage_WithAdditionalHeaders()
     {
         var headers = new Dictionary<string, string>
         {
@@ -826,14 +852,14 @@ public sealed class EurekaHttpClientTest : AbstractBaseTest
         };
 
         var client = new EurekaHttpClient(configuration, headers);
-        HttpRequestMessage result = client.GetRequestMessage(HttpMethod.Post, new Uri("http://boo:123/eureka/"));
+        HttpRequestMessage result = await client.GetRequestMessageAsync(HttpMethod.Post, new Uri("http://boo:123/eureka/"), CancellationToken.None);
         Assert.Equal(HttpMethod.Post, result.Method);
         Assert.Equal(new Uri("http://boo:123/eureka/"), result.RequestUri);
         Assert.True(result.Headers.Contains("foo"));
     }
 
     [Fact]
-    public void GetRequestMessage_No_Auth_When_Credentials_Not_In_Url()
+    public async Task GetRequestMessage_No_Auth_When_Credentials_Not_In_Url()
     {
         var configuration = new EurekaClientConfiguration
         {
@@ -841,7 +867,10 @@ public sealed class EurekaHttpClientTest : AbstractBaseTest
         };
 
         var client = new EurekaHttpClient(configuration);
-        HttpRequestMessage result = client.GetRequestMessage(HttpMethod.Post, new Uri(configuration.EurekaServerServiceUrls));
+
+        HttpRequestMessage result =
+            await client.GetRequestMessageAsync(HttpMethod.Post, new Uri(configuration.EurekaServerServiceUrls), CancellationToken.None);
+
         Assert.Equal(HttpMethod.Post, result.Method);
         Assert.Equal(new Uri("http://boo:123/eureka/"), result.RequestUri);
         Assert.False(result.Headers.Contains("Authorization"));
@@ -854,7 +883,7 @@ public sealed class EurekaHttpClientTest : AbstractBaseTest
         var optionsMonitor = new TestOptionMonitorWrapper<EurekaClientOptions>(clientOptions);
         client = new EurekaHttpClient(optionsMonitor);
 
-        result = client.GetRequestMessage(HttpMethod.Post, new Uri(clientOptions.EurekaServerServiceUrls));
+        result = await client.GetRequestMessageAsync(HttpMethod.Post, new Uri(clientOptions.EurekaServerServiceUrls), CancellationToken.None);
 
         Assert.Equal(HttpMethod.Post, result.Method);
         Assert.Equal(new Uri("http://boo:123/eureka/"), result.RequestUri);
@@ -862,7 +891,7 @@ public sealed class EurekaHttpClientTest : AbstractBaseTest
     }
 
     [Fact]
-    public void GetRequestMessage_Adds_Auth_When_Credentials_In_Url()
+    public async Task GetRequestMessage_Adds_Auth_When_Credentials_In_Url()
     {
         var configuration = new EurekaClientConfiguration
         {
@@ -870,7 +899,10 @@ public sealed class EurekaHttpClientTest : AbstractBaseTest
         };
 
         var client = new EurekaHttpClient(configuration);
-        HttpRequestMessage result = client.GetRequestMessage(HttpMethod.Post, new Uri(configuration.EurekaServerServiceUrls));
+
+        HttpRequestMessage result =
+            await client.GetRequestMessageAsync(HttpMethod.Post, new Uri(configuration.EurekaServerServiceUrls), CancellationToken.None);
+
         Assert.Equal(HttpMethod.Post, result.Method);
         Assert.Equal(new Uri("http://boo:123/eureka/"), result.RequestUri);
         Assert.True(result.Headers.Contains("Authorization"));
@@ -883,7 +915,7 @@ public sealed class EurekaHttpClientTest : AbstractBaseTest
         var optionsMonitor = new TestOptionMonitorWrapper<EurekaClientOptions>(clientOptions);
         client = new EurekaHttpClient(optionsMonitor);
 
-        result = client.GetRequestMessage(HttpMethod.Post, new Uri(clientOptions.EurekaServerServiceUrls));
+        result = await client.GetRequestMessageAsync(HttpMethod.Post, new Uri(clientOptions.EurekaServerServiceUrls), CancellationToken.None);
 
         Assert.Equal(HttpMethod.Post, result.Method);
         Assert.Equal(new Uri("http://boo:123/eureka/"), result.RequestUri);
@@ -891,7 +923,7 @@ public sealed class EurekaHttpClientTest : AbstractBaseTest
     }
 
     [Fact]
-    public void GetRequestMessage_Adds_Auth_When_JustPassword_In_Url()
+    public async Task GetRequestMessage_Adds_Auth_When_JustPassword_In_Url()
     {
         var configuration = new EurekaClientConfiguration
         {
@@ -899,7 +931,10 @@ public sealed class EurekaHttpClientTest : AbstractBaseTest
         };
 
         var client = new EurekaHttpClient(configuration);
-        HttpRequestMessage result = client.GetRequestMessage(HttpMethod.Post, new Uri(configuration.EurekaServerServiceUrls));
+
+        HttpRequestMessage result =
+            await client.GetRequestMessageAsync(HttpMethod.Post, new Uri(configuration.EurekaServerServiceUrls), CancellationToken.None);
+
         Assert.Equal(HttpMethod.Post, result.Method);
         Assert.Equal(new Uri("http://boo:123/eureka/"), result.RequestUri);
         Assert.True(result.Headers.Contains("Authorization"));
@@ -912,7 +947,7 @@ public sealed class EurekaHttpClientTest : AbstractBaseTest
         var optionsMonitor = new TestOptionMonitorWrapper<EurekaClientOptions>(clientOptions);
         client = new EurekaHttpClient(optionsMonitor);
 
-        result = client.GetRequestMessage(HttpMethod.Post, new Uri(clientOptions.EurekaServerServiceUrls));
+        result = await client.GetRequestMessageAsync(HttpMethod.Post, new Uri(clientOptions.EurekaServerServiceUrls), CancellationToken.None);
 
         Assert.Equal(HttpMethod.Post, result.Method);
         Assert.Equal(new Uri("http://boo:123/eureka/"), result.RequestUri);

--- a/src/Discovery/test/Kubernetes.Test/Discovery/KubernetesDiscoveryClientTest.cs
+++ b/src/Discovery/test/Kubernetes.Test/Discovery/KubernetesDiscoveryClientTest.cs
@@ -35,7 +35,7 @@ public sealed class KubernetesDiscoveryClientTest
     }
 
     [Fact]
-    public void GetInstances_ThrowsOnNull()
+    public async Task GetInstances_ThrowsOnNull()
     {
         var k8SDiscoveryOptions = new TestOptionsMonitor<KubernetesDiscoveryOptions>(new KubernetesDiscoveryOptions());
 
@@ -47,11 +47,11 @@ public sealed class KubernetesDiscoveryClientTest
         var testK8SDiscoveryClient = new KubernetesDiscoveryClient(
             new DefaultIsServicePortSecureResolver(k8SDiscoveryOptions.CurrentValue), client, k8SDiscoveryOptions);
 
-        Assert.Throws<ArgumentNullException>(() => testK8SDiscoveryClient.GetInstances(null));
+        await Assert.ThrowsAsync<ArgumentNullException>(async () => await testK8SDiscoveryClient.GetInstancesAsync(null, CancellationToken.None));
     }
 
     [Fact]
-    public void GetInstances_ShouldBeAbleToHandleEndpointsFromMultipleNamespaces()
+    public async Task GetInstances_ShouldBeAbleToHandleEndpointsFromMultipleNamespaces()
     {
         var mockHttpMessageHandler = new MockHttpMessageHandler();
 
@@ -83,7 +83,7 @@ public sealed class KubernetesDiscoveryClientTest
 
         IDiscoveryClient discoveryClient = new KubernetesDiscoveryClient(new DefaultIsServicePortSecureResolver(options.CurrentValue), client, options);
 
-        IList<IServiceInstance>? genericInstances = discoveryClient.GetInstances("endpoint");
+        IList<IServiceInstance>? genericInstances = await discoveryClient.GetInstancesAsync("endpoint", CancellationToken.None);
         List<KubernetesServiceInstance> instances = genericInstances.Select(s => (KubernetesServiceInstance)s).ToList();
 
         Assert.NotNull(instances);
@@ -96,7 +96,7 @@ public sealed class KubernetesDiscoveryClientTest
     }
 
     [Fact]
-    public void GetInstances_ShouldBeAbleToHandleEndpointsSingleAddress()
+    public async Task GetInstances_ShouldBeAbleToHandleEndpointsSingleAddress()
     {
         var mockHttpMessageHandler = new MockHttpMessageHandler();
 
@@ -124,7 +124,7 @@ public sealed class KubernetesDiscoveryClientTest
 
         IDiscoveryClient discoveryClient = new KubernetesDiscoveryClient(new DefaultIsServicePortSecureResolver(options.CurrentValue), client, options);
 
-        IList<IServiceInstance>? genericInstances = discoveryClient.GetInstances("endpoint");
+        IList<IServiceInstance>? genericInstances = await discoveryClient.GetInstancesAsync("endpoint", CancellationToken.None);
         List<KubernetesServiceInstance> instances = genericInstances.Select(s => (KubernetesServiceInstance)s).ToList();
 
         Assert.NotNull(instances);
@@ -134,7 +134,7 @@ public sealed class KubernetesDiscoveryClientTest
     }
 
     [Fact]
-    public void GetInstances_ShouldBeAbleToHandleEndpointsSingleAddressAndMultiplePorts()
+    public async Task GetInstances_ShouldBeAbleToHandleEndpointsSingleAddressAndMultiplePorts()
     {
         var mockHttpMessageHandler = new MockHttpMessageHandler();
 
@@ -162,7 +162,7 @@ public sealed class KubernetesDiscoveryClientTest
 
         IDiscoveryClient discoveryClient = new KubernetesDiscoveryClient(new DefaultIsServicePortSecureResolver(options.CurrentValue), client, options);
 
-        IList<IServiceInstance>? genericInstances = discoveryClient.GetInstances("endpoint");
+        IList<IServiceInstance>? genericInstances = await discoveryClient.GetInstancesAsync("endpoint", CancellationToken.None);
         List<KubernetesServiceInstance> instances = genericInstances.Select(s => (KubernetesServiceInstance)s).ToList();
 
         Assert.NotNull(instances);
@@ -173,7 +173,7 @@ public sealed class KubernetesDiscoveryClientTest
     }
 
     [Fact]
-    public void GetInstances_ShouldBeAbleToHandleEndpointsMultipleAddresses()
+    public async Task GetInstances_ShouldBeAbleToHandleEndpointsMultipleAddresses()
     {
         var mockHttpMessageHandler = new MockHttpMessageHandler();
 
@@ -201,7 +201,7 @@ public sealed class KubernetesDiscoveryClientTest
 
         IDiscoveryClient discoveryClient = new KubernetesDiscoveryClient(new DefaultIsServicePortSecureResolver(options.CurrentValue), client, options);
 
-        IList<IServiceInstance>? instances = discoveryClient.GetInstances("endpoint");
+        IList<IServiceInstance>? instances = await discoveryClient.GetInstancesAsync("endpoint", CancellationToken.None);
 
         Assert.NotNull(instances);
         Assert.Equal(2, instances.Count);
@@ -210,7 +210,7 @@ public sealed class KubernetesDiscoveryClientTest
     }
 
     [Fact]
-    public void GetServices_ShouldReturnAllServicesWhenNoLabelsAreAppliedToTheClient()
+    public async Task GetServices_ShouldReturnAllServicesWhenNoLabelsAreAppliedToTheClient()
     {
         var mockHttpMessageHandler = new MockHttpMessageHandler();
 
@@ -236,7 +236,7 @@ public sealed class KubernetesDiscoveryClientTest
 
         var discoveryClient = new KubernetesDiscoveryClient(new DefaultIsServicePortSecureResolver(options.CurrentValue), client, options);
 
-        IList<string>? services = discoveryClient.Services;
+        IList<string>? services = await discoveryClient.GetServicesAsync(CancellationToken.None);
 
         Assert.NotNull(services);
         Assert.Equal(3, services.Count);
@@ -246,7 +246,7 @@ public sealed class KubernetesDiscoveryClientTest
     }
 
     [Fact]
-    public void GetServices_ShouldReturnOnlyMatchingServicesWhenLabelsAreAppliedToTheClient()
+    public async Task GetServices_ShouldReturnOnlyMatchingServicesWhenLabelsAreAppliedToTheClient()
     {
         var mockHttpMessageHandler = new MockHttpMessageHandler();
 
@@ -272,10 +272,10 @@ public sealed class KubernetesDiscoveryClientTest
 
         var discoveryClient = new KubernetesDiscoveryClient(new DefaultIsServicePortSecureResolver(options.CurrentValue), client, options);
 
-        IList<string>? services = discoveryClient.GetLabeledServices(new Dictionary<string, string>
+        IList<string>? services = await discoveryClient.GetLabeledServicesAsync(new Dictionary<string, string>
         {
             { "label", "value" }
-        });
+        }, CancellationToken.None);
 
         Assert.NotNull(services);
         Assert.Equal(2, services.Count);
@@ -284,7 +284,7 @@ public sealed class KubernetesDiscoveryClientTest
     }
 
     [Fact]
-    public void EnabledPropertyWorksBothWays()
+    public async Task EnabledPropertyWorksBothWays()
     {
         var mockHttpMessageHandler = new MockHttpMessageHandler();
 
@@ -312,7 +312,7 @@ public sealed class KubernetesDiscoveryClientTest
 
         var discoveryClient = new KubernetesDiscoveryClient(new DefaultIsServicePortSecureResolver(options.CurrentValue), client, options);
 
-        IList<string>? services = discoveryClient.Services;
+        IList<string>? services = await discoveryClient.GetServicesAsync(CancellationToken.None);
 
         Assert.NotNull(services);
         Assert.Empty(services);
@@ -320,7 +320,7 @@ public sealed class KubernetesDiscoveryClientTest
         // turn it on
         discoveryOptions.Enabled = true;
 
-        services = discoveryClient.Services;
+        services = await discoveryClient.GetServicesAsync(CancellationToken.None);
 
         Assert.NotNull(services);
         Assert.Equal(2, services.Count);

--- a/src/Integration/src/Integration/Handler/MethodInvokingMessageProcessor.cs
+++ b/src/Integration/src/Integration/Handler/MethodInvokingMessageProcessor.cs
@@ -67,9 +67,8 @@ public class MethodInvokingMessageProcessor<T> : AbstractMessageProcessor<T>, IL
         try
         {
             object result = _invocableHandlerMethod.Invoke(message);
-#pragma warning disable S2219 // Runtime type checking should be simplified
-            if (result != null && typeof(T).IsAssignableFrom(result.GetType()))
-#pragma warning restore S2219 // Runtime type checking should be simplified
+
+            if (result is T)
             {
                 return (T)ConversionService.Convert(result, result?.GetType(), typeof(T));
             }

--- a/src/Integration/test/Integration.Test/Channel/QueueChannelTest.cs
+++ b/src/Integration/test/Integration.Test/Channel/QueueChannelTest.cs
@@ -169,7 +169,7 @@ public sealed class QueueChannelTest
             IMessage message = await channel.ReceiveAsync(cancellationTokenSource.Token);
             messageNull = message == null;
             latch.Signal();
-        });
+        }, CancellationToken.None);
 
         cancellationTokenSource.Cancel();
         Assert.True(latch.Wait(10000));
@@ -214,7 +214,7 @@ public sealed class QueueChannelTest
             IMessage message = await channel.ReceiveAsync(cancellationTokenSource.Token);
             messageNull = message == null;
             latch.Signal();
-        });
+        }, CancellationToken.None);
 
         cancellationTokenSource.Cancel();
         Assert.True(latch.Wait(10000));
@@ -254,7 +254,7 @@ public sealed class QueueChannelTest
         {
             await channel.SendAsync(Message.Create("test-2"), cancellationTokenSource.Token);
             latch.Signal();
-        });
+        }, CancellationToken.None);
 
         cancellationTokenSource.Cancel();
 
@@ -298,7 +298,7 @@ public sealed class QueueChannelTest
             cancellationTokenSource.CancelAfter(5);
             await channel.SendAsync(Message.Create("test-2"), cancellationTokenSource.Token);
             latch.Signal();
-        });
+        }, CancellationToken.None);
 
         Assert.True(latch.Wait(10000));
     }

--- a/src/Integration/test/Integration.Test/Channel/QueueChannelTest.cs
+++ b/src/Integration/test/Integration.Test/Channel/QueueChannelTest.cs
@@ -2,9 +2,10 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System.Threading.Channels;
-using Microsoft.Extensions.DependencyInjection;
-using Steeltoe.Common.Contexts;
+using FluentAssertions;
 using Steeltoe.Integration.Channel;
 using Steeltoe.Messaging;
 using Xunit;
@@ -13,338 +14,223 @@ namespace Steeltoe.Integration.Test.Channel;
 
 public sealed class QueueChannelTest
 {
+    private static readonly TimeSpan DefaultTestTimeout = TimeSpan.FromSeconds(5);
+    private static readonly Action<AbstractMessageChannel> SendTestMessage = channel => channel.Send(Message.Create("testing"));
+
+    private static readonly Func<AbstractPollableChannel, int?, IMessage?> ReceiveTestMessage = (channel, timeout) =>
+        timeout == null ? channel.Receive() : channel.Receive(timeout.Value);
+
     [Fact]
     public void TestSimpleSendAndReceive()
     {
-        var services = new ServiceCollection();
-        services.AddSingleton<IIntegrationServices, IntegrationServices>();
-        ServiceProvider provider = services.BuildServiceProvider();
-        var latch = new CountdownEvent(1);
-        var channel = new QueueChannel(provider.GetService<IApplicationContext>());
+        var channel = new QueueChannel();
 
-        Task.Run(() =>
-        {
-            IMessage message = channel.Receive();
-
-            if (message != null)
-            {
-                latch.Signal();
-            }
-        });
-
-        channel.Send(Message.Create("testing"));
-        Assert.True(latch.Wait(10000));
+        AssertMessageExchange(() => ReceiveTestMessage(channel, null) != null, () => SendTestMessage(channel));
     }
 
     [Fact]
     public void TestSimpleSendAndReceiveWithNonBlockingQueue()
     {
-        var services = new ServiceCollection();
-        services.AddSingleton<IIntegrationServices, IntegrationServices>();
-        ServiceProvider provider = services.BuildServiceProvider();
-        var latch = new CountdownEvent(1);
-
-        var chan = System.Threading.Channels.Channel.CreateBounded<IMessage>(new BoundedChannelOptions(int.MaxValue)
+        var boundedChannel = System.Threading.Channels.Channel.CreateBounded<IMessage>(new BoundedChannelOptions(int.MaxValue)
         {
             FullMode = BoundedChannelFullMode.DropWrite
         });
 
-        var channel = new QueueChannel(provider.GetService<IApplicationContext>(), chan);
+        var channel = new QueueChannel(null, boundedChannel);
 
-        Task.Run(() =>
-        {
-            IMessage message = channel.Receive();
-
-            if (message != null)
-            {
-                latch.Signal();
-            }
-        });
-
-        channel.Send(Message.Create("testing"));
-        Assert.True(latch.Wait(10000));
+        AssertMessageExchange(() => ReceiveTestMessage(channel, null) != null, () => SendTestMessage(channel));
     }
 
     [Fact]
     public void TestSimpleSendAndReceiveWithNonBlockingQueueWithTimeout()
     {
-        var services = new ServiceCollection();
-        services.AddSingleton<IIntegrationServices, IntegrationServices>();
-        ServiceProvider provider = services.BuildServiceProvider();
-        var latch = new CountdownEvent(1);
-
-        var chan = System.Threading.Channels.Channel.CreateBounded<IMessage>(new BoundedChannelOptions(int.MaxValue)
+        var boundedChannel = System.Threading.Channels.Channel.CreateBounded<IMessage>(new BoundedChannelOptions(int.MaxValue)
         {
             FullMode = BoundedChannelFullMode.DropWrite
         });
 
-        var channel = new QueueChannel(provider.GetService<IApplicationContext>(), chan);
+        var channel = new QueueChannel(null, boundedChannel);
+        const int receiveTimeout = 500;
 
-        Task.Run(() =>
-        {
-            IMessage message = channel.Receive(1);
-
-            if (message != null)
-            {
-                latch.Signal();
-            }
-        });
-
-        channel.Send(Message.Create("testing"));
-        Assert.True(latch.Wait(10000));
+        AssertMessageExchange(() => ReceiveTestMessage(channel, receiveTimeout) != null, () => SendTestMessage(channel));
     }
 
     [Fact]
     public void TestSimpleSendAndReceiveWithTimeout()
     {
-        var services = new ServiceCollection();
-        services.AddSingleton<IIntegrationServices, IntegrationServices>();
-        ServiceProvider provider = services.BuildServiceProvider();
-        var latch = new CountdownEvent(1);
-        var channel = new QueueChannel(provider.GetService<IApplicationContext>());
+        var channel = new QueueChannel();
+        const int receiveTimeout = 500;
 
-        Task.Run(() =>
-        {
-            IMessage message = channel.Receive(1);
-
-            if (message != null)
-            {
-                latch.Signal();
-            }
-        });
-
-        channel.Send(Message.Create("testing"));
-        Assert.True(latch.Wait(10000));
+        AssertMessageExchange(() => ReceiveTestMessage(channel, receiveTimeout) != null, () => SendTestMessage(channel));
     }
 
     [Fact]
     public void TestImmediateReceive()
     {
-        var services = new ServiceCollection();
-        services.AddSingleton<IIntegrationServices, IntegrationServices>();
-        ServiceProvider provider = services.BuildServiceProvider();
-        bool messageNull = false;
-        var channel = new QueueChannel(provider.GetService<IApplicationContext>());
-        var latch1 = new CountdownEvent(1);
-        var latch2 = new CountdownEvent(1);
+        var channel = new QueueChannel();
+        const int receiveTimeout = 0;
 
-        void ReceiveAction1()
-        {
-            IMessage message = channel.Receive(0);
-            messageNull = message == null;
-            latch1.Signal();
-        }
-
-        Task.Run(ReceiveAction1);
-        Assert.True(latch1.Wait(10000));
-        channel.Send(Message.Create("testing"));
-
-        void ReceiveAction2()
-        {
-            IMessage message = channel.Receive(0);
-
-            if (message != null)
-            {
-                latch2.Signal();
-            }
-        }
-
-        Task.Run(ReceiveAction2);
-        Assert.True(latch2.Wait(10000));
+        AssertMessageExchange(() => ReceiveTestMessage(channel, receiveTimeout) == null, null);
+        SendTestMessage(channel);
+        AssertMessageExchange(() => ReceiveTestMessage(channel, receiveTimeout) != null, null);
     }
 
     [Fact]
-    public void TestBlockingReceiveAsyncWithNoTimeout()
+    public async Task TestBlockingReceiveAsyncWithNoTimeout()
     {
-        var services = new ServiceCollection();
-        services.AddSingleton<IIntegrationServices, IntegrationServices>();
-        ServiceProvider provider = services.BuildServiceProvider();
-        bool messageNull = false;
-        var channel = new QueueChannel(provider.GetService<IApplicationContext>());
-        var latch = new CountdownEvent(1);
+        var channel = new QueueChannel();
         var cancellationTokenSource = new CancellationTokenSource();
 
-        Task.Run(async () =>
-        {
-            IMessage message = await channel.ReceiveAsync(cancellationTokenSource.Token);
-            messageNull = message == null;
-            latch.Signal();
-        }, CancellationToken.None);
-
-        cancellationTokenSource.Cancel();
-        Assert.True(latch.Wait(10000));
-        Assert.True(messageNull);
+        await AssertMessageExchangeAsync(async () => await channel.ReceiveAsync(cancellationTokenSource.Token) == null, cancellationTokenSource.Cancel);
     }
 
     [Fact]
     public void TestBlockingReceiveWithTimeout()
     {
-        var services = new ServiceCollection();
-        services.AddSingleton<IIntegrationServices, IntegrationServices>();
-        ServiceProvider provider = services.BuildServiceProvider();
-        bool messageNull = false;
-        var channel = new QueueChannel(provider.GetService<IApplicationContext>());
-        var latch = new CountdownEvent(1);
+        var channel = new QueueChannel();
+        const int receiveTimeout = 500;
 
-        Task.Run(() =>
-        {
-            IMessage message = channel.Receive(5);
-            messageNull = message == null;
-            latch.Signal();
-        });
-
-        Assert.True(latch.Wait(10000));
-        Assert.True(messageNull);
+        AssertMessageExchange(() => ReceiveTestMessage(channel, receiveTimeout) == null, null);
     }
 
     [Fact]
-    public void TestBlockingReceiveAsyncWithTimeout()
+    public async Task TestBlockingReceiveAsyncWithTimeout()
     {
-        var services = new ServiceCollection();
-        services.AddSingleton<IIntegrationServices, IntegrationServices>();
-        ServiceProvider provider = services.BuildServiceProvider();
-        bool messageNull = false;
-        var channel = new QueueChannel(provider.GetService<IApplicationContext>());
-        var latch = new CountdownEvent(1);
+        var channel = new QueueChannel();
+        const int receiveTimeout = 500;
+
         var cancellationTokenSource = new CancellationTokenSource();
-        cancellationTokenSource.CancelAfter(10000);
+        cancellationTokenSource.CancelAfter(receiveTimeout);
 
-        Task.Run(async () =>
-        {
-            IMessage message = await channel.ReceiveAsync(cancellationTokenSource.Token);
-            messageNull = message == null;
-            latch.Signal();
-        }, CancellationToken.None);
-
-        cancellationTokenSource.Cancel();
-        Assert.True(latch.Wait(10000));
-        Assert.True(messageNull);
+        await AssertMessageExchangeAsync(async () => await channel.ReceiveAsync(cancellationTokenSource.Token) == null, cancellationTokenSource.Cancel);
     }
 
     [Fact]
     public void TestImmediateSend()
     {
-        var services = new ServiceCollection();
-        services.AddSingleton<IIntegrationServices, IntegrationServices>();
-        ServiceProvider provider = services.BuildServiceProvider();
-        var channel = new QueueChannel(provider.GetService<IApplicationContext>(), 3);
-        bool result1 = channel.Send(Message.Create("test-1"));
-        Assert.True(result1);
-        bool result2 = channel.Send(Message.Create("test-2"), 100);
-        Assert.True(result2);
-        bool result3 = channel.Send(Message.Create("test-3"), 0);
-        Assert.True(result3);
-        bool result4 = channel.Send(Message.Create("test-4"), 0);
-        Assert.False(result4);
+        var channel = new QueueChannel(null, 3);
+        const int receiveTimeout = 500;
+        const int receiveTimeoutZero = 0;
+
+        channel.Send(Message.Create("test-1")).Should().BeTrue();
+        channel.Send(Message.Create("test-2"), receiveTimeout).Should().BeTrue();
+        channel.Send(Message.Create("test-3"), receiveTimeoutZero).Should().BeTrue();
+        channel.Send(Message.Create("test-4"), receiveTimeoutZero).Should().BeFalse();
     }
 
     [Fact]
-    public void TestBlockingSendAsyncWithNoTimeout()
+    public async Task TestBlockingSendAsyncWithNoTimeout()
     {
-        var services = new ServiceCollection();
-        services.AddSingleton<IIntegrationServices, IntegrationServices>();
-        ServiceProvider provider = services.BuildServiceProvider();
-        var channel = new QueueChannel(provider.GetService<IApplicationContext>(), 1);
-        bool result1 = channel.Send(Message.Create("test-1"));
-        Assert.True(result1);
-        var latch = new CountdownEvent(1);
+        var channel = new QueueChannel(null, 1);
+
+        (await channel.SendAsync(Message.Create("test-1"))).Should().BeTrue();
+
         var cancellationTokenSource = new CancellationTokenSource();
 
-        Task.Run(async () =>
-        {
-            await channel.SendAsync(Message.Create("test-2"), cancellationTokenSource.Token);
-            latch.Signal();
-        }, CancellationToken.None);
-
-        cancellationTokenSource.Cancel();
-
-        Assert.True(latch.Wait(10000));
+        await AssertMessageExchangeAsync(async () => !await channel.SendAsync(Message.Create("test-2"), cancellationTokenSource.Token),
+            cancellationTokenSource.Cancel);
     }
 
     [Fact]
     public void TestBlockingSendWithTimeout()
     {
-        var services = new ServiceCollection();
-        services.AddSingleton<IIntegrationServices, IntegrationServices>();
-        ServiceProvider provider = services.BuildServiceProvider();
-        var channel = new QueueChannel(provider.GetService<IApplicationContext>(), 1);
-        bool result1 = channel.Send(Message.Create("test-1"));
-        Assert.True(result1);
-        var latch = new CountdownEvent(1);
+        var channel = new QueueChannel(null, 1);
 
-        Task.Run(() =>
-        {
-            channel.Send(Message.Create("test-2"), 5);
-            latch.Signal();
-        });
+        channel.Send(Message.Create("test-1")).Should().BeTrue();
 
-        Assert.True(latch.Wait(10000));
+        const int sendTimeout = 500;
+        AssertMessageExchange(() => !channel.Send(Message.Create("test-2"), sendTimeout), null);
     }
 
     [Fact]
-    public void TestBlockingSendAsyncWithTimeout()
+    public async Task TestBlockingSendAsyncWithTimeout()
     {
-        var services = new ServiceCollection();
-        services.AddSingleton<IIntegrationServices, IntegrationServices>();
-        ServiceProvider provider = services.BuildServiceProvider();
-        var channel = new QueueChannel(provider.GetService<IApplicationContext>(), 1);
-        bool result1 = channel.Send(Message.Create("test-1"));
-        Assert.True(result1);
-        var latch = new CountdownEvent(1);
+        var channel = new QueueChannel(null, 1);
+
+        (await channel.SendAsync(Message.Create("test-1"))).Should().BeTrue();
+
         var cancellationTokenSource = new CancellationTokenSource();
+        const int sendTimeout = 500;
 
-        Task.Run(async () =>
+        await AssertMessageExchangeAsync(async () =>
         {
-            cancellationTokenSource.CancelAfter(5);
-            await channel.SendAsync(Message.Create("test-2"), cancellationTokenSource.Token);
-            latch.Signal();
-        }, CancellationToken.None);
-
-        Assert.True(latch.Wait(10000));
+            cancellationTokenSource.CancelAfter(sendTimeout);
+            return !await channel.SendAsync(Message.Create("test-2"), cancellationTokenSource.Token);
+        }, null);
     }
 
     [Fact]
     public void TestClear()
     {
-        var services = new ServiceCollection();
-        services.AddSingleton<IIntegrationServices, IntegrationServices>();
-        ServiceProvider provider = services.BuildServiceProvider();
-        var channel = new QueueChannel(provider.GetService<IApplicationContext>(), 2);
+        var channel = new QueueChannel(null, 2);
+
         IMessage<string> message1 = Message.Create("test1");
         IMessage<string> message2 = Message.Create("test2");
         IMessage<string> message3 = Message.Create("test3");
-        Assert.True(channel.Send(message1));
-        Assert.True(channel.Send(message2));
-        Assert.False(channel.Send(message3, 0));
-        Assert.Equal(2, channel.QueueSize);
-        Assert.Equal(2 - 2, channel.RemainingCapacity);
+
+        channel.Send(message1).Should().BeTrue();
+        channel.Send(message2).Should().BeTrue();
+        channel.Send(message3, 0).Should().BeFalse();
+
+        channel.QueueSize.Should().Be(2);
+        channel.RemainingCapacity.Should().Be(2 - 2);
+
         IList<IMessage> clearedMessages = channel.Clear();
-        Assert.NotNull(clearedMessages);
-        Assert.Equal(2, clearedMessages.Count);
-        Assert.Equal(0, channel.QueueSize);
-        Assert.Equal(2, channel.RemainingCapacity);
-        Assert.True(channel.Send(message3));
+        clearedMessages.Should().HaveCount(2);
+
+        channel.QueueSize.Should().Be(0);
+        channel.RemainingCapacity.Should().Be(2);
+
+        channel.Send(message3).Should().BeTrue();
     }
 
     [Fact]
     public void TestClearEmptyChannel()
     {
-        var services = new ServiceCollection();
-        services.AddSingleton<IIntegrationServices, IntegrationServices>();
-        ServiceProvider provider = services.BuildServiceProvider();
-        var channel = new QueueChannel(provider.GetService<IApplicationContext>());
+        var channel = new QueueChannel();
+
         IList<IMessage> clearedMessages = channel.Clear();
-        Assert.NotNull(clearedMessages);
-        Assert.Empty(clearedMessages);
+
+        clearedMessages.Should().BeEmpty();
     }
 
     [Fact]
     public void TestPurge()
     {
-        var services = new ServiceCollection();
-        services.AddSingleton<IIntegrationServices, IntegrationServices>();
-        ServiceProvider provider = services.BuildServiceProvider();
-        var channel = new QueueChannel(provider.GetService<IApplicationContext>());
-        Assert.Throws<NotSupportedException>(() => channel.Purge(null));
+        var channel = new QueueChannel();
+
+        Func<IList<IMessage>> action = () => channel.Purge(null);
+        action.Should().ThrowExactly<NotSupportedException>();
+    }
+
+    private static void AssertMessageExchange(Func<bool> backgroundOperation, Action? foregroundOperation)
+    {
+        Task backgroundTask = Task.Run(() =>
+        {
+            bool succeeded = backgroundOperation();
+            succeeded.Should().BeTrue("background operation should succeed");
+        });
+
+        foregroundOperation?.Invoke();
+
+        bool succeeded = backgroundTask.Wait(DefaultTestTimeout);
+
+        if (!succeeded)
+        {
+            throw new TimeoutException($"Background operation timed out unexpectedly after {DefaultTestTimeout}.");
+        }
+    }
+
+    private static async Task AssertMessageExchangeAsync(Func<Task<bool>> backgroundAsyncOperation, Action? foregroundOperation)
+    {
+        Task backgroundTask = Task.Run(async () =>
+        {
+            bool succeeded = await backgroundAsyncOperation();
+            succeeded.Should().BeTrue("async background operation should succeed");
+        });
+
+        foregroundOperation?.Invoke();
+
+        await backgroundTask.WaitAsync(DefaultTestTimeout);
     }
 }

--- a/src/Logging/test/DynamicLogger.Test/DynamicLoggingBuilderTest.cs
+++ b/src/Logging/test/DynamicLogger.Test/DynamicLoggingBuilderTest.cs
@@ -280,10 +280,11 @@ public sealed class DynamicLoggingBuilderTest
 
         string log = console.ToString();
 
-        log.Should().Be($@"fail: {typeof(DynamicLoggingBuilderTest).FullName}[0]
+        // Casting to object as workaround, see https://github.com/fluentassertions/fluentassertions/issues/2339.
+        ((object)log).Should().BeEquivalentTo($@"fail: {typeof(DynamicLoggingBuilderTest).FullName}[0]
       => Outer Scope => InnerScopeKey=InnerScopeValue
       Something bad.
-");
+", options => options.Using(IgnoreLineEndingsComparer.Instance));
     }
 
     [Fact]
@@ -319,9 +320,10 @@ public sealed class DynamicLoggingBuilderTest
 
         string log = console.ToString();
 
-        log.Should().Be($@"fail: {typeof(DynamicLoggingBuilderTest).FullName}[0]
+        // Casting to object as workaround, see https://github.com/fluentassertions/fluentassertions/issues/2339.
+        ((object)log).Should().BeEquivalentTo($@"fail: {typeof(DynamicLoggingBuilderTest).FullName}[0]
       => Outer Scope => InnerScopeKey=InnerScopeValue
       Something bad.
-");
+", options => options.Using(IgnoreLineEndingsComparer.Instance));
     }
 }

--- a/src/Management/src/Endpoint/CloudFoundry/SecurityUtils.cs
+++ b/src/Management/src/Endpoint/CloudFoundry/SecurityUtils.cs
@@ -78,7 +78,7 @@ internal sealed class SecurityUtils
             Permissions permissions = await GetPermissionsAsync(response, cancellationToken);
             return new SecurityResult(permissions);
         }
-        catch (Exception exception) when (exception is not OperationCanceledException)
+        catch (Exception exception) when (!exception.IsCancellation())
         {
             _logger.LogError(exception, "Cloud Foundry returned exception while obtaining permissions from: {PermissionsUri}", checkPermissionsUri);
 
@@ -107,7 +107,7 @@ internal sealed class SecurityUtils
                 permissions = enabled ? Permissions.Full : Permissions.Restricted;
             }
         }
-        catch (Exception exception) when (exception is not OperationCanceledException)
+        catch (Exception exception) when (!exception.IsCancellation())
         {
             _logger.LogError(exception, "Exception extracting permissions from {json}", SecurityUtilities.SanitizeInput(json));
             throw;

--- a/src/Management/src/Endpoint/Health/Contributor/DiskSpaceContributor.cs
+++ b/src/Management/src/Endpoint/Health/Contributor/DiskSpaceContributor.cs
@@ -22,7 +22,7 @@ internal sealed class DiskSpaceContributor : IHealthContributor
         _optionsMonitor = optionsMonitor;
     }
 
-    public Task<HealthCheckResult?> HealthAsync(CancellationToken cancellationToken)
+    public Task<HealthCheckResult?> CheckHealthAsync(CancellationToken cancellationToken)
     {
         HealthCheckResult? result = Health();
         return Task.FromResult(result);

--- a/src/Management/src/Endpoint/Health/Contributor/DiskSpaceContributor.cs
+++ b/src/Management/src/Endpoint/Health/Contributor/DiskSpaceContributor.cs
@@ -22,7 +22,13 @@ internal sealed class DiskSpaceContributor : IHealthContributor
         _optionsMonitor = optionsMonitor;
     }
 
-    public HealthCheckResult? Health()
+    public Task<HealthCheckResult?> HealthAsync(CancellationToken cancellationToken)
+    {
+        HealthCheckResult? result = Health();
+        return Task.FromResult(result);
+    }
+
+    private HealthCheckResult? Health()
     {
         DiskSpaceContributorOptions options = _optionsMonitor.CurrentValue;
 

--- a/src/Management/src/Endpoint/Health/DefaultHealthAggregator.cs
+++ b/src/Management/src/Endpoint/Health/DefaultHealthAggregator.cs
@@ -30,7 +30,7 @@ internal class DefaultHealthAggregator : IHealthAggregator
 
             try
             {
-                healthCheckResult = await contributor.HealthAsync(cancellationToken);
+                healthCheckResult = await contributor.CheckHealthAsync(cancellationToken);
             }
             catch (Exception exception) when (!exception.IsCancellation())
             {

--- a/src/Management/src/Endpoint/Health/DefaultHealthAggregator.cs
+++ b/src/Management/src/Endpoint/Health/DefaultHealthAggregator.cs
@@ -32,7 +32,7 @@ internal class DefaultHealthAggregator : IHealthAggregator
             {
                 healthCheckResult = await contributor.HealthAsync(cancellationToken);
             }
-            catch (Exception exception) when (exception is not OperationCanceledException)
+            catch (Exception exception) when (!exception.IsCancellation())
             {
                 healthCheckResult = new HealthCheckResult();
             }

--- a/src/Management/src/Endpoint/Health/HealthEndpointResponse.cs
+++ b/src/Management/src/Endpoint/Health/HealthEndpointResponse.cs
@@ -15,6 +15,8 @@ public sealed class HealthEndpointResponse : HealthCheckResult
     /// </summary>
     public IList<string> Groups { get; set; } = new List<string>();
 
+    public bool Exists { get; set; } = true;
+
     public HealthEndpointResponse(HealthCheckResult? result)
     {
         result ??= new HealthCheckResult();

--- a/src/Management/src/Endpoint/Health/HealthRegistrationsAggregator.cs
+++ b/src/Management/src/Endpoint/Health/HealthRegistrationsAggregator.cs
@@ -55,7 +55,7 @@ internal sealed class HealthRegistrationsAggregator : DefaultHealthAggregator, I
             {
                 healthCheckResult = await RunMicrosoftHealthCheckAsync(serviceProvider, registration, cancellationToken);
             }
-            catch (Exception exception) when (exception is not OperationCanceledException)
+            catch (Exception exception) when (!exception.IsCancellation())
             {
                 healthCheckResult = new SteeltoeHealthCheckResult();
             }
@@ -100,7 +100,7 @@ internal sealed class HealthRegistrationsAggregator : DefaultHealthAggregator, I
                 healthCheckResult.Details.Add("error", result.Exception.Message);
             }
         }
-        catch (Exception exception) when (exception is not OperationCanceledException)
+        catch (Exception exception) when (!exception.IsCancellation())
         {
             // Catch all exceptions so that a status can always be returned
             healthCheckResult.Details.Add("exception", exception.Message);

--- a/src/Management/src/Endpoint/Health/IHealthRegistrationsAggregator.cs
+++ b/src/Management/src/Endpoint/Health/IHealthRegistrationsAggregator.cs
@@ -10,6 +10,6 @@ namespace Steeltoe.Management.Endpoint.Health;
 
 public interface IHealthRegistrationsAggregator : IHealthAggregator
 {
-    HealthCheckResult Aggregate(ICollection<IHealthContributor> contributors, ICollection<HealthCheckRegistration> healthCheckRegistrations,
+    Task<HealthCheckResult> AggregateAsync(ICollection<IHealthContributor> contributors, ICollection<HealthCheckRegistration> healthCheckRegistrations,
         IServiceProvider serviceProvider, CancellationToken cancellationToken);
 }

--- a/src/Management/src/Endpoint/Info/InfoEndpointHandler.cs
+++ b/src/Management/src/Endpoint/Info/InfoEndpointHandler.cs
@@ -38,7 +38,7 @@ internal sealed class InfoEndpointHandler : IInfoEndpointHandler
             {
                 await contributor.ContributeAsync(builder, cancellationToken);
             }
-            catch (Exception exception) when (exception is not OperationCanceledException)
+            catch (Exception exception) when (!exception.IsCancellation())
             {
                 _logger.LogError(exception, "Operation failed.");
             }

--- a/src/Management/src/Endpoint/Loggers/LoggersEndpointMiddleware.cs
+++ b/src/Management/src/Endpoint/Loggers/LoggersEndpointMiddleware.cs
@@ -7,6 +7,7 @@ using System.Text.Json;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Steeltoe.Common;
 using Steeltoe.Management.Endpoint.ContentNegotiation;
 using Steeltoe.Management.Endpoint.Middleware;
 using Steeltoe.Management.Endpoint.Options;
@@ -88,7 +89,7 @@ internal sealed class LoggersEndpointMiddleware : EndpointMiddleware<LoggersRequ
                 return dictionary;
             }
         }
-        catch (Exception exception) when (exception is not OperationCanceledException)
+        catch (Exception exception) when (!exception.IsCancellation())
         {
             _logger.LogError(exception, "Exception deserializing loggers endpoint request.");
         }

--- a/src/Management/src/Endpoint/PublicAPI.Unshipped.txt
+++ b/src/Management/src/Endpoint/PublicAPI.Unshipped.txt
@@ -215,7 +215,7 @@ Steeltoe.Management.Endpoint.Health.HealthGroupOptions.Include.get -> string?
 Steeltoe.Management.Endpoint.Health.HealthGroupOptions.Include.set -> void
 Steeltoe.Management.Endpoint.Health.IHealthEndpointHandler
 Steeltoe.Management.Endpoint.Health.IHealthRegistrationsAggregator
-Steeltoe.Management.Endpoint.Health.IHealthRegistrationsAggregator.Aggregate(System.Collections.Generic.ICollection<Steeltoe.Common.HealthChecks.IHealthContributor!>! contributors, System.Collections.Generic.ICollection<Microsoft.Extensions.Diagnostics.HealthChecks.HealthCheckRegistration!>! healthCheckRegistrations, System.IServiceProvider! serviceProvider, System.Threading.CancellationToken cancellationToken) -> Steeltoe.Common.HealthChecks.HealthCheckResult!
+Steeltoe.Management.Endpoint.Health.IHealthRegistrationsAggregator.AggregateAsync(System.Collections.Generic.ICollection<Steeltoe.Common.HealthChecks.IHealthContributor!>! contributors, System.Collections.Generic.ICollection<Microsoft.Extensions.Diagnostics.HealthChecks.HealthCheckRegistration!>! healthCheckRegistrations, System.IServiceProvider! serviceProvider, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Steeltoe.Common.HealthChecks.HealthCheckResult!>!
 Steeltoe.Management.Endpoint.Health.ServiceCollectionExtensions
 Steeltoe.Management.Endpoint.Health.ServiceProviderExtensions
 Steeltoe.Management.Endpoint.Health.ShowDetails

--- a/src/Management/src/Endpoint/PublicAPI.Unshipped.txt
+++ b/src/Management/src/Endpoint/PublicAPI.Unshipped.txt
@@ -206,6 +206,8 @@ Steeltoe.Management.Endpoint.Health.HealthEndpointRequest.GroupName.get -> strin
 Steeltoe.Management.Endpoint.Health.HealthEndpointRequest.HasClaim.get -> bool
 Steeltoe.Management.Endpoint.Health.HealthEndpointRequest.HealthEndpointRequest(string! groupName, bool hasClaim) -> void
 Steeltoe.Management.Endpoint.Health.HealthEndpointResponse
+Steeltoe.Management.Endpoint.Health.HealthEndpointResponse.Exists.get -> bool
+Steeltoe.Management.Endpoint.Health.HealthEndpointResponse.Exists.set -> void
 Steeltoe.Management.Endpoint.Health.HealthEndpointResponse.Groups.get -> System.Collections.Generic.IList<string!>!
 Steeltoe.Management.Endpoint.Health.HealthEndpointResponse.Groups.set -> void
 Steeltoe.Management.Endpoint.Health.HealthEndpointResponse.HealthEndpointResponse(Steeltoe.Common.HealthChecks.HealthCheckResult? result) -> void

--- a/src/Management/src/Endpoint/SpringBootAdminClient/SpringBootAdminClientHostedService.cs
+++ b/src/Management/src/Endpoint/SpringBootAdminClient/SpringBootAdminClientHostedService.cs
@@ -60,7 +60,7 @@ internal sealed class SpringBootAdminClientHostedService : IHostedService
         {
             response = await _httpClient.PostAsJsonAsync($"{_clientOptions.Url}/instances", app, cancellationToken);
         }
-        catch (Exception exception) when (exception is not OperationCanceledException)
+        catch (Exception exception) when (!exception.IsCancellation())
         {
             _logger.LogError(exception, "Error connecting to SpringBootAdmin: {Message}", exception.Message);
         }

--- a/src/Management/src/Endpoint/ThreadDump/EventPipeThreadDumper.cs
+++ b/src/Management/src/Endpoint/ThreadDump/EventPipeThreadDumper.cs
@@ -76,7 +76,7 @@ public sealed class EventPipeThreadDumper
             using EventPipeSession session = client.StartEventPipeSession(providers);
             await DumpThreadsAsync(session, results, cancellationToken);
         }
-        catch (Exception exception) when (exception is not OperationCanceledException)
+        catch (Exception exception) when (!exception.IsCancellation())
         {
             _logger.LogError(exception, "Unable to dump threads");
         }
@@ -161,7 +161,7 @@ public sealed class EventPipeThreadDumper
                 }
             }
         }
-        catch (Exception exception) when (exception is not OperationCanceledException)
+        catch (Exception exception) when (!exception.IsCancellation())
         {
             _logger.LogError(exception, "Error processing trace file for thread dump");
             results.Clear();
@@ -451,7 +451,7 @@ public sealed class EventPipeThreadDumper
             // using the generated trace file, symbolocate and compute stacks.
             return TraceLog.CreateFromEventPipeDataFile(tempNetTraceFilename);
         }
-        catch (Exception exception) when (exception is not OperationCanceledException)
+        catch (Exception exception) when (!exception.IsCancellation())
         {
             _logger.LogError(exception, "Error creating trace file for thread dump");
             return string.Empty;

--- a/src/Management/test/Endpoint.Test/DbMigrations/DbMigrationsEndpointTests.cs
+++ b/src/Management/test/Endpoint.Test/DbMigrations/DbMigrationsEndpointTests.cs
@@ -38,7 +38,7 @@ public sealed class DbMigrationsEndpointTests : BaseTest
     {
         var sut = new DbMigrationsEndpointHandler.DatabaseMigrationScanner();
 
-        sut.Invoking(scanner => scanner.GetMigrations(new MockDbContext())).Should().Throw<TargetInvocationException>()
+        sut.Invoking(scanner => scanner.GetMigrations(new MockDbContext())).Should().ThrowExactly<TargetInvocationException>()
             .WithInnerException<InvalidOperationException>().WithMessage("*No database provider has been configured for this DbContext*");
     }
 

--- a/src/Management/test/Endpoint.Test/Health/Contributor/DiskSpaceContributorTest.cs
+++ b/src/Management/test/Endpoint.Test/Health/Contributor/DiskSpaceContributorTest.cs
@@ -22,12 +22,12 @@ public sealed class DiskSpaceContributorTest : BaseTest
     }
 
     [Fact]
-    public void Health_InitializedWithDefaults_ReturnsExpected()
+    public async Task Health_InitializedWithDefaults_ReturnsExpected()
     {
         IOptionsMonitor<DiskSpaceContributorOptions> optionsMonitor = GetOptionsMonitorFromSettings<DiskSpaceContributorOptions>();
         var contributor = new DiskSpaceContributor(optionsMonitor);
         Assert.Equal("diskSpace", contributor.Id);
-        HealthCheckResult? result = contributor.Health();
+        HealthCheckResult? result = await contributor.HealthAsync(CancellationToken.None);
         Assert.NotNull(result);
         Assert.Equal(HealthStatus.Up, result.Status);
         Assert.NotNull(result.Details);
@@ -38,7 +38,7 @@ public sealed class DiskSpaceContributorTest : BaseTest
     }
 
     [Fact]
-    public void Health_UnknownDirectory_ReportsError()
+    public async Task Health_UnknownDirectory_ReportsError()
     {
         var optionsMonitor = new TestOptionsMonitor<DiskSpaceContributorOptions>(new DiskSpaceContributorOptions
         {
@@ -47,7 +47,7 @@ public sealed class DiskSpaceContributorTest : BaseTest
 
         var contributor = new DiskSpaceContributor(optionsMonitor);
 
-        HealthCheckResult? result = contributor.Health();
+        HealthCheckResult? result = await contributor.HealthAsync(CancellationToken.None);
 
         result.Should().NotBeNull();
         result!.Status.Should().Be(HealthStatus.Unknown);

--- a/src/Management/test/Endpoint.Test/Health/Contributor/DiskSpaceContributorTest.cs
+++ b/src/Management/test/Endpoint.Test/Health/Contributor/DiskSpaceContributorTest.cs
@@ -27,7 +27,7 @@ public sealed class DiskSpaceContributorTest : BaseTest
         IOptionsMonitor<DiskSpaceContributorOptions> optionsMonitor = GetOptionsMonitorFromSettings<DiskSpaceContributorOptions>();
         var contributor = new DiskSpaceContributor(optionsMonitor);
         Assert.Equal("diskSpace", contributor.Id);
-        HealthCheckResult? result = await contributor.HealthAsync(CancellationToken.None);
+        HealthCheckResult? result = await contributor.CheckHealthAsync(CancellationToken.None);
         Assert.NotNull(result);
         Assert.Equal(HealthStatus.Up, result.Status);
         Assert.NotNull(result.Details);
@@ -47,7 +47,7 @@ public sealed class DiskSpaceContributorTest : BaseTest
 
         var contributor = new DiskSpaceContributor(optionsMonitor);
 
-        HealthCheckResult? result = await contributor.HealthAsync(CancellationToken.None);
+        HealthCheckResult? result = await contributor.CheckHealthAsync(CancellationToken.None);
 
         result.Should().NotBeNull();
         result!.Status.Should().Be(HealthStatus.Unknown);

--- a/src/Management/test/Endpoint.Test/Health/DefaultHealthAggregatorTest.cs
+++ b/src/Management/test/Endpoint.Test/Health/DefaultHealthAggregatorTest.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Diagnostics;
+using FluentAssertions;
 using Steeltoe.Common.HealthChecks;
 using Steeltoe.Management.Endpoint.Health;
 using Steeltoe.Management.Endpoint.Test.Health.TestContributors;
@@ -13,17 +14,17 @@ namespace Steeltoe.Management.Endpoint.Test.Health;
 public sealed class DefaultHealthAggregatorTest : BaseTest
 {
     [Fact]
-    public void Aggregate_EmptyContributorList_ReturnsExpectedHealth()
+    public async Task Aggregate_EmptyContributorList_ReturnsExpectedHealth()
     {
         var aggregator = new DefaultHealthAggregator();
-        HealthCheckResult result = aggregator.Aggregate(Array.Empty<IHealthContributor>(), CancellationToken.None);
+        HealthCheckResult result = await aggregator.AggregateAsync(Array.Empty<IHealthContributor>(), CancellationToken.None);
         Assert.NotNull(result);
         Assert.Equal(HealthStatus.Unknown, result.Status);
         Assert.NotNull(result.Details);
     }
 
     [Fact]
-    public void Aggregate_DisabledContributorOnly_ReturnsExpectedHealth()
+    public async Task Aggregate_DisabledContributorOnly_ReturnsExpectedHealth()
     {
         var contributors = new List<IHealthContributor>
         {
@@ -31,14 +32,14 @@ public sealed class DefaultHealthAggregatorTest : BaseTest
         };
 
         var aggregator = new DefaultHealthAggregator();
-        HealthCheckResult result = aggregator.Aggregate(contributors, CancellationToken.None);
+        HealthCheckResult result = await aggregator.AggregateAsync(contributors, CancellationToken.None);
         Assert.NotNull(result);
         Assert.Equal(HealthStatus.Unknown, result.Status);
         Assert.NotNull(result.Details);
     }
 
     [Fact]
-    public void Aggregate_SingleContributor_ReturnsExpectedHealth()
+    public async Task Aggregate_SingleContributor_ReturnsExpectedHealth()
     {
         var contributors = new List<IHealthContributor>
         {
@@ -46,14 +47,31 @@ public sealed class DefaultHealthAggregatorTest : BaseTest
         };
 
         var aggregator = new DefaultHealthAggregator();
-        HealthCheckResult result = aggregator.Aggregate(contributors, CancellationToken.None);
+        HealthCheckResult result = await aggregator.AggregateAsync(contributors, CancellationToken.None);
         Assert.NotNull(result);
         Assert.Equal(HealthStatus.Up, result.Status);
         Assert.NotNull(result.Details);
     }
 
     [Fact]
-    public void Aggregate_MultipleContributor_ReturnsExpectedHealth()
+    public async Task Aggregate_SingleCanceledContributor_Throws()
+    {
+        var contributors = new List<IHealthContributor>
+        {
+            new UpContributor(5000)
+        };
+
+        var source = new CancellationTokenSource();
+        source.Cancel();
+
+        var aggregator = new DefaultHealthAggregator();
+        Func<Task> action = async () => await aggregator.AggregateAsync(contributors, source.Token);
+
+        await action.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    [Fact]
+    public async Task Aggregate_MultipleContributor_ReturnsExpectedHealth()
     {
         var contributors = new List<IHealthContributor>
         {
@@ -65,14 +83,14 @@ public sealed class DefaultHealthAggregatorTest : BaseTest
         };
 
         var aggregator = new DefaultHealthAggregator();
-        HealthCheckResult result = aggregator.Aggregate(contributors, CancellationToken.None);
+        HealthCheckResult result = await aggregator.AggregateAsync(contributors, CancellationToken.None);
         Assert.NotNull(result);
         Assert.Equal(HealthStatus.Down, result.Status);
         Assert.NotNull(result.Details);
     }
 
     [Fact]
-    public void Aggregate_DuplicateContributor_ReturnsExpectedHealth()
+    public async Task Aggregate_DuplicateContributor_ReturnsExpectedHealth()
     {
         var contributors = new List<IHealthContributor>();
 
@@ -82,14 +100,14 @@ public sealed class DefaultHealthAggregatorTest : BaseTest
         }
 
         var aggregator = new DefaultHealthAggregator();
-        HealthCheckResult result = aggregator.Aggregate(contributors, CancellationToken.None);
+        HealthCheckResult result = await aggregator.AggregateAsync(contributors, CancellationToken.None);
         Assert.NotNull(result);
         Assert.Equal(HealthStatus.Up, result.Status);
         Assert.Contains("Up-9", result.Details.Keys);
     }
 
     [Fact]
-    public void Aggregate_MultipleContributor_OrderDoesNotMatter_ReturnsExpectedHealth()
+    public async Task Aggregate_MultipleContributor_OrderDoesNotMatter_ReturnsExpectedHealth()
     {
         var contributors = new List<IHealthContributor>
         {
@@ -99,14 +117,14 @@ public sealed class DefaultHealthAggregatorTest : BaseTest
         };
 
         var aggregator = new DefaultHealthAggregator();
-        HealthCheckResult result = aggregator.Aggregate(contributors, CancellationToken.None);
+        HealthCheckResult result = await aggregator.AggregateAsync(contributors, CancellationToken.None);
         Assert.NotNull(result);
         Assert.Equal(HealthStatus.OutOfService, result.Status);
         Assert.NotNull(result.Details);
     }
 
     [Fact]
-    public void AggregatesInParallel()
+    public async Task AggregatesInParallel()
     {
         var stopwatch = new Stopwatch();
 
@@ -119,7 +137,7 @@ public sealed class DefaultHealthAggregatorTest : BaseTest
 
         var aggregator = new DefaultHealthAggregator();
         stopwatch.Start();
-        HealthCheckResult result = aggregator.Aggregate(contributors, CancellationToken.None);
+        HealthCheckResult result = await aggregator.AggregateAsync(contributors, CancellationToken.None);
         stopwatch.Stop();
         Assert.NotNull(result);
         Assert.Equal(HealthStatus.Up, result.Status);

--- a/src/Management/test/Endpoint.Test/Health/DefaultHealthAggregatorTest.cs
+++ b/src/Management/test/Endpoint.Test/Health/DefaultHealthAggregatorTest.cs
@@ -67,7 +67,7 @@ public sealed class DefaultHealthAggregatorTest : BaseTest
         var aggregator = new DefaultHealthAggregator();
         Func<Task> action = async () => await aggregator.AggregateAsync(contributors, source.Token);
 
-        await action.Should().ThrowAsync<OperationCanceledException>();
+        await action.Should().ThrowExactlyAsync<TaskCanceledException>();
     }
 
     [Fact]

--- a/src/Management/test/Endpoint.Test/Health/EndpointMiddlewareTest.cs
+++ b/src/Management/test/Endpoint.Test/Health/EndpointMiddlewareTest.cs
@@ -355,6 +355,21 @@ public sealed class EndpointMiddlewareTest : BaseTest
     }
 
     [Fact]
+    public async Task GetStatusCode_InvalidGroupName_Returns404()
+    {
+        IWebHostBuilder builder = new WebHostBuilder().UseStartup<Startup>();
+        using var server = new TestServer(builder);
+        HttpClient client = server.CreateClient();
+
+        HttpResponseMessage responseMessage = await client.GetAsync(new Uri("http://localhost/actuator/health/foo"));
+
+        Assert.Equal(HttpStatusCode.NotFound, responseMessage.StatusCode);
+
+        string body = await responseMessage.Content.ReadAsStringAsync();
+        Assert.Empty(body);
+    }
+
+    [Fact]
     public void RoutesByPathAndVerb()
     {
         var endpointOptions = GetOptionsFromSettings<HealthEndpointOptions>();

--- a/src/Management/test/Endpoint.Test/Health/HealthEndpointTest.cs
+++ b/src/Management/test/Endpoint.Test/Health/HealthEndpointTest.cs
@@ -104,7 +104,7 @@ public sealed class HealthEndpointTest : BaseTest
         HealthEndpointRequest healthRequest = GetHealthRequest();
         Func<Task> action = async () => await handler.InvokeAsync(healthRequest, source.Token);
 
-        await action.Should().ThrowAsync<OperationCanceledException>();
+        await action.Should().ThrowExactlyAsync<TaskCanceledException>();
     }
 
     [Fact]

--- a/src/Management/test/Endpoint.Test/Health/TestContributors/DisabledContributor.cs
+++ b/src/Management/test/Endpoint.Test/Health/TestContributors/DisabledContributor.cs
@@ -10,7 +10,7 @@ internal sealed class DisabledContributor : IHealthContributor
 {
     public string Id => "Disabled";
 
-    public Task<HealthCheckResult?> HealthAsync(CancellationToken cancellationToken)
+    public Task<HealthCheckResult?> CheckHealthAsync(CancellationToken cancellationToken)
     {
         return Task.FromResult<HealthCheckResult?>(null);
     }

--- a/src/Management/test/Endpoint.Test/Health/TestContributors/DisabledContributor.cs
+++ b/src/Management/test/Endpoint.Test/Health/TestContributors/DisabledContributor.cs
@@ -10,8 +10,8 @@ internal sealed class DisabledContributor : IHealthContributor
 {
     public string Id => "Disabled";
 
-    public HealthCheckResult? Health()
+    public Task<HealthCheckResult?> HealthAsync(CancellationToken cancellationToken)
     {
-        return null;
+        return Task.FromResult<HealthCheckResult?>(null);
     }
 }

--- a/src/Management/test/Endpoint.Test/Health/TestContributors/DownContributor.cs
+++ b/src/Management/test/Endpoint.Test/Health/TestContributors/DownContributor.cs
@@ -10,7 +10,7 @@ internal sealed class DownContributor : IHealthContributor
 {
     public string Id => "Down";
 
-    public Task<HealthCheckResult?> HealthAsync(CancellationToken cancellationToken)
+    public Task<HealthCheckResult?> CheckHealthAsync(CancellationToken cancellationToken)
     {
         return Task.FromResult<HealthCheckResult?>(new HealthCheckResult
         {

--- a/src/Management/test/Endpoint.Test/Health/TestContributors/DownContributor.cs
+++ b/src/Management/test/Endpoint.Test/Health/TestContributors/DownContributor.cs
@@ -10,11 +10,11 @@ internal sealed class DownContributor : IHealthContributor
 {
     public string Id => "Down";
 
-    public HealthCheckResult Health()
+    public Task<HealthCheckResult?> HealthAsync(CancellationToken cancellationToken)
     {
-        return new HealthCheckResult
+        return Task.FromResult<HealthCheckResult?>(new HealthCheckResult
         {
             Status = HealthStatus.Down
-        };
+        });
     }
 }

--- a/src/Management/test/Endpoint.Test/Health/TestContributors/HealthTestContributor.cs
+++ b/src/Management/test/Endpoint.Test/Health/TestContributors/HealthTestContributor.cs
@@ -19,8 +19,10 @@ internal sealed class HealthTestContributor : IHealthContributor
         Throws = throws;
     }
 
-    public HealthCheckResult Health()
+    public async Task<HealthCheckResult?> HealthAsync(CancellationToken cancellationToken)
     {
+        await Task.Yield();
+
         if (Throws)
         {
             throw new Exception();

--- a/src/Management/test/Endpoint.Test/Health/TestContributors/HealthTestContributor.cs
+++ b/src/Management/test/Endpoint.Test/Health/TestContributors/HealthTestContributor.cs
@@ -19,7 +19,7 @@ internal sealed class HealthTestContributor : IHealthContributor
         Throws = throws;
     }
 
-    public async Task<HealthCheckResult?> HealthAsync(CancellationToken cancellationToken)
+    public async Task<HealthCheckResult?> CheckHealthAsync(CancellationToken cancellationToken)
     {
         await Task.Yield();
 

--- a/src/Management/test/Endpoint.Test/Health/TestContributors/OutOfServiceContributor.cs
+++ b/src/Management/test/Endpoint.Test/Health/TestContributors/OutOfServiceContributor.cs
@@ -10,11 +10,11 @@ internal sealed class OutOfServiceContributor : IHealthContributor
 {
     public string Id => "Out";
 
-    public HealthCheckResult Health()
+    public Task<HealthCheckResult?> HealthAsync(CancellationToken cancellationToken)
     {
-        return new HealthCheckResult
+        return Task.FromResult<HealthCheckResult?>(new HealthCheckResult
         {
             Status = HealthStatus.OutOfService
-        };
+        });
     }
 }

--- a/src/Management/test/Endpoint.Test/Health/TestContributors/OutOfServiceContributor.cs
+++ b/src/Management/test/Endpoint.Test/Health/TestContributors/OutOfServiceContributor.cs
@@ -10,7 +10,7 @@ internal sealed class OutOfServiceContributor : IHealthContributor
 {
     public string Id => "Out";
 
-    public Task<HealthCheckResult?> HealthAsync(CancellationToken cancellationToken)
+    public Task<HealthCheckResult?> CheckHealthAsync(CancellationToken cancellationToken)
     {
         return Task.FromResult<HealthCheckResult?>(new HealthCheckResult
         {

--- a/src/Management/test/Endpoint.Test/Health/TestContributors/UnknownContributor.cs
+++ b/src/Management/test/Endpoint.Test/Health/TestContributors/UnknownContributor.cs
@@ -10,11 +10,11 @@ internal sealed class UnknownContributor : IHealthContributor
 {
     public string Id => "Unknown";
 
-    public HealthCheckResult Health()
+    public Task<HealthCheckResult?> HealthAsync(CancellationToken cancellationToken)
     {
-        return new HealthCheckResult
+        return Task.FromResult<HealthCheckResult?>(new HealthCheckResult
         {
             Status = HealthStatus.Unknown
-        };
+        });
     }
 }

--- a/src/Management/test/Endpoint.Test/Health/TestContributors/UnknownContributor.cs
+++ b/src/Management/test/Endpoint.Test/Health/TestContributors/UnknownContributor.cs
@@ -10,7 +10,7 @@ internal sealed class UnknownContributor : IHealthContributor
 {
     public string Id => "Unknown";
 
-    public Task<HealthCheckResult?> HealthAsync(CancellationToken cancellationToken)
+    public Task<HealthCheckResult?> CheckHealthAsync(CancellationToken cancellationToken)
     {
         return Task.FromResult<HealthCheckResult?>(new HealthCheckResult
         {

--- a/src/Management/test/Endpoint.Test/Health/TestContributors/UpContributor.cs
+++ b/src/Management/test/Endpoint.Test/Health/TestContributors/UpContributor.cs
@@ -17,7 +17,7 @@ internal sealed class UpContributor : IHealthContributor
         _sleepTime = sleepTime;
     }
 
-    public async Task<HealthCheckResult?> HealthAsync(CancellationToken cancellationToken)
+    public async Task<HealthCheckResult?> CheckHealthAsync(CancellationToken cancellationToken)
     {
         if (_sleepTime != null)
         {

--- a/src/Management/test/Endpoint.Test/Health/TestContributors/UpContributor.cs
+++ b/src/Management/test/Endpoint.Test/Health/TestContributors/UpContributor.cs
@@ -17,11 +17,11 @@ internal sealed class UpContributor : IHealthContributor
         _sleepTime = sleepTime;
     }
 
-    public HealthCheckResult Health()
+    public async Task<HealthCheckResult?> HealthAsync(CancellationToken cancellationToken)
     {
         if (_sleepTime != null)
         {
-            Thread.Sleep((int)_sleepTime);
+            await Task.Delay(_sleepTime.Value, cancellationToken);
         }
 
         return new HealthCheckResult

--- a/src/Management/test/Endpoint.Test/Info/AppSettingsInfoContributorTest.cs
+++ b/src/Management/test/Endpoint.Test/Info/AppSettingsInfoContributorTest.cs
@@ -33,14 +33,14 @@ public sealed class AppSettingsInfoContributorTest : BaseTest
     }
 
     [Fact]
-    public void ContributeWithNullBuilderThrows()
+    public async Task ContributeWithNullBuilderThrows()
     {
         var configurationBuilder = new ConfigurationBuilder();
         configurationBuilder.AddInMemoryCollection(_appSettings);
         IConfigurationRoot configurationRoot = configurationBuilder.Build();
         var settings = new AppSettingsInfoContributor(configurationRoot);
 
-        Assert.ThrowsAsync<ArgumentNullException>(() => settings.ContributeAsync(null!, CancellationToken.None));
+        await Assert.ThrowsAsync<ArgumentNullException>(async () => await settings.ContributeAsync(null!, CancellationToken.None));
     }
 
     [Fact]

--- a/src/Management/test/Endpoint.Test/Info/Contributor/AppSettingsInfoContributorTest.cs
+++ b/src/Management/test/Endpoint.Test/Info/Contributor/AppSettingsInfoContributorTest.cs
@@ -23,7 +23,7 @@ public sealed class AppSettingsInfoContributorTest : BaseTest
     }
 
     [Fact]
-    public void ContributeWithNullBuilderThrows()
+    public async Task ContributeWithNullBuilderThrows()
     {
         var appsettings = new Dictionary<string, string?>
         {
@@ -40,7 +40,7 @@ public sealed class AppSettingsInfoContributorTest : BaseTest
         IConfigurationRoot configurationRoot = configurationBuilder.Build();
         var settings = new AppSettingsInfoContributor(configurationRoot);
 
-        Assert.ThrowsAsync<ArgumentNullException>(() => settings.ContributeAsync(null!, CancellationToken.None));
+        await Assert.ThrowsAsync<ArgumentNullException>(async () => await settings.ContributeAsync(null!, CancellationToken.None));
     }
 
     [Fact]

--- a/src/Management/test/Endpoint.Test/Info/Contributor/GitInfoContributorTest.cs
+++ b/src/Management/test/Endpoint.Test/Info/Contributor/GitInfoContributorTest.cs
@@ -64,11 +64,11 @@ public sealed class GitInfoContributorTest : BaseTest
     }
 
     [Fact]
-    public void ContributeWithNullBuilderThrows()
+    public async Task ContributeWithNullBuilderThrows()
     {
         // Uses git.properties file in test project
         var contributor = new GitInfoContributor(NullLogger<GitInfoContributor>.Instance);
-        Assert.ThrowsAsync<ArgumentNullException>(() => contributor.ContributeAsync(null!, CancellationToken.None));
+        await Assert.ThrowsAsync<ArgumentNullException>(async () => await contributor.ContributeAsync(null!, CancellationToken.None));
     }
 
     [Fact]

--- a/src/Messaging/src/Messaging/Core/AbstractMessageReceivingTemplate.cs
+++ b/src/Messaging/src/Messaging/Core/AbstractMessageReceivingTemplate.cs
@@ -38,7 +38,7 @@ public abstract class AbstractMessageReceivingTemplate<TDestination> : AbstractM
 
     public virtual Task<T> ReceiveAndConvertAsync<T>(CancellationToken cancellationToken = default)
     {
-        return ReceiveAndConvertAsync<T>(RequiredDefaultReceiveDestination);
+        return ReceiveAndConvertAsync<T>(RequiredDefaultReceiveDestination, cancellationToken);
     }
 
     public virtual async Task<T> ReceiveAndConvertAsync<T>(TDestination destination, CancellationToken cancellationToken = default)

--- a/src/Messaging/src/Messaging/Core/AbstractMessagingTemplate.cs
+++ b/src/Messaging/src/Messaging/Core/AbstractMessagingTemplate.cs
@@ -39,7 +39,7 @@ public abstract class AbstractMessagingTemplate<TDestination> : AbstractMessageR
         IMessagePostProcessor requestPostProcessor, CancellationToken cancellationToken = default)
     {
         IMessage requestMessage = DoConvert(request, headers, requestPostProcessor);
-        IMessage replyMessage = await SendAndReceiveAsync(destination, requestMessage);
+        IMessage replyMessage = await SendAndReceiveAsync(destination, requestMessage, cancellationToken);
 
         if (replyMessage != null)
         {

--- a/src/Messaging/src/Messaging/Support/TaskSchedulerSubscribableChannel.cs
+++ b/src/Messaging/src/Messaging/Support/TaskSchedulerSubscribableChannel.cs
@@ -79,11 +79,7 @@ public class TaskSchedulerSubscribableChannel : AbstractSubscribableChannel
             }
             else
             {
-                Task task = Factory.StartNew(() =>
-                {
-                    Invoke(interceptors, message, handler);
-                });
-
+                Task task = Factory.StartNew(() => Invoke(interceptors, message, handler), cancellationToken);
                 task.GetAwaiter().GetResult();
             }
         }

--- a/src/Messaging/src/RabbitMQ/Core/RabbitTemplate.cs
+++ b/src/Messaging/src/RabbitMQ/Core/RabbitTemplate.cs
@@ -700,7 +700,7 @@ public class RabbitTemplate
 
     public virtual Task<T> ReceiveAndConvertAsync<T>(string queueName, int timeoutMillis, CancellationToken cancellationToken = default)
     {
-        return Task.Run(() => (T)DoReceiveAndConvert(queueName, timeoutMillis, typeof(T), cancellationToken));
+        return Task.Run(() => (T)DoReceiveAndConvert(queueName, timeoutMillis, typeof(T), cancellationToken), cancellationToken);
     }
 
     public virtual Task<object> ReceiveAndConvertAsync(Type type, CancellationToken cancellation = default)
@@ -720,7 +720,7 @@ public class RabbitTemplate
 
     public virtual Task<object> ReceiveAndConvertAsync(string queueName, int timeoutMillis, Type type, CancellationToken cancellationToken = default)
     {
-        return Task.Run(() => DoReceiveAndConvert(queueName, timeoutMillis, type, cancellationToken));
+        return Task.Run(() => DoReceiveAndConvert(queueName, timeoutMillis, type, cancellationToken), cancellationToken);
     }
 
     public virtual bool ReceiveAndReply<TReceive, TReply>(Func<TReceive, TReply> callback)

--- a/src/Messaging/test/Messaging.Test/Core/DestinationResolvingMessagingTemplateTest.cs
+++ b/src/Messaging/test/Messaging.Test/Core/DestinationResolvingMessagingTemplateTest.cs
@@ -62,7 +62,7 @@ public sealed class DestinationResolvingMessagingTemplateTest
     public Task SendAsyncNoDestinationResolver()
     {
         var template = new TestDestinationResolvingMessagingTemplate();
-        return Assert.ThrowsAsync<InvalidOperationException>(() => template.SendAsync("myChannel", Message.Create("payload")));
+        return Assert.ThrowsAsync<InvalidOperationException>(async () => await template.SendAsync("myChannel", Message.Create("payload")));
     }
 
     [Fact]

--- a/src/Messaging/test/Messaging.Test/Core/MessageReceivingTemplateTest.cs
+++ b/src/Messaging/test/Messaging.Test/Core/MessageReceivingTemplateTest.cs
@@ -45,7 +45,7 @@ public sealed class MessageReceivingTemplateTest
     [Fact]
     public async Task ReceiveAsyncMissingDefaultDestination()
     {
-        await Assert.ThrowsAsync<InvalidOperationException>(() => _template.ReceiveAsync());
+        await Assert.ThrowsAsync<InvalidOperationException>(async () => await _template.ReceiveAsync());
     }
 
     [Fact]
@@ -124,7 +124,7 @@ public sealed class MessageReceivingTemplateTest
         IMessage expected = Message.Create("not a number test");
         _template.ReceiveMessage = expected;
         _template.MessageConverter = new GenericMessageConverter();
-        var ext = await Assert.ThrowsAsync<MessageConversionException>(() => _template.ReceiveAndConvertAsync<int>("somewhere"));
+        var ext = await Assert.ThrowsAsync<MessageConversionException>(async () => await _template.ReceiveAndConvertAsync<int>("somewhere"));
         Assert.IsType<ConversionFailedException>(ext.InnerException);
     }
 

--- a/src/Messaging/test/Messaging.Test/Core/MessageRequestReplyTemplateTest.cs
+++ b/src/Messaging/test/Messaging.Test/Core/MessageRequestReplyTemplateTest.cs
@@ -57,7 +57,7 @@ public sealed class MessageRequestReplyTemplateTest
     [Fact]
     public async Task SendAndReceiveAsyncMissingDestination()
     {
-        await Assert.ThrowsAsync<InvalidOperationException>(() => _template.SendAndReceiveAsync(Message.Create("request")));
+        await Assert.ThrowsAsync<InvalidOperationException>(async () => await _template.SendAndReceiveAsync(Message.Create("request")));
     }
 
     [Fact]

--- a/src/Messaging/test/Messaging.Test/Core/MessageSendingTemplateTest.cs
+++ b/src/Messaging/test/Messaging.Test/Core/MessageSendingTemplateTest.cs
@@ -56,7 +56,7 @@ public sealed class MessageSendingTemplateTest
     public async Task SendAsyncMissingDestination()
     {
         IMessage<string> message = Message.Create("payload");
-        await Assert.ThrowsAsync<InvalidOperationException>(() => _template.SendAsync(message));
+        await Assert.ThrowsAsync<InvalidOperationException>(async () => await _template.SendAsync(message));
     }
 
     [Fact]
@@ -164,7 +164,7 @@ public sealed class MessageSendingTemplateTest
         _template.MessageConverter = converter;
 
         _headers.Add(MessageHeaders.ContentType, MimeTypeUtils.ApplicationXml);
-        await Assert.ThrowsAsync<MessageConversionException>(() => _template.ConvertAndSendAsync("home", "payload", new MessageHeaders(_headers)));
+        await Assert.ThrowsAsync<MessageConversionException>(async () => await _template.ConvertAndSendAsync("home", "payload", new MessageHeaders(_headers)));
     }
 
     [Fact]

--- a/src/Messaging/test/RabbitMQ.Test/Attributes/RabbitListenerAttributeProcessorTest.cs
+++ b/src/Messaging/test/RabbitMQ.Test/Attributes/RabbitListenerAttributeProcessorTest.cs
@@ -34,13 +34,13 @@ public sealed class RabbitListenerAttributeProcessorTest
 
         ServiceProvider provider = await Configuration.CreateAndStartServicesAsync(null, queues, typeof(SimpleMessageListenerTestBean));
         var context = provider.GetService<IApplicationContext>();
-        var factory = context.GetService<IRabbitListenerContainerFactory>() as RabbitListenerContainerTestFactory;
+        var factory = (RabbitListenerContainerTestFactory)context.GetService<IRabbitListenerContainerFactory>();
         Assert.Single(factory.GetListenerContainers());
         MessageListenerTestContainer container = factory.GetListenerContainers()[0];
 
         IRabbitListenerEndpoint endpoint = container.Endpoint;
         Assert.IsType<MethodRabbitListenerEndpoint>(endpoint);
-        var methodEndpoint = endpoint as MethodRabbitListenerEndpoint;
+        var methodEndpoint = (MethodRabbitListenerEndpoint)endpoint;
         Assert.NotNull(methodEndpoint.Instance);
         Assert.NotNull(methodEndpoint.Method);
 
@@ -48,7 +48,7 @@ public sealed class RabbitListenerAttributeProcessorTest
         methodEndpoint.SetupListenerContainer(listenerContainer);
         Assert.NotNull(listenerContainer.MessageListener);
         Assert.True(container.IsStarted);
-        provider.Dispose();
+        await provider.DisposeAsync();
         Assert.True(container.IsStopped);
     }
 
@@ -74,13 +74,13 @@ public sealed class RabbitListenerAttributeProcessorTest
             await Configuration.CreateAndStartServicesAsync(configurationRoot, queues, typeof(SimpleMessageListenerWithMixedAnnotationsTestBean));
 
         var context = provider.GetService<IApplicationContext>();
-        var factory = context.GetService<IRabbitListenerContainerFactory>() as RabbitListenerContainerTestFactory;
+        var factory = (RabbitListenerContainerTestFactory)context.GetService<IRabbitListenerContainerFactory>();
         Assert.Single(factory.GetListenerContainers());
         MessageListenerTestContainer container = factory.GetListenerContainers()[0];
 
         IRabbitListenerEndpoint endpoint = container.Endpoint;
         Assert.IsType<MethodRabbitListenerEndpoint>(endpoint);
-        var methodEndpoint = endpoint as MethodRabbitListenerEndpoint;
+        var methodEndpoint = (MethodRabbitListenerEndpoint)endpoint;
         Assert.NotNull(methodEndpoint.Instance);
         Assert.NotNull(methodEndpoint.Method);
 
@@ -92,7 +92,7 @@ public sealed class RabbitListenerAttributeProcessorTest
         methodEndpoint.SetupListenerContainer(listenerContainer);
         Assert.NotNull(listenerContainer.MessageListener);
         Assert.True(container.IsStarted);
-        provider.Dispose();
+        await provider.DisposeAsync();
         Assert.True(container.IsStopped);
     }
 
@@ -107,7 +107,7 @@ public sealed class RabbitListenerAttributeProcessorTest
 
         ServiceProvider provider = await Configuration.CreateAndStartServicesAsync(null, queues, typeof(MultipleQueueNamesTestBean));
         var context = provider.GetService<IApplicationContext>();
-        var factory = context.GetService<IRabbitListenerContainerFactory>() as RabbitListenerContainerTestFactory;
+        var factory = (RabbitListenerContainerTestFactory)context.GetService<IRabbitListenerContainerFactory>();
         Assert.Single(factory.GetListenerContainers());
         MessageListenerTestContainer container = factory.GetListenerContainers()[0];
 
@@ -135,7 +135,7 @@ public sealed class RabbitListenerAttributeProcessorTest
 
         ServiceProvider provider = await Configuration.CreateAndStartServicesAsync(null, queues, typeof(MultipleQueuesTestBean));
         var context = provider.GetService<IApplicationContext>();
-        var factory = context.GetService<IRabbitListenerContainerFactory>() as RabbitListenerContainerTestFactory;
+        var factory = (RabbitListenerContainerTestFactory)context.GetService<IRabbitListenerContainerFactory>();
         Assert.Single(factory.GetListenerContainers());
         MessageListenerTestContainer container = factory.GetListenerContainers()[0];
 
@@ -162,7 +162,7 @@ public sealed class RabbitListenerAttributeProcessorTest
 
         ServiceProvider provider = await Configuration.CreateAndStartServicesAsync(null, queues, typeof(MixedQueuesAndQueueNamesTestBean));
         var context = provider.GetService<IApplicationContext>();
-        var factory = context.GetService<IRabbitListenerContainerFactory>() as RabbitListenerContainerTestFactory;
+        var factory = (RabbitListenerContainerTestFactory)context.GetService<IRabbitListenerContainerFactory>();
         Assert.Single(factory.GetListenerContainers());
         MessageListenerTestContainer container = factory.GetListenerContainers()[0];
 
@@ -201,7 +201,7 @@ public sealed class RabbitListenerAttributeProcessorTest
             await Configuration.CreateAndStartServicesAsync(configurationRoot, queues, typeof(PropertyPlaceholderResolvingToQueueTestBean));
 
         var context = provider.GetService<IApplicationContext>();
-        var factory = context.GetService<IRabbitListenerContainerFactory>() as RabbitListenerContainerTestFactory;
+        var factory = (RabbitListenerContainerTestFactory)context.GetService<IRabbitListenerContainerFactory>();
         Assert.Single(factory.GetListenerContainers());
         MessageListenerTestContainer container = factory.GetListenerContainers()[0];
 
@@ -227,7 +227,8 @@ public sealed class RabbitListenerAttributeProcessorTest
             queue2
         };
 
-        await Assert.ThrowsAsync<ExpressionException>(() => Configuration.CreateAndStartServicesAsync(null, queues, typeof(InvalidValueInAnnotationTestBean)));
+        await Assert.ThrowsAsync<ExpressionException>(async () =>
+            await Configuration.CreateAndStartServicesAsync(null, queues, typeof(InvalidValueInAnnotationTestBean)));
     }
 
     [Fact]
@@ -236,7 +237,7 @@ public sealed class RabbitListenerAttributeProcessorTest
         var services = new ServiceCollection();
 
         RabbitListenerDeclareAttributeProcessor.ProcessDeclareAttributes(services, null, typeof(TestTarget));
-        IEnumerable<IExchange> exchanges = services.BuildServiceProvider().GetServices<IExchange>();
+        IExchange[] exchanges = services.BuildServiceProvider().GetServices<IExchange>().ToArray();
         Assert.Contains(exchanges, ex => ex.Type == ExchangeType.Direct);
         Assert.Contains(exchanges, ex => ex.Type == ExchangeType.Topic);
         Assert.Contains(exchanges, ex => ex.Type == ExchangeType.FanOut);

--- a/src/Messaging/test/RabbitMQ.Test/Connection/CachePropertiesTest.cs
+++ b/src/Messaging/test/RabbitMQ.Test/Connection/CachePropertiesTest.cs
@@ -16,11 +16,9 @@ public sealed class CachePropertiesTest
     [Fact]
     public void TestChannelCache()
     {
-        using var channelCf = new CachingConnectionFactory("localhost")
-        {
-            ServiceName = "testChannelCache",
-            ChannelCacheSize = 4
-        };
+        using var channelCf = new CachingConnectionFactory("localhost");
+        channelCf.ServiceName = "testChannelCache";
+        channelCf.ChannelCacheSize = 4;
 
         using IConnection c1 = channelCf.CreateConnection();
         using IConnection c2 = channelCf.CreateConnection();
@@ -73,13 +71,11 @@ public sealed class CachePropertiesTest
     [Fact]
     public void TestConnectionCache()
     {
-        using var connectionCf = new CachingConnectionFactory("localhost")
-        {
-            ChannelCacheSize = 10,
-            ConnectionCacheSize = 5,
-            CacheMode = CachingMode.Connection,
-            ServiceName = "testConnectionCache"
-        };
+        using var connectionCf = new CachingConnectionFactory("localhost");
+        connectionCf.ChannelCacheSize = 10;
+        connectionCf.ConnectionCacheSize = 5;
+        connectionCf.CacheMode = CachingMode.Connection;
+        connectionCf.ServiceName = "testConnectionCache";
 
         using IConnection c1 = connectionCf.CreateConnection();
         using IConnection c2 = connectionCf.CreateConnection();

--- a/versions.props
+++ b/versions.props
@@ -14,7 +14,7 @@
     <MicrosoftAzureCosmosVersion>3.33.*</MicrosoftAzureCosmosVersion>
     <StackExchangeVersion>2.6.*</StackExchangeVersion>
     <CoverletVersion>3.2.*</CoverletVersion>
-    <FluentAssertionsVersion>6.8.*</FluentAssertionsVersion>
+    <FluentAssertionsVersion>6.12.*</FluentAssertionsVersion>
     <FluentAssertionsJsonVersion>6.1.*</FluentAssertionsJsonVersion>
     <MockHttpVersion>6.0.*</MockHttpVersion>
     <MoqVersion>4.18.*</MoqVersion>


### PR DESCRIPTION
## Description

This PR changes `IHealthContributor` to become async and take a `CancellationToken`. This improves scalability and removes a fair number of `task.GetAwaiter().GetResult()` calls.

Additionally, I've cleaned up one of the tests that often fail during cibuild; let's hope this improves reliability, or at least give some insight into why they randomly fail.

I found the existing timeout/cancellation behavior of `IMessageChannel.SendAsync` and `IPollableChannel.ReceiveAsync` awkward, but did not change it. They take a `CancellationToken` that the caller must trigger to force a timeout. Because of this, there is no way to distinguish between a timeout downstream versus the incoming request being canceled. In both cases, it throws an `OperationCanceledException` and there's no way to distinguish between them. Instead, these methods should take both a `CancellationToken` and a `TimeSpan timeout` parameter. When the timeout expires, it should throw a `TimeoutException`. Internally, all async methods delegate to sync implementations, which should be the other way around. Unfortunately, `RabbitMQ.Client` does not provide cancellable async APIs, so we can't fully solve this.

Fixes #878.

## Quality checklist

- [x] Your code complies with our [Coding Style](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-code-style.md).
- [x] You've updated unit and/or integration tests for your change, where applicable.
- [ ] You've updated documentation for your change, where applicable.
      If your change affects other repositories, such as [Documentation](https://github.com/SteeltoeOSS/Documentation), [Samples](https://github.com/SteeltoeOSS/Samples) and/or [MainSite](https://github.com/SteeltoeOSS/MainSite), add linked PRs here.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
- [x] You've added required license files and/or file headers (explaining where the code came from with proper attribution), where code is copied from StackOverflow, a blog, or OSS.
