### PR TITLE
Fixed: Consul broken health check

### DIFF
--- a/src/Discovery/src/Consul/Configuration/ConsulDiscoveryOptions.cs
+++ b/src/Discovery/src/Consul/Configuration/ConsulDiscoveryOptions.cs
@@ -63,7 +63,7 @@ public sealed class ConsulDiscoveryOptions
     /// Gets or sets a value indicating whether to add the "passing" parameter to /v1/health/service/serviceName. This pushes health check passing to the
     /// server.
     /// </summary>
-    public bool QueryPassing { get; set; }
+    public bool QueryPassing { get; set; } = true;
 
     /// <summary>
     /// Gets or sets whether to register an http or https service.

--- a/src/Discovery/src/Consul/Configuration/ConsulDiscoveryOptions.cs
+++ b/src/Discovery/src/Consul/Configuration/ConsulDiscoveryOptions.cs
@@ -136,11 +136,6 @@ public sealed class ConsulDiscoveryOptions
     public string? InstanceId { get; set; }
 
     /// <summary>
-    /// Gets or sets a value indicating whether to use agent address or hostname.
-    /// </summary>
-    public bool PreferAgentAddress { get; set; }
-
-    /// <summary>
     /// Gets or sets the instance zone to use during registration.
     /// </summary>
     public string? InstanceZone { get; set; }

