### PR TITLE
Skip this Eureka test on Mac

### DIFF
--- a/src/Discovery/test/Eureka.Test/EurekaDiscoveryClientBuilderExtensionsTest.cs
+++ b/src/Discovery/test/Eureka.Test/EurekaDiscoveryClientBuilderExtensionsTest.cs
@@ -58,6 +58,7 @@ public sealed class EurekaDiscoveryClientBuilderExtensionsTest
     }
 
     [Fact]
+    [Trait("Category", "SkipOnMacOS")]
     public void ApplyServicesUsesServerTimeout()
     {
         var appSettings = new Dictionary<string, string>
@@ -70,7 +71,6 @@ public sealed class EurekaDiscoveryClientBuilderExtensionsTest
         var serviceCollection = new ServiceCollection();
         serviceCollection.AddSingleton<IConfiguration>(configurationRoot);
         serviceCollection.RegisterDefaultApplicationInstanceInfo();
-        serviceCollection.AddAllActuators();
         var extension = new EurekaDiscoveryClientExtension();
 
         extension.ApplyServices(serviceCollection);


### PR DESCRIPTION
## Description

According to our [DevOps stats](https://dev.azure.com/SteeltoeOSS/Steeltoe/_test/analytics?definitionId=4&contextType=build), this test fails on Mac about 10% of the time - when it fails, the test takes about 15 seconds to execute instead of around 2 as expected. This would align with the default values (5 second timeout, retried 3 times) instead of configured values (2 attempts with 1 second timeout)

This test also doesn't have anything to do with actuators, so I removed that line.
