### PR TITLE
Remove dependency on IFileProvider in ConfigureCertificateOptions

### DIFF
--- a/src/Common/src/Common.Certificates/CertificateServiceCollectionExtensions.cs
+++ b/src/Common/src/Common.Certificates/CertificateServiceCollectionExtensions.cs
@@ -5,7 +5,6 @@
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
-using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Options;
 using Steeltoe.Common.Configuration;
 
@@ -24,34 +23,15 @@ public static class CertificateServiceCollectionExtensions
     /// </param>
     public static IServiceCollection ConfigureCertificateOptions(this IServiceCollection services, string? certificateName)
     {
-        return ConfigureCertificateOptions(services, certificateName, null);
-    }
-
-    /// <summary>
-    /// Binds certificate paths in configuration to <see cref="CertificateOptions" /> for use with client certificates.
-    /// </summary>
-    /// <param name="services">
-    /// The <see cref="IServiceCollection" /> to add services to.
-    /// </param>
-    /// <param name="certificateName">
-    /// Name of the certificate used in configuration and IOptions, or <see cref="string.Empty" /> for an unnamed certificate.
-    /// </param>
-    /// <param name="fileProvider">
-    /// Provides access to the file system.
-    /// </param>
-    public static IServiceCollection ConfigureCertificateOptions(this IServiceCollection services, string? certificateName, IFileProvider? fileProvider)
-    {
         ArgumentGuard.NotNull(services);
-
-        fileProvider ??= new PhysicalFileProvider(Environment.CurrentDirectory);
 
         string configurationKey = string.IsNullOrEmpty(certificateName)
             ? CertificateOptions.ConfigurationKeyPrefix
             : ConfigurationPath.Combine(CertificateOptions.ConfigurationKeyPrefix, certificateName);
 
         services.AddOptions<CertificateOptions>().BindConfiguration(configurationKey);
-        services.WatchFilePathInOptions<CertificateOptions>(configurationKey, certificateName, "CertificateFileName", fileProvider);
-        services.WatchFilePathInOptions<CertificateOptions>(configurationKey, certificateName, "PrivateKeyFileName", fileProvider);
+        services.WatchFilePathInOptions<CertificateOptions>(configurationKey, certificateName, "CertificateFileName");
+        services.WatchFilePathInOptions<CertificateOptions>(configurationKey, certificateName, "PrivateKeyFileName");
 
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IConfigureOptions<CertificateOptions>, ConfigureCertificateOptions>());
         return services;

--- a/src/Common/src/Common.Certificates/FilePathInOptionsChangeTokenSource.cs
+++ b/src/Common/src/Common.Certificates/FilePathInOptionsChangeTokenSource.cs
@@ -4,52 +4,126 @@
 
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.FileProviders.Physical;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Primitives;
 
 namespace Steeltoe.Common.Certificates;
 
