### PR TITLE
Prevent adding PlaceholderResolver multiple times

### DIFF
--- a/src/Configuration/src/Placeholder/PlaceholderConfigurationExtensions.cs
+++ b/src/Configuration/src/Placeholder/PlaceholderConfigurationExtensions.cs
@@ -48,15 +48,18 @@ public static class PlaceholderConfigurationExtensions
         ArgumentGuard.NotNull(builder);
         ArgumentGuard.NotNull(loggerFactory);
 
-        if (builder is IConfigurationRoot configuration)
+        if (!builder.Sources.Any(source => source is PlaceholderResolverSource))
         {
-            builder.Add(new PlaceholderResolverSource(configuration, loggerFactory));
-        }
-        else
-        {
-            var resolver = new PlaceholderResolverSource(builder.Sources, loggerFactory);
-            builder.Sources.Clear();
-            builder.Add(resolver);
+            if (builder is IConfigurationRoot configuration)
+            {
+                builder.Add(new PlaceholderResolverSource(configuration, loggerFactory));
+            }
+            else
+            {
+                var resolver = new PlaceholderResolverSource(builder.Sources, loggerFactory);
+                builder.Sources.Clear();
+                builder.Add(resolver);
+            }
         }
 
         return builder;
@@ -100,6 +103,11 @@ public static class PlaceholderConfigurationExtensions
         if (configuration is not IConfigurationRoot root)
         {
             throw new InvalidOperationException($"Configuration must implement '{typeof(IConfigurationRoot)}'.");
+        }
+
+        if (root.Providers.Any(provider => provider is IPlaceholderResolverProvider))
+        {
+            return configuration;
         }
 
         return new ConfigurationRoot(new List<IConfigurationProvider>


### PR DESCRIPTION
## Description

Fixed: Prevent adding `PlaceholderResolver` multiple times, which breaks the ENV actuator.

## Quality checklist

- [x] Your code complies with our [Coding Style](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-code-style.md).
- [x] You've updated unit and/or integration tests for your change, where applicable.
- [ ] You've updated documentation for your change, where applicable.
      If your change affects other repositories, such as [Documentation](https://github.com/SteeltoeOSS/Documentation), [Samples](https://github.com/SteeltoeOSS/Samples) and/or [MainSite](https://github.com/SteeltoeOSS/MainSite), add linked PRs here.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
- [ ] You've added required license files and/or file headers (explaining where the code came from with proper attribution), where code is copied from StackOverflow, a blog, or OSS.
