### PR TITLE
Update OpenTelemetry packages

### DIFF
--- a/shared-package.props
+++ b/shared-package.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <NoWarn>$(NoWarn);CS1591;NU5104</NoWarn>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 

--- a/shared-test.props
+++ b/shared-test.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <NoWarn>$(NoWarn);S2094</NoWarn>
+    <NoWarn>$(NoWarn);S2094;NU5104</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Common/src/Abstractions/ITracingOptions.cs
+++ b/src/Common/src/Abstractions/ITracingOptions.cs
@@ -67,11 +67,6 @@ public interface ITracingOptions
     bool SingleB3Header { get; }
 
     /// <summary>
-    /// Gets a value indicating whether GRPC requests should participate in tracing.
-    /// </summary>
-    bool EnableGrpcAspNetCoreSupport { get; }
-
-    /// <summary>
     /// Gets a value representing the endpoint used for exporting traces.
     /// </summary>
     Uri ExporterEndpoint { get; }

--- a/src/Common/src/Common/TracingOptions.cs
+++ b/src/Common/src/Common/TracingOptions.cs
@@ -44,9 +44,6 @@ public class TracingOptions : ITracingOptions
     public bool SingleB3Header { get; set; } = true;
 
     /// <inheritdoc />
-    public bool EnableGrpcAspNetCoreSupport { get; set; } = true;
-
-    /// <inheritdoc />
     public Uri ExporterEndpoint { get; set; }
 
     public TracingOptions(IApplicationInstanceInfo appInfo, IConfiguration configuration)

--- a/src/Management/src/Tracing/Steeltoe.Management.Tracing.csproj
+++ b/src/Management/src/Tracing/Steeltoe.Management.Tracing.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <Description>Enables request tracing in distributed systems.</Description>
@@ -16,8 +16,8 @@
   <ItemGroup>
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="$(OpenTelemetryVersion)" />
     <PackageReference Include="OpenTelemetry.Extensions.Propagators" Version="$(OpenTelemetryVersion)" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="$(OpenTelemetryInstrumentationVersion)" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="$(OpenTelemetryInstrumentationVersion)" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="$(OpenTelemetryVersion)" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="$(OpenTelemetryVersion)" />
     <PackageReference Include="OpenTelemetry.Exporter.Zipkin" Version="$(OpenTelemetryVersion)" PrivateAssets="all" />
     <PackageReference Include="OpenTelemetry.Exporter.Jaeger" Version="$(OpenTelemetryExporterJaegerVersion)" PrivateAssets="all" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="$(OpenTelemetryVersion)" PrivateAssets="all" />

--- a/src/Management/src/Tracing/TracingCoreServiceCollectionExtensions.cs
+++ b/src/Management/src/Tracing/TracingCoreServiceCollectionExtensions.cs
@@ -44,11 +44,10 @@ public static class TracingCoreServiceCollectionExtensions
 
         action += builder => builder.AddAspNetCoreInstrumentation();
 
-        services.AddOptions<AspNetCoreInstrumentationOptions>().PostConfigure<ITracingOptions>((options, traceOpts) =>
+        services.AddOptions<AspNetCoreTraceInstrumentationOptions>().PostConfigure<ITracingOptions>((instrumentationOptions, tracingOptions) =>
         {
-            var pathMatcher = new Regex(traceOpts.IngressIgnorePattern);
-            options.EnableGrpcAspNetCoreSupport = traceOpts.EnableGrpcAspNetCoreSupport;
-            options.Filter += context => !pathMatcher.IsMatch(context.Request.Path);
+            var pathMatcher = new Regex(tracingOptions.IngressIgnorePattern);
+            instrumentationOptions.Filter += context => !pathMatcher.IsMatch(context.Request.Path);
         });
 
         return services.AddDistributedTracing(action);

--- a/src/Management/src/Wavefront/Exporters/TagExtensions.cs
+++ b/src/Management/src/Wavefront/Exporters/TagExtensions.cs
@@ -12,9 +12,9 @@ internal static class TagExtensions
     {
         var tags = new Dictionary<string, string?>();
 
-        foreach (KeyValuePair<string, object> tag in tagCollection)
+        foreach (KeyValuePair<string, object?> tag in tagCollection)
         {
-            if (string.IsNullOrEmpty(tag.Key) || string.IsNullOrEmpty(tag.Value.ToString()))
+            if (string.IsNullOrEmpty(tag.Key) || tag.Value == null || string.IsNullOrEmpty(tag.Value.ToString()))
             {
                 continue;
             }

--- a/src/Management/src/Wavefront/Exporters/TagExtensions.cs
+++ b/src/Management/src/Wavefront/Exporters/TagExtensions.cs
@@ -14,7 +14,7 @@ internal static class TagExtensions
 
         foreach (KeyValuePair<string, object?> tag in tagCollection)
         {
-            if (string.IsNullOrEmpty(tag.Key) || tag.Value == null || string.IsNullOrEmpty(tag.Value.ToString()))
+            if (string.IsNullOrEmpty(tag.Key) || string.IsNullOrEmpty(tag.Value?.ToString()))
             {
                 continue;
             }

--- a/versions.props
+++ b/versions.props
@@ -68,10 +68,9 @@
       -->
       8.0.*
     </FoundationalVersion>
-    <OpenTelemetryExporterJaegerVersion>1.5.*</OpenTelemetryExporterJaegerVersion>
-    <OpenTelemetryExporterPrometheusVersion>1.4.0-rc.3</OpenTelemetryExporterPrometheusVersion>
-    <OpenTelemetryInstrumentationVersion>1.0.0-rc9.2</OpenTelemetryInstrumentationVersion>
-    <OpenTelemetryVersion>1.6.*</OpenTelemetryVersion>
+    <OpenTelemetryExporterJaegerVersion>1.6.*-*</OpenTelemetryExporterJaegerVersion>
+    <OpenTelemetryExporterPrometheusVersion>1.8.*-*</OpenTelemetryExporterPrometheusVersion>
+    <OpenTelemetryVersion>1.8.*</OpenTelemetryVersion>
     <SerilogExtensionsLoggingVersion>7.0.*</SerilogExtensionsLoggingVersion>
     <SerilogSettingsConfigurationVersion>7.0.*</SerilogSettingsConfigurationVersion>
     <SerilogSinksConsoleVersion>4.1.*</SerilogSinksConsoleVersion>


### PR DESCRIPTION
## Description

Updates Steeltoe to depend on stable OpenTelemetry packages, where available. Fixes broken build.

- `EnableGrpcAspNetCoreSupport` was replaced by environment variable `OTEL_DOTNET_EXPERIMENTAL_ASPNETCORE_ENABLE_GRPC_INSTRUMENTATION`, see https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/test/OpenTelemetry.Instrumentation.Grpc.Tests/GrpcTests.server.cs
- Replace usage of `IDeferredTracerProviderBuilder`, see https://github.com/open-telemetry/opentelemetry-dotnet/issues/4228

## Quality checklist

- [x] Your code complies with our [Coding Style](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-code-style.md).
- [x] You've updated unit and/or integration tests for your change, where applicable.
- [ ] You've updated documentation for your change, where applicable.
      If your change affects other repositories, such as [Documentation](https://github.com/SteeltoeOSS/Documentation), [Samples](https://github.com/SteeltoeOSS/Samples) and/or [MainSite](https://github.com/SteeltoeOSS/MainSite), add linked PRs here.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
- [ ] You've added required license files and/or file headers (explaining where the code came from with proper attribution), where code is copied from StackOverflow, a blog, or OSS.
