### PR TITLE
Eureka fixes

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,11 +27,10 @@ jobs:
         skipFilter: '--filter "Category!=SkipOnLinux"'
         sonarAnalyze: true
         integrationTests: true
-      MacOS:
-        # Downgrade to macOS-12 because 'latest' fails to resolve localhost.
-        # https://learn.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops&tabs=yaml
-        imageName: macOS-12
-        skipFilter: '--filter "Category!=Integration&Category!=SkipOnMacOS"'
+      # MacOS is turned off because it causes flaky builds.
+      #MacOS:
+      #  imageName: macOS-latest
+      #  skipFilter: '--filter "Category!=Integration&Category!=SkipOnMacOS"'
       Windows:
         imageName: windows-latest
         skipFilter: '--filter "Category!=Integration"'
@@ -40,7 +39,7 @@ jobs:
   steps:
   - task: PowerShell@2
     displayName: Turn off certificates on macOS
-    condition: eq(variables['imageName'], 'macOS-12')
+    condition: eq(variables['imageName'], 'macOS-latest')
     inputs:
       targetType: 'inline'
       script: |
@@ -64,7 +63,7 @@ jobs:
       version: 8.0.x
   - task: DotNetCoreCLI@2
     displayName: Install Nerdbank.GitVersioning tool
-    condition: eq(variables['imageName'], 'macOS-12')
+    condition: eq(variables['imageName'], 'macOS-latest')
     inputs:
       command: custom
       custom: tool

--- a/build/common.yml
+++ b/build/common.yml
@@ -20,9 +20,4 @@ jobs:
   - template: templates/component-build.yaml
     parameters:
       component: Common
-      OS: macOS
-      skipFilter: --filter "Category!=SkipOnMacOS"
-  - template: templates/component-build.yaml
-    parameters:
-      component: Common
       OS: windows

--- a/src/Common/src/Common/HealthChecks/DefaultHealthAggregator.cs
+++ b/src/Common/src/Common/HealthChecks/DefaultHealthAggregator.cs
@@ -2,11 +2,11 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Concurrent;
-using Steeltoe.Common;
-using Steeltoe.Common.HealthChecks;
+#nullable enable
 
