### PR TITLE
Update Sonar from v9.11 to v9.25

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "jetbrains.resharper.globaltools": {
-      "version": "2024.1.0",
+      "version": "2024.1.2",
       "commands": [
         "jb"
       ]

--- a/Steeltoe.Debug.ruleset
+++ b/Steeltoe.Debug.ruleset
@@ -24,6 +24,7 @@
     <Rule Id="S1186" Action="None" />
     <Rule Id="S1244" Action="Warning" />
     <Rule Id="S125" Action="Info" />
+    <Rule Id="S127" Action="None" />
     <Rule Id="S138" Action="Warning" />
     <Rule Id="S1449" Action="Warning" />
     <Rule Id="S1479" Action="Warning" />
@@ -63,6 +64,7 @@
     <Rule Id="S3776" Action="Info" />
     <Rule Id="S3872" Action="Warning" />
     <Rule Id="S3874" Action="Warning" />
+    <Rule Id="S3878" Action="None" />
     <Rule Id="S3889" Action="None" />
     <Rule Id="S3898" Action="Warning" />
     <Rule Id="S3906" Action="Warning" />
@@ -108,6 +110,9 @@
     <Rule Id="S6507" Action="Warning" />
     <Rule Id="S6513" Action="Warning" />
     <Rule Id="S6563" Action="Warning" />
+    <Rule Id="S6797" Action="None" />
+    <Rule Id="S6798" Action="None" />
+    <Rule Id="S6800" Action="None" />
     <Rule Id="S881" Action="Warning" />
   </Rules>
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">

--- a/Steeltoe.Release.ruleset
+++ b/Steeltoe.Release.ruleset
@@ -17,6 +17,7 @@
     <Rule Id="S1151" Action="Warning" />
     <Rule Id="S1186" Action="None" />
     <Rule Id="S1244" Action="Warning" />
+    <Rule Id="S127" Action="None" />
     <Rule Id="S138" Action="Warning" />
     <Rule Id="S1449" Action="Warning" />
     <Rule Id="S1479" Action="Warning" />
@@ -46,6 +47,7 @@
     <Rule Id="S3598" Action="None" />
     <Rule Id="S3872" Action="Warning" />
     <Rule Id="S3874" Action="Warning" />
+    <Rule Id="S3878" Action="None" />
     <Rule Id="S3889" Action="None" />
     <Rule Id="S3898" Action="Warning" />
     <Rule Id="S3900" Action="Warning" />
@@ -90,6 +92,9 @@
     <Rule Id="S6507" Action="Warning" />
     <Rule Id="S6513" Action="Warning" />
     <Rule Id="S6563" Action="Warning" />
+    <Rule Id="S6797" Action="None" />
+    <Rule Id="S6798" Action="None" />
+    <Rule Id="S6800" Action="None" />
     <Rule Id="S881" Action="Warning" />
   </Rules>
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">

--- a/src/Bootstrap/src/AutoConfiguration/AssemblyLoader.cs
+++ b/src/Bootstrap/src/AutoConfiguration/AssemblyLoader.cs
@@ -56,9 +56,6 @@ internal sealed class AssemblyLoader
 
         public static Assembly? LoadAnyVersion(object? sender, ResolveEventArgs args)
         {
-            // Workaround for Sonar bug at https://github.com/SonarSource/sonar-dotnet/issues/8371.
-            _ = sender;
-
             // Load whatever version is available (ignore Version, Culture and PublicKeyToken).
             string assemblySimpleName = new AssemblyName(args.Name).Name!;
 

--- a/src/Common/src/Common.Http/HttpClientHelper.cs
+++ b/src/Common/src/Common.Http/HttpClientHelper.cs
@@ -203,7 +203,7 @@ public static class HttpClientHelper
 
             if (!response.IsSuccessStatusCode)
             {
-                logger?.LogInformation("GetAccessTokenAsync returned status: {statusCode} while obtaining access token from: {uri}", response.StatusCode,
+                logger?.LogInformation("GetAccessTokenAsync returned status: {StatusCode} while obtaining access token from: {Uri}", response.StatusCode,
                     WebUtility.UrlEncode(accessTokenUri.OriginalString));
 
                 return null;
@@ -216,7 +216,7 @@ public static class HttpClientHelper
         }
         catch (Exception exception) when (!exception.IsCancellation())
         {
-            logger?.LogError(exception, "GetAccessTokenAsync exception obtaining access token from: {uri}",
+            logger?.LogError(exception, "GetAccessTokenAsync exception obtaining access token from: {Uri}",
                 WebUtility.UrlEncode(accessTokenUri.OriginalString));
         }
         finally

--- a/src/Common/src/Common.Security/PemConfigureCertificateOptions.cs
+++ b/src/Common/src/Common.Security/PemConfigureCertificateOptions.cs
@@ -37,7 +37,8 @@ public class PemConfigureCertificateOptions : IConfigureNamedOptions<Certificate
             return;
         }
 
-        List<X509Certificate2> certChain = Regex.Matches(pemCert, "-+BEGIN CERTIFICATE-+.+?-+END CERTIFICATE-+", RegexOptions.Singleline)
+        List<X509Certificate2> certChain = Regex
+            .Matches(pemCert, "-+BEGIN CERTIFICATE-+.+?-+END CERTIFICATE-+", RegexOptions.Singleline, TimeSpan.FromSeconds(1))
             .Select(x => new X509Certificate2(Encoding.Default.GetBytes(x.Value))).ToList();
 
         options.Certificate = certChain.FirstOrDefault().CopyWithPrivateKey(ReadRsaKeyFromString(pemKey));

--- a/src/Common/src/Common/Availability/ApplicationAvailability.cs
+++ b/src/Common/src/Common/Availability/ApplicationAvailability.cs
@@ -63,7 +63,7 @@ public class ApplicationAvailability
             throw new InvalidOperationException($"{stateKey} state can only be of type {stateKey}State");
         }
 
-        _logger?.LogTrace("{stateKey} availability has been set to {newState} by {caller}", stateKey, newState, caller ?? "unspecified");
+        _logger?.LogTrace("{StateKey} availability has been set to {NewState} by {Caller}", stateKey, newState, caller ?? "unspecified");
         _availabilityStates[stateKey] = newState;
 
         if (stateKey == LivenessKey)

--- a/src/Common/src/Common/Configuration/ConfigurationKeyConverter.cs
+++ b/src/Common/src/Common/Configuration/ConfigurationKeyConverter.cs
@@ -16,7 +16,7 @@ internal static class ConfigurationKeyConverter
     private const char EscapeChar = '\\';
     private const string EscapeString = "\\";
 
-    private static readonly Regex ArrayRegex = new(@"\[(?<digits>\d+)\]", RegexOptions.Compiled | RegexOptions.Singleline);
+    private static readonly Regex ArrayRegex = new(@"\[(?<digits>\d+)\]", RegexOptions.Compiled | RegexOptions.Singleline, TimeSpan.FromSeconds(1));
 
     public static string AsDotNetConfigurationKey(string key)
     {

--- a/src/Common/src/Common/Configuration/PropertyPlaceHolderHelper.cs
+++ b/src/Common/src/Common/Configuration/PropertyPlaceHolderHelper.cs
@@ -67,7 +67,7 @@ public static class PropertyPlaceholderHelper
         foreach (KeyValuePair<string, string> entry in configuration.AsEnumerable().Where(e =>
             e.Value != null && e.Value.Contains(Prefix, StringComparison.Ordinal) && e.Value.Contains(Suffix, StringComparison.Ordinal)))
         {
-            logger?.LogTrace("Found a property placeholder '{placeholder}' to resolve for key '{key}", entry.Value, entry.Key);
+            logger?.LogTrace("Found a property placeholder '{Placeholder}' to resolve for key '{Key}", entry.Value, entry.Key);
             resolvedValues.Add(entry.Key, ParseStringValue(entry.Value, configuration, visitedPlaceholders, logger, useEmptyStringIfNotFound));
         }
 
@@ -150,7 +150,7 @@ public static class PropertyPlaceholderHelper
                     // previously resolved placeholder value.
                     propVal = ParseStringValue(propVal, configuration, visitedPlaceHolders);
                     result.Replace(startIndex, endIndex + Suffix.Length, propVal);
-                    logger?.LogDebug("Resolved placeholder '{placeholder}'", placeholder);
+                    logger?.LogDebug("Resolved placeholder '{Placeholder}'", placeholder);
                     startIndex = result.IndexOf(Prefix, startIndex + propVal.Length);
                 }
                 else

--- a/src/Common/src/Common/Net/InetUtils.cs
+++ b/src/Common/src/Common/Net/InetUtils.cs
@@ -60,7 +60,7 @@ internal class InetUtils
             {
                 if (networkInterface is { OperationalStatus: OperationalStatus.Up, IsReceiveOnly: false })
                 {
-                    _logger.LogTrace("Testing interface: {name}, {id}", networkInterface.Name, networkInterface.Id);
+                    _logger.LogTrace("Testing interface: {Name}, {Id}", networkInterface.Name, networkInterface.Id);
 
                     IPInterfaceProperties properties = networkInterface.GetIPProperties();
                     IPv4InterfaceProperties iPv4Properties = properties.GetIPv4Properties();
@@ -82,7 +82,7 @@ internal class InetUtils
 
                             if (IsInet4Address(address) && !IsLoopbackAddress(address) && IsPreferredAddress(address, inetOptions))
                             {
-                                _logger.LogTrace("Found non-loopback interface: {name}", networkInterface.Name);
+                                _logger.LogTrace("Found non-loopback interface: {Name}", networkInterface.Name);
                                 result = address;
                             }
                         }
@@ -121,7 +121,7 @@ internal class InetUtils
 
             if (!siteLocalAddress)
             {
-                _logger.LogTrace("Ignoring address: {address} [UseOnlySiteLocalInterfaces=true, this address is not]", address);
+                _logger.LogTrace("Ignoring address: {Address} [UseOnlySiteLocalInterfaces=true, this address is not]", address);
             }
 
             return siteLocalAddress;
@@ -145,7 +145,7 @@ internal class InetUtils
             }
         }
 
-        _logger.LogTrace("Ignoring address: {address}", address);
+        _logger.LogTrace("Ignoring address: {Address}", address);
         return false;
     }
 
@@ -162,7 +162,7 @@ internal class InetUtils
 
             if (matcher.IsMatch(interfaceName))
             {
-                _logger.LogTrace("Ignoring interface: {name}", interfaceName);
+                _logger.LogTrace("Ignoring interface: {Name}", interfaceName);
                 return true;
             }
         }