-internal sealed class FilePathInOptionsChangeTokenSource<T> : IOptionsChangeTokenSource<T>
+internal sealed class FilePathInOptionsChangeTokenSource<T> : IOptionsChangeTokenSource<T>, IDisposable
 {
-    private readonly IFileProvider _fileProvider;
+    private readonly FileSystemChangeWatcher _fileWatcher = new();
     private string _filePath;
     private ConfigurationReloadToken _changeFilePathToken = new();
 
     public string Name { get; }
 
-    public FilePathInOptionsChangeTokenSource(string? optionName, string filePath, IFileProvider fileProvider)
+    public FilePathInOptionsChangeTokenSource(string? optionName, string filePath)
     {
-        ArgumentNullException.ThrowIfNull(filePath);
-        ArgumentNullException.ThrowIfNull(fileProvider);
+        ArgumentGuard.NotNull(filePath);
 
         Name = optionName ?? Microsoft.Extensions.Options.Options.DefaultName;
         _filePath = filePath;
-        _fileProvider = fileProvider;
     }
 
     public void ChangePath(string filePath)
     {
-        if (filePath == _filePath)
+        if (filePath != _filePath)
         {
-            return;
+            _filePath = filePath;
+
+            // Wait until the file is fully written to disk.
+            Thread.Sleep(500);
+
+            ConfigurationReloadToken previousToken = Interlocked.Exchange(ref _changeFilePathToken, new ConfigurationReloadToken());
+            previousToken.OnReload();
         }
-
-        _filePath = filePath;
-
-        // Wait until the file is fully written to disk.
-        Thread.Sleep(500);
-
-        ConfigurationReloadToken previousToken = Interlocked.Exchange(ref _changeFilePathToken, new ConfigurationReloadToken());
-        previousToken.OnReload();
     }
 
     public IChangeToken GetChangeToken()
     {
-        IChangeToken watcherChangeToken = _fileProvider.Watch(_filePath);
+        IChangeToken watcherChangeToken = _fileWatcher.GetChangeToken(_filePath);
 
         return new CompositeChangeToken([
             watcherChangeToken,
             _changeFilePathToken
         ]);
+    }
+
+    public void Dispose()
+    {
+        _fileWatcher.Dispose();
+    }
+
+    private sealed class FileSystemChangeWatcher : IDisposable
+    {
+        private PhysicalFilesWatcher? _filesWatcher;
+        private string? _previousFilePath;
+
+        public IChangeToken GetChangeToken(string filePath)
+        {
+            if (filePath == _previousFilePath)
+            {
+                if (_filesWatcher == null)
+                {
+                    // Determined earlier that this path is not watchable.
+                    return NullChangeToken.Singleton;
+                }
+
+                // Return new token for the same file.
+                string absolutePath = Path.GetFullPath(filePath);
+                string fileName = Path.GetFileName(absolutePath);
+                return _filesWatcher.CreateFileChangeToken(fileName);
+            }
+
+            // Path has changed. Stop watching the previous file, if any.
+            _previousFilePath = filePath;
+            Dispose();
+
+            if (filePath.Length > 0)
+            {
+                string absolutePath = Path.GetFullPath(filePath);
+                string? directory = Path.GetDirectoryName(absolutePath);
+
+                if (directory != null)
+                {
+                    string root = EnsureTrailingSlash(directory);
+
+                    // Because PhysicalFilesWatcher implicitly disposes FileSystemWatcher (despite not owning it),
+                    // we can't just update the existing FileSystemWatcher.Path, but instead we must recreate everything.
+                    var fileSystemWatcher = new FileSystemWatcher(root);
+
+                    try
+                    {
+                        // This throws on macOS, because it requires polling. But to make polling actually work, we need to
+                        // set the internal UseActivePolling property. See https://github.com/dotnet/runtime/issues/48602.
+                        _filesWatcher = new PhysicalFilesWatcher(root, fileSystemWatcher, false);
+
+                        string fileName = Path.GetFileName(absolutePath);
+                        return _filesWatcher.CreateFileChangeToken(fileName);
+                    }
+                    catch (Exception)
+                    {
+                        Dispose();
+                        fileSystemWatcher.Dispose();
+                        throw;
+                    }
+                }
+            }
+
+            // New path is not watchable.
+            return NullChangeToken.Singleton;
+        }
+
+        public void Dispose()
+        {
+            _filesWatcher?.Dispose();
+            _filesWatcher = null;
+        }
+
+        private static string EnsureTrailingSlash(string path)
+        {
+            return path.Length > 0 && path[^1] != Path.DirectorySeparatorChar ? $"{path}{Path.DirectorySeparatorChar}" : path;
+        }
     }
 }

--- a/src/Common/src/Common.Certificates/ServiceCollectionExtensions.cs
+++ b/src/Common/src/Common.Certificates/ServiceCollectionExtensions.cs
@@ -4,7 +4,6 @@
 
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Primitives;
 
@@ -28,16 +27,12 @@ internal static class ServiceCollectionExtensions
     /// The named option, which gets added to <paramref name="key" />.
     /// </param>
     /// <param name="pathPropertyName">
-    /// The name of the property that contains a file path, whose value is relative to the root of <paramref name="fileProvider" />.
-    /// </param>
-    /// <param name="fileProvider">
-    /// Provides access to the file system.
+    /// The name of the property that contains a file path.
     /// </param>
     /// <returns>
     /// The incoming <paramref name="services" /> so that additional calls can be chained.
     /// </returns>
