### PR TITLE
[wip] Add sanitizing to refresh endpoint

### DIFF
--- a/src/Management/src/Endpoint/Refresh/ConfigureRefreshEndpointOptions.cs
+++ b/src/Management/src/Endpoint/Refresh/ConfigureRefreshEndpointOptions.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.Configuration;
+using Steeltoe.Common;
 using Steeltoe.Management.Endpoint.Options;
 
 namespace Steeltoe.Management.Endpoint.Refresh;
@@ -11,8 +12,32 @@ internal sealed class ConfigureRefreshEndpointOptions : ConfigureEndpointOptions
 {
     private const string ManagementInfoPrefix = "management:endpoints:refresh";
 
+    private static readonly string[] DefaultKeysToSanitize =
+    {
+        "password",
+        "secret",
+        "key",
+        "token",
+        ".*credentials.*",
+        "vcap_services"
+    };
+
     public ConfigureRefreshEndpointOptions(IConfiguration configuration)
         : base(configuration, ManagementInfoPrefix, "refresh")
     {
+    }
+
+    public override void Configure(RefreshEndpointOptions options)
+    {
+        ArgumentGuard.NotNull(options);
+
+        base.Configure(options);
+
+        // It's not possible to distinguish between null and an empty list in configuration.
+        // See https://github.com/dotnet/extensions/issues/1341.
+        if (options.KeysToSanitize.Count == 0)
+        {
+            options.KeysToSanitize = DefaultKeysToSanitize;
+        }
     }
 }

--- a/src/Management/src/Endpoint/Refresh/RefreshEndpointHandler.cs
+++ b/src/Management/src/Endpoint/Refresh/RefreshEndpointHandler.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Steeltoe.Common;
+using Steeltoe.Management.Endpoint.Environment;
 
 namespace Steeltoe.Management.Endpoint.Refresh;
 
@@ -13,6 +14,7 @@ internal sealed class RefreshEndpointHandler : IRefreshEndpointHandler
 {
     private readonly IOptionsMonitor<RefreshEndpointOptions> _optionsMonitor;
     private readonly IConfiguration _configuration;
+    private readonly Sanitizer _sanitizer;
     private readonly ILogger<RefreshEndpointHandler> _logger;
 
     public EndpointOptions Options => _optionsMonitor.CurrentValue;
@@ -25,6 +27,7 @@ internal sealed class RefreshEndpointHandler : IRefreshEndpointHandler
 
         _optionsMonitor = optionsMonitor;
         _configuration = configuration;
+        _sanitizer = new Sanitizer(optionsMonitor.CurrentValue.KeysToSanitize);
         _logger = loggerFactory.CreateLogger<RefreshEndpointHandler>();
     }
 
@@ -43,6 +46,8 @@ internal sealed class RefreshEndpointHandler : IRefreshEndpointHandler
         {
             foreach (KeyValuePair<string, string?> kvp in _configuration.AsEnumerable())
             {
+                // _sanitizer.Sanitize(kvp.Key, kvp.Value);
+
                 keys.Add(kvp.Key);
             }
         }

--- a/src/Management/src/Endpoint/Refresh/RefreshEndpointOptions.cs
+++ b/src/Management/src/Endpoint/Refresh/RefreshEndpointOptions.cs
@@ -11,5 +11,7 @@ public sealed class RefreshEndpointOptions : EndpointOptions
         "Post"
     };
 
+    public IList<string> KeysToSanitize { get; set; } = new List<string>();
+
     public bool ReturnConfiguration { get; set; } = true;
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->

<!-- If this is your first PR in this repo, please read our [Contributing Guidelines (https://github.com/SteeltoeOSS/.github/blob/master/CONTRIBUTING.md) and remember to sign the [Contributor License Agreement](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-license.md). Our bot will notify you shortly after the PR has been created. -->

## Description

Hi all,

I've stumpled upon another `help wanted` issue (#656) and decided to give it a try.
However, the longer I started inspecting the code, the more questions appeared.

So let's try to agree on solution (if there is any) before continuing the code changes.

Here's the result of my investigation:
- At the moment `Sanitizer` is used in `EnvironmentEndpoint` which returns a list of key-value pairs with settings/properties/configuration
- It makes sense to sanitize (so replace with asterisks) some of the values which should not be exposed to the outer world
- The requester of #656 claims that similar treatment should be given to `RefreshEndpoint`
- After futher investigation, `RefreshEndpoint` returns only a list of keys (not values) from the configuration. So there isn't anything to sanitize - unless we'd like to return values as well?
- I've compared `3.x` and `4.x` and it's the same output from the `RefreshEndpoint` (keys only)

So kindly please advise how to approach this issue and whether it's actually an existing issue.

I'm happy to continue with code changes, if we agree what's the desired solution.

cc: @bart-vmware & @TimHess 

<!-- *Could fixes #656* -->

## Quality checklist

<!-- Please run through the checklist below to ensure a smooth review and merge process for your PR. -->

- [ ] Your code complies with our [Coding Style](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-code-style.md).
- [ ] You've updated unit and/or integration tests for your change, where applicable.
- [ ] You've updated documentation for your change, where applicable.
      If your change affects other repositories, such as [Documentation](https://github.com/SteeltoeOSS/Documentation), [Samples](https://github.com/SteeltoeOSS/Samples) and/or [MainSite](https://github.com/SteeltoeOSS/MainSite), add linked PRs here.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
- [ ] You've added required license files and/or file headers (explaining where the code came from with proper attribution), where code is copied from StackOverflow, a blog, or OSS.