--- a/src/Common/src/Common/Net/InetUtils.cs
+++ b/src/Common/src/Common/Net/InetUtils.cs
@@ -137,7 +137,7 @@ internal class InetUtils
         foreach (string regex in preferredNetworks)
         {
             string hostAddress = address.ToString();
-            var matcher = new Regex(regex);
+            var matcher = new Regex(regex, RegexOptions.None, TimeSpan.FromSeconds(1));
 
             if (matcher.IsMatch(hostAddress) || hostAddress.StartsWith(regex, StringComparison.Ordinal))
             {
@@ -158,7 +158,7 @@ internal class InetUtils
 
         foreach (string regex in inetOptions.GetIgnoredInterfaces())
         {
-            var matcher = new Regex(regex);
+            var matcher = new Regex(regex, RegexOptions.None, TimeSpan.FromSeconds(1));
 
             if (matcher.IsMatch(interfaceName))
             {

--- a/src/Common/test/Common.TestResources/CancellationTokenSourceExtensions.cs
+++ b/src/Common/test/Common.TestResources/CancellationTokenSourceExtensions.cs
@@ -1,0 +1,18 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+#if NET6_0
+// ReSharper disable once CheckNamespace
+namespace System.Threading;
+
+public static class CancellationTokenSourceExtensions
+{
+    // Workaround for Sonar S6966 bug: CancelAsync is suggested, which isn't available in .NET 6.
+    public static Task CancelAsync(this CancellationTokenSource source)
+    {
+        source.Cancel();
+        return Task.CompletedTask;
+    }
+}
+#endif

--- a/src/Configuration/src/CloudFoundry.ServiceBinding/PostProcessors/CloudFoundryPostProcessor.cs
+++ b/src/Configuration/src/CloudFoundry.ServiceBinding/PostProcessors/CloudFoundryPostProcessor.cs
@@ -9,7 +9,8 @@ namespace Steeltoe.Configuration.CloudFoundry.ServiceBinding.PostProcessors;
 
 internal abstract class CloudFoundryPostProcessor : IConfigurationPostProcessor
 {
-    private static readonly Regex TagsConfigurationKeyRegex = new("^vcap:services:[^:]+:[0-9]+:tags:[0-9]+", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+    private static readonly Regex TagsConfigurationKeyRegex =
+        new("^vcap:services:[^:]+:[0-9]+:tags:[0-9]+", RegexOptions.Compiled | RegexOptions.IgnoreCase, TimeSpan.FromSeconds(1));
 
     public abstract void PostProcessConfiguration(PostProcessorConfigurationProvider provider, IDictionary<string, string?> configurationData);
 

--- a/src/Configuration/src/ConfigServer/ConfigServerConfigurationProvider.cs
+++ b/src/Configuration/src/ConfigServer/ConfigServerConfigurationProvider.cs
@@ -213,7 +213,7 @@ internal sealed class ConfigServerConfigurationProvider : ConfigurationProvider,
 
             do
             {
-                Logger.LogInformation("Fetching configuration from server at: {uri}", Settings.Uri);
+                Logger.LogInformation("Fetching configuration from server at: {Uri}", Settings.Uri);
 
                 try
                 {
@@ -221,7 +221,7 @@ internal sealed class ConfigServerConfigurationProvider : ConfigurationProvider,
                 }
                 catch (ConfigServerException exception)
                 {
-                    Logger.LogInformation(exception, "Failed fetching configuration from server at: {uri}.", Settings.Uri);
+                    Logger.LogInformation(exception, "Failed fetching configuration from server at: {Uri}.", Settings.Uri);
                     attempts++;
 
                     if (attempts < Settings.RetryAttempts)
@@ -239,7 +239,7 @@ internal sealed class ConfigServerConfigurationProvider : ConfigurationProvider,
             while (true);
         }
 
-        Logger.LogInformation("Fetching configuration from server at: {uri}", Settings.Uri);
+        Logger.LogInformation("Fetching configuration from server at: {Uri}", Settings.Uri);
         return await DoLoadAsync(updateDictionary, cancellationToken);
     }
 
@@ -265,7 +265,7 @@ internal sealed class ConfigServerConfigurationProvider : ConfigurationProvider,
                 // Update configuration Data dictionary with any results
                 if (env != null)
                 {
-                    Logger.LogInformation("Located environment name: {name}, profiles: {profiles}, labels: {label}, version: {version}, state: {state}",
+                    Logger.LogInformation("Located environment name: {Name}, profiles: {Profiles}, labels: {Label}, version: {Version}, state: {State}",
                         env.Name, env.Profiles, env.Label, env.Version, env.State);
 
                     if (updateDictionary)
@@ -525,7 +525,7 @@ internal sealed class ConfigServerConfigurationProvider : ConfigurationProvider,
             {
                 using HttpResponseMessage response = await HttpClient.SendAsync(request, cancellationToken);
 
-                Logger.LogInformation("Config Server returned status: {statusCode} invoking path: {requestUri}", response.StatusCode,
+                Logger.LogInformation("Config Server returned status: {StatusCode} invoking path: {RequestUri}", response.StatusCode,
                     WebUtility.UrlEncode(requestUri));
 
                 if (response.StatusCode != HttpStatusCode.OK)
@@ -634,7 +634,7 @@ internal sealed class ConfigServerConfigurationProvider : ConfigurationProvider,
             }
             catch (Exception exception)
             {
-                Logger.LogError(exception, "Config Server exception, property: {key}={type}", pair.Key, pair.Value.GetType());
+                Logger.LogError(exception, "Config Server exception, property: {Key}={Type}", pair.Key, pair.Value.GetType());
             }
         }
     }
@@ -701,18 +701,18 @@ internal sealed class ConfigServerConfigurationProvider : ConfigurationProvider,
             Uri uri = GetVaultRenewUri();
             HttpRequestMessage message = await GetVaultRenewMessageAsync(uri, cancellationToken);
 
-            Logger.LogInformation("Renewing Vault token {token} for {ttl} milliseconds at Uri {uri}", obscuredToken, Settings.TokenTtl, uri);
+            Logger.LogInformation("Renewing Vault token {Token} for {Ttl} milliseconds at Uri {Uri}", obscuredToken, Settings.TokenTtl, uri);
 
             using HttpResponseMessage response = await HttpClient.SendAsync(message, cancellationToken);
 
             if (response.StatusCode != HttpStatusCode.OK)
             {
-                Logger.LogWarning("Renewing Vault token {token} returned status: {status}", obscuredToken, response.StatusCode);
+                Logger.LogWarning("Renewing Vault token {Token} returned status: {Status}", obscuredToken, response.StatusCode);
             }
         }
         catch (Exception exception) when (!exception.IsCancellation())
         {
-            Logger.LogError(exception, "Unable to renew Vault token {token}. Is the token invalid or expired?", obscuredToken);
+            Logger.LogError(exception, "Unable to renew Vault token {Token}. Is the token invalid or expired?", obscuredToken);
         }
     }
 

--- a/src/Configuration/src/ConfigServer/ConfigServerConfigurationProvider.cs
+++ b/src/Configuration/src/ConfigServer/ConfigServerConfigurationProvider.cs
@@ -552,8 +552,6 @@ internal sealed class ConfigServerConfigurationProvider : ConfigurationProvider,
             {
                 error = exception;
 
-                Logger.LogError(exception, "Config Server exception, path: {requestUri}", WebUtility.UrlEncode(requestUri));
-
                 if (IsSocketError(exception))
                 {
                     continue;

--- a/src/Configuration/src/ConfigServer/ConfigServerDiscoveryService.cs
+++ b/src/Configuration/src/ConfigServer/ConfigServerDiscoveryService.cs
@@ -111,7 +111,7 @@ internal sealed class ConfigServerDiscoveryService
 
         do
         {
-            _logger.LogDebug("Locating ConfigServer {serviceId} via discovery", _settings.DiscoveryServiceId);
+            _logger.LogDebug("Locating ConfigServer {ServiceId} via discovery", _settings.DiscoveryServiceId);
 
             if (_settings.DiscoveryServiceId != null)
             {

--- a/src/Configuration/src/ConfigServer/ConfigServerHealthContributor.cs
+++ b/src/Configuration/src/ConfigServer/ConfigServerHealthContributor.cs
@@ -72,7 +72,7 @@ internal sealed class ConfigServerHealthContributor : IHealthContributor
 
         foreach (PropertySource source in sources)
         {
-            _logger.LogDebug("Returning property source: {propertySource}", source.Name);
+            _logger.LogDebug("Returning property source: {PropertySource}", source.Name);
             names.Add(source.Name);
         }
 

--- a/src/Configuration/src/Encryption/EncryptionResolverProvider.cs
+++ b/src/Configuration/src/Encryption/EncryptionResolverProvider.cs
@@ -20,7 +20,7 @@ namespace Steeltoe.Configuration.Encryption;
 internal sealed class EncryptionResolverProvider : IConfigurationProvider, IDisposable
 {
     // regex for matching {cipher}{key:keyAlias} at the start of the string
-    private readonly Regex _cipherRegex = new("^{cipher}({key:(?<alias>.*)})?(?<cipher>.*)");
+    private readonly Regex _cipherRegex = new("^{cipher}({key:(?<alias>.*)})?(?<cipher>.*)", RegexOptions.None, TimeSpan.FromSeconds(1));
     private bool _isDisposed;
 
     /// <summary>

--- a/src/Configuration/src/RandomValue/RandomValueProvider.cs
+++ b/src/Configuration/src/RandomValue/RandomValueProvider.cs
@@ -61,7 +61,7 @@ internal sealed class RandomValueProvider : ConfigurationProvider
         }
 
         value = GetRandomValue(key[_prefix.Length..]);
-        _logger.LogDebug("Generated random value {value} for '{key}'", value, key);
+        _logger.LogDebug("Generated random value {Value} for '{Key}'", value, key);
         return true;
     }
 

--- a/src/Configuration/test/ConfigServer.Integration.Test/ConfigServerConfigurationExtensionsIntegrationTest.cs
+++ b/src/Configuration/test/ConfigServer.Integration.Test/ConfigServerConfigurationExtensionsIntegrationTest.cs
@@ -268,7 +268,7 @@ public sealed class ConfigServerConfigurationExtensionsIntegrationTest
         Assert.Equal("spambarcelonaSpring Cloud Sampleshttps://github.com/spring-cloud-samples", result);
     }
 
-    [Fact(Skip = "Config Server image needs to be enhanced to support discovery-first")]
+    [Fact(Skip = "Integration test - Requires local Eureka server and local Config Server with discovery-first enabled")]
     [Trait("Category", "Integration")]
     public void SpringCloudConfigServer_DiscoveryFirst_ReturnsExpectedDefaultData()
     {

--- a/src/Configuration/test/ConfigServer.Integration.Test/Steeltoe.Configuration.ConfigServer.Integration.Test.csproj
+++ b/src/Configuration/test/ConfigServer.Integration.Test/Steeltoe.Configuration.ConfigServer.Integration.Test.csproj
@@ -16,6 +16,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\Common\src\Common.Utils\Steeltoe.Common.Utils.csproj" />
+    <ProjectReference Include="..\..\..\Discovery\src\Eureka\Steeltoe.Discovery.Eureka.csproj" />
     <ProjectReference Include="..\..\src\ConfigServer\Steeltoe.Configuration.ConfigServer.csproj" />
     <ProjectReference Include="..\..\src\Encryption\Steeltoe.Configuration.Encryption.csproj" />
   </ItemGroup>

--- a/src/Connectors/test/Connectors.Test/CosmosDb/CosmosDbHealthContributorTest.cs
+++ b/src/Connectors/test/Connectors.Test/CosmosDb/CosmosDbHealthContributorTest.cs
@@ -101,7 +101,7 @@ public sealed class CosmosDbHealthContributorTest
         using var healthContributor = new CosmosDbHealthContributor(cosmosClientMock.Object, "localhost", NullLogger<CosmosDbHealthContributor>.Instance);
 
         using var source = new CancellationTokenSource();
-        source.Cancel();
+        await source.CancelAsync();
 
         Func<Task> action = async () => await healthContributor.CheckHealthAsync(source.Token);
 

--- a/src/Connectors/test/Connectors.Test/MongoDb/MongoDbHealthContributorTest.cs
+++ b/src/Connectors/test/Connectors.Test/MongoDb/MongoDbHealthContributorTest.cs
@@ -75,7 +75,7 @@ public sealed class MongoDbHealthContributorTest
         var healthContributor = new MongoDbHealthContributor(mongoClientMock.Object, "localhost", NullLogger<MongoDbHealthContributor>.Instance);
 
         using var source = new CancellationTokenSource();
-        source.Cancel();
+        await source.CancelAsync();
 
         Func<Task> action = async () => await healthContributor.CheckHealthAsync(source.Token);
 

--- a/src/Connectors/test/Connectors.Test/RabbitMQ/RabbitMQHealthContributorTest.cs
+++ b/src/Connectors/test/Connectors.Test/RabbitMQ/RabbitMQHealthContributorTest.cs
@@ -113,7 +113,7 @@ public sealed class RabbitMQHealthContributorTest
         using var healthContributor = new RabbitMQHealthContributor(connectionFactoryMock.Object, "localhost", NullLogger<RabbitMQHealthContributor>.Instance);
 
         using var source = new CancellationTokenSource();
-        source.Cancel();
+        await source.CancelAsync();
 
         Func<Task> action = async () => await healthContributor.CheckHealthAsync(source.Token);
 

--- a/src/Connectors/test/Connectors.Test/Redis/RedisHealthContributorTest.cs
+++ b/src/Connectors/test/Connectors.Test/Redis/RedisHealthContributorTest.cs
@@ -76,7 +76,7 @@ public sealed class RedisHealthContributorTest
         using var healthContributor = new RedisHealthContributor("localhost", NullLogger<RedisHealthContributor>.Instance);
 
         using var source = new CancellationTokenSource();
-        source.Cancel();
+        await source.CancelAsync();
 
         Func<Task> action = async () => await healthContributor.CheckHealthAsync(source.Token);
 

--- a/src/Connectors/test/Connectors.Test/RelationalDatabaseHealthContributorTest.cs
+++ b/src/Connectors/test/Connectors.Test/RelationalDatabaseHealthContributorTest.cs
@@ -182,7 +182,7 @@ public sealed class RelationalDatabaseHealthContributorTest
             new RelationalDatabaseHealthContributor(connectionMock.Object, "localhost", NullLogger<RelationalDatabaseHealthContributor>.Instance);
 
         using var source = new CancellationTokenSource();
-        source.Cancel();
+        await source.CancelAsync();
 
         Func<Task> action = async () => await healthContributor.CheckHealthAsync(source.Token);
 

--- a/src/Discovery/src/Consul/PeriodicHeartbeat.cs
+++ b/src/Discovery/src/Consul/PeriodicHeartbeat.cs
@@ -52,9 +52,9 @@ internal sealed class PeriodicHeartbeat : IAsyncDisposable
                 }
             }
         }
-        catch (OperationCanceledException)
+        catch (OperationCanceledException exception)
         {
-            _logger.LogDebug("Stop sending periodic Consul heartbeats for '{ServiceId}'.", _serviceId);
+            _logger.LogDebug(exception, "Stop sending periodic Consul heartbeats for '{ServiceId}'.", _serviceId);
         }
     }
 

--- a/src/Discovery/src/Consul/Registry/ConsulServiceRegistry.cs
+++ b/src/Discovery/src/Consul/Registry/ConsulServiceRegistry.cs
@@ -110,7 +110,7 @@ public sealed class ConsulServiceRegistry : IAsyncDisposable
                 await _scheduler.RemoveAsync(registration.InstanceId);
             }
 
-            _logger.LogInformation("Deregistering service {instanceId} with Consul.", registration.InstanceId);
+            _logger.LogInformation("Deregistering service {InstanceId} with Consul.", registration.InstanceId);
             await _client.Agent.ServiceDeregister(registration.InstanceId, cancellationToken);
         }
         catch (Exception exception)when (!exception.IsCancellation())

--- a/src/Discovery/src/Consul/TtlScheduler.cs
+++ b/src/Discovery/src/Consul/TtlScheduler.cs
@@ -65,7 +65,7 @@ public sealed class TtlScheduler : IAsyncDisposable
 
         if (heartbeatOptions != null)
         {
-            _schedulerLogger.LogDebug("Adding instance '{instanceId}'.", instanceId);
+            _schedulerLogger.LogDebug("Adding instance '{InstanceId}'.", instanceId);
 
             TimeSpan interval = heartbeatOptions.ComputeHeartbeatInterval();
             string checkId = instanceId;
@@ -92,7 +92,7 @@ public sealed class TtlScheduler : IAsyncDisposable
 
         if (ServiceHeartbeats.TryRemove(instanceId, out PeriodicHeartbeat? heartbeat))
         {
-            _schedulerLogger.LogDebug("Removing instance '{instanceId}'.", instanceId);
+            _schedulerLogger.LogDebug("Removing instance '{InstanceId}'.", instanceId);
             await heartbeat.DisposeAsync();
         }
     }

--- a/src/Discovery/src/Eureka/Configuration/EurekaInstanceOptions.cs
+++ b/src/Discovery/src/Eureka/Configuration/EurekaInstanceOptions.cs
@@ -9,7 +9,7 @@ using Microsoft.Extensions.Logging;
 using Steeltoe.Common;
 using Steeltoe.Discovery.Eureka.AppInfo;
 
-// Workaround for Sonar bug, which has been fixed in SonarAnalyzer.CSharp v9.12.
+// Workaround for Sonar bug, which incorrectly flags boolean expression as redundant.
 #pragma warning disable S2589 // Boolean expressions should not be gratuitous
 
 namespace Steeltoe.Discovery.Eureka.Configuration;

--- a/src/Discovery/src/Eureka/EurekaDiscoveryClient.cs
+++ b/src/Discovery/src/Eureka/EurekaDiscoveryClient.cs
@@ -215,7 +215,7 @@ public sealed class EurekaDiscoveryClient : IDiscoveryClient
         {
             if (!exception.IsCancellation())
             {
-                _logger.LogError(exception, $"Failed to handle {nameof(EurekaApplicationInfoManager.InstanceChanged)} event.");
+                _logger.LogError(exception, "Failed to handle {EventName} event.", nameof(EurekaApplicationInfoManager.InstanceChanged));
             }
         }
     }
@@ -353,7 +353,7 @@ public sealed class EurekaDiscoveryClient : IDiscoveryClient
                 }
                 catch (Exception exception)
                 {
-                    _logger.LogError(exception, $"Failed to handle {nameof(ApplicationsFetched)} event.");
+                    _logger.LogError(exception, "Failed to handle {EventName} event.", nameof(ApplicationsFetched));
                 }
             });
         }