--- a/src/Discovery/src/Consul/Configuration/ConsulDiscoveryOptions.cs
+++ b/src/Discovery/src/Consul/Configuration/ConsulDiscoveryOptions.cs
@@ -13,160 +13,167 @@ public sealed class ConsulDiscoveryOptions
 {
     internal const string ConfigurationPrefix = "consul:discovery";
 
-    /// <summary>
-    /// Gets a value indicating whether heart beats are enabled.
-    /// </summary>
     internal bool IsHeartbeatEnabled => Heartbeat is { Enabled: true };
-
-    /// <summary>
-    /// Gets a value indicating whether retries are enabled.
-    /// </summary>
     internal bool IsRetryEnabled => Retry is { Enabled: true };
 
     /// <summary>
-    /// Gets or sets a value indicating whether the Consul discovery client is enabled.
+    /// Gets or sets a value indicating whether to enable the Consul client. Default value: true.
     /// </summary>
     public bool Enabled { get; set; } = true;
 
     /// <summary>
-    /// Gets tags to use when registering a service.
+    /// Gets the tags used when registering the running app.
     /// </summary>
     public IList<string> Tags { get; } = new List<string>();
 
     /// <summary>
-    /// Gets metadata to use when registering a service.
+    /// Gets metadata key/value pairs used when registering the running app.
     /// </summary>
     public IDictionary<string, string> Metadata { get; } = new Dictionary<string, string>();
 
     /// <summary>
     /// Gets or sets a value indicating whether <see cref="NetworkInterface.GetAllNetworkInterfaces" /> is used to determine <see cref="IPAddress" /> and
-    /// <see cref="HostName" /> .
+    /// <see cref="HostName" />. Default value: false.
     /// </summary>
     public bool UseNetworkInterfaces { get; set; }
 
     /// <summary>
-    /// Gets or sets values related to heartbeat.
+    /// Gets or sets settings related to heartbeats.
     /// </summary>
     public ConsulHeartbeatOptions? Heartbeat { get; set; } = new();
 
     /// <summary>
-    /// Gets values related to retrying requests.
+    /// Gets settings related to retrying requests.
     /// </summary>
     public ConsulRetryOptions Retry { get; } = new();
 
     /// <summary>
-    /// Gets or sets the tag to query for in the service list, if one is not listed in serverListQueryTags.
+    /// Gets or sets the tag to filter on when querying for service instances.
     /// </summary>
     public string? DefaultQueryTag { get; set; }
 
     /// <summary>
-    /// Gets or sets a value indicating whether to add the "passing" parameter to /v1/health/service/serviceName. This pushes health check passing to the
-    /// server.
+    /// Gets or sets a value indicating whether to filter on health status 'passing' when querying for service instances. Default value: true.
     /// </summary>
     public bool QueryPassing { get; set; } = true;
 
     /// <summary>
-    /// Gets or sets whether to register an http or https service.
+    /// Gets or sets the scheme to register the running app with ("http" or "https"). Default value: http.
     /// </summary>
     public string? Scheme { get; set; } = "http";
 
     /// <summary>
-    /// Gets or sets a value indicating whether to register health checks in Consul. Useful during development of a service.
+    /// Gets or sets a value indicating whether to enable periodic health checking for the running app. Default value: true.
     /// </summary>
     public bool RegisterHealthCheck { get; set; } = true;
 
     /// <summary>
-    /// Gets or sets a custom health check url, to override the default.
+    /// Gets or sets the absolute URL to the health endpoint of the running app (overrides <see cref="HealthCheckPath" />).
     /// </summary>
+    /// <remarks>
+    /// This setting only has effect when <see cref="RegisterHealthCheck" /> is true and <see cref="ConsulHeartbeatOptions.Enabled" /> is false.
+    /// </remarks>
     public string? HealthCheckUrl { get; set; }
 
     /// <summary>
-    /// Gets or sets an alternate server path to invoke for health checking.
+    /// Gets or sets the relative URL to the health endpoint of the running app. Default value: /actuator/health.
     /// </summary>
+    /// <remarks>
+    /// This setting only has effect when <see cref="RegisterHealthCheck" /> is true and <see cref="ConsulHeartbeatOptions.Enabled" /> is false.
+    /// </remarks>
     public string? HealthCheckPath { get; set; } = "/actuator/health";
 
     /// <summary>
-    /// Gets or sets how often to perform the health check (e.g. 10s), defaults to 10s.
+    /// Gets or sets how often Concur should perform an HTTP health check. Default value: 10s.
     /// </summary>
+    /// <remarks>
+    /// This setting only has effect when <see cref="RegisterHealthCheck" /> is true and <see cref="ConsulHeartbeatOptions.Enabled" /> is false.
+    /// </remarks>
     public string? HealthCheckInterval { get; set; } = "10s";
 
     /// <summary>
-    /// Gets or sets the timeout for health checks (e.g. 10s), defaults to 10s.
+    /// Gets or sets the timeout Concur should use for an HTTP health check. Default value: 10s.
     /// </summary>
+    /// <remarks>
+    /// This setting only has effect when <see cref="RegisterHealthCheck" /> is true and <see cref="ConsulHeartbeatOptions.Enabled" /> is false.
+    /// </remarks>
     public string? HealthCheckTimeout { get; set; } = "10s";
 
     /// <summary>
-    /// Gets or sets the timeout to deregister services critical for longer than timeout (e.g. 30m). Requires Consul version 7.x or higher.
+    /// Gets or sets the duration after which Consul deregisters the running app when in state critical. Default value: 30m.
     /// </summary>
+    /// <remarks>
+    /// This setting only has effect when <see cref="RegisterHealthCheck" /> is true.
+    /// </remarks>
     public string? HealthCheckCriticalTimeout { get; set; } = "30m";
 
     /// <summary>
-    /// Gets or sets a value indicating whether health check verifies TLS.
+    /// Gets or sets a value indicating whether Concur should skip TLS verification for HTTP health checks. Default value: false.
     /// </summary>
     public bool HealthCheckTlsSkipVerify { get; set; }
 
     /// <summary>
-    /// Gets or sets the hostname to use when accessing the Consul server.
+    /// Gets or sets the host name to register the running app with (if <see cref="PreferIPAddress" /> is false).
     /// </summary>
     public string? HostName { get; set; }
 
     /// <summary>
-    /// Gets or sets the IP address to use when accessing the service (must also set <see cref="PreferIPAddress" /> to use).
+    /// Gets or sets the IP address to register the running app with (if <see cref="PreferIPAddress" /> is true).
     /// </summary>
     public string? IPAddress { get; set; }
 
     /// <summary>
-    /// Gets or sets the port to register the service under.
+    /// Gets or sets the port number to register the running app with.
     /// </summary>
     public int Port { get; set; }
 
     /// <summary>
-    /// Gets or sets a value indicating whether to use an IP address rather than a hostname during registration.
+    /// Gets or sets a value indicating whether to register the running app with IP address instead of host name. Default: false.
     /// </summary>
     public bool PreferIPAddress { get; set; }
 
     /// <summary>
-    /// Gets or sets the service name.
+    /// Gets or sets the friendly name to register the running app with.
     /// </summary>
     public string? ServiceName { get; set; }
 
     /// <summary>
-    /// Gets or sets the unique service instance ID.
+    /// Gets or sets the unique ID to register the running app under.
     /// </summary>
     public string? InstanceId { get; set; }
 
     /// <summary>
-    /// Gets or sets the instance zone to use during registration.
+    /// Gets or sets the metadata zone value to use when registering the running app.
     /// </summary>
     public string? InstanceZone { get; set; }
 
     /// <summary>
-    /// Gets or sets the instance group to use during registration.
+    /// Gets or sets the metadata "group" value to use when registering the running app.
     /// </summary>
     public string? InstanceGroup { get; set; }
 
     /// <summary>
-    /// Gets or sets the metadata tag name of the zone.
+    /// Gets or sets the metadata key name for <see cref="InstanceZone" />.
     /// </summary>
     public string? DefaultZoneMetadataName { get; set; } = "zone";
 
     /// <summary>
-    /// Gets or sets a value indicating whether to throw exceptions during service registration. If false, logs warnings. Defaults to true.
+    /// Gets or sets a value indicating whether to throw an exception (instead of logging an error) if registration fails. Default value: true.
     /// </summary>
     public bool FailFast { get; set; } = true;
 
     /// <summary>
-    /// Gets or sets a value indicating whether to register as a service in Consul.
+    /// Gets or sets a value indicating whether to register the running app as a service instance. Default value: true.
     /// </summary>
     public bool Register { get; set; } = true;
 
     /// <summary>
-    /// Gets or sets a value indicating whether to use automatic de-registration of a service in Consul.
+    /// Gets or sets a value indicating whether to de-register the running app on shutdown. Default value: true.
     /// </summary>
     public bool Deregister { get; set; } = true;
 
     /// <summary>
-    /// Gets or sets a value indicating whether to determine <see cref="Port" /> from ASP.NET Core listening addresses configuration.
+    /// Gets or sets a value indicating whether to register with the port number ASP.NET Core is listening on. Default value: true.
     /// </summary>
     public bool UseAspNetCoreUrls { get; set; } = true;
 }

