### PR TITLE
Add CorsPolicyBuilder to WebApp/WebHost extensions

### DIFF
--- a/src/Management/src/EndpointCore/ManagementWebApplicationBuilderExtensions.cs
+++ b/src/Management/src/EndpointCore/ManagementWebApplicationBuilderExtensions.cs
@@ -217,7 +217,9 @@ namespace Steeltoe.Management.Endpoint
         /// <param name="applicationBuilder">Your <see cref="WebApplicationBuilder" /></param>
         /// <param name="configureEndpoints"><see cref="IEndpointConventionBuilder" /></param>
         /// <param name="mediaTypeVersion">Specify the media type version to use in the response</param>
-        public static WebApplicationBuilder AddAllActuators(this WebApplicationBuilder applicationBuilder, Action<IEndpointConventionBuilder> configureEndpoints = null, MediaTypeVersion mediaTypeVersion = MediaTypeVersion.V2, Action<CorsPolicyBuilder> buildCorsPolicy = null)        {
+        /// <param name="buildCorsPolicy">Customize the CORS policy. </param>
+        public static WebApplicationBuilder AddAllActuators(this WebApplicationBuilder applicationBuilder, Action<IEndpointConventionBuilder> configureEndpoints = null, MediaTypeVersion mediaTypeVersion = MediaTypeVersion.V2, Action<CorsPolicyBuilder> buildCorsPolicy = null)
+        {
             applicationBuilder.Logging.AddDynamicConsole();
             applicationBuilder.Services.AddAllActuators(applicationBuilder.Configuration, mediaTypeVersion, buildCorsPolicy);
             applicationBuilder.AddCommonServices();

--- a/src/Management/src/EndpointCore/ManagementWebApplicationBuilderExtensions.cs
+++ b/src/Management/src/EndpointCore/ManagementWebApplicationBuilderExtensions.cs
@@ -4,6 +4,7 @@
 
 #if NET6_0_OR_GREATER
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Cors.Infrastructure;
 using Steeltoe.Common.HealthChecks;
 using Steeltoe.Common.Hosting;
 using Steeltoe.Extensions.Logging;
@@ -216,10 +217,9 @@ namespace Steeltoe.Management.Endpoint
         /// <param name="applicationBuilder">Your <see cref="WebApplicationBuilder" /></param>
         /// <param name="configureEndpoints"><see cref="IEndpointConventionBuilder" /></param>
         /// <param name="mediaTypeVersion">Specify the media type version to use in the response</param>
-        public static WebApplicationBuilder AddAllActuators(this WebApplicationBuilder applicationBuilder, Action<IEndpointConventionBuilder> configureEndpoints = null, MediaTypeVersion mediaTypeVersion = MediaTypeVersion.V2)
-        {
+        public static WebApplicationBuilder AddAllActuators(this WebApplicationBuilder applicationBuilder, Action<IEndpointConventionBuilder> configureEndpoints = null, MediaTypeVersion mediaTypeVersion = MediaTypeVersion.V2, Action<CorsPolicyBuilder> buildCorsPolicy = null)        {
             applicationBuilder.Logging.AddDynamicConsole();
-            applicationBuilder.Services.AddAllActuators(applicationBuilder.Configuration, mediaTypeVersion);
+            applicationBuilder.Services.AddAllActuators(applicationBuilder.Configuration, mediaTypeVersion, buildCorsPolicy);
             applicationBuilder.AddCommonServices();
             return applicationBuilder;
         }

--- a/src/Management/src/EndpointCore/ManagementWebHostBuilderExtensions.cs
+++ b/src/Management/src/EndpointCore/ManagementWebHostBuilderExtensions.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Cors.Infrastructure;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
@@ -238,12 +239,12 @@ public static class ManagementWebHostBuilderExtensions
     /// <param name="hostBuilder">Your HostBuilder</param>
     /// <param name="configureEndpoints"><see cref="IEndpointConventionBuilder" /></param>
     /// <param name="mediaTypeVersion">Specify the media type version to use in the response</param>
-    public static IWebHostBuilder AddAllActuators(this IWebHostBuilder hostBuilder, Action<IEndpointConventionBuilder> configureEndpoints = null, MediaTypeVersion mediaTypeVersion = MediaTypeVersion.V2)
+    public static IWebHostBuilder AddAllActuators(this IWebHostBuilder hostBuilder, Action<IEndpointConventionBuilder> configureEndpoints = null, MediaTypeVersion mediaTypeVersion = MediaTypeVersion.V2, Action<CorsPolicyBuilder> buildCorsPolicy = null)
         => hostBuilder.AddManagementPort()
             .ConfigureLogging(builder => builder.AddDynamicConsole())
             .ConfigureServices((context, collection) =>
             {
-                collection.AddAllActuators(context.Configuration, mediaTypeVersion);
+                collection.AddAllActuators(context.Configuration, mediaTypeVersion, buildCorsPolicy);
                 collection.ActivateActuatorEndpoints(configureEndpoints);
             });
 

--- a/src/Management/src/EndpointCore/ManagementWebHostBuilderExtensions.cs
+++ b/src/Management/src/EndpointCore/ManagementWebHostBuilderExtensions.cs
@@ -239,6 +239,7 @@ public static class ManagementWebHostBuilderExtensions
     /// <param name="hostBuilder">Your HostBuilder</param>
     /// <param name="configureEndpoints"><see cref="IEndpointConventionBuilder" /></param>
     /// <param name="mediaTypeVersion">Specify the media type version to use in the response</param>
+    /// <param name="buildCorsPolicy">Customize the CORS policy. </param>
     public static IWebHostBuilder AddAllActuators(this IWebHostBuilder hostBuilder, Action<IEndpointConventionBuilder> configureEndpoints = null, MediaTypeVersion mediaTypeVersion = MediaTypeVersion.V2, Action<CorsPolicyBuilder> buildCorsPolicy = null)
         => hostBuilder.AddManagementPort()
             .ConfigureLogging(builder => builder.AddDynamicConsole())


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->

<!-- If this is your first PR in this repo, please read our [Contributing Guidelines (https://github.com/SteeltoeOSS/.github/blob/master/CONTRIBUTING.md) and remember to sign the [Contributor License Agreement](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-license.md). Our bot will notify you shortly after the PR has been created. -->

## Description

Hi all,

This PR addresses issue #1251 by adding optional parameter `Action<CorsPolicyBuilder>` to two extension methods:

- `ManagementWebHostBuilderExtensions` => `AddAllActuators`
- `ManagementWebApplicationBuilderExtensions` => `AddAllActuators`

Fixes #1251

I'd like to ask for guidance and suggestion about testing this change.
I can see that there aren't many unit tests for those extension methods in general.

My only idea would be to inspect `IServiceCollection` whether the underlying call to `ActuatorServiceCollectionExtensions` => `AddSteeltoeCors` was made. 
Kindly please advise if such implementation would be good.

Thanks in advance!

## Quality checklist

<!-- Please run through the checklist below to ensure a smooth review and merge process for your PR. -->

- [x] Your code complies with our [Coding Style](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-code-style.md).
- [ ] You've updated unit and/or integration tests for your change, where applicable.
- [ ] You've updated documentation for your change, where applicable.
      If your change affects other repositories, such as [Documentation](https://github.com/SteeltoeOSS/Documentation), [Samples](https://github.com/SteeltoeOSS/Samples) and/or [MainSite](https://github.com/SteeltoeOSS/MainSite), add linked PRs here.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
- [ ] You've added required license files and/or file headers (explaining where the code came from with proper attribution), where code is copied from StackOverflow, a blog, or OSS.
