### PR TITLE
Consul :: Port tests to cover health check path being used when heartbeat is off

### DIFF
--- a/src/Discovery/test/Consul.Test/Registry/ConsulRegistrationTest.cs
+++ b/src/Discovery/test/Consul.Test/Registry/ConsulRegistrationTest.cs
@@ -290,6 +290,7 @@ public sealed class ConsulRegistrationTest
     public void CreateCheck_WhenHealthCheckPathIsSetAndHeartbeatIsEnabled_ThenHttpShouldBeNull()
     {
         const string path = "/my/custom/health";
+
         var options = new ConsulDiscoveryOptions
         {
             HealthCheckPath = path,
@@ -299,7 +300,7 @@ public sealed class ConsulRegistrationTest
             }
         };
 
-        var check = ConsulRegistration.CreateCheck(1234, options);
+        AgentServiceCheck check = ConsulRegistration.CreateCheck(1234, options);
 
         Assert.Null(check.HTTP);
     }
@@ -309,7 +310,7 @@ public sealed class ConsulRegistrationTest
     {
         var options = new ConsulDiscoveryOptions
         {
-            Heartbeat = new ConsulHeartbeatOptions()
+            Heartbeat = new ConsulHeartbeatOptions
             {
                 Enabled = false
             }

--- a/src/Discovery/test/Consul.Test/Registry/ConsulRegistrationTest.cs
+++ b/src/Discovery/test/Consul.Test/Registry/ConsulRegistrationTest.cs
@@ -267,4 +267,56 @@ public sealed class ConsulRegistrationTest
         Assert.NotNull(reg.Service.Check);
         Assert.NotNull(reg.Service.Tags);
     }
+
+    [Fact]
+    public void CreateCheck_WhenHealthCheckPathIsSetAndHeartbeatIsDisabled_ThenShouldSetHttp()
+    {
+        const string path = "/my/custom/health";
+        var options = new ConsulDiscoveryOptions
+        {
+            HealthCheckPath = path,
+            Heartbeat = new ConsulHeartbeatOptions
+            {
+                Enabled = false
+            }
+        };
+
+        var check = ConsulRegistration.CreateCheck(1234, options);
+
+        Assert.Contains(path, check.HTTP);
+    }
+
+    [Fact]
+    public void CreateCheck_WhenHealthCheckPathIsSetAndHeartbeatIsEnabled_ThenHttpShouldBeNull()
+    {
+        const string path = "/my/custom/health";
+        var options = new ConsulDiscoveryOptions
+        {
+            HealthCheckPath = path,
+            Heartbeat = new ConsulHeartbeatOptions
+            {
+                Enabled = true
+            }
+        };
+
+        var check = ConsulRegistration.CreateCheck(1234, options);
+
+        Assert.Null(check.HTTP);
+    }
+
+    [Fact]
+    public void CreateCheck_WhenHeartbeatIsDisabledAndPortIsANegativeNumber_ThenShouldThrow()
+    {
+        var options = new ConsulDiscoveryOptions
+        {
+            Heartbeat = new ConsulHeartbeatOptions()
+            {
+                Enabled = false
+            }
+        };
+
+        const int port = -1234;
+
+        Assert.Throws<ArgumentException>(() => ConsulRegistration.CreateCheck(port, options));
+    }
 }

--- a/src/Discovery/test/Consul.Test/Registry/ConsulRegistrationTest.cs
+++ b/src/Discovery/test/Consul.Test/Registry/ConsulRegistrationTest.cs
@@ -272,6 +272,7 @@ public sealed class ConsulRegistrationTest
     public void CreateCheck_WhenHealthCheckPathIsSetAndHeartbeatIsDisabled_ThenShouldSetHttp()
     {
         const string path = "/my/custom/health";
+
         var options = new ConsulDiscoveryOptions
         {
             HealthCheckPath = path,

--- a/src/Discovery/test/Consul.Test/Registry/ConsulRegistrationTest.cs
+++ b/src/Discovery/test/Consul.Test/Registry/ConsulRegistrationTest.cs
@@ -318,6 +318,6 @@ public sealed class ConsulRegistrationTest
 
         const int port = -1234;
 
-        Assert.Throws<ArgumentException>(() => ConsulRegistration.CreateCheck(port, options));
+        Assert.Throws<ArgumentOutOfRangeException>(() => ConsulRegistration.CreateCheck(port, options));
     }
 }

--- a/src/Discovery/test/Consul.Test/Registry/ConsulRegistrationTest.cs
+++ b/src/Discovery/test/Consul.Test/Registry/ConsulRegistrationTest.cs
@@ -281,7 +281,7 @@ public sealed class ConsulRegistrationTest
             }
         };
 
-        var check = ConsulRegistration.CreateCheck(1234, options);
+        AgentServiceCheck check = ConsulRegistration.CreateCheck(1234, options);
 
         Assert.Contains(path, check.HTTP, StringComparison.InvariantCulture);
     }

--- a/src/Discovery/test/Consul.Test/Registry/ConsulRegistrationTest.cs
+++ b/src/Discovery/test/Consul.Test/Registry/ConsulRegistrationTest.cs
@@ -283,7 +283,7 @@ public sealed class ConsulRegistrationTest
 
         var check = ConsulRegistration.CreateCheck(1234, options);
 
-        Assert.Contains(path, check.HTTP);
+        Assert.Contains(path, check.HTTP, StringComparison.InvariantCulture);
     }
 
     [Fact]


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->

<!-- If this is your first PR in this repo, please read our [Contributing Guidelines (https://github.com/SteeltoeOSS/.github/blob/master/CONTRIBUTING.md) and remember to sign the [Contributor License Agreement](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-license.md). Our bot will notify you shortly after the PR has been created. -->

## Description

Hi all,

This PR ports unit tests added in #1245 for `3.2`.

It covers scenarios for setting health check path (HTTP) in respect to the heartbeat check.

It also adds unit tests to coner validation of negative port for HTTP check.

I hope it could be of some use in the `v4` of Steeltoe.

## Quality checklist

<!-- Please run through the checklist below to ensure a smooth review and merge process for your PR. -->

- [x] Your code complies with our [Coding Style](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-code-style.md).
- [x] You've updated unit and/or integration tests for your change, where applicable.
- [ ] You've updated documentation for your change, where applicable.
      If your change affects other repositories, such as [Documentation](https://github.com/SteeltoeOSS/Documentation), [Samples](https://github.com/SteeltoeOSS/Samples) and/or [MainSite](https://github.com/SteeltoeOSS/MainSite), add linked PRs here.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
- [ ] You've added required license files and/or file headers (explaining where the code came from with proper attribution), where code is copied from StackOverflow, a blog, or OSS.