--- a/src/Discovery/src/Consul/Configuration/ConsulDiscoveryOptions.cs
+++ b/src/Discovery/src/Consul/Configuration/ConsulDiscoveryOptions.cs
@@ -84,7 +84,7 @@ public sealed class ConsulDiscoveryOptions
     public string? HealthCheckPath { get; set; } = "/actuator/health";
 
     /// <summary>
-    /// Gets or sets how often Concur should perform an HTTP health check. Default value: 10s.
+    /// Gets or sets how often Consul should perform an HTTP health check. Default value: 10s.
     /// </summary>
     /// <remarks>
     /// This setting only has effect when <see cref="RegisterHealthCheck" /> is true and <see cref="ConsulHeartbeatOptions.Enabled" /> is false.
@@ -92,7 +92,7 @@ public sealed class ConsulDiscoveryOptions
     public string? HealthCheckInterval { get; set; } = "10s";
 
     /// <summary>
-    /// Gets or sets the timeout Concur should use for an HTTP health check. Default value: 10s.
+    /// Gets or sets the timeout Consul should use for an HTTP health check. Default value: 10s.
     /// </summary>
     /// <remarks>
     /// This setting only has effect when <see cref="RegisterHealthCheck" /> is true and <see cref="ConsulHeartbeatOptions.Enabled" /> is false.
@@ -108,7 +108,7 @@ public sealed class ConsulDiscoveryOptions
     public string? HealthCheckCriticalTimeout { get; set; } = "30m";
 
     /// <summary>