-    public static IServiceCollection WatchFilePathInOptions<TOptions>(this IServiceCollection services, string key, string? optionName, string pathPropertyName,
-        IFileProvider fileProvider)
+    public static IServiceCollection WatchFilePathInOptions<TOptions>(this IServiceCollection services, string key, string? optionName, string pathPropertyName)
     {
         ArgumentGuard.NotNull(services);
         ArgumentGuard.NotNull(key);
@@ -47,7 +42,7 @@ internal static class ServiceCollectionExtensions
         {
             var configuration = serviceProvider.GetRequiredService<IConfiguration>();
             string filePath = GetFilePath(configuration, key, optionName, pathPropertyName);
-            var watcher = new FilePathInOptionsChangeTokenSource<TOptions>(optionName, filePath, fileProvider);
+            var watcher = new FilePathInOptionsChangeTokenSource<TOptions>(optionName, filePath);
 
             _ = ChangeToken.OnChange(configuration.GetReloadToken, () =>
             {

--- a/src/Common/test/Common.Certificates.Test/ConfigureCertificateOptionsTest.cs
+++ b/src/Common/test/Common.Certificates.Test/ConfigureCertificateOptionsTest.cs
@@ -119,10 +119,16 @@ public sealed class ConfigureCertificateOptionsTest
         string certificateFilePath = sandbox.CreateFile("cert", firstCertificateContent);
         string privateKeyFilePath = sandbox.CreateFile("key", firstPrivateKeyContent);
 
-        IConfigurationRoot configuration = new ConfigurationBuilder().AddCertificate(CertificateName, certificateFilePath, privateKeyFilePath).Build();
+        var configurationBuilder = new ConfigurationBuilder();
+        configurationBuilder.AddCertificate(CertificateName, certificateFilePath, privateKeyFilePath);
+        IConfiguration configuration = configurationBuilder.Build();
 
-        ServiceProvider serviceProvider = new ServiceCollection().AddLogging().AddSingleton<IConfiguration>(configuration)
-            .ConfigureCertificateOptions(Microsoft.Extensions.Options.Options.DefaultName).BuildServiceProvider();
+        IServiceCollection services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton(configuration);
+        services.ConfigureCertificateOptions(Microsoft.Extensions.Options.Options.DefaultName);
+
+        await using ServiceProvider serviceProvider = services.BuildServiceProvider();
 
         var optionsMonitor = serviceProvider.GetRequiredService<IOptionsMonitor<CertificateOptions>>();
 
@@ -150,10 +156,16 @@ public sealed class ConfigureCertificateOptionsTest
         string certificate2FilePath = sandbox.CreateFile("cert2", instance2Certificate);
         string privateKey2FilePath = sandbox.CreateFile("key2", instance2PrivateKey);
 
-        IConfigurationRoot configuration = new ConfigurationBuilder().AddCertificate(CertificateName, certificate1FilePath, privateKey1FilePath).Build();
+        var configurationBuilder = new ConfigurationBuilder();
+        configurationBuilder.AddCertificate(CertificateName, certificate1FilePath, privateKey1FilePath);
+        IConfigurationRoot configuration = configurationBuilder.Build();
 
-        ServiceProvider serviceProvider = new ServiceCollection().AddLogging().AddSingleton<IConfiguration>(configuration)
-            .ConfigureCertificateOptions(CertificateName).BuildServiceProvider();
+        IServiceCollection services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton<IConfiguration>(configuration);
+        services.ConfigureCertificateOptions(CertificateName);
+
+        await using ServiceProvider serviceProvider = services.BuildServiceProvider();
 
         var optionsMonitor = serviceProvider.GetRequiredService<IOptionsMonitor<CertificateOptions>>();
         optionsMonitor.Get(CertificateName).Certificate.Should().BeEquivalentTo(firstX509);


### PR DESCRIPTION
## Description

Using `FileSystemWatcher` directly involves adding a lot more code. Instead, I've found the ([poorly designed](https://github.com/dotnet/runtime/issues/48602)) `PhysicalFilesWatcher`, which sits in-between `PhysicalFileProvider` and `FileSystemWatcher`.

It currently doesn't work on macOS, because it requires polling. But to make polling actually work, an internal property must be set. Although that's not hard to implement, I didn't do so because we're not using macOS anymore, and these runtime internals are subject to change.

Fixes #1314.

## Quality checklist

<!-- Please run through the checklist below to ensure a smooth review and merge process for your PR. -->

- [x] Your code complies with our [Coding Style](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-code-style.md).
- [x] You've updated unit and/or integration tests for your change, where applicable.
- [ ] You've updated documentation for your change, where applicable.
      If your change affects other repositories, such as [Documentation](https://github.com/SteeltoeOSS/Documentation), [Samples](https://github.com/SteeltoeOSS/Samples) and/or [MainSite](https://github.com/SteeltoeOSS/MainSite), add linked PRs here.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
- [ ] You've added required license files and/or file headers (explaining where the code came from with proper attribution), where code is copied from StackOverflow, a blog, or OSS.