--- a/src/Discovery/src/HttpClients/LoadBalancers/RandomLoadBalancer.cs
+++ b/src/Discovery/src/HttpClients/LoadBalancers/RandomLoadBalancer.cs
@@ -41,13 +41,13 @@ public sealed class RandomLoadBalancer : ILoadBalancer
         ArgumentGuard.NotNull(requestUri);
 
         string serviceName = requestUri.Host;
-        _logger.LogTrace("Resolving service instance for '{serviceName}'.", serviceName);
+        _logger.LogTrace("Resolving service instance for '{ServiceName}'.", serviceName);
 
         IList<IServiceInstance> availableServiceInstances = await _serviceInstancesResolver.ResolveInstancesAsync(serviceName, cancellationToken);
 
         if (availableServiceInstances.Count == 0)
         {
-            _logger.LogWarning("No service instances are available for '{serviceName}'.", serviceName);
+            _logger.LogWarning("No service instances are available for '{ServiceName}'.", serviceName);
             return requestUri;
         }
 
@@ -55,7 +55,7 @@ public sealed class RandomLoadBalancer : ILoadBalancer
         int index = Random.Shared.Next(availableServiceInstances.Count);
         IServiceInstance serviceInstance = availableServiceInstances[index];
 
-        _logger.LogDebug("Resolved '{serviceName}' to '{serviceInstance}'.", serviceName, serviceInstance.Uri);
+        _logger.LogDebug("Resolved '{ServiceName}' to '{ServiceInstance}'.", serviceName, serviceInstance.Uri);
         return new Uri(serviceInstance.Uri, requestUri.PathAndQuery);
     }
 

--- a/src/Discovery/src/HttpClients/LoadBalancers/RoundRobinLoadBalancer.cs
+++ b/src/Discovery/src/HttpClients/LoadBalancers/RoundRobinLoadBalancer.cs
@@ -70,20 +70,20 @@ public sealed class RoundRobinLoadBalancer : ILoadBalancer
         ArgumentGuard.NotNull(requestUri);
 
         string serviceName = requestUri.Host;
-        _logger.LogTrace("Resolving service instance for '{serviceName}'.", serviceName);
+        _logger.LogTrace("Resolving service instance for '{ServiceName}'.", serviceName);
 
         IList<IServiceInstance> availableServiceInstances = await _serviceInstancesResolver.ResolveInstancesAsync(serviceName, cancellationToken);
 
         if (availableServiceInstances.Count == 0)
         {
-            _logger.LogWarning("No service instances are available for '{serviceName}'.", serviceName);
+            _logger.LogWarning("No service instances are available for '{ServiceName}'.", serviceName);
             return requestUri;
         }
 
         int instanceIndex = await GetNextInstanceIndexAsync(serviceName, availableServiceInstances.Count, cancellationToken);
         IServiceInstance serviceInstance = availableServiceInstances[instanceIndex];
 
-        _logger.LogDebug("Resolved '{serviceName}' to '{serviceInstance}'.", serviceName, serviceInstance.Uri);
+        _logger.LogDebug("Resolved '{ServiceName}' to '{ServiceInstance}'.", serviceName, serviceInstance.Uri);
         return new Uri(serviceInstance.Uri, requestUri.PathAndQuery);
     }
 

--- a/src/Management/src/Abstractions/Diagnostics/DiagnosticObserver.cs
+++ b/src/Management/src/Abstractions/Diagnostics/DiagnosticObserver.cs
@@ -41,7 +41,7 @@ public abstract class DiagnosticObserver : IDiagnosticObserver
             _subscription?.Dispose();
             _subscription = null;
 
-            _logger.LogInformation("DiagnosticObserver {observer} Disposed", ObserverName);
+            _logger.LogInformation("DiagnosticObserver {Observer} Disposed", ObserverName);
         }
     }
 
@@ -57,7 +57,7 @@ public abstract class DiagnosticObserver : IDiagnosticObserver
             }
 
             _subscription = listener.Subscribe(this);
-            _logger.LogInformation("DiagnosticObserver {observer} Subscribed to {listener}", ObserverName, listener.Name);
+            _logger.LogInformation("DiagnosticObserver {Observer} Subscribed to {Listener}", ObserverName, listener.Name);
         }
     }
 

--- a/src/Management/src/Abstractions/Diagnostics/DiagnosticsManager.cs
+++ b/src/Management/src/Abstractions/Diagnostics/DiagnosticsManager.cs
@@ -89,7 +89,7 @@ internal sealed class DiagnosticsManager : IObserver<DiagnosticListener>, IDispo
                 source.AddInstrumentation();
             }
 
-            _logger.LogTrace("Subscribed to EventListeners: {eventListeners}", string.Join(",", _eventListeners.Select(listener => listener.GetType().Name)));
+            _logger.LogTrace("Subscribed to EventListeners: {EventListeners}", string.Join(",", _eventListeners.Select(listener => listener.GetType().Name)));
         }
     }
 

--- a/src/Management/src/Endpoint/ActuatorEndpointMapper.cs
+++ b/src/Management/src/Endpoint/ActuatorEndpointMapper.cs
@@ -90,7 +90,7 @@ internal sealed class ActuatorEndpointMapper
             }
             else
             {
-                _logger.LogError("Skipping over duplicate path at {path}", requestPath);
+                _logger.LogError("Skipping over duplicate path at {Path}", requestPath);
             }
         }
     }

--- a/src/Management/src/Endpoint/CloudFoundry/CloudFoundryEndpointMiddleware.cs
+++ b/src/Management/src/Endpoint/CloudFoundry/CloudFoundryEndpointMiddleware.cs
@@ -32,7 +32,7 @@ internal sealed class CloudFoundryEndpointMiddleware : EndpointMiddleware<string
     {
         ArgumentGuard.NotNull(context);
 
-        _logger.LogDebug("InvokeAsync({method}, {path})", context.Request.Method, context.Request.Path.Value);
+        _logger.LogDebug("InvokeAsync({Method}, {Path})", context.Request.Method, context.Request.Path.Value);
         string uri = GetRequestUri(context);
         return await EndpointHandler.InvokeAsync(uri, cancellationToken);
     }