-    /// Gets or sets a value indicating whether Concur should skip TLS verification for HTTP health checks. Default value: false.
+    /// Gets or sets a value indicating whether Consul should skip TLS verification for HTTP health checks. Default value: false.
     /// </summary>
     public bool HealthCheckTlsSkipVerify { get; set; }
 

--- a/src/Discovery/src/Consul/Configuration/ConsulHeartbeatOptions.cs
+++ b/src/Discovery/src/Consul/Configuration/ConsulHeartbeatOptions.cs
@@ -11,28 +11,29 @@ namespace Steeltoe.Discovery.Consul.Configuration;
 /// </summary>
 public sealed class ConsulHeartbeatOptions
 {
-    /// <summary>
-    /// Gets the time-to-live setting.
-    /// </summary>
     internal string TimeToLive => $"{TtlValue}{TtlUnit}";
 
     /// <summary>
-    /// Gets or sets a value indicating whether heartbeats are enabled, default true.
+    /// Gets or sets a value indicating whether the running app periodically sends TTL (time-to-live) heartbeats. Default value: true.
     /// </summary>
+    /// <remarks>
+    /// This setting only has effect when <see cref="ConsulDiscoveryOptions.RegisterHealthCheck" /> is true.
+    /// </remarks>
     public bool Enabled { get; set; } = true;
 
     /// <summary>
-    /// Gets or sets the time to live heartbeat time, default 30.
+    /// Gets or sets how often a TTL heartbeat must be sent to be considered healthy. Default value: 30.
     /// </summary>
     public int TtlValue { get; set; } = 30;
 
     /// <summary>
-    /// Gets or sets the time unit of the TtlValue, default "s".
+    /// Gets or sets the unit for <see cref="TtlValue" /> ("ms", "s", "m" or "h"). Default value: s.
     /// </summary>
     public string? TtlUnit { get; set; } = "s";
 
     /// <summary>
-    /// Gets or sets the interval ratio.
+    /// Gets or sets the rate at which the running app sends TTL heartbeats, relative to <see cref="TtlValue" /> and <see cref="TtlUnit" />. Default value:
+    /// 0.66.
     /// </summary>
     public double IntervalRatio { get; set; } = 2.0 / 3.0;
 

--- a/src/Discovery/src/Consul/Configuration/ConsulOptions.cs
+++ b/src/Discovery/src/Consul/Configuration/ConsulOptions.cs
@@ -12,42 +12,42 @@ public sealed class ConsulOptions
     internal const string ConfigurationPrefix = "consul";
 
     /// <summary>
-    /// Gets or sets the host address of the Consul server, default localhost.
+    /// Gets or sets the host name or IP address of the Consul server. Default value: localhost.
     /// </summary>
     public string? Host { get; set; } = "localhost";
 
     /// <summary>
-    /// Gets or sets the scheme used for the Consul server, default http.
+    /// Gets or sets the scheme to connect with the Consul server ("http" or "https"). Default value: http.
     /// </summary>
     public string? Scheme { get; set; } = "http";
 
     /// <summary>
-    /// Gets or sets the port number used for the Consul server, default 8500.
+    /// Gets or sets the port number the Consul server is listening on. Default value: 8500.
     /// </summary>
     public int Port { get; set; } = 8500;
 
     /// <summary>
-    /// Gets or sets the data center to use.
+    /// Gets or sets the datacenter name passed in each request to the server.
     /// </summary>
     public string? Datacenter { get; set; }
 
     /// <summary>
-    /// Gets or sets the access token to use.
+    /// Gets or sets the authentication token passed in each request to the server.
     /// </summary>
     public string? Token { get; set; }
 
     /// <summary>
-    /// Gets or sets the wait time to use.
+    /// Gets or sets the maximum duration for a blocking request.
     /// </summary>
     public string? WaitTime { get; set; }
 
     /// <summary>
-    /// Gets or sets the username to use.
+    /// Gets or sets the username for HTTP authentication.
     /// </summary>
     public string? Username { get; set; }
 
     /// <summary>
-    /// Gets or sets password to use.
+    /// Gets or sets password for HTTP authentication.
     /// </summary>
     public string? Password { get; set; }
 }

