### PR TITLE
Fix issue where "Spring:Cloud:Config:Timeout" configuration property isn't respected

### DIFF
--- a/src/Common/src/Common.Http/HttpClientHelper.cs
+++ b/src/Common/src/Common.Http/HttpClientHelper.cs
@@ -72,7 +72,11 @@ public static class HttpClientHelper
             }
         }
 
-        client.Timeout = TimeSpan.FromMilliseconds(timeoutMillis);
+        if (timeoutMillis > 0)
+        {
+            client.Timeout = TimeSpan.FromMilliseconds(timeoutMillis);
+        }
+
         client.DefaultRequestHeaders.UserAgent.ParseAdd(SteeltoeUserAgent);
         return client;
     }

--- a/src/Configuration/src/ConfigServerBase/ConfigServerConfigurationProvider.cs
+++ b/src/Configuration/src/ConfigServerBase/ConfigServerConfigurationProvider.cs
@@ -140,9 +140,9 @@ public class ConfigServerConfigurationProvider : ConfigurationProvider, IConfigu
         }
 
         _settings = settings;
-        _httpClient = httpClient ?? GetHttpClient(_settings);
-
         OnSettingsChanged();
+
+        _httpClient = httpClient ?? GetHttpClient(_settings);
     }
 
     private void OnSettingsChanged()
@@ -960,7 +960,7 @@ public class ConfigServerConfigurationProvider : ConfigurationProvider, IConfigu
     }
 
     /// <summary>
-    /// Creates an appropriatly configured HttpClient that will be used in communicating with the
+    /// Creates an appropriately configured HttpClient that will be used in communicating with the
     /// Spring Cloud Configuration Server
     /// </summary>
     /// <param name="settings">the settings used in configuring the HttpClient</param>

--- a/src/Configuration/test/ConfigServerBase.Test/ConfigServerConfigurationProviderTest.cs
+++ b/src/Configuration/test/ConfigServerBase.Test/ConfigServerConfigurationProviderTest.cs
@@ -83,6 +83,21 @@ public class ConfigServerConfigurationProviderTest
     }
 
     [Fact]
+    public void SourceConstructor_WithTimeoutConfigured_InitializesHttpClientWithConfiguredTimeout()
+    {
+        IConfiguration configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string>
+            {
+                { "spring:cloud:config:timeout", "30000" }
+            })
+            .Build();
+        var source = new ConfigServerConfigurationSource(configuration);
+        var provider = new TestConfigServerConfigurationProvider(source);
+
+        Assert.Equal(TimeSpan.FromMilliseconds(30000), provider.TheConfiguredClient.Timeout);
+    }
+
+    [Fact]
     public void SourceConstructor_WithDefaults_ThrowsIfHttpClientNull()
     {
         IConfiguration configuration = new ConfigurationBuilder().Build();
@@ -1157,6 +1172,11 @@ public class ConfigServerConfigurationProviderTest
     {
         public TestConfigServerConfigurationProvider(ConfigServerClientSettings settings)
             : base(settings)
+        {
+        }
+
+        public TestConfigServerConfigurationProvider(ConfigServerConfigurationSource source)
+            : base(source)
         {
         }
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->

<!-- If this is your first PR in this repo, please read our [Contributing Guidelines (https://github.com/SteeltoeOSS/.github/blob/master/CONTRIBUTING.md) and remember to sign the [Contributor License Agreement](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-license.md). Our bot will notify you shortly after the PR has been created. -->

## Description
The ConfigServerConfigurationProvider's _httpClient field was being initialized using the "default" timeout setting and was not updated with the configured timeout. Fixed by deferring initializing the _httpClient field until after the settings are updated with the configured values.

Fixes #1178

## Quality checklist

<!-- Please run through the checklist below to ensure a smooth review and merge process for your PR. -->

- [x] Your code complies with our [Coding Style](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-code-style.md).
- [x] You've updated unit and/or integration tests for your change, where applicable.
- [x] You've updated documentation for your change, where applicable.
      If your change affects other repositories, such as [Documentation](https://github.com/SteeltoeOSS/Documentation), [Samples](https://github.com/SteeltoeOSS/Samples) and/or [MainSite](https://github.com/SteeltoeOSS/MainSite), add linked PRs here.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
- [x] You've added required license files and/or file headers (explaining where the code came from with proper attribution), where code is copied from StackOverflow, a blog, or OSS.