--- a/src/Management/src/Endpoint/CloudFoundry/CloudFoundrySecurityMiddleware.cs
+++ b/src/Management/src/Endpoint/CloudFoundry/CloudFoundrySecurityMiddleware.cs
@@ -46,7 +46,7 @@ public sealed class CloudFoundrySecurityMiddleware
     {
         ArgumentGuard.NotNull(context);
 
-        _logger.LogDebug("InvokeAsync({requestPath})", context.Request.Path.Value);
+        _logger.LogDebug("InvokeAsync({RequestPath})", context.Request.Path.Value);
         CloudFoundryEndpointOptions endpointOptions = _endpointOptionsMonitor.CurrentValue;
 
         if (Platform.IsCloudFoundry && endpointOptions.IsEnabled(_managementOptionsMonitor.CurrentValue) &&
@@ -166,13 +166,13 @@ public sealed class CloudFoundrySecurityMiddleware
 
     private void LogError(HttpContext context, SecurityResult error)
     {
-        _logger.LogError("Actuator Security Error: {code} - {message}", error.Code, error.Message);
+        _logger.LogError("Actuator Security Error: {Code} - {Message}", error.Code, error.Message);
 
         if (_logger.IsEnabled(LogLevel.Trace))
         {
             foreach (KeyValuePair<string, StringValues> header in context.Request.Headers)
             {
-                _logger.LogTrace("Header: {key} - {value}", header.Key, header.Value);
+                _logger.LogTrace("Header: {Key} - {Value}", header.Key, header.Value);
             }
         }
     }

--- a/src/Management/src/Endpoint/CloudFoundry/SecurityUtils.cs
+++ b/src/Management/src/Endpoint/CloudFoundry/SecurityUtils.cs
@@ -4,6 +4,7 @@
 
 using System.Net;
 using System.Net.Http.Headers;
+using System.Security;
 using System.Text.Json;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
@@ -109,8 +110,7 @@ internal sealed class SecurityUtils
         }
         catch (Exception exception) when (!exception.IsCancellation())
         {
-            _logger.LogError(exception, "Exception extracting permissions from {json}", SecurityUtilities.SanitizeInput(json));
-            throw;
+            throw new SecurityException($"Exception extracting permissions from json: {SecurityUtilities.SanitizeInput(json)}", exception);
         }
 
         _logger.LogDebug("GetPermissionsAsync returning: {permissions}", permissions);

--- a/src/Management/src/Endpoint/CloudFoundry/SecurityUtils.cs
+++ b/src/Management/src/Endpoint/CloudFoundry/SecurityUtils.cs
@@ -62,7 +62,7 @@ internal sealed class SecurityUtils
 
         try
         {
-            _logger.LogDebug("GetPermissionsAsync({uri}, {accessToken})", checkPermissionsUri, SecurityUtilities.SanitizeInput(accessToken));
+            _logger.LogDebug("GetPermissionsAsync({Uri}, {AccessToken})", checkPermissionsUri, SecurityUtilities.SanitizeInput(accessToken));
             _httpClient ??= HttpClientHelper.GetHttpClient(_options.ValidateCertificates, DefaultGetPermissionsTimeout);
             using HttpResponseMessage response = await _httpClient.SendAsync(request, cancellationToken);
 
@@ -98,7 +98,7 @@ internal sealed class SecurityUtils
         {
             json = await response.Content.ReadAsStringAsync(cancellationToken);
 
-            _logger.LogDebug("GetPermissionsAsync returned json: {json}", SecurityUtilities.SanitizeInput(json));
+            _logger.LogDebug("GetPermissionsAsync returned json: {Json}", SecurityUtilities.SanitizeInput(json));
 
             var result = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(json);
 
@@ -113,7 +113,7 @@ internal sealed class SecurityUtils
             throw new SecurityException($"Exception extracting permissions from json: {SecurityUtilities.SanitizeInput(json)}", exception);
         }
 
-        _logger.LogDebug("GetPermissionsAsync returning: {permissions}", permissions);
+        _logger.LogDebug("GetPermissionsAsync returning: {Permissions}", permissions);
         return permissions;
     }
 }

--- a/src/Management/src/Endpoint/ContentNegotiation/ContentNegotiationExtensions.cs
+++ b/src/Management/src/Endpoint/ContentNegotiation/ContentNegotiationExtensions.cs
@@ -35,14 +35,14 @@ internal static class ContentNegotiationExtensions
 
     private static void LogContentType(ILogger logger, IHeaderDictionary requestHeaders, string contentType)
     {
-        logger.LogTrace("setting contentType to {type}", contentType);
+        logger.LogTrace("setting contentType to {Type}", contentType);
         bool? logTrace = logger.IsEnabled(LogLevel.Trace);
 
         if (logTrace.GetValueOrDefault())
         {
             foreach (KeyValuePair<string, StringValues> header in requestHeaders)
             {
-                logger.LogTrace("Header: {key} - {value}", header.Key, header.Value);
+                logger.LogTrace("Header: {Key} - {Value}", header.Key, header.Value);
             }
         }
     }

--- a/src/Management/src/Endpoint/DbMigrations/DbMigrationsEndpointHandler.cs
+++ b/src/Management/src/Endpoint/DbMigrations/DbMigrationsEndpointHandler.cs
@@ -83,7 +83,7 @@ internal sealed class DbMigrationsEndpointHandler : IDbMigrationsEndpointHandler
                 }
                 catch (DbException exception) when (exception.Message.Contains("exist", StringComparison.Ordinal))
                 {
-                    _logger.LogWarning(exception, "Encountered exception loading migrations: {exception}", exception.Message);
+                    _logger.LogWarning(exception, "Encountered exception loading migrations: {Exception}", exception.Message);
                     AddRange(descriptor.PendingMigrations, _scanner.GetMigrations(dbContext));
                 }
             }

--- a/src/Management/src/Endpoint/Environment/Sanitizer.cs
+++ b/src/Management/src/Endpoint/Environment/Sanitizer.cs
@@ -26,7 +26,7 @@ internal sealed class Sanitizer
         foreach (string key in keysToSanitize)
         {
             string regexPattern = IsRegex(key) ? key : $".*{key}$";
-            _matchers.Add(new Regex(regexPattern, RegexOptions.IgnoreCase));
+            _matchers.Add(new Regex(regexPattern, RegexOptions.IgnoreCase, TimeSpan.FromSeconds(1)));
         }
     }
 