--- a/src/Discovery/src/Consul/Configuration/ConsulRetryOptions.cs
+++ b/src/Discovery/src/Consul/Configuration/ConsulRetryOptions.cs
@@ -9,11 +9,6 @@ namespace Steeltoe.Discovery.Consul.Configuration;
 /// </summary>
 public sealed class ConsulRetryOptions
 {
-    internal const int DefaultMaxRetryAttempts = 6;
-    internal const int DefaultInitialRetryInterval = 1000;
-    internal const double DefaultRetryMultiplier = 1.1;
-    internal const int DefaultMaxRetryInterval = 2000;
-
     /// <summary>
     /// Gets or sets a value indicating whether retries are enabled, default false.
     /// </summary>
@@ -22,20 +17,20 @@ public sealed class ConsulRetryOptions
     /// <summary>
     /// Gets or sets the initial interval to use during retries, default 1000ms.
     /// </summary>
-    public int InitialInterval { get; set; } = DefaultInitialRetryInterval;
+    public int InitialInterval { get; set; } = 1000;
 
     /// <summary>
     /// Gets or sets the maximum interval to use during retries, default 2000ms.
     /// </summary>
-    public int MaxInterval { get; set; } = DefaultMaxRetryInterval;
+    public int MaxInterval { get; set; } = 2000;
 
     /// <summary>
     /// Gets or sets the multiplier used when doing retries, default 1.1.
     /// </summary>
-    public double Multiplier { get; set; } = DefaultRetryMultiplier;
+    public double Multiplier { get; set; } = 1.1;
 
     /// <summary>
     /// Gets or sets the maximum number of attempts, default 6.
     /// </summary>
-    public int MaxAttempts { get; set; } = DefaultMaxRetryAttempts;
+    public int MaxAttempts { get; set; } = 6;
 }

--- a/src/Discovery/src/Consul/Configuration/ConsulRetryOptions.cs
+++ b/src/Discovery/src/Consul/Configuration/ConsulRetryOptions.cs
@@ -10,27 +10,27 @@ namespace Steeltoe.Discovery.Consul.Configuration;
 public sealed class ConsulRetryOptions
 {
     /// <summary>
-    /// Gets or sets a value indicating whether retries are enabled, default false.
+    /// Gets or sets a value indicating whether to try again When registering the running app fails. Default value: false.
     /// </summary>
     public bool Enabled { get; set; }
 
     /// <summary>
-    /// Gets or sets the initial interval to use during retries, default 1000ms.
+    /// Gets or sets the time to wait (in milliseconds) after the first registration failure. Default value: 1000.
     /// </summary>
     public int InitialInterval { get; set; } = 1000;
 
     /// <summary>
-    /// Gets or sets the maximum interval to use during retries, default 2000ms.
+    /// Gets or sets the upper bound (in milliseconds) for intervals. Default value: 2000.
     /// </summary>
     public int MaxInterval { get; set; } = 2000;
 
     /// <summary>
-    /// Gets or sets the multiplier used when doing retries, default 1.1.
+    /// Gets or sets the factor to increment the next interval with. Default value: 1.1.
     /// </summary>
     public double Multiplier { get; set; } = 1.1;
 
     /// <summary>
-    /// Gets or sets the maximum number of attempts, default 6.
+    /// Gets or sets the maximum number of registration attempts (if retries are enabled). Default value: 6.
     /// </summary>
     public int MaxAttempts { get; set; } = 6;
 }

--- a/src/Discovery/src/Consul/PublicAPI.Unshipped.txt
+++ b/src/Discovery/src/Consul/PublicAPI.Unshipped.txt
@@ -39,8 +39,6 @@ Steeltoe.Discovery.Consul.Configuration.ConsulDiscoveryOptions.IPAddress.set -> 
 Steeltoe.Discovery.Consul.Configuration.ConsulDiscoveryOptions.Metadata.get -> System.Collections.Generic.IDictionary<string!, string!>!
 Steeltoe.Discovery.Consul.Configuration.ConsulDiscoveryOptions.Port.get -> int
 Steeltoe.Discovery.Consul.Configuration.ConsulDiscoveryOptions.Port.set -> void
