### PR TITLE
Add package readme that shows on NuGet.org

### DIFF
--- a/PackageReadme.md
+++ b/PackageReadme.md
@@ -4,8 +4,8 @@ Features include:
 - Management endpoints ([actuators](https://docs.spring.io/spring-boot/docs/current/reference/html/actuator.html)), providing system info, heap/thread dumps, health checks, and changing log levels at runtime
 - Connectivity to databases ([SQL Server](https://www.microsoft.com/en-us/sql-server)/[Azure SQL](https://azure.microsoft.com/en-us/products/azure-sql), [Cosmos DB](https://azure.microsoft.com/en-us/products/cosmos-db/), [MongoDB](https://www.mongodb.com/), [Redis](https://redis.io/), [RabbitMQ](https://www.rabbitmq.com/), [PostgreSQL](https://www.postgresql.org/), and [MySQL](https://www.mysql.com/)), including support for [Entity Framework Core](https://learn.microsoft.com/en-us/ef/core/)
 - Distributed tracing and metrics exporters for [Prometheus](https://prometheus.io/) and [Wavefront](https://docs.wavefront.com/tracing_basics.html)
-- Service discovery with [Eureka](https://www.tutorialspoint.com/spring_boot/spring_boot_eureka_server.htm) and [Consul](https://www.consul.io/)
-- External (encrypted) configuration using [Spring Config Server](https://docs.spring.io/spring-cloud-config/docs/current/reference/html/)
+- Service discovery with [Eureka](https://spring.io/projects/spring-cloud-netflix) and [HashiCorp Consul](https://www.consul.io/)
+- External (encrypted) configuration using [Spring Cloud Config Server](https://docs.spring.io/spring-cloud-config/docs/current/reference/html/)
 - Single sign-on with [Cloud Foundry](https://www.cloudfoundry.org/)
 - An easy-to-use API for [RabbitMQ message exchange](https://www.rabbitmq.com/features.html), providing [RabbitTemplate](https://spring.io/guides/gs/messaging-rabbitmq/) and annotation-driven listeners
 - Streaming with [Spring Cloud Data Flow](https://spring.io/projects/spring-cloud-dataflow), enabling orchestration with Java stream apps

--- a/PackageReadme.md
+++ b/PackageReadme.md
@@ -1,0 +1,12 @@
+[Steeltoe](https://steeltoe.io/) provides building blocks for development of ASP.NET Core Web APIs and microservices that integrate with [Java Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) ([Tanzu](https://tanzu.vmware.com/tanzu)).
+
+Features include:
+- Management endpoints ([actuators](https://docs.spring.io/spring-boot/docs/current/reference/html/actuator.html)), providing system info, heap/thread dumps, health checks, and changing log levels at runtime
+- Connectivity to databases ([SQL Server](https://www.microsoft.com/en-us/sql-server)/[Azure SQL](https://azure.microsoft.com/en-us/products/azure-sql), [Cosmos DB](https://azure.microsoft.com/en-us/products/cosmos-db/), [MongoDB](https://www.mongodb.com/), [Redis](https://redis.io/), [RabbitMQ](https://www.rabbitmq.com/), [PostgreSQL](https://www.postgresql.org/), and [MySQL](https://www.mysql.com/)), including support for [Entity Framework Core](https://learn.microsoft.com/en-us/ef/core/)
+- Distributed tracing and metrics exporters for [Prometheus](https://prometheus.io/) and [Wavefront](https://docs.wavefront.com/tracing_basics.html)
+- Service discovery with [Eureka](https://www.tutorialspoint.com/spring_boot/spring_boot_eureka_server.htm) and [Consul](https://www.consul.io/)
+- External (encrypted) configuration using [Spring Config Server](https://docs.spring.io/spring-cloud-config/docs/current/reference/html/)
+- Single sign-on with [Cloud Foundry](https://www.cloudfoundry.org/)
+- An easy-to-use API for [RabbitMQ message exchange](https://www.rabbitmq.com/features.html), providing [RabbitTemplate](https://spring.io/guides/gs/messaging-rabbitmq/) and annotation-driven listeners
+- Streaming with [Spring Cloud Data Flow](https://spring.io/projects/spring-cloud-dataflow), enabling orchestration with Java stream apps
+- Steeltoe converts [Spring Expression Language (SpEL)](https://docs.spring.io/spring-framework/docs/3.0.x/reference/expressions.html) to .NET compiled code

--- a/shared-package.props
+++ b/shared-package.props
@@ -38,8 +38,10 @@
   <ItemGroup>
     <None Include="$(MSBuildThisFileDirectory)\build\icon.png" Pack="true" PackagePath="\" Visible="false" />
     <!-- Add a PackageReadme.md file in the project directory to override the default one. -->
-    <None Condition="Exists('$(MSBuildProjectDirectory)\PackageReadme.md')" Include="$(MSBuildProjectDirectory)\PackageReadme.md" Visible="false" Pack="True" PackagePath="" />
-    <None Condition="!Exists('$(MSBuildProjectDirectory)\PackageReadme.md')" Include="$(MSBuildThisFileDirectory)\PackageReadme.md" Visible="false" Pack="True" PackagePath="" />
+    <None Condition="Exists('$(MSBuildProjectDirectory)\PackageReadme.md')" Include="$(MSBuildProjectDirectory)\PackageReadme.md" Visible="false" Pack="True"
+      PackagePath="" />
+    <None Condition="!Exists('$(MSBuildProjectDirectory)\PackageReadme.md')" Include="$(MSBuildThisFileDirectory)\PackageReadme.md" Visible="false" Pack="True"
+      PackagePath="" />
   </ItemGroup>
 
   <ItemGroup>

--- a/shared-package.props
+++ b/shared-package.props
@@ -12,6 +12,7 @@
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageReleaseNotes>See https://github.com/SteeltoeOSS/Steeltoe/releases.</PackageReleaseNotes>
+    <PackageReadmeFile>PackageReadme.md</PackageReadmeFile>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -36,6 +37,9 @@
 
   <ItemGroup>
     <None Include="$(MSBuildThisFileDirectory)\build\icon.png" Pack="true" PackagePath="\" Visible="false" />
+    <!-- Add a PackageReadme.md file in the project directory to override the default one. -->
+    <None Condition="Exists('$(MSBuildProjectDirectory)\PackageReadme.md')" Include="$(MSBuildProjectDirectory)\PackageReadme.md" Visible="false" Pack="True" PackagePath="" />
+    <None Condition="!Exists('$(MSBuildProjectDirectory)\PackageReadme.md')" Include="$(MSBuildThisFileDirectory)\PackageReadme.md" Visible="false" Pack="True" PackagePath="" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Description

Adds a shared package readme that shows on NuGet.org, which can be overridden per project. Based on the guidance [here](https://devblogs.microsoft.com/nuget/add-a-readme-to-your-nuget-package/).

## Quality checklist

<!-- Please run through the checklist below to ensure a smooth review and merge process for your PR. -->

- [x] Your code complies with our [Coding Style](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-code-style.md).
- [ ] You've updated unit and/or integration tests for your change, where applicable.
- [ ] You've updated documentation for your change, where applicable.
      If your change affects other repositories, such as [Documentation](https://github.com/SteeltoeOSS/Documentation), [Samples](https://github.com/SteeltoeOSS/Samples) and/or [MainSite](https://github.com/SteeltoeOSS/MainSite), add linked PRs here.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
- [ ] You've added required license files and/or file headers (explaining where the code came from with proper attribution), where code is copied from StackOverflow, a blog, or OSS.