--- a/src/Management/src/Endpoint/HeapDump/HeapDumpEndpointMiddleware.cs
+++ b/src/Management/src/Endpoint/HeapDump/HeapDumpEndpointMiddleware.cs
@@ -29,7 +29,7 @@ internal sealed class HeapDumpEndpointMiddleware : EndpointMiddleware<object?, s
 
     protected override async Task WriteResponseAsync(string? fileName, HttpContext context, CancellationToken cancellationToken)
     {
-        _logger.LogDebug("Returning: {fileName}", fileName);
+        _logger.LogDebug("Returning: {FileName}", fileName);
 
         if (!File.Exists(fileName))
         {

--- a/src/Management/src/Endpoint/HeapDump/HeapDumper.cs
+++ b/src/Management/src/Endpoint/HeapDump/HeapDumper.cs
@@ -64,7 +64,7 @@ public sealed class HeapDumper
                 dumpType = DumpType.Full;
             }
 
-            _logger.LogInformation($"Attempting to create a '{dumpType}' dump");
+            _logger.LogInformation("Attempting to create a '{DumpType}' dump", dumpType);
             var client = new DiagnosticsClient(process.Id);
             client.WriteDump(dumpType, fileName);
             return fileName;

--- a/src/Management/src/Endpoint/Loggers/LoggersEndpointHandler.cs
+++ b/src/Management/src/Endpoint/Loggers/LoggersEndpointHandler.cs
@@ -44,7 +44,7 @@ internal sealed class LoggersEndpointHandler : ILoggersEndpointHandler
     {
         ArgumentGuard.NotNull(request);
 
-        _logger.LogDebug("Invoke({request})", SecurityUtilities.SanitizeInput(request.ToString()));
+        _logger.LogDebug("Invoke({Request})", SecurityUtilities.SanitizeInput(request.ToString()));
 
         IDictionary<string, object> result;
 
@@ -74,7 +74,7 @@ internal sealed class LoggersEndpointHandler : ILoggersEndpointHandler
 
         foreach (DynamicLoggerConfiguration configuration in configurations.OrderBy(entry => entry.CategoryName))
         {
-            _logger.LogTrace("Adding {configuration}", configuration);
+            _logger.LogTrace("Adding {Configuration}", configuration);
             var levels = new LoggerLevels(configuration.ConfigurationMinLevel, configuration.EffectiveMinLevel);
             loggers.Add(configuration.CategoryName, levels);
         }

--- a/src/Management/src/Endpoint/Loggers/LoggersEndpointMiddleware.cs
+++ b/src/Management/src/Endpoint/Loggers/LoggersEndpointMiddleware.cs
@@ -41,7 +41,7 @@ internal sealed class LoggersEndpointMiddleware : EndpointMiddleware<LoggersRequ
         if (context.Request.Method == "POST")
         {
             // POST - change a logger level
-            _logger.LogDebug("Incoming path: {path}", request.Path.Value);
+            _logger.LogDebug("Incoming path: {Path}", request.Path.Value);
             string? baseRequestPath = ManagementOptionsMonitor.CurrentValue.GetBaseRequestPath(context.Request);
 
             string? path = EndpointHandler.Options.Path;
@@ -60,13 +60,13 @@ internal sealed class LoggersEndpointMiddleware : EndpointMiddleware<LoggersRequ
 
                 change.TryGetValue("configuredLevel", out string? level);
 
-                _logger.LogDebug("Change Request: {name}, {level}", loggerName, level ?? "RESET");
+                _logger.LogDebug("Change Request: {Name}, {Level}", loggerName, level ?? "RESET");
 
                 if (!string.IsNullOrEmpty(loggerName))
                 {
                     if (!string.IsNullOrEmpty(level) && LoggerLevels.StringToLogLevel(level) == null)
                     {
-                        _logger.LogDebug("Invalid LogLevel specified: {level}", level);
+                        _logger.LogDebug("Invalid LogLevel specified: {Level}", level);
                         return null;
                     }
 

--- a/src/Management/src/Endpoint/ManagementPort/ManagementPortMiddleware.cs
+++ b/src/Management/src/Endpoint/ManagementPort/ManagementPortMiddleware.cs
@@ -32,7 +32,7 @@ internal sealed class ManagementPortMiddleware
         ArgumentGuard.NotNull(context);
 
         ManagementOptions managementOptions = _managementOptionsMonitor.CurrentValue;
-        _logger.LogDebug("InvokeAsync({requestPath}), optionsPath: {optionsPath}", context.Request.Path.Value, managementOptions.Path);
+        _logger.LogDebug("InvokeAsync({RequestPath}), optionsPath: {OptionsPath}", context.Request.Path.Value, managementOptions.Path);
 
         bool isManagementPath = context.Request.Path.StartsWithSegments(managementOptions.Path);
 
@@ -62,7 +62,7 @@ internal sealed class ManagementPortMiddleware
             defaultPort = context.Request.Scheme == "http" ? 80 : 443;
         }
 
-        _logger.LogError("ManagementMiddleWare Error: Access denied on {port} since Management Port is set to {managementPort}",
+        _logger.LogError("ManagementMiddleWare Error: Access denied on {Port} since Management Port is set to {ManagementPort}",
             defaultPort ?? context.Request.Host.Port, managementPort);
 
         context.Response.StatusCode = StatusCodes.Status404NotFound;

--- a/src/Management/src/Endpoint/Metrics/MetricsEndpointHandler.cs
+++ b/src/Management/src/Endpoint/Metrics/MetricsEndpointHandler.cs
@@ -42,7 +42,7 @@ internal sealed class MetricsEndpointHandler : IMetricsEndpointHandler
         {
             if (metricNames.Contains(request.MetricName))
             {
-                _logger.LogTrace("Fetching metrics for " + request.MetricName);
+                _logger.LogTrace("Fetching metrics for {Name}", request.MetricName);
                 IList<MetricSample> sampleList = GetMetricSamplesByTags(measurements, request.MetricName, request.Tags);
 
                 response = GetMetric(request, sampleList, availableTags.GetOrAdd(request.MetricName, new List<MetricTag>()));

--- a/src/Management/src/Endpoint/Metrics/MetricsEndpointMiddleware.cs
+++ b/src/Management/src/Endpoint/Metrics/MetricsEndpointMiddleware.cs
@@ -32,7 +32,7 @@ internal sealed class MetricsEndpointMiddleware : EndpointMiddleware<MetricsRequ
     private MetricsRequest? GetMetricsRequest(HttpContext context)
     {
         HttpRequest request = context.Request;
-        _logger.LogDebug("Handling metrics for path: {path}", request.Path.Value);
+        _logger.LogDebug("Handling metrics for path: {Path}", request.Path.Value);
 
         string metricName = GetMetricName(request);
 

--- a/src/Management/src/Endpoint/Metrics/Observer/AspNetCoreHostingObserver.cs
+++ b/src/Management/src/Endpoint/Metrics/Observer/AspNetCoreHostingObserver.cs
@@ -38,7 +38,7 @@ internal sealed class AspNetCoreHostingObserver : MetricsObserver
 
         if (ingressIgnorePattern != null)
         {
-            SetPathMatcher(new Regex(ingressIgnorePattern));
+            SetPathMatcher(new Regex(ingressIgnorePattern, RegexOptions.None, TimeSpan.FromSeconds(1)));
         }
 
         Meter meter = SteeltoeMetrics.Meter;

--- a/src/Management/src/Endpoint/Metrics/Observer/AspNetCoreHostingObserver.cs
+++ b/src/Management/src/Endpoint/Metrics/Observer/AspNetCoreHostingObserver.cs
@@ -64,7 +64,7 @@ internal sealed class AspNetCoreHostingObserver : MetricsObserver
 
         if (eventName == StopEventName)
         {
-            _logger.LogTrace("HandleStopEvent start {thread}", Thread.CurrentThread.ManagedThreadId);
+            _logger.LogTrace("HandleStopEvent start {Thread}", Thread.CurrentThread.ManagedThreadId);
 
             var context = GetPropertyOrDefault<HttpContext>(value, "HttpContext");
 
@@ -73,7 +73,7 @@ internal sealed class AspNetCoreHostingObserver : MetricsObserver
                 HandleStopEvent(current, context);
             }
 
-            _logger.LogTrace("HandleStopEvent finish {thread}", Thread.CurrentThread.ManagedThreadId);
+            _logger.LogTrace("HandleStopEvent finish {Thread}", Thread.CurrentThread.ManagedThreadId);
         }
     }
 
@@ -84,7 +84,7 @@ internal sealed class AspNetCoreHostingObserver : MetricsObserver
 
         if (ShouldIgnoreRequest(context.Request.Path))
         {
-            _logger.LogDebug("HandleStopEvent: Ignoring path: {path}", context.Request.Path);
+            _logger.LogDebug("HandleStopEvent: Ignoring path: {Path}", context.Request.Path);
             return;
         }
 

--- a/src/Management/src/Endpoint/Metrics/Observer/HttpClientCoreObserver.cs
+++ b/src/Management/src/Endpoint/Metrics/Observer/HttpClientCoreObserver.cs
@@ -68,21 +68,21 @@ internal sealed class HttpClientCoreObserver : MetricsObserver
 
         if (eventName == StopEventName)
         {
-            _logger.LogTrace("HandleStopEvent start {thread}", Thread.CurrentThread.ManagedThreadId);
+            _logger.LogTrace("HandleStopEvent start {Thread}", Thread.CurrentThread.ManagedThreadId);
 
             var response = GetPropertyOrDefault<HttpResponseMessage>(value, "Response");
             var requestStatus = GetPropertyOrDefault<TaskStatus>(value, "RequestTaskStatus");
             HandleStopEvent(current, request, response, requestStatus);
 
-            _logger.LogTrace("HandleStopEvent finished {thread}", Thread.CurrentThread.ManagedThreadId);
+            _logger.LogTrace("HandleStopEvent finished {Thread}", Thread.CurrentThread.ManagedThreadId);
         }
         else if (eventName == ExceptionEvent)
         {
-            _logger.LogTrace("HandleExceptionEvent start {thread}", Thread.CurrentThread.ManagedThreadId);
+            _logger.LogTrace("HandleExceptionEvent start {Thread}", Thread.CurrentThread.ManagedThreadId);
 
             HandleExceptionEvent(current, request);
 
-            _logger.LogTrace("HandleExceptionEvent finished {thread}", Thread.CurrentThread.ManagedThreadId);
+            _logger.LogTrace("HandleExceptionEvent finished {Thread}", Thread.CurrentThread.ManagedThreadId);
         }
     }
 
@@ -95,7 +95,7 @@ internal sealed class HttpClientCoreObserver : MetricsObserver
     {
         if (ShouldIgnoreRequest(request.RequestUri?.AbsolutePath))
         {
-            _logger.LogDebug("HandleStopEvent: Ignoring path: {path}", SecurityUtilities.SanitizeInput(request.RequestUri?.AbsolutePath));
+            _logger.LogDebug("HandleStopEvent: Ignoring path: {Path}", SecurityUtilities.SanitizeInput(request.RequestUri?.AbsolutePath));
             return;
         }
 

--- a/src/Management/src/Endpoint/Metrics/Observer/HttpClientCoreObserver.cs
+++ b/src/Management/src/Endpoint/Metrics/Observer/HttpClientCoreObserver.cs
@@ -37,7 +37,7 @@ internal sealed class HttpClientCoreObserver : MetricsObserver
 
         if (egressIgnorePattern != null)
         {
-            SetPathMatcher(new Regex(egressIgnorePattern));
+            SetPathMatcher(new Regex(egressIgnorePattern, RegexOptions.None, TimeSpan.FromSeconds(1)));
         }
 
         _clientTimeMeasure = SteeltoeMetrics.Meter.CreateHistogram<double>("http.client.request.time");

--- a/src/Management/src/Endpoint/Metrics/Observer/HttpClientDesktopObserver.cs
+++ b/src/Management/src/Endpoint/Metrics/Observer/HttpClientDesktopObserver.cs
@@ -69,7 +69,7 @@ internal sealed class HttpClientDesktopObserver : MetricsObserver
 
         if (eventName == StopEventName)
         {
-            _logger.LogTrace("HandleStopEvent start {thread}", Thread.CurrentThread.ManagedThreadId);
+            _logger.LogTrace("HandleStopEvent start {Thread}", Thread.CurrentThread.ManagedThreadId);
 
             var response = GetPropertyOrDefault<HttpWebResponse>(value, "Response");
 
@@ -78,17 +78,17 @@ internal sealed class HttpClientDesktopObserver : MetricsObserver
                 HandleStopEvent(current, request, response.StatusCode);
             }
 
-            _logger.LogTrace("HandleStopEvent finished {thread}", Thread.CurrentThread.ManagedThreadId);
+            _logger.LogTrace("HandleStopEvent finished {Thread}", Thread.CurrentThread.ManagedThreadId);
         }
         else if (eventName == StopExEventName)
         {
-            _logger.LogTrace("HandleStopEventEx start {thread}", Thread.CurrentThread.ManagedThreadId);
+            _logger.LogTrace("HandleStopEventEx start {Thread}", Thread.CurrentThread.ManagedThreadId);
 
             var statusCode = GetPropertyOrDefault<HttpStatusCode>(value, "StatusCode");
 
             HandleStopEvent(current, request, statusCode);
 
-            _logger.LogTrace("HandleStopEventEx finished {thread}", Thread.CurrentThread.ManagedThreadId);
+            _logger.LogTrace("HandleStopEventEx finished {Thread}", Thread.CurrentThread.ManagedThreadId);
         }
     }
 
@@ -96,7 +96,7 @@ internal sealed class HttpClientDesktopObserver : MetricsObserver
     {
         if (ShouldIgnoreRequest(request.RequestUri.AbsolutePath))
         {
-            _logger.LogDebug("HandleStopEvent: Ignoring path: {path}", SecurityUtilities.SanitizeInput(request.RequestUri.AbsolutePath));
+            _logger.LogDebug("HandleStopEvent: Ignoring path: {Path}", SecurityUtilities.SanitizeInput(request.RequestUri.AbsolutePath));
             return;
         }
 

--- a/src/Management/src/Endpoint/Metrics/Observer/HttpClientDesktopObserver.cs
+++ b/src/Management/src/Endpoint/Metrics/Observer/HttpClientDesktopObserver.cs
@@ -38,7 +38,7 @@ internal sealed class HttpClientDesktopObserver : MetricsObserver
 
         if (egressIgnorePattern != null)
         {
-            SetPathMatcher(new Regex(egressIgnorePattern));
+            SetPathMatcher(new Regex(egressIgnorePattern, RegexOptions.None, TimeSpan.FromSeconds(1)));
         }
 
         _clientTimeMeasure = SteeltoeMetrics.Meter.CreateHistogram<double>("http.desktop.client.request.time");

--- a/src/Management/src/Endpoint/Metrics/ServiceCollectionExtensions.cs
+++ b/src/Management/src/Endpoint/Metrics/ServiceCollectionExtensions.cs
@@ -71,15 +71,18 @@ public static class ServiceCollectionExtensions
             var logger = provider.GetRequiredService<ILogger<MetricsExporter>>();
 
             var aggregationManager = new AggregationManager(exporterOptions.MaxTimeSeries, exporterOptions.MaxHistograms, exporter.AddMetrics,
-                (intervalStartTime, nextIntervalStartTime) => logger.LogTrace($"Begin collection from {intervalStartTime} to {nextIntervalStartTime}"),
-                (intervalStartTime, nextIntervalStartTime) => logger.LogTrace($"End collection from {intervalStartTime} to {nextIntervalStartTime}"),
-                instrument => logger.LogTrace($"Begin measurements from {instrument.Name} for {instrument.Meter.Name}"),
-                instrument => logger.LogTrace($"End measurements from {instrument.Name} for {instrument.Meter.Name}"),
-                instrument => logger.LogTrace($"Instrument {instrument.Name} published for {instrument.Meter.Name}"),
+                (intervalStartTime, nextIntervalStartTime) => logger.LogTrace("Begin collection from {IntervalStartTime} to {NextIntervalStartTime}",
+                    intervalStartTime, nextIntervalStartTime),
+                (intervalStartTime, nextIntervalStartTime) => logger.LogTrace("End collection from {IntervalStartTime} to {NextIntervalStartTime}",
+                    intervalStartTime, nextIntervalStartTime),
+                instrument => logger.LogTrace("Begin measurements from {InstrumentName} for {MeterName}", instrument.Name, instrument.Meter.Name),
+                instrument => logger.LogTrace("End measurements from {InstrumentName} for {MeterName}", instrument.Name, instrument.Meter.Name),
+                instrument => logger.LogTrace("Instrument {InstrumentName} published for {MeterName}", instrument.Name, instrument.Meter.Name),
                 () => logger.LogTrace("Steeltoe metrics collector started."), exception => logger.LogError(exception, "An error occurred while collecting"),
-                () => logger.LogWarning($"Cannot collect any more time series because the configured limit of {exporterOptions.MaxTimeSeries} was reached"),
-                () => logger.LogWarning($"Cannot collect any more Histograms because the configured limit of {exporterOptions.MaxHistograms} was reached"),
-                exception => logger.LogError(exception, "An error occurred while collecting observable instruments"));
+                () => logger.LogWarning("Cannot collect any more time series because the configured limit of {MaxTimeSeries} was reached",
+                    exporterOptions.MaxTimeSeries),
+                () => logger.LogWarning("Cannot collect any more Histograms because the configured limit of {MaxHistograms} was reached",
+                    exporterOptions.MaxHistograms), exception => logger.LogError(exception, "An error occurred while collecting observable instruments"));
 
             exporter.SetCollect(aggregationManager.Collect);
             aggregationManager.Include(SteeltoeMetrics.InstrumentationName); // Default to Steeltoe Metrics

--- a/src/Management/src/Endpoint/Middleware/EndpointMiddleware.cs
+++ b/src/Management/src/Endpoint/Middleware/EndpointMiddleware.cs
@@ -45,8 +45,10 @@ public abstract class EndpointMiddleware<TArgument, TResult> : IEndpointMiddlewa
         bool isCloudFoundryEndpoint = requestPath.StartsWithSegments(ConfigureManagementOptions.DefaultCloudFoundryPath);
         bool returnValue = isCloudFoundryEndpoint ? managementOptions.IsCloudFoundryEnabled && isEnabled : isEnabled && isExposed;
 
-        _logger.LogDebug($"Returned {returnValue} for endpointHandler: {EndpointOptions.Id}, requestPath: {requestPath}, isEnabled: {isEnabled}, " +
-            $"isExposed: {isExposed}, isCloudFoundryEndpoint: {isCloudFoundryEndpoint}, isCloudFoundryEnabled: {managementOptions.IsCloudFoundryEnabled}");
+        _logger.LogDebug(
+            "Returned {ReturnValue} for endpointHandler: {EndpointHandler}, requestPath: {RequestPath}, isEnabled: {IsEnabled}, " +
+            "isExposed: {IsExposed}, isCloudFoundryEndpoint: {IsCloudFoundryEndpoint}, isCloudFoundryEnabled: {IsCloudFoundryEnabled}", returnValue,
+            EndpointOptions.Id, requestPath, isEnabled, isExposed, isCloudFoundryEndpoint, managementOptions.IsCloudFoundryEnabled);
 
         return returnValue;
     }

--- a/src/Management/src/Endpoint/SpringBootAdminClient/SpringBootAdminClientHostedService.cs
+++ b/src/Management/src/Endpoint/SpringBootAdminClient/SpringBootAdminClientHostedService.cs
@@ -40,7 +40,7 @@ internal sealed class SpringBootAdminClientHostedService : IHostedService
 
     public async Task StartAsync(CancellationToken cancellationToken)
     {
-        _logger.LogInformation("Registering with Spring Boot Admin Server at {url}", _clientOptions.Url);
+        _logger.LogInformation("Registering with Spring Boot Admin Server at {Url}", _clientOptions.Url);
 
         if (_clientOptions.BasePath == null || _clientOptions.ApplicationName == null)
         {

--- a/src/Management/src/Endpoint/ThreadDump/EventPipeThreadDumper.cs
+++ b/src/Management/src/Endpoint/ThreadDump/EventPipeThreadDumper.cs
@@ -83,7 +83,7 @@ public sealed class EventPipeThreadDumper
         finally
         {
             long totalMemory = GC.GetTotalMemory(true);
-            _logger.LogDebug("Total Memory {memory}", totalMemory);
+            _logger.LogDebug("Total Memory {Memory}", totalMemory);
         }
 
         return results;
@@ -143,7 +143,7 @@ public sealed class EventPipeThreadDumper
 
                 foreach ((int threadId, List<StackSourceSample> samples) in samplesForThread)
                 {
-                    _logger.LogDebug("Found {stacks} stacks for thread {thread}", samples.Count, threadId);
+                    _logger.LogDebug("Found {Stacks} stacks for thread {Thread}", samples.Count, threadId);
 
                     var threadInfo = new ThreadInfo
                     {
@@ -200,7 +200,7 @@ public sealed class EventPipeThreadDumper
     private List<StackTraceElement> GetStackTrace(int threadId, StackSourceSample stackSourceSample, TraceEventStackSource stackSource,
         SymbolReader symbolReader)
     {
-        _logger.LogDebug("Processing thread with ID: {thread}", threadId);
+        _logger.LogDebug("Processing thread with ID: {Thread}", threadId);
 
         var result = new List<StackTraceElement>();
 
@@ -408,7 +408,7 @@ public sealed class EventPipeThreadDumper
             {
                 if (moduleFile.PdbSignature != Guid.Empty && symbolReaderModule.PdbGuid != moduleFile.PdbSignature)
                 {
-                    _logger.LogTrace("ERROR: the PDB we opened does not match the PDB desired. PDB GUID = {pdbGuid}, DESIRED GUID = {desiredGuid}",
+                    _logger.LogTrace("ERROR: the PDB we opened does not match the PDB desired. PDB GUID = {PdbGuid}, DESIRED GUID = {DesiredGuid}",
                         symbolReaderModule.PdbGuid, moduleFile.PdbSignature);
 
                     return null;

--- a/src/Management/src/Endpoint/Web/Hypermedia/ActuatorHypermediaEndpointMiddleware.cs
+++ b/src/Management/src/Endpoint/Web/Hypermedia/ActuatorHypermediaEndpointMiddleware.cs
@@ -27,7 +27,7 @@ internal sealed class ActuatorHypermediaEndpointMiddleware : EndpointMiddleware<
     {
         ArgumentGuard.NotNull(context);
 
-        _logger.LogDebug("InvokeAsync({method}, {path})", context.Request.Method, context.Request.Path.Value);
+        _logger.LogDebug("InvokeAsync({Method}, {Path})", context.Request.Method, context.Request.Path.Value);
         string requestUri = GetRequestUri(context.Request);
         return await EndpointHandler.InvokeAsync(requestUri, cancellationToken);
     }

--- a/src/Management/src/Task/TaskWebHostExtensions.cs
+++ b/src/Management/src/Task/TaskWebHostExtensions.cs
@@ -82,7 +82,7 @@ public static class TaskWebHostExtensions
             {
                 var loggerFactory = provider.GetRequiredService<ILoggerFactory>();
                 ILogger logger = loggerFactory.CreateLogger($"{typeof(TaskWebHostExtensions).Namespace}.CloudFoundryTasks");
-                logger.LogError($"No task with name {taskName} is found registered in service container");
+                logger.LogError("No task with name {TaskName} is found registered in service container", taskName);
             }
 
             return true;

--- a/src/Management/src/Tracing/TracingBaseServiceCollectionExtensions.cs
+++ b/src/Management/src/Tracing/TracingBaseServiceCollectionExtensions.cs
@@ -110,7 +110,7 @@ public static class TracingBaseServiceCollectionExtensions
         {
             var tracingOptions = serviceProvider.GetRequiredService<ITracingOptions>();
 
-            var pathMatcher = new Regex(tracingOptions.EgressIgnorePattern);
+            var pathMatcher = new Regex(tracingOptions.EgressIgnorePattern, RegexOptions.None, TimeSpan.FromSeconds(1));
             options.FilterHttpRequestMessage += requestMessage => !pathMatcher.IsMatch(requestMessage.RequestUri?.PathAndQuery ?? string.Empty);
         });
 

--- a/src/Management/src/Tracing/TracingBaseServiceCollectionExtensions.cs
+++ b/src/Management/src/Tracing/TracingBaseServiceCollectionExtensions.cs
@@ -124,7 +124,7 @@ public static class TracingBaseServiceCollectionExtensions
             ILogger logger = serviceProvider.GetRequiredService<ILoggerFactory>()
                 .CreateLogger($"{typeof(TracingBaseServiceCollectionExtensions).Namespace}.Setup");
 
-            logger.LogTrace("Found Zipkin exporter: {exportToZipkin}. Found Jaeger exporter: {exportToJaeger}. Found OTLP exporter: {exportToOtlp}.",
+            logger.LogTrace("Found Zipkin exporter: {ExportToZipkin}. Found Jaeger exporter: {ExportToJaeger}. Found OTLP exporter: {ExportToOtlp}.",
                 exportToZipkin, exportToJaeger, exportToOpenTelemetryProtocol);
 
             tracerProviderBuilder.SetResourceBuilder(ResourceBuilder.CreateDefault().AddService(appName));

--- a/src/Management/src/Tracing/TracingCoreServiceCollectionExtensions.cs
+++ b/src/Management/src/Tracing/TracingCoreServiceCollectionExtensions.cs
@@ -46,7 +46,7 @@ public static class TracingCoreServiceCollectionExtensions
 
         services.AddOptions<AspNetCoreTraceInstrumentationOptions>().PostConfigure<ITracingOptions>((instrumentationOptions, tracingOptions) =>
         {
-            var pathMatcher = new Regex(tracingOptions.IngressIgnorePattern);
+            var pathMatcher = new Regex(tracingOptions.IngressIgnorePattern, RegexOptions.None, TimeSpan.FromSeconds(1));
             instrumentationOptions.Filter += context => !pathMatcher.IsMatch(context.Request.Path);
         });
 

--- a/src/Management/src/Wavefront/Exporters/WavefrontTraceExporter.cs
+++ b/src/Management/src/Wavefront/Exporters/WavefrontTraceExporter.cs
@@ -80,7 +80,7 @@ public sealed class WavefrontTraceExporter : BaseExporter<Activity>
             }
         }
 
-        _logger.LogTrace($"Exported {spanCount} spans to {_options.Uri}");
+        _logger.LogTrace("Exported {Count} spans to {Uri}", spanCount, _options.Uri);
         return ExportResult.Success;
     }
 

--- a/src/Management/test/Endpoint.Test/Health/DefaultHealthAggregatorTest.cs
+++ b/src/Management/test/Endpoint.Test/Health/DefaultHealthAggregatorTest.cs
@@ -61,7 +61,7 @@ public sealed class DefaultHealthAggregatorTest : BaseTest
         };
 
         var source = new CancellationTokenSource();
-        source.Cancel();
+        await source.CancelAsync();
 
         var aggregator = new DefaultHealthAggregator();
         Func<Task> action = async () => await aggregator.AggregateAsync(contributors, source.Token);

--- a/src/Management/test/Endpoint.Test/Health/DefaultHealthAggregatorTest.cs
+++ b/src/Management/test/Endpoint.Test/Health/DefaultHealthAggregatorTest.cs
@@ -60,7 +60,7 @@ public sealed class DefaultHealthAggregatorTest : BaseTest
             new UpContributor(5000)
         };
 
-        var source = new CancellationTokenSource();
+        using var source = new CancellationTokenSource();
         await source.CancelAsync();
 
         var aggregator = new DefaultHealthAggregator();

--- a/src/Management/test/Endpoint.Test/Health/HealthEndpointTest.cs
+++ b/src/Management/test/Endpoint.Test/Health/HealthEndpointTest.cs
@@ -98,7 +98,7 @@ public sealed class HealthEndpointTest : BaseTest
 
         var handler = testContext.GetRequiredScopedService<IHealthEndpointHandler>();
 
-        var source = new CancellationTokenSource();
+        using var source = new CancellationTokenSource();
         await source.CancelAsync();
 
         HealthEndpointRequest healthRequest = GetHealthRequest();

--- a/src/Management/test/Endpoint.Test/Health/HealthEndpointTest.cs
+++ b/src/Management/test/Endpoint.Test/Health/HealthEndpointTest.cs
@@ -99,7 +99,7 @@ public sealed class HealthEndpointTest : BaseTest
         var handler = testContext.GetRequiredScopedService<IHealthEndpointHandler>();
 
         var source = new CancellationTokenSource();
-        source.Cancel();
+        await source.CancelAsync();
 
         HealthEndpointRequest healthRequest = GetHealthRequest();
         Func<Task> action = async () => await handler.InvokeAsync(healthRequest, source.Token);

--- a/src/Management/test/Endpoint.Test/ManagementPort/ManagementEndpointServedOnDifferentPortTest.cs
+++ b/src/Management/test/Endpoint.Test/ManagementPort/ManagementEndpointServedOnDifferentPortTest.cs
@@ -36,7 +36,7 @@ public sealed class ManagementEndpointServedOnDifferentPortTest
 
         await using WebApplication app = hostBuilder.Build();
         app.MapGet("/", () => "Hello World!");
-        app.Start();
+        await app.StartAsync();
 
         var addressFeature = ((IApplicationBuilder)app).ServerFeatures.Get<IServerAddressesFeature>();
         addressFeature.Should().NotBeNull();
@@ -59,7 +59,7 @@ public sealed class ManagementEndpointServedOnDifferentPortTest
 
         await using WebApplication app = hostBuilder.Build();
         app.MapGet("/", () => "Hello World!");
-        app.Start();
+        await app.StartAsync();
 
         using var httpClient = new HttpClient();
         HttpResponseMessage response = await httpClient.GetAsync(new Uri("http://localhost:9090/actuator"));
@@ -85,7 +85,7 @@ public sealed class ManagementEndpointServedOnDifferentPortTest
 
         await using WebApplication app = hostBuilder.Build();
         app.MapGet("/", () => "Hello World!");
-        app.Start();
+        await app.StartAsync();
 
         var addressFeature = ((IApplicationBuilder)app).ServerFeatures.Get<IServerAddressesFeature>();
         addressFeature.Should().NotBeNull();
@@ -109,7 +109,7 @@ public sealed class ManagementEndpointServedOnDifferentPortTest
 
         await using WebApplication app = hostBuilder.Build();
         app.MapGet("/", () => "Hello World!");
-        app.Start();
+        await app.StartAsync();
 
         using var httpClient = new HttpClient();
         HttpResponseMessage response = await httpClient.GetAsync(new Uri("http://localhost:9090/actuator"));
@@ -139,7 +139,7 @@ public sealed class ManagementEndpointServedOnDifferentPortTest
 
         await using WebApplication app = hostBuilder.Build();
         app.MapGet("/", () => "Hello World!");
-        app.Start();
+        await app.StartAsync();
 
         using var httpClient = new HttpClient(new HttpClientHandler
         {
@@ -189,7 +189,7 @@ public sealed class ManagementEndpointServedOnDifferentPortTest
         });
 
         using IHost host = hostBuilder.Build();
-        host.Start();
+        await host.StartAsync();
 
         using var httpClient = new HttpClient();
         HttpResponseMessage response = await httpClient.GetAsync(new Uri("http://localhost:9090/actuator"));
@@ -237,7 +237,7 @@ public sealed class ManagementEndpointServedOnDifferentPortTest
         });
 
         using IHost host = hostBuilder.Build();
-        host.Start();
+        await host.StartAsync();
 
         using var httpClient = new HttpClient();
         HttpResponseMessage response = await httpClient.GetAsync(new Uri("http://localhost:9090/actuator"));
@@ -264,7 +264,7 @@ public sealed class ManagementEndpointServedOnDifferentPortTest
         });
 
         using IHost host = hostBuilder.Build();
-        host.Start();
+        await host.StartAsync();
 
         using var httpClient = new HttpClient(new HttpClientHandler
         {

--- a/src/Security/src/Authentication.CloudFoundry/CloudFoundryInstanceCertificate.cs
+++ b/src/Security/src/Authentication.CloudFoundry/CloudFoundryInstanceCertificate.cs
@@ -37,11 +37,13 @@ public class CloudFoundryInstanceCertificate
             return false;
         }
 
-        Match cfInstanceMatch = Regex.Match(certificate.Subject.Replace("\"", string.Empty, StringComparison.Ordinal), CloudFoundryInstanceCertSubjectRegex);
+        Match cfInstanceMatch = Regex.Match(certificate.Subject.Replace("\"", string.Empty, StringComparison.Ordinal), CloudFoundryInstanceCertSubjectRegex,
+            RegexOptions.None, TimeSpan.FromSeconds(1));
 
         if (!cfInstanceMatch.Success)
         {
-            cfInstanceMatch = Regex.Match(certificate.Subject.Replace("\"", string.Empty, StringComparison.Ordinal), ValidInstanceCertSubjectRegex);
+            cfInstanceMatch = Regex.Match(certificate.Subject.Replace("\"", string.Empty, StringComparison.Ordinal), ValidInstanceCertSubjectRegex,
+                RegexOptions.None, TimeSpan.FromSeconds(1));
         }
 
         if (cfInstanceMatch.Success)

--- a/src/Security/src/Authentication.CloudFoundry/CloudFoundryOAuthHandler.cs
+++ b/src/Security/src/Authentication.CloudFoundry/CloudFoundryOAuthHandler.cs
@@ -32,7 +32,7 @@ public class CloudFoundryOAuthHandler : OAuthHandler<CloudFoundryOAuthOptions>
 
     protected internal virtual Dictionary<string, string> GetTokenInfoRequestParameters(OAuthTokenResponse tokens)
     {
-        _logger?.LogDebug("GetTokenInfoRequestParameters() using token: {token}", tokens.AccessToken);
+        _logger?.LogDebug("GetTokenInfoRequestParameters() using token: {Token}", tokens.AccessToken);
 
         return new Dictionary<string, string>
         {
@@ -42,7 +42,7 @@ public class CloudFoundryOAuthHandler : OAuthHandler<CloudFoundryOAuthOptions>
 
     protected internal virtual HttpRequestMessage GetTokenInfoRequestMessage(OAuthTokenResponse tokens)
     {
-        _logger?.LogDebug("GetTokenInfoRequestMessage({token}) with {clientId}", tokens.AccessToken, Options.ClientId);
+        _logger?.LogDebug("GetTokenInfoRequestMessage({Token}) with {ClientId}", tokens.AccessToken, Options.ClientId);
 
         Dictionary<string, string> tokenRequestParameters = GetTokenInfoRequestParameters(tokens);
 
@@ -69,7 +69,7 @@ public class CloudFoundryOAuthHandler : OAuthHandler<CloudFoundryOAuthOptions>
 
     protected override async Task<OAuthTokenResponse> ExchangeCodeAsync(OAuthCodeExchangeContext context)
     {
-        _logger?.LogDebug("ExchangeCodeAsync({code}, {redirectUri})", context.Code, context.RedirectUri);
+        _logger?.LogDebug("ExchangeCodeAsync({Code}, {RedirectUri})", context.Code, context.RedirectUri);
 
         AuthServerOptions options = Options.BaseOptions();
         options.CallbackUrl = context.RedirectUri;
@@ -81,7 +81,7 @@ public class CloudFoundryOAuthHandler : OAuthHandler<CloudFoundryOAuthOptions>
         {
             string result = await response.Content.ReadAsStringAsync();
 
-            _logger?.LogDebug("ExchangeCodeAsync() received json: {json}", result);
+            _logger?.LogDebug("ExchangeCodeAsync() received json: {Json}", result);
             JsonDocument payload = JsonDocument.Parse(result);
             OAuthTokenResponse tokenResponse = OAuthTokenResponse.Success(payload);
 
@@ -104,13 +104,13 @@ public class CloudFoundryOAuthHandler : OAuthHandler<CloudFoundryOAuthOptions>
 
         if (!response.IsSuccessStatusCode)
         {
-            _logger?.LogDebug("CreateTicketAsync() failure getting token info from {requestUri}", request.RequestUri);
+            _logger?.LogDebug("CreateTicketAsync() failure getting token info from {RequestUri}", request.RequestUri);
             throw new HttpRequestException($"An error occurred while retrieving token information ({response.StatusCode}).");
         }
 
         string resp = await response.Content.ReadAsStringAsync();
 
-        _logger?.LogDebug("CreateTicketAsync() received json: {json}", resp);
+        _logger?.LogDebug("CreateTicketAsync() received json: {Json}", resp);
         JsonElement payload = JsonDocument.Parse(resp).RootElement;
         var context = new OAuthCreatingTicketContext(new ClaimsPrincipal(identity), properties, Context, Scheme, Options, Backchannel, tokens, payload);
         context.RunClaimActions();
@@ -129,7 +129,7 @@ public class CloudFoundryOAuthHandler : OAuthHandler<CloudFoundryOAuthOptions>
 
     protected override string BuildChallengeUrl(AuthenticationProperties properties, string redirectUri)
     {
-        _logger?.LogDebug("BuildChallengeUrl({redirectUri}) with {clientId}", redirectUri, Options.ClientId);
+        _logger?.LogDebug("BuildChallengeUrl({RedirectUri}) with {ClientId}", redirectUri, Options.ClientId);
 
         string scope = FormatScope();
 

--- a/src/Security/src/Authentication.CloudFoundry/MutualTlsAuthenticationOptionsPostConfigurer.cs
+++ b/src/Security/src/Authentication.CloudFoundry/MutualTlsAuthenticationOptionsPostConfigurer.cs
@@ -14,13 +14,12 @@ namespace Steeltoe.Security.Authentication.CloudFoundry;
 public class MutualTlsAuthenticationOptionsPostConfigurer : IPostConfigureOptions<MutualTlsAuthenticationOptions>
 {
     private readonly IOptionsMonitor<CertificateOptions> _containerIdentityOptions;
-    private readonly ILogger<CloudFoundryInstanceCertificate> _logger;
+    private readonly ILogger<CloudFoundryInstanceCertificate> _cloudFoundryLogger;
 
-    public MutualTlsAuthenticationOptionsPostConfigurer(IOptionsMonitor<CertificateOptions> containerIdentityOptions,
-        ILogger<CloudFoundryInstanceCertificate> logger = null)
+    public MutualTlsAuthenticationOptionsPostConfigurer(IOptionsMonitor<CertificateOptions> containerIdentityOptions, ILoggerFactory loggerFactory)
     {
         _containerIdentityOptions = containerIdentityOptions;
-        _logger = logger;
+        _cloudFoundryLogger = loggerFactory?.CreateLogger<CloudFoundryInstanceCertificate>();
     }
 
     public void PostConfigure(string name, MutualTlsAuthenticationOptions options)
@@ -33,7 +32,7 @@ public class MutualTlsAuthenticationOptionsPostConfigurer : IPostConfigureOption
             {
                 var claims = new List<Claim>(context.Principal.Claims);
 
-                if (CloudFoundryInstanceCertificate.TryParse(context.ClientCertificate, out CloudFoundryInstanceCertificate cfCert, _logger))
+                if (CloudFoundryInstanceCertificate.TryParse(context.ClientCertificate, out CloudFoundryInstanceCertificate cfCert, _cloudFoundryLogger))
                 {
                     claims.Add(new Claim(ApplicationClaimTypes.CloudFoundryInstanceId, cfCert.InstanceId, ClaimValueTypes.String,
                         context.Options.ClaimsIssuer));

--- a/src/Security/src/Authentication.CloudFoundry/TokenExchanger.cs
+++ b/src/Security/src/Authentication.CloudFoundry/TokenExchanger.cs
@@ -44,7 +44,7 @@ public class TokenExchanger
     {
         List<KeyValuePair<string, string>> requestParameters = AuthCodeTokenRequestParameters(code);
         HttpRequestMessage requestMessage = GetTokenRequestMessage(requestParameters, targetUrl);
-        _logger?.LogDebug("Exchanging code {code} for token at {accessTokenUrl}", code, targetUrl);
+        _logger?.LogDebug("Exchanging code {Code} for token at {AccessTokenUrl}", code, targetUrl);
 
         return await _httpClient.SendAsync(requestMessage, cancellationToken);
     }
@@ -67,15 +67,15 @@ public class TokenExchanger
             _logger?.LogTrace("Successfully exchanged auth code for a token");
             var tokens = JsonSerializer.Deserialize<OpenIdTokenResponse>(await response.Content.ReadAsStringAsync());
 #if DEBUG
-            _logger?.LogTrace("Identity token received: {identityToken}", tokens.IdentityToken);
-            _logger?.LogTrace("Access token received: {accessToken}", tokens.AccessToken);
+            _logger?.LogTrace("Identity token received: {IdentityToken}", tokens.IdentityToken);
+            _logger?.LogTrace("Access token received: {AccessToken}", tokens.AccessToken);
 #endif
             var securityToken = new JwtSecurityToken(tokens.IdentityToken);
 
             return BuildIdentityWithClaims(securityToken.Claims, tokens.Scope, tokens.AccessToken);
         }
 
-        _logger?.LogError("Failed call to exchange code for token: {status}", response.StatusCode);
+        _logger?.LogError("Failed call to exchange code for token: {Status}", response.StatusCode);
         _logger?.LogWarning(response.ReasonPhrase);
         _logger?.LogInformation(await response.Content.ReadAsStringAsync());
 
@@ -170,7 +170,7 @@ public class TokenExchanger
 #if DEBUG
         foreach (Claim claim in claims)
         {
-            _logger?.LogTrace("{type} : {value}", claim.Type, claim.Value);
+            _logger?.LogTrace("{Type} : {Value}", claim.Type, claim.Value);
         }
 #endif
         string[] typedClaimNames =

--- a/src/Security/test/DataProtection.Redis.Test/RedisDataProtectionBuilderExtensionsTest.cs
+++ b/src/Security/test/DataProtection.Redis.Test/RedisDataProtectionBuilderExtensionsTest.cs
@@ -77,7 +77,7 @@ public sealed class RedisDataProtectionBuilderExtensionsTest
             return Task.CompletedTask;
         });
 
-        app.Start();
+        await app.StartAsync();
 
         using var httpClient = new HttpClient();
         HttpResponseMessage response = await httpClient.GetAsync(new Uri("http://localhost:5000/set-session"));

--- a/versions.props
+++ b/versions.props
@@ -26,7 +26,7 @@
     <RabbitClientTestVersion>6.5.*</RabbitClientTestVersion>
     <SerilogEnrichersThreadVersion>3.1.*</SerilogEnrichersThreadVersion>
     <SerilogExceptionsVersion>8.4.*</SerilogExceptionsVersion>
-    <SonarAnalyzerVersion>9.11.*</SonarAnalyzerVersion>
+    <SonarAnalyzerVersion>9.25.*</SonarAnalyzerVersion>
     <SourceLinkGitHubVersion>8.0.*</SourceLinkGitHubVersion>
     <StackExchangeVersion>2.7.*</StackExchangeVersion>
     <StyleCopVersion>1.2.0-beta.435</StyleCopVersion>

--- a/versions.props
+++ b/versions.props
@@ -29,7 +29,7 @@
     <SonarAnalyzerVersion>9.25.*</SonarAnalyzerVersion>
     <SourceLinkGitHubVersion>8.0.*</SourceLinkGitHubVersion>
     <StackExchangeVersion>2.7.*</StackExchangeVersion>
-    <StyleCopVersion>1.2.0-beta.435</StyleCopVersion>
+    <StyleCopVersion>1.2.0-beta.556</StyleCopVersion>
     <SystemSqlClientVersion>4.8.*</SystemSqlClientVersion>
     <TestSdkVersion>17.8.*</TestSdkVersion>
     <XunitAbstractionsVersion>2.0.*</XunitAbstractionsVersion>


### PR DESCRIPTION
## Description

This PR updates to the latest version of SonarAnalyzer, addressing the rule changes.
The overview below summarizes what's changed, and how that affects the Steeltoe codebase.

| Rule                                                                                                                          | Title                                                                                                                            | Sonar v8.47 | Sonar v9.11 | Change   | Steeltoe main | Main uses default? | Steeltoe PR | PR uses default? | Unchanged in PR?      | Comments                                         |
| ----------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- | ----------- | ----------- | -------- | ------------- | ------------------ | ----------- | ---------------- | --------------------- | ------------------------------------------------ |
| [S1244](https://sonarsource.github.io/rspec/#/rspec/S1244/csharp) | Floating point numbers should not be tested for equality                                                                         | None        | Warning     | 🟨 | Warning       | 🟨No                 | Warning     | Yes              | Yes                   |                                                  |
| [S127](https://sonarsource.github.io/rspec/#/rspec/S127/csharp)    | "for" loop stop conditions should be invariant                                                                                   | None        | Warning     | 🟨 | None          | Yes                | None        | 🟨No               | Yes                   | Rule is somewhat puristic                        |
| [S1312](https://sonarsource.github.io/rspec/#/rspec/S1312/csharp) | Logger fields should be "private static readonly"                                                                                |             | None        | 🟩    |               |                    | None        | Yes              | Yes                   | Rule doesn't make sense                          |
| [S1696](https://sonarsource.github.io/rspec/#/rspec/S1696/csharp) | NullReferenceException should not be caught                                                                                      | None        | Warning     | 🟨 | None          | Yes                | Warning     | Yes              | 🟨No (severity changed) |                                                  |
| [S1994](https://sonarsource.github.io/rspec/#/rspec/S1994/csharp) | "for" loop increment clauses should modify the loops' counters                                                                   | None        | Warning     | 🟨 | Warning       | 🟨No                 | Warning     | Yes              | Yes                   |                                                  |
| [S2139](https://sonarsource.github.io/rspec/#/rspec/S2139/csharp) | Exceptions should be either logged or rethrown but not both                                                                      |             | Warning     | 🟩    |               |                    | Warning     | Yes              | 🟨No (new rule)         |                                                  |
| [S2228](https://sonarsource.github.io/rspec/#/rspec/S2228/csharp) | Console logging should not be used                                                                                               | None        |             | 🟥  | None          | Yes                |             |                  | 🟨No (removed rule)     |                                                  |
| [S2629](https://sonarsource.github.io/rspec/#/rspec/S2629/csharp) | Logging templates should be constant                                                                                             |             | Warning     | 🟩    |               |                    | Warning     | Yes              | 🟨No (new rule)         |                                                  |
| [S2701](https://sonarsource.github.io/rspec/#/rspec/S2701/csharp) | Literal boolean values should not be used in assertions                                                                          | None        | Warning     | 🟨 | None          | Yes                | None        | 🟨No               | Yes                   | Already covered by xUnit analyzer                |
| [S2955](https://sonarsource.github.io/rspec/#/rspec/S2955/csharp) | Generic parameters not constrained to reference types should not be compared to "null"                                           | None        | Warning     | 🟨 | Warning       | 🟨No                 | Warning     | Yes              | Yes                   |                                                  |
| [S3416](https://sonarsource.github.io/rspec/#/rspec/S3416/csharp) | Loggers should be named for their enclosing types                                                                                |             | None        | 🟩    |               |                    | None        | Yes              | Yes                   | Rule is too simplistic                           |
| [S3878](https://sonarsource.github.io/rspec/#/rspec/S3878/csharp) | Arrays should not be created for params parameters                                                                               | Warning     | Warning     |          | Warning       | Yes                | None        | 🟨No               | 🟨No (severity changed) | Rule now forbids collection expressions |
| [S6664](https://sonarsource.github.io/rspec/#/rspec/S6664/csharp) | The code block contains too many logging calls                                                                                   |             | None        | 🟩    |               |                    | None        | Yes              | Yes                   | The heuristic doesn't always apply               |
| [S6667](https://sonarsource.github.io/rspec/#/rspec/S6667/csharp) | Logging in a catch clause should pass the caught exception as a parameter                                                        |             | Warning     | 🟩    |               |                    | Warning     | Yes              | 🟨No (new rule)         |                                                  |
| [S6668](https://sonarsource.github.io/rspec/#/rspec/S6668/csharp) | Logging arguments should be passed to the correct parameter                                                                      |             | Warning     | 🟩    |               |                    | Warning     | Yes              | 🟨No (new rule)         |                                                  |
| [S6669](https://sonarsource.github.io/rspec/#/rspec/S6669/csharp) | Logger field or property name should comply with a naming convention                                                             |             | None        | 🟩    |               |                    | None        | Yes              | Yes                   | Rule is too simplistic                           |
| [S6670](https://sonarsource.github.io/rspec/#/rspec/S6670/csharp) | "Trace.Write" and "Trace.WriteLine" should not be used                                                                           |             | Warning     | 🟩    |               |                    | Warning     | Yes              | 🟨No (new rule)         |                                                  |
| [S6672](https://sonarsource.github.io/rspec/#/rspec/S6672/csharp) | Generic logger injection should match enclosing type                                                                             |             | Warning     | 🟩    |               |                    | Warning     | Yes              | 🟨No (new rule)         |                                                  |
| [S6673](https://sonarsource.github.io/rspec/#/rspec/S6673/csharp) | Log message template placeholders should be in the right order                                                                   |             | Warning     | 🟩    |               |                    | Warning     | Yes              | 🟨No (new rule)         |                                                  |
| [S6674](https://sonarsource.github.io/rspec/#/rspec/S6674/csharp) | Log message template should be syntactically correct                                                                             |             | Warning     | 🟩    |               |                    | Warning     | Yes              | 🟨No (new rule)         |                                                  |
| [S6675](https://sonarsource.github.io/rspec/#/rspec/S6675/csharp) | "Trace.WriteLineIf" should not be used with "TraceSwitch" levels                                                                 |             | Warning     | 🟩    |               |                    | Warning     | Yes              | 🟨No (new rule)         |                                                  |
| [S6677](https://sonarsource.github.io/rspec/#/rspec/S6677/csharp) | Message template placeholders should be unique                                                                                   |             | Warning     | 🟩    |               |                    | Warning     | Yes              | 🟨No (new rule)         |                                                  |
| [S6678](https://sonarsource.github.io/rspec/#/rspec/S6678/csharp) | Use PascalCase for named placeholders                                                                                            |             | Warning     | 🟩    |               |                    | Warning     | Yes              | 🟨No (new rule)         |                                                  |
| [S6797](https://sonarsource.github.io/rspec/#/rspec/S6797/csharp) | Blazor query parameter type should be supported                                                                                  |             | Warning     | 🟩    |               |                    | None        | 🟨No               | Yes                   | Blazor rule, not used in Steeltoe codebase       |
| [S6798](https://sonarsource.github.io/rspec/#/rspec/S6798/csharp) | [JSInvokable] attribute should only be used on public methods                                                                    |             | Warning     | 🟩    |               |                    | None        | 🟨No               | Yes                   | Blazor rule, not used in Steeltoe codebase       |
| [S6800](https://sonarsource.github.io/rspec/#/rspec/S6800/csharp) | Component parameter type should match the route parameter type constraint                                                        |             | Warning     | 🟩    |               |                    | None        | 🟨No               | Yes                   | Blazor rule, not used in Steeltoe codebase       |
| [S6802](https://sonarsource.github.io/rspec/#/rspec/S6802/csharp) | Using lambda expressions in loops should be avoided in Blazor markup section                                                     |             | None        | 🟩    |               |                    | None        | Yes              | Yes                   | Blazor rule, not used in Steeltoe codebase       |
| [S6803](https://sonarsource.github.io/rspec/#/rspec/S6803/csharp) | Parameters with SupplyParameterFromQuery attribute should be used only in routable components                                    |             | None        | 🟩    |               |                    | None        | Yes              | Yes                   | Deprecated rule, to be removed in future version |
| [S6930](https://sonarsource.github.io/rspec/#/rspec/S6930/csharp) | Backslash should be avoided in route templates                                                                                   |             | Warning     | 🟩    |               |                    | Warning     | Yes              | 🟨No (new rule)         |                                                  |
| [S6931](https://sonarsource.github.io/rspec/#/rspec/S6931/csharp) | ASP.NET controller actions should not have a route template starting with "/"                                                    |             | Warning     | 🟩    |               |                    | Warning     | Yes              | 🟨No (new rule)         |                                                  |
| [S6934](https://sonarsource.github.io/rspec/#/rspec/S6934/csharp) | A Route attribute should be added to the controller when a route template is specified at the action level                       |             | Warning     | 🟩    |               |                    | Warning     | Yes              | 🟨No (new rule)         |                                                  |
| [S6960](https://sonarsource.github.io/rspec/#/rspec/S6960/csharp) | Controllers should not have mixed responsibilities                                                                               |             | Warning     | 🟩    |               |                    | Warning     | Yes              | 🟨No (new rule)         |                                                  |
| [S6961](https://sonarsource.github.io/rspec/#/rspec/S6961/csharp) | API Controllers should derive from ControllerBase instead of Controller                                                          |             | Warning     | 🟩    |               |                    | Warning     | Yes              | 🟨No (new rule)         |                                                  |
| [S6962](https://sonarsource.github.io/rspec/#/rspec/S6962/csharp) | You should pool HTTP connections with HttpClientFactory                                                                          |             | Warning     | 🟩    |               |                    | Warning     | Yes              | 🟨No (new rule)         |                                                  |
| [S6964](https://sonarsource.github.io/rspec/#/rspec/S6964/csharp) | Property used as input in a controller action should be nullable or annotated with the Required attribute to avoid under-posting |             | Warning     | 🟩    |               |                    | Warning     | Yes              | 🟨No (new rule)         |                                                  |
| [S6965](https://sonarsource.github.io/rspec/#/rspec/S6965/csharp) | REST API actions should be annotated with an HTTP verb attribute                                                                 |             | Warning     | 🟩    |               |                    | Warning     | Yes              | 🟨No (new rule)         |                                                  |
| [S6966](https://sonarsource.github.io/rspec/#/rspec/S6966/csharp) | Awaitable method should be used                                                                                                  |             | Warning     | 🟩    |               |                    | Warning     | Yes              | 🟨No (new rule)         |                                                  |
| [S6967](https://sonarsource.github.io/rspec/#/rspec/S6967/csharp) | ModelState.IsValid should be called in controller actions                                                                        |             | Warning     | 🟩    |               |                    | Warning     | Yes              | 🟨No (new rule)         |                                                  |
| [S6968](https://sonarsource.github.io/rspec/#/rspec/S6968/csharp) | Actions that return a value should be annotated with ProducesResponseTypeAttribute containing the return type                    |             | Warning     | 🟩    |               |                    | Warning     | Yes              | 🟨No (new rule)         |

## Quality checklist
- [x] Your code complies with our [Coding Style](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-code-style.md).
- [ ] You've updated unit and/or integration tests for your change, where applicable.
- [ ] You've updated documentation for your change, where applicable.
      If your change affects other repositories, such as [Documentation](https://github.com/SteeltoeOSS/Documentation), [Samples](https://github.com/SteeltoeOSS/Samples) and/or [MainSite](https://github.com/SteeltoeOSS/MainSite), add linked PRs here.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
- [ ] You've added required license files and/or file headers (explaining where the code came from with proper attribution), where code is copied from StackOverflow, a blog, or OSS.