-Steeltoe.Discovery.Consul.Configuration.ConsulDiscoveryOptions.PreferAgentAddress.get -> bool
-Steeltoe.Discovery.Consul.Configuration.ConsulDiscoveryOptions.PreferAgentAddress.set -> void
 Steeltoe.Discovery.Consul.Configuration.ConsulDiscoveryOptions.PreferIPAddress.get -> bool
 Steeltoe.Discovery.Consul.Configuration.ConsulDiscoveryOptions.PreferIPAddress.set -> void
 Steeltoe.Discovery.Consul.Configuration.ConsulDiscoveryOptions.QueryPassing.get -> bool

--- a/src/Discovery/src/Consul/Registry/ConsulRegistration.cs
+++ b/src/Discovery/src/Consul/Registry/ConsulRegistration.cs
@@ -92,13 +92,9 @@ public sealed class ConsulRegistration : IServiceInstance
 
         var agentServiceRegistration = new AgentServiceRegistration
         {
-            ID = GetInstanceId(options, applicationInfo)
+            ID = GetInstanceId(options, applicationInfo),
+            Address = options.HostName
         };
-
-        if (!options.PreferAgentAddress)
-        {
-            agentServiceRegistration.Address = options.HostName;
-        }
 
         string appName = applicationInfo.GetApplicationNameInContext(SteeltoeComponent.Discovery, $"{ConsulDiscoveryOptions.ConfigurationPrefix}:serviceName");
 

--- a/src/Discovery/src/Consul/Registry/ConsulRegistration.cs
+++ b/src/Discovery/src/Consul/Registry/ConsulRegistration.cs
@@ -121,16 +121,16 @@ public sealed class ConsulRegistration : IServiceInstance
 
         if (!string.IsNullOrEmpty(options.InstanceZone) && !string.IsNullOrEmpty(options.DefaultZoneMetadataName))
         {
-            metadata.Add(options.DefaultZoneMetadataName, options.InstanceZone);
+            metadata.TryAdd(options.DefaultZoneMetadataName, options.InstanceZone);
         }
 
         if (!string.IsNullOrEmpty(options.InstanceGroup))
         {
-            metadata.Add("group", options.InstanceGroup);
+            metadata.TryAdd("group", options.InstanceGroup);
         }
 
         // store the secure flag in the metadata so that clients will be able to figure out whether to use http or https automatically
-        metadata.Add("secure", options.Scheme == "https" ? "true" : "false");
+        metadata.TryAdd("secure", options.Scheme == "https" ? "true" : "false");
 
         return metadata;
     }

--- a/src/Discovery/test/Consul.Test/Discovery/ConsulRetryOptionsTest.cs
+++ b/src/Discovery/test/Consul.Test/Discovery/ConsulRetryOptionsTest.cs
@@ -15,9 +15,9 @@ public sealed class ConsulRetryOptionsTest
         var options = new ConsulRetryOptions();
 
         Assert.False(options.Enabled);
-        Assert.Equal(ConsulRetryOptions.DefaultMaxRetryAttempts, options.MaxAttempts);
-        Assert.Equal(ConsulRetryOptions.DefaultInitialRetryInterval, options.InitialInterval);
-        Assert.Equal(ConsulRetryOptions.DefaultRetryMultiplier, options.Multiplier);
-        Assert.Equal(ConsulRetryOptions.DefaultMaxRetryInterval, options.MaxInterval);
+        Assert.Equal(6, options.MaxAttempts);
+        Assert.Equal(1000, options.InitialInterval);
+        Assert.Equal(1.1, options.Multiplier);
+        Assert.Equal(2000, options.MaxInterval);
     }
 }

--- a/src/Discovery/test/Consul.Test/Discovery/PostConfigureConsulDiscoveryOptionsTest.cs
+++ b/src/Discovery/test/Consul.Test/Discovery/PostConfigureConsulDiscoveryOptionsTest.cs
@@ -40,7 +40,6 @@ public sealed class PostConfigureConsulDiscoveryOptionsTest
         Assert.Null(options.InstanceGroup);
         Assert.Null(options.InstanceZone);
         Assert.False(options.PreferIPAddress);