-namespace Steeltoe.Management.Endpoint.Health;
+using System.Collections.Concurrent;
+
+namespace Steeltoe.Common.HealthChecks;
 
 internal class DefaultHealthAggregator : IHealthAggregator
 {

--- a/src/Common/src/Common/HealthChecks/HealthRegistrationsAggregator.cs
+++ b/src/Common/src/Common/HealthChecks/HealthRegistrationsAggregator.cs
@@ -2,17 +2,17 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System.Collections.Concurrent;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
-using Steeltoe.Common;
-using Steeltoe.Common.HealthChecks;
 using Steeltoe.Common.Util;
 using MicrosoftHealthCheckResult = Microsoft.Extensions.Diagnostics.HealthChecks.HealthCheckResult;
 using MicrosoftHealthStatus = Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus;
 using SteeltoeHealthCheckResult = Steeltoe.Common.HealthChecks.HealthCheckResult;
 using SteeltoeHealthStatus = Steeltoe.Common.HealthChecks.HealthStatus;
 
-namespace Steeltoe.Management.Endpoint.Health;
+namespace Steeltoe.Common.HealthChecks;
 
 internal sealed class HealthRegistrationsAggregator : DefaultHealthAggregator, IHealthRegistrationsAggregator
 {

--- a/src/Common/src/Common/HealthChecks/IHealthRegistrationsAggregator.cs
+++ b/src/Common/src/Common/HealthChecks/IHealthRegistrationsAggregator.cs
@@ -2,11 +2,11 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.Extensions.Diagnostics.HealthChecks;
-using Steeltoe.Common.HealthChecks;
-using HealthCheckResult = Steeltoe.Common.HealthChecks.HealthCheckResult;
+#nullable enable
 
-namespace Steeltoe.Management.Endpoint.Health;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace Steeltoe.Common.HealthChecks;
 
 public interface IHealthRegistrationsAggregator : IHealthAggregator
 {

--- a/src/Common/src/Common/Properties/AssemblyInfo.cs
+++ b/src/Common/src/Common/Properties/AssemblyInfo.cs
@@ -19,5 +19,6 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("Steeltoe.Management.Tracing")]
 [assembly: InternalsVisibleTo("Steeltoe.Management.Tracing.Test")]
 [assembly: InternalsVisibleTo("Steeltoe.Management.Endpoint")]
+[assembly: InternalsVisibleTo("Steeltoe.Management.Endpoint.Test")]
 [assembly: InternalsVisibleTo("Steeltoe.Management.Wavefront")]
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]

--- a/src/Common/src/Common/Steeltoe.Common.csproj
+++ b/src/Common/src/Common/Steeltoe.Common.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="$(FoundationalVersion)" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="$(FoundationalVersion)" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(FoundationalVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="$(MatchTargetFrameworkVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="$(MatchTargetFrameworkVersion)" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="$(FoundationalVersion)" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="$(FoundationalVersion)" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="$(FoundationalVersion)" />

--- a/src/Common/src/Common/Steeltoe.Common.csproj
+++ b/src/Common/src/Common/Steeltoe.Common.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="$(FoundationalVersion)" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="$(FoundationalVersion)" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(FoundationalVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="$(MatchTargetFrameworkVersion)" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="$(FoundationalVersion)" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="$(FoundationalVersion)" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="$(FoundationalVersion)" />

--- a/src/Configuration/src/ConfigServer/ConfigServerHealthContributor.cs
+++ b/src/Configuration/src/ConfigServer/ConfigServerHealthContributor.cs
@@ -46,10 +46,7 @@ internal sealed class ConfigServerHealthContributor : IHealthContributor
 
         if (!IsEnabled())
         {
-            _logger.LogDebug("Config Server health check disabled");
-            health.Status = HealthStatus.Unknown;
-            health.Details.Add("info", "Health check disabled");
-            return health;
+            return null;
         }
 
         IList<PropertySource>? sources = await GetPropertySourcesAsync(Provider, cancellationToken);

--- a/src/Configuration/test/ConfigServer.Test/ConfigServerHealthContributorTest.cs
+++ b/src/Configuration/test/ConfigServer.Test/ConfigServerHealthContributorTest.cs
@@ -206,8 +206,7 @@ public sealed class ConfigServerHealthContributorTest
         var contributor = new ConfigServerHealthContributor(configurationRoot, NullLogger<ConfigServerHealthContributor>.Instance);
         Assert.NotNull(contributor.Provider);
         HealthCheckResult? health = await contributor.CheckHealthAsync(CancellationToken.None);
-        Assert.NotNull(health);
-        Assert.Equal(HealthStatus.Unknown, health.Status);
+        Assert.Null(health);
     }
 
     [Fact]

--- a/src/Discovery/src/Consul/Registry/ConsulServiceRegistrar.cs
+++ b/src/Discovery/src/Consul/Registry/ConsulServiceRegistrar.cs
@@ -73,7 +73,7 @@ public sealed class ConsulServiceRegistrar : IAsyncDisposable
     {
         if (!Options.Enabled)
         {
-            _logger.LogDebug("Discovery Lifecycle disabled. Not starting");
+            _logger.LogDebug("Consul discovery client is turned off.");
             return;
         }
 
@@ -94,7 +94,7 @@ public sealed class ConsulServiceRegistrar : IAsyncDisposable
     {
         if (!Options.Register)
         {
-            _logger.LogDebug("Registration disabled");
+            _logger.LogDebug("Consul registration is turned off.");
             return;
         }
 
@@ -105,7 +105,7 @@ public sealed class ConsulServiceRegistrar : IAsyncDisposable
     {
         if (!Options.Register || !Options.Deregister)
         {
-            _logger.LogDebug("Deregistration disabled");
+            _logger.LogDebug("Consul deregistration is turned off.");
             return;
         }
 

--- a/src/Discovery/src/Eureka/AppInfo/NullableValueWrapper.cs
+++ b/src/Discovery/src/Eureka/AppInfo/NullableValueWrapper.cs
@@ -16,4 +16,9 @@ internal sealed class NullableValueWrapper<T>
     {
         Value = value;
     }
+
+    public override string ToString()
+    {
+        return $"NullableValueWrapper: {Value}";
+    }
 }

--- a/src/Discovery/src/Eureka/Configuration/EurekaHealthOptions.cs
+++ b/src/Discovery/src/Eureka/Configuration/EurekaHealthOptions.cs
@@ -22,5 +22,5 @@ public sealed class EurekaHealthOptions
     /// <summary>
     /// Gets or sets a value indicating whether to enable the Eureka health check handler. Configuration property: eureka:client:health:checkEnabled.
     /// </summary>
-    public bool CheckEnabled { get; set; } = true;
+    public bool CheckEnabled { get; set; }
 }

--- a/src/Discovery/src/Eureka/EurekaApplicationInfoManager.cs
+++ b/src/Discovery/src/Eureka/EurekaApplicationInfoManager.cs
@@ -159,7 +159,7 @@ public sealed class EurekaApplicationInfoManager : IDisposable
             instanceOptions.InstanceId = previousInstance.InstanceId;
         }
 
-        if (instanceOptions.AppName != previousInstance.AppName)
+        if (!string.Equals(instanceOptions.AppName, previousInstance.AppName, StringComparison.OrdinalIgnoreCase))
         {
             // A change of AppName would require unregister, then re-register.
             _logger.LogWarning("Discarding change of AppName, which is not supported.");

--- a/src/Discovery/src/Eureka/EurekaDiscoveryClient.cs
+++ b/src/Discovery/src/Eureka/EurekaDiscoveryClient.cs
@@ -407,6 +407,12 @@ public sealed class EurekaDiscoveryClient : IDiscoveryClient
         {
             try
             {
+                if (_appInfoManager.Instance.Status == InstanceStatus.Starting)
+                {
+                    _logger.LogDebug("Skipping health check handler in starting state.");
+                    return;
+                }
+
                 InstanceStatus aggregatedStatus = await HealthCheckHandler.GetStatusAsync(cancellationToken);
                 _logger.LogDebug("Health check handler returned status {Status}.", aggregatedStatus);
 

--- a/src/Discovery/src/Eureka/EurekaHealthCheckHandler.cs
+++ b/src/Discovery/src/Eureka/EurekaHealthCheckHandler.cs
@@ -16,7 +16,7 @@ namespace Steeltoe.Discovery.Eureka;
 /// <summary>
 /// Computes the Eureka <see cref="InstanceStatus" /> from ASP.NET health checks and all registered Steeltoe <see cref="IHealthContributor" />s.
 /// </summary>
-public sealed class EurekaHealthCheckHandler : IHealthCheckHandler
+internal sealed class EurekaHealthCheckHandler : IHealthCheckHandler
 {
     private static readonly List<HealthStatus> HealthStatusOrder =
     [

--- a/src/Discovery/src/Eureka/EurekaServiceCollectionExtensions.cs
+++ b/src/Discovery/src/Eureka/EurekaServiceCollectionExtensions.cs
@@ -31,8 +31,11 @@ public static class EurekaServiceCollectionExtensions
     {
         ArgumentGuard.NotNull(services);
 
-        ConfigureEurekaServices(services);
-        AddEurekaServices(services);
+        if (services.All(descriptor => descriptor.ImplementationType != typeof(EurekaDiscoveryClient)))
+        {
+            ConfigureEurekaServices(services);
+            AddEurekaServices(services);
+        }
 
         return services;
     }
@@ -79,7 +82,7 @@ public static class EurekaServiceCollectionExtensions
         services.AddSingleton<EurekaApplicationInfoManager>();
 
         services.TryAddSingleton<EurekaDiscoveryClient>();
-        services.TryAddEnumerable(ServiceDescriptor.Singleton(typeof(IDiscoveryClient), typeof(EurekaDiscoveryClient)));
+        services.AddSingleton<IDiscoveryClient>(serviceProvider => serviceProvider.GetRequiredService<EurekaDiscoveryClient>());
         services.TryAddEnumerable(ServiceDescriptor.Singleton(typeof(IHostedService), typeof(DiscoveryClientHostedService)));
 
         AddEurekaClient(services);

--- a/src/Discovery/src/Eureka/EurekaServiceCollectionExtensions.cs
+++ b/src/Discovery/src/Eureka/EurekaServiceCollectionExtensions.cs
@@ -83,6 +83,9 @@ public static class EurekaServiceCollectionExtensions
         services.TryAddEnumerable(ServiceDescriptor.Singleton(typeof(IHostedService), typeof(DiscoveryClientHostedService)));
 
         AddEurekaClient(services);
+
+        services.TryAddSingleton<IHealthCheckHandler, EurekaHealthCheckHandler>();
+        services.TryAddSingleton<IHealthAggregator, HealthRegistrationsAggregator>();
     }
 
     private static void AddEurekaClient(IServiceCollection services)

--- a/src/Discovery/src/Eureka/HealthCheckHandlerProvider.cs
+++ b/src/Discovery/src/Eureka/HealthCheckHandlerProvider.cs
@@ -21,8 +21,8 @@ public sealed class HealthCheckHandlerProvider
         _serviceProvider = serviceProvider;
     }
 
-    internal IHealthCheckHandler? GetHandler()
+    internal IHealthCheckHandler GetHandler()
     {
-        return _serviceProvider.GetService<IHealthCheckHandler>();
+        return _serviceProvider.GetRequiredService<IHealthCheckHandler>();
     }
 }

--- a/src/Discovery/src/Eureka/IHealthCheckHandler.cs
+++ b/src/Discovery/src/Eureka/IHealthCheckHandler.cs
@@ -11,5 +11,5 @@ namespace Steeltoe.Discovery.Eureka;
 /// </summary>
 public interface IHealthCheckHandler
 {
-    Task<InstanceStatus> GetStatusAsync(CancellationToken cancellationToken);
+    Task<InstanceStatus> GetStatusAsync(bool hasFirstHeartbeatCompleted, CancellationToken cancellationToken);
 }

--- a/src/Discovery/src/Eureka/PublicAPI.Unshipped.txt
+++ b/src/Discovery/src/Eureka/PublicAPI.Unshipped.txt
@@ -225,7 +225,7 @@ Steeltoe.Discovery.Eureka.EurekaDiscoveryClient.GetLocalServiceInstance() -> Ste
 Steeltoe.Discovery.Eureka.EurekaDiscoveryClient.GetServiceIdsAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.ISet<string!>!>!
 Steeltoe.Discovery.Eureka.EurekaDiscoveryClient.ShutdownAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
 Steeltoe.Discovery.Eureka.EurekaHealthCheckHandler
-Steeltoe.Discovery.Eureka.EurekaHealthCheckHandler.EurekaHealthCheckHandler(System.IServiceProvider! serviceProvider, Microsoft.Extensions.Logging.ILogger<Steeltoe.Discovery.Eureka.EurekaHealthCheckHandler!>! logger) -> void
+Steeltoe.Discovery.Eureka.EurekaHealthCheckHandler.EurekaHealthCheckHandler(Steeltoe.Common.HealthChecks.IHealthAggregator! healthAggregator, Microsoft.Extensions.Options.IOptionsMonitor<Microsoft.Extensions.Diagnostics.HealthChecks.HealthCheckServiceOptions!>! healthOptionsMonitor, System.IServiceProvider! serviceProvider) -> void
 Steeltoe.Discovery.Eureka.EurekaHealthCheckHandler.GetStatusAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Steeltoe.Discovery.Eureka.AppInfo.InstanceStatus>!
 Steeltoe.Discovery.Eureka.EurekaServiceCollectionExtensions
 Steeltoe.Discovery.Eureka.EurekaServiceUriStateManager

--- a/src/Discovery/src/Eureka/PublicAPI.Unshipped.txt
+++ b/src/Discovery/src/Eureka/PublicAPI.Unshipped.txt
@@ -224,9 +224,6 @@ Steeltoe.Discovery.Eureka.EurekaDiscoveryClient.GetInstancesAsync(string! servic
 Steeltoe.Discovery.Eureka.EurekaDiscoveryClient.GetLocalServiceInstance() -> Steeltoe.Common.Discovery.IServiceInstance!
 Steeltoe.Discovery.Eureka.EurekaDiscoveryClient.GetServiceIdsAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.ISet<string!>!>!
 Steeltoe.Discovery.Eureka.EurekaDiscoveryClient.ShutdownAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
-Steeltoe.Discovery.Eureka.EurekaHealthCheckHandler
-Steeltoe.Discovery.Eureka.EurekaHealthCheckHandler.EurekaHealthCheckHandler(Steeltoe.Common.HealthChecks.IHealthAggregator! healthAggregator, Microsoft.Extensions.Options.IOptionsMonitor<Microsoft.Extensions.Diagnostics.HealthChecks.HealthCheckServiceOptions!>! healthOptionsMonitor, System.IServiceProvider! serviceProvider) -> void
-Steeltoe.Discovery.Eureka.EurekaHealthCheckHandler.GetStatusAsync(bool hasFirstHeartbeatCompleted, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Steeltoe.Discovery.Eureka.AppInfo.InstanceStatus>!
 Steeltoe.Discovery.Eureka.EurekaServiceCollectionExtensions
 Steeltoe.Discovery.Eureka.EurekaServiceUriStateManager
 Steeltoe.Discovery.Eureka.EurekaServiceUriStateManager.EurekaServiceUriStateManager(Microsoft.Extensions.Options.IOptionsMonitor<Steeltoe.Discovery.Eureka.Configuration.EurekaClientOptions!>! optionsMonitor, Microsoft.Extensions.Logging.ILogger<Steeltoe.Discovery.Eureka.EurekaServiceUriStateManager!>! logger) -> void

--- a/src/Discovery/src/Eureka/PublicAPI.Unshipped.txt
+++ b/src/Discovery/src/Eureka/PublicAPI.Unshipped.txt
@@ -226,14 +226,14 @@ Steeltoe.Discovery.Eureka.EurekaDiscoveryClient.GetServiceIdsAsync(System.Thread
 Steeltoe.Discovery.Eureka.EurekaDiscoveryClient.ShutdownAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
 Steeltoe.Discovery.Eureka.EurekaHealthCheckHandler
 Steeltoe.Discovery.Eureka.EurekaHealthCheckHandler.EurekaHealthCheckHandler(Steeltoe.Common.HealthChecks.IHealthAggregator! healthAggregator, Microsoft.Extensions.Options.IOptionsMonitor<Microsoft.Extensions.Diagnostics.HealthChecks.HealthCheckServiceOptions!>! healthOptionsMonitor, System.IServiceProvider! serviceProvider) -> void
-Steeltoe.Discovery.Eureka.EurekaHealthCheckHandler.GetStatusAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Steeltoe.Discovery.Eureka.AppInfo.InstanceStatus>!
+Steeltoe.Discovery.Eureka.EurekaHealthCheckHandler.GetStatusAsync(bool hasFirstHeartbeatCompleted, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Steeltoe.Discovery.Eureka.AppInfo.InstanceStatus>!
 Steeltoe.Discovery.Eureka.EurekaServiceCollectionExtensions
 Steeltoe.Discovery.Eureka.EurekaServiceUriStateManager
 Steeltoe.Discovery.Eureka.EurekaServiceUriStateManager.EurekaServiceUriStateManager(Microsoft.Extensions.Options.IOptionsMonitor<Steeltoe.Discovery.Eureka.Configuration.EurekaClientOptions!>! optionsMonitor, Microsoft.Extensions.Logging.ILogger<Steeltoe.Discovery.Eureka.EurekaServiceUriStateManager!>! logger) -> void
 Steeltoe.Discovery.Eureka.HealthCheckHandlerProvider
 Steeltoe.Discovery.Eureka.HealthCheckHandlerProvider.HealthCheckHandlerProvider(System.IServiceProvider! serviceProvider) -> void
 Steeltoe.Discovery.Eureka.IHealthCheckHandler
-Steeltoe.Discovery.Eureka.IHealthCheckHandler.GetStatusAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Steeltoe.Discovery.Eureka.AppInfo.InstanceStatus>!
+Steeltoe.Discovery.Eureka.IHealthCheckHandler.GetStatusAsync(bool hasFirstHeartbeatCompleted, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Steeltoe.Discovery.Eureka.AppInfo.InstanceStatus>!
 Steeltoe.Discovery.Eureka.Transport.EurekaTransportException
 Steeltoe.Discovery.Eureka.Transport.EurekaTransportException.EurekaTransportException(string? message) -> void
 Steeltoe.Discovery.Eureka.Transport.EurekaTransportException.EurekaTransportException(string? message, System.Exception? innerException) -> void

--- a/src/Discovery/test/Eureka.Test/EurekaClientOptionsTest.cs
+++ b/src/Discovery/test/Eureka.Test/EurekaClientOptionsTest.cs
@@ -36,7 +36,7 @@ public sealed class EurekaClientOptionsTest
         Assert.Equal(EurekaClientOptions.DefaultServerServiceUrl, clientOptions.EurekaServerServiceUrls);
         Assert.NotNull(clientOptions.Health);
         Assert.True(clientOptions.Health.ContributorEnabled);
-        Assert.True(clientOptions.Health.CheckEnabled);
+        Assert.False(clientOptions.Health.CheckEnabled);
         Assert.Null(clientOptions.Health.MonitoredApps);
     }
 
@@ -63,7 +63,10 @@ public sealed class EurekaClientOptionsTest
                   "shouldRegisterWithEureka": true,
                   "registryFetchIntervalSeconds": 100,
                   "instanceInfoReplicationIntervalSeconds": 100,
-                  "serviceUrl": "https://foo.bar:8761/eureka/"
+                  "serviceUrl": "https://foo.bar:8761/eureka/",
+                  "Health": {
+                    "CheckEnabled": "true"
+                  }
                 },
                 "instance": {
                   "registrationMethod": "foobar",

--- a/src/Discovery/test/Eureka.Test/EurekaDiscoveryClientTest.cs
+++ b/src/Discovery/test/Eureka.Test/EurekaDiscoveryClientTest.cs
@@ -717,7 +717,7 @@ public sealed class EurekaDiscoveryClientTest
             _status = status;
         }
 
-        public async Task<InstanceStatus> GetStatusAsync(CancellationToken cancellationToken)
+        public async Task<InstanceStatus> GetStatusAsync(bool hasFirstHeartbeatCompleted, CancellationToken cancellationToken)
         {
             await Task.Yield();
 

--- a/src/Discovery/test/Eureka.Test/EurekaDiscoveryClientTest.cs
+++ b/src/Discovery/test/Eureka.Test/EurekaDiscoveryClientTest.cs
@@ -561,15 +561,16 @@ public sealed class EurekaDiscoveryClientTest
         var appSettings = new Dictionary<string, string?>
         {
             ["Eureka:Client:ShouldFetchRegistry"] = "false",
-            ["Eureka:Client:ShouldRegisterWithEureka"] = "false"
+            ["Eureka:Client:ShouldRegisterWithEureka"] = "false",
+            ["Eureka:Client:Health:CheckEnabled"] = "true"
         };
 
         var myHandler = new TestHealthCheckHandler(InstanceStatus.Down);
 
         WebApplicationBuilder builder = WebApplication.CreateBuilder();
         builder.Configuration.AddInMemoryCollection(appSettings);
-        builder.Services.AddEurekaDiscoveryClient();
         builder.Services.AddSingleton<IHealthCheckHandler>(myHandler);
+        builder.Services.AddEurekaDiscoveryClient();
 
         await using WebApplication webApplication = builder.Build();
 

--- a/src/Discovery/test/Eureka.Test/EurekaHealthCheckHandlerTest.cs
+++ b/src/Discovery/test/Eureka.Test/EurekaHealthCheckHandlerTest.cs
@@ -134,7 +134,8 @@ public sealed class EurekaHealthCheckHandlerTest
             ["eureka:instance:leaseRenewalIntervalInSeconds"] = "1",
             ["eureka:client:eurekaServer:retryCount"] = "0",
             ["Eureka:Client:Health:CheckEnabled"] = "true",
-            ["Eureka:Instance:AppName"] = "FOO"
+            ["Eureka:Instance:AppName"] = "FOO",
+            ["Eureka:Instance:InstanceId"] = "localhost:foo"
         };
 
         builder.Configuration.AddInMemoryCollection(appSettings);
@@ -142,6 +143,7 @@ public sealed class EurekaHealthCheckHandlerTest
 
         var handler = new DelegateToMockHttpClientHandler();
         handler.Mock.Expect(HttpMethod.Post, "http://localhost:8761/eureka/apps/FOO").Respond(HttpStatusCode.NoContent);
+        handler.Mock.Expect(HttpMethod.Put, "http://localhost:8761/eureka/apps/FOO/localhost%3Afoo").Respond("application/json", "{}");
 
         WebApplication app = builder.Build();
 

--- a/src/Discovery/test/Eureka.Test/EurekaHealthCheckHandlerTest.cs
+++ b/src/Discovery/test/Eureka.Test/EurekaHealthCheckHandlerTest.cs
@@ -39,7 +39,7 @@ public sealed class EurekaHealthCheckHandlerTest
 
         var optionsMonitor = new TestOptionsMonitor<HealthCheckServiceOptions>();
         var handler = new EurekaHealthCheckHandler(new DefaultHealthAggregator(), optionsMonitor, serviceProvider);
-        InstanceStatus result = await handler.GetStatusAsync(CancellationToken.None);
+        InstanceStatus result = await handler.GetStatusAsync(false, CancellationToken.None);
 
         result.Should().Be(expectedStatus);
     }
@@ -52,7 +52,7 @@ public sealed class EurekaHealthCheckHandlerTest
 
         var optionsMonitor = new TestOptionsMonitor<HealthCheckServiceOptions>();
         var handler = new EurekaHealthCheckHandler(new DefaultHealthAggregator(), optionsMonitor, serviceProvider);
-        InstanceStatus result = await handler.GetStatusAsync(CancellationToken.None);
+        InstanceStatus result = await handler.GetStatusAsync(false, CancellationToken.None);
 
         result.Should().Be(InstanceStatus.Up);
     }
@@ -68,7 +68,7 @@ public sealed class EurekaHealthCheckHandlerTest
 
         var optionsMonitor = new TestOptionsMonitor<HealthCheckServiceOptions>();
         var handler = new EurekaHealthCheckHandler(new DefaultHealthAggregator(), optionsMonitor, serviceProvider);
-        InstanceStatus result = await handler.GetStatusAsync(CancellationToken.None);
+        InstanceStatus result = await handler.GetStatusAsync(false, CancellationToken.None);
 
         result.Should().Be(InstanceStatus.Unknown);
     }
@@ -115,7 +115,7 @@ public sealed class EurekaHealthCheckHandlerTest
 
         var optionsMonitor = new TestOptionsMonitor<HealthCheckServiceOptions>();
         var handler = new EurekaHealthCheckHandler(new DefaultHealthAggregator(), optionsMonitor, serviceProvider);
-        InstanceStatus result = await handler.GetStatusAsync(CancellationToken.None);
+        InstanceStatus result = await handler.GetStatusAsync(false, CancellationToken.None);
 
         result.Should().Be(expectedStatus);
     }

--- a/src/Management/src/Endpoint/Health/HealthEndpointHandler.cs
+++ b/src/Management/src/Endpoint/Health/HealthEndpointHandler.cs
@@ -68,9 +68,9 @@ internal sealed class HealthEndpointHandler : IHealthEndpointHandler
             healthCheckRegistrations = _healthOptionsMonitor.CurrentValue.Registrations;
         }
 
-        HealthCheckResult result = _healthAggregator is not IHealthRegistrationsAggregator registrationAggregator
-            ? await _healthAggregator.AggregateAsync(filteredContributors, cancellationToken)
-            : await registrationAggregator.AggregateAsync(filteredContributors, healthCheckRegistrations, _serviceProvider, cancellationToken);
+        HealthCheckResult result = _healthAggregator is IHealthRegistrationsAggregator registrationAggregator
+            ? await registrationAggregator.AggregateAsync(filteredContributors, healthCheckRegistrations, _serviceProvider, cancellationToken)
+            : await _healthAggregator.AggregateAsync(filteredContributors, cancellationToken);
 
         var response = new HealthEndpointResponse(result);
 

--- a/src/Management/src/Endpoint/PublicAPI.Unshipped.txt
+++ b/src/Management/src/Endpoint/PublicAPI.Unshipped.txt
@@ -220,8 +220,6 @@ Steeltoe.Management.Endpoint.Health.HealthGroupOptions.HealthGroupOptions() -> v
 Steeltoe.Management.Endpoint.Health.HealthGroupOptions.Include.get -> string?
 Steeltoe.Management.Endpoint.Health.HealthGroupOptions.Include.set -> void
 Steeltoe.Management.Endpoint.Health.IHealthEndpointHandler
-Steeltoe.Management.Endpoint.Health.IHealthRegistrationsAggregator
-Steeltoe.Management.Endpoint.Health.IHealthRegistrationsAggregator.AggregateAsync(System.Collections.Generic.ICollection<Steeltoe.Common.HealthChecks.IHealthContributor!>! contributors, System.Collections.Generic.ICollection<Microsoft.Extensions.Diagnostics.HealthChecks.HealthCheckRegistration!>! healthCheckRegistrations, System.IServiceProvider! serviceProvider, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Steeltoe.Common.HealthChecks.HealthCheckResult!>!
 Steeltoe.Management.Endpoint.Health.ServiceCollectionExtensions
 Steeltoe.Management.Endpoint.Health.ServiceProviderExtensions
 Steeltoe.Management.Endpoint.Health.ShowDetails

--- a/src/Management/src/Endpoint/Steeltoe.Management.Endpoint.csproj
+++ b/src/Management/src/Endpoint/Steeltoe.Management.Endpoint.csproj
@@ -21,7 +21,6 @@
     <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="$(DiagnosticsTracingVersion)" />
     <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="$(FoundationalVersion)" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(FoundationalVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="$(MatchTargetFrameworkVersion)" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="$(FoundationalVersion)" />
     <PackageReference Include="Microsoft.DiaSymReader" Version="$(SymReaderVersion)" />
     <PackageReference Include="Microsoft.DiaSymReader.PortablePdb" Version="$(SymReaderPortableVersion)" />

--- a/src/Management/test/Endpoint.Test/Health/DefaultHealthAggregatorTest.cs
+++ b/src/Management/test/Endpoint.Test/Health/DefaultHealthAggregatorTest.cs
@@ -5,7 +5,6 @@
 using System.Diagnostics;
 using FluentAssertions;
 using Steeltoe.Common.HealthChecks;
-using Steeltoe.Management.Endpoint.Health;
 using Steeltoe.Management.Endpoint.Test.Health.TestContributors;
 using Xunit;
 

--- a/src/Management/test/Endpoint.Test/Health/Startup.cs
+++ b/src/Management/test/Endpoint.Test/Health/Startup.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Options;
+using Steeltoe.Common.HealthChecks;
 using Steeltoe.Management.Endpoint.Health;
 using Steeltoe.Management.Endpoint.Health.Contributor;
 using Steeltoe.Management.Endpoint.Test.Health.TestContributors;

--- a/src/Management/test/Endpoint.Test/ManagementHostBuilderExtensionsTest.cs
+++ b/src/Management/test/Endpoint.Test/ManagementHostBuilderExtensionsTest.cs
@@ -12,6 +12,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Steeltoe.Common;
 using Steeltoe.Common.Availability;
+using Steeltoe.Common.HealthChecks;
 using Steeltoe.Common.TestResources;
 using Steeltoe.Logging.DynamicLogger;
 using Steeltoe.Logging.DynamicSerilog;

--- a/src/Management/test/Endpoint.Test/ManagementWebApplicationBuilderExtensionsTest.cs
+++ b/src/Management/test/Endpoint.Test/ManagementWebApplicationBuilderExtensionsTest.cs
@@ -11,6 +11,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Steeltoe.Common;
 using Steeltoe.Common.Availability;
+using Steeltoe.Common.HealthChecks;
 using Steeltoe.Common.TestResources;
 using Steeltoe.Logging.DynamicLogger;
 using Steeltoe.Logging.DynamicSerilog;

--- a/src/Management/test/Endpoint.Test/ManagementWebHostBuilderExtensionsTest.cs
+++ b/src/Management/test/Endpoint.Test/ManagementWebHostBuilderExtensionsTest.cs
@@ -11,6 +11,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Steeltoe.Common;
 using Steeltoe.Common.Availability;
+using Steeltoe.Common.HealthChecks;
 using Steeltoe.Common.TestResources;
 using Steeltoe.Logging.DynamicLogger;
 using Steeltoe.Logging.DynamicSerilog;


### PR DESCRIPTION
## Description

Eureka health fixes: 

- Make `IHealthCheckHandler` also read from ASP.NET health checks (requires move into Common)
- `EurekaHealthCheckHandler` is now automatically registered, but off by default in configuration (was: not registered but on by default, so effectively off)
- Fixes in translation from `HealthStatus` to `InstanceStatus`, add more tests
  - When a contributor is turned off, it must be ignored (not result in `InstanceStatus.Unknown`)
  - When a contributor reports warning, translate to `InstanceStatus.Up` (not `Unknown`)
  - When there are no contributors, translate to `InstanceStatus.Up` (not `Unknown`)
  - Ignore the result from `EurekaServerHealthContributor` the first time, as its dependent data are still being determined.
- Fixed a case where the IoC container would create multiple instances of `EurekaDiscoveryClient`.
- Fixed ConfigServer health status when turned off.
- Skip running health checks while the instance is still in `Starting` state.
- Remove warning that the app name changed, when only its casing changed.

Additionally, turned off macOS in cibuilds, because it fails randomly.

## Quality checklist

- [x] Your code complies with our [Coding Style](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-code-style.md).
- [x] You've updated unit and/or integration tests for your change, where applicable.
- [ ] You've updated documentation for your change, where applicable.
      If your change affects other repositories, such as [Documentation](https://github.com/SteeltoeOSS/Documentation), [Samples](https://github.com/SteeltoeOSS/Samples) and/or [MainSite](https://github.com/SteeltoeOSS/MainSite), add linked PRs here.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
- [ ] You've added required license files and/or file headers (explaining where the code came from with proper attribution), where code is copied from StackOverflow, a blog, or OSS.
