### PR TITLE
Fix issues with refresh polling

### DIFF
--- a/src/Configuration/src/ConfigServerBase/ConfigServerConfigurationProvider.cs
+++ b/src/Configuration/src/ConfigServerBase/ConfigServerConfigurationProvider.cs
@@ -188,7 +188,7 @@ public class ConfigServerConfigurationProvider : ConfigurationProvider, IConfigu
         }
         catch (Exception e)
         {
-            _logger.LogWarning("Could not reload configuration during polling" + e);
+            _logger.LogWarning(e, "Could not reload configuration during polling");
         }
     }
 


### PR DESCRIPTION
## Description

If polling was enabled along with the fail fast setting, it was possible for unhandled exceptions to be thrown within a Timer callback, which crashed the application. Also the polling was not disabled when the Enabled configuration was set to false. This PR wraps the load in the Timer callback within a try/catch. It also only starts polling if Enabled is true.

Fixes #1217
Fixes #1218

## Quality checklist

<!-- Please run through the checklist below to ensure a smooth review and merge process for your PR. -->

- [x] Your code complies with our [Coding Style](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-code-style.md).
- [x] You've updated unit and/or integration tests for your change, where applicable.
- [x] You've updated documentation for your change, where applicable.
      If your change affects other repositories, such as [Documentation](https://github.com/SteeltoeOSS/Documentation), [Samples](https://github.com/SteeltoeOSS/Samples) and/or [MainSite](https://github.com/SteeltoeOSS/MainSite), add linked PRs here.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
- [x] You've added required license files and/or file headers (explaining where the code came from with proper attribution), where code is copied from StackOverflow, a blog, or OSS.