-        Assert.False(options.PreferAgentAddress);
         Assert.False(options.QueryPassing);
         Assert.Equal("http", options.Scheme);
         Assert.Null(options.ServiceName);

--- a/src/Discovery/test/Consul.Test/Discovery/PostConfigureConsulDiscoveryOptionsTest.cs
+++ b/src/Discovery/test/Consul.Test/Discovery/PostConfigureConsulDiscoveryOptionsTest.cs
@@ -40,7 +40,7 @@ public sealed class PostConfigureConsulDiscoveryOptionsTest
         Assert.Null(options.InstanceGroup);
         Assert.Null(options.InstanceZone);
         Assert.False(options.PreferIPAddress);
-        Assert.False(options.QueryPassing);
+        Assert.True(options.QueryPassing);
         Assert.Equal("http", options.Scheme);
         Assert.Null(options.ServiceName);
         Assert.Empty(options.Tags);

--- a/src/Discovery/test/Consul.Test/Registry/ConsulRegistrationTest.cs
+++ b/src/Discovery/test/Consul.Test/Registry/ConsulRegistrationTest.cs
@@ -230,8 +230,6 @@ public sealed class ConsulRegistrationTest
         Assert.Equal(DateTimeConversions.ToTimeSpan(options.HealthCheckCriticalTimeout!), result.DeregisterCriticalServiceAfter);
 
         options.Heartbeat = null;
-        Assert.Throws<ArgumentOutOfRangeException>(() => ConsulRegistration.CreateCheck(0, options));
-
         const int port = 1234;
         result = ConsulRegistration.CreateCheck(port, options);
         var uri = new Uri($"{options.Scheme}://{options.HostName}:{port}{options.HealthCheckPath}");
@@ -312,21 +310,5 @@ public sealed class ConsulRegistrationTest
         AgentServiceCheck check = ConsulRegistration.CreateCheck(1234, options);
 
         Assert.Null(check.HTTP);
-    }
-
-    [Fact]
-    public void CreateCheck_WhenHeartbeatIsDisabledAndPortIsANegativeNumber_ThenShouldThrow()
-    {
-        var options = new ConsulDiscoveryOptions
-        {
-            Heartbeat = new ConsulHeartbeatOptions
-            {
-                Enabled = false
-            }
-        };
-
-        const int port = -1234;
-
-        Assert.Throws<ArgumentOutOfRangeException>(() => ConsulRegistration.CreateCheck(port, options));
     }
 }


### PR DESCRIPTION
## Description

As described at https://developer.hashicorp.com/consul/api-docs/agent/check, Consul only looks at the HTTP status code from health check URLs:
> [HTTP](https://developer.hashicorp.com/consul/api-docs/agent/check#http) (string: "") - Specifies an HTTP check to perform a GET request against the value of HTTP (expected to be a URL) every Interval. If the response is any 2xx code, the check is passing. If the response is 429 Too Many Requests, the check is warning. Otherwise, the check is critical. HTTP checks also support SSL. By default, a valid SSL certificate is expected. Certificate verification can be controlled using the TLSSkipVerify.

When `Management:Endpoints:UseStatusCodeFromResponse` is set to `false`, Consul will _always_ consider the app to be healthy. To fix this, I've added a custom HTTP header that overrides the configured setting.

_Update: Additional fixes added for Consul, see the individual commits._

## Quality checklist

- [x] Your code complies with our [Coding Style](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-code-style.md).
- [x] You've updated unit and/or integration tests for your change, where applicable.
- [ ] You've updated documentation for your change, where applicable.
      If your change affects other repositories, such as [Documentation](https://github.com/SteeltoeOSS/Documentation), [Samples](https://github.com/SteeltoeOSS/Samples) and/or [MainSite](https://github.com/SteeltoeOSS/MainSite), add linked PRs here.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
- [ ] You've added required license files and/or file headers (explaining where the code came from with proper attribution), where code is copied from StackOverflow, a blog, or OSS.
