### PR TITLE
Config schema generator: named options

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -121,7 +121,9 @@
       <GeneratedConfigurationSchemaFileContent>$([System.IO.File]::ReadAllText('$(GeneratedConfigurationSchemaOutputPath)'))</GeneratedConfigurationSchemaFileContent>
     </PropertyGroup>
 
-    <Error Condition="'$(CurrentConfigurationSchemaFileContent)' != '$(GeneratedConfigurationSchemaFileContent)'"
+    <Warning Condition="'$(CurrentConfigurationSchemaFileContent)' != '$(GeneratedConfigurationSchemaFileContent)' And '$(Configuration)' == 'Debug'"
+           Text="ConfigurationSchema.json is out of date. Run 'dotnet build --no-incremental /p:UpdateConfigurationSchema=true' to update it." />
+    <Error Condition="'$(CurrentConfigurationSchemaFileContent)' != '$(GeneratedConfigurationSchemaFileContent)' And '$(Configuration)' != 'Debug'"
            Text="ConfigurationSchema.json is out of date. Run 'dotnet build --no-incremental /p:UpdateConfigurationSchema=true' to update it." />
   </Target>
 

--- a/src/Common/src/Common.Certificates/ConfigurationSchema.json
+++ b/src/Common/src/Common.Certificates/ConfigurationSchema.json
@@ -28,7 +28,21 @@
           "description": "Gets or sets the local path to a private key file on disk (optional)."
         }
       },
-      "description": "Indicates where to load a 'System.Security.Cryptography.X509Certificates.X509Certificate2' from."
+      "description": "Indicates where to load a 'System.Security.Cryptography.X509Certificates.X509Certificate2' from.",
+      "additionalProperties": {
+        "type": "object",
+        "properties": {
+          "CertificateFilePath": {
+            "type": "string",
+            "description": "Gets or sets the local path to a certificate file on disk. Use 'Steeltoe.Common.Certificates.CertificateSettings.PrivateKeyFilePath' if the private key is stored in another file."
+          },
+          "PrivateKeyFilePath": {
+            "type": "string",
+            "description": "Gets or sets the local path to a private key file on disk (optional)."
+          }
+        },
+        "description": "Indicates where to load a 'System.Security.Cryptography.X509Certificates.X509Certificate2' from."
+      }
     }
   }
 }

--- a/src/Common/src/Common.Certificates/Properties/AssemblyInfo.cs
+++ b/src/Common/src/Common.Certificates/Properties/AssemblyInfo.cs
@@ -7,6 +7,7 @@ using Aspire;
 using Steeltoe.Common.Certificates;
 
 [assembly: ConfigurationSchema("Certificates", typeof(CertificateSettings))]
+[assembly: ConfigurationSchema("Certificates:*", typeof(CertificateSettings))]
 [assembly: LoggingCategories("Steeltoe", "Steeltoe.Common", "Steeltoe.Common.Certificates")]
 
 [assembly: InternalsVisibleTo("Steeltoe.Common.Certificates.Test")]

--- a/src/Connectors/src/Connectors/ConfigurationSchema.json
+++ b/src/Connectors/src/Connectors/ConfigurationSchema.json
@@ -36,6 +36,20 @@
                   },
                   "description": "Provides configuration settings to connect to a data source."
                 }
+              },
+              "additionalProperties": {
+                "type": "object",
+                "properties": {
+                  "ConnectionString": {
+                    "type": "string",
+                    "description": "Gets or sets the connection string for this data source."
+                  },
+                  "Database": {
+                    "type": "string",
+                    "description": "Gets or sets the name of the CosmosDB database."
+                  }
+                },
+                "description": "Provides configuration settings to connect to a data source."
               }
             },
             "MongoDb": {
@@ -55,6 +69,20 @@
                   },
                   "description": "Provides configuration settings to connect to a data source."
                 }
+              },
+              "additionalProperties": {
+                "type": "object",
+                "properties": {
+                  "ConnectionString": {
+                    "type": "string",
+                    "description": "Gets or sets the connection string for this data source."
+                  },
+                  "Database": {
+                    "type": "string",
+                    "description": "Gets or sets the name of the MongoDB database."
+                  }
+                },
+                "description": "Provides configuration settings to connect to a data source."
               }
             },
             "MySql": {
@@ -70,6 +98,16 @@
                   },
                   "description": "Provides configuration settings to connect to a data source."
                 }
+              },
+              "additionalProperties": {
+                "type": "object",
+                "properties": {
+                  "ConnectionString": {
+                    "type": "string",
+                    "description": "Gets or sets the connection string for this data source."
+                  }
+                },
+                "description": "Provides configuration settings to connect to a data source."
               }
             },
             "PostgreSql": {
@@ -85,6 +123,16 @@
                   },
                   "description": "Provides configuration settings to connect to a data source."
                 }
+              },
+              "additionalProperties": {
+                "type": "object",
+                "properties": {
+                  "ConnectionString": {
+                    "type": "string",
+                    "description": "Gets or sets the connection string for this data source."
+                  }
+                },
+                "description": "Provides configuration settings to connect to a data source."
               }
             },
             "RabbitMQ": {
@@ -100,6 +148,16 @@
                   },
                   "description": "Provides configuration settings to connect to a data source."
                 }
+              },
+              "additionalProperties": {
+                "type": "object",
+                "properties": {
+                  "ConnectionString": {
+                    "type": "string",
+                    "description": "Gets or sets the connection string for this data source."
+                  }
+                },
+                "description": "Provides configuration settings to connect to a data source."
               }
             },
             "Redis": {
@@ -115,6 +173,16 @@
                   },
                   "description": "Provides configuration settings to connect to a data source."
                 }
+              },
+              "additionalProperties": {
+                "type": "object",
+                "properties": {
+                  "ConnectionString": {
+                    "type": "string",
+                    "description": "Gets or sets the connection string for this data source."
+                  }
+                },
+                "description": "Provides configuration settings to connect to a data source."
               }
             },
             "SqlServer": {
@@ -130,6 +198,16 @@
                   },
                   "description": "Provides configuration settings to connect to a data source."
                 }
+              },
+              "additionalProperties": {
+                "type": "object",
+                "properties": {
+                  "ConnectionString": {
+                    "type": "string",
+                    "description": "Gets or sets the connection string for this data source."
+                  }
+                },
+                "description": "Provides configuration settings to connect to a data source."
               }
             }
           }

--- a/src/Connectors/src/Connectors/Properties/AssemblyInfo.cs
+++ b/src/Connectors/src/Connectors/Properties/AssemblyInfo.cs
@@ -13,12 +13,19 @@ using Steeltoe.Connectors.Redis;
 using Steeltoe.Connectors.SqlServer;
 
 [assembly: ConfigurationSchema("Steeltoe:Client:CosmosDb:Default", typeof(CosmosDbOptions))]
+[assembly: ConfigurationSchema("Steeltoe:Client:CosmosDb:*", typeof(CosmosDbOptions))]
 [assembly: ConfigurationSchema("Steeltoe:Client:MongoDb:Default", typeof(MongoDbOptions))]
+[assembly: ConfigurationSchema("Steeltoe:Client:MongoDb:*", typeof(MongoDbOptions))]
 [assembly: ConfigurationSchema("Steeltoe:Client:MySql:Default", typeof(MySqlOptions))]
+[assembly: ConfigurationSchema("Steeltoe:Client:MySql:*", typeof(MySqlOptions))]
 [assembly: ConfigurationSchema("Steeltoe:Client:PostgreSql:Default", typeof(PostgreSqlOptions))]
+[assembly: ConfigurationSchema("Steeltoe:Client:PostgreSql:*", typeof(PostgreSqlOptions))]
 [assembly: ConfigurationSchema("Steeltoe:Client:RabbitMQ:Default", typeof(RabbitMQOptions))]
+[assembly: ConfigurationSchema("Steeltoe:Client:RabbitMQ:*", typeof(RabbitMQOptions))]
 [assembly: ConfigurationSchema("Steeltoe:Client:Redis:Default", typeof(RedisOptions))]
+[assembly: ConfigurationSchema("Steeltoe:Client:Redis:*", typeof(RedisOptions))]
 [assembly: ConfigurationSchema("Steeltoe:Client:SqlServer:Default", typeof(SqlServerOptions))]
+[assembly: ConfigurationSchema("Steeltoe:Client:SqlServer:*", typeof(SqlServerOptions))]
 [assembly: LoggingCategories("Steeltoe", "Steeltoe.Connectors")]
 
 [assembly: InternalsVisibleTo("Steeltoe.Bootstrap.AutoConfiguration")]

--- a/src/Tools/src/ConfigurationSchemaGenerator/ConfigSchemaEmitter.cs
+++ b/src/Tools/src/ConfigurationSchemaGenerator/ConfigSchemaEmitter.cs
@@ -24,6 +24,7 @@ internal sealed partial class ConfigSchemaEmitter(SchemaGenerationSpec spec, Com
 {
     internal const string RootPathPrefix = "--empty--";
     private static readonly string[] s_lineBreaks = ["\r\n", "\r", "\n"];
+    private static readonly JsonNodeOptions s_ignoreCaseNodeOptions = new() { PropertyNameCaseInsensitive = true };
 
     private static readonly JsonSerializerOptions s_serializerOptions = new()
     {
@@ -59,12 +60,12 @@ internal sealed partial class ConfigSchemaEmitter(SchemaGenerationSpec spec, Com
             return;
         }
 
-        var propertiesNode = new JsonObject();
+        var propertiesNode = new JsonObject(s_ignoreCaseNodeOptions);
         for (var i = 0; i < categories.Count; i++)
         {
-            var catObj = new JsonObject();
-            catObj["$ref"] = "#/definitions/logLevelThreshold";
-            propertiesNode.Add(categories[i], catObj);
+            var categoryNode = new JsonObject();
+            categoryNode["$ref"] = "#/definitions/logLevelThreshold";
+            propertiesNode[categories[i]] = categoryNode;
         }
 
         parent["definitions"] = new JsonObject
@@ -109,6 +110,8 @@ internal sealed partial class ConfigSchemaEmitter(SchemaGenerationSpec spec, Com
         }
 
         var pathSegment = pathSegments.Dequeue();
+        var isAsterisk = pathSegment == "*";
+        var propertiesName = isAsterisk ? "additionalProperties" : "properties";
 
         // While descending into the node tree, a container node is created or an existing one is reused, which is then passed to the subtree generator.
         // Each generator is responsible for reverting to the original state of its children and return false, in case there's nothing to generate.
@@ -121,19 +124,42 @@ internal sealed partial class ConfigSchemaEmitter(SchemaGenerationSpec spec, Com
         currentNode["type"] = "object";
 
         var ownsProperties = false;
-        if (currentNode["properties"] is not JsonObject propertiesNode)
+        if (currentNode[propertiesName] is not JsonObject propertiesNode)
         {
-            propertiesNode = new JsonObject();
-            currentNode["properties"] = propertiesNode;
+            propertiesNode = new JsonObject(s_ignoreCaseNodeOptions);
+            currentNode[propertiesName] = propertiesNode;
             ownsProperties = true;
         }
 
         var ownsPathSegment = false;
+        string? backupCasingOfPathSegmentName = null;
         if (propertiesNode[pathSegment] is not JsonObject pathSegmentNode)
         {
-            pathSegmentNode = new JsonObject();
-            propertiesNode[pathSegment] = pathSegmentNode;
-            ownsPathSegment = true;
+            if (isAsterisk)
+            {
+                pathSegmentNode = propertiesNode;
+            }
+            else
+            {
+                pathSegmentNode = new JsonObject();
+                propertiesNode[pathSegment] = pathSegmentNode;
+                ownsPathSegment = true;
+            }
+        }
+        else
+        {
+            backupCasingOfPathSegmentName = propertiesNode[pathSegment].GetPropertyName();
+
+            if (backupCasingOfPathSegmentName != pathSegment)
+            {
+                // Re-add existing node, so the new casing of pathSegment is used.
+                propertiesNode.Remove(pathSegment);
+                propertiesNode[pathSegment] = pathSegmentNode;
+            }
+            else
+            {
+                backupCasingOfPathSegmentName = null;
+            }
         }
 
         var hasGenerated = GeneratePathSegment(pathSegmentNode, type, pathSegments);
@@ -143,11 +169,18 @@ internal sealed partial class ConfigSchemaEmitter(SchemaGenerationSpec spec, Com
 
             if (ownsProperties)
             {
-                currentNode.Remove("properties");
+                currentNode.Remove(propertiesName);
             }
             else if (ownsPathSegment)
             {
                 propertiesNode.Remove(pathSegment);
+            }
+            else if (backupCasingOfPathSegmentName != null)
+            {
+                // Revert casing change of pathSegment.
+                var existingValue = propertiesNode[pathSegment];
+                propertiesNode.Remove(pathSegment);
+                propertiesNode[backupCasingOfPathSegmentName] = existingValue;
             }
         }
 
@@ -462,18 +495,15 @@ internal sealed partial class ConfigSchemaEmitter(SchemaGenerationSpec spec, Com
             .Trim('\n');
     }
 
-    private void GenerateDescriptionForType(JsonObject? currentNode, TypeSpec type)
+    private void GenerateDescriptionForType(JsonObject currentNode, TypeSpec type)
     {
-        if (currentNode is not null && currentNode["description"] is null)
+        var typeSymbol = _compilation.GetBestTypeByMetadataName(type.FullName);
+        if (typeSymbol is not null)
         {
-            var typeSymbol = _compilation.GetBestTypeByMetadataName(type.FullName);
-            if (typeSymbol is not null)
+            var docComment = GetDocComment(typeSymbol);
+            if (!string.IsNullOrEmpty(docComment))
             {
-                var docComment = GetDocComment(typeSymbol);
-                if (!string.IsNullOrEmpty(docComment))
-                {
-                    GenerateDescriptionFromDocComment(currentNode, docComment);
-                }
+                GenerateDescriptionFromDocComment(currentNode, docComment);
             }
         }
     }

--- a/src/Tools/test/ConfigurationSchemaGenerator.Tests/GeneratorTests.cs
+++ b/src/Tools/test/ConfigurationSchemaGenerator.Tests/GeneratorTests.cs
@@ -53,6 +53,8 @@ public partial class GeneratorTests
         MetadataReference.CreateFromFile(typeof(HttpContent).Assembly.Location)
     ];
 
+    private static readonly JsonSerializerOptions s_testSerializerOptions = new() { WriteIndented = true };
+
     [Theory]
     [InlineData("abc\n  def", "abc def")]
     [InlineData("\n  def", "def")]
@@ -833,7 +835,7 @@ public partial class GeneratorTests
     }
 
     [Fact]
-    public void ShouldAllowEmptyComponentPath()
+    public void ShouldAllowEmptyConfigPath()
     {
         var source =
             """
@@ -870,7 +872,7 @@ public partial class GeneratorTests
     }
 
     [Fact]
-    public void ShouldAllowNestedComponentPath()
+    public void ShouldAllowNestedConfigPath()
     {
         var source =
             """
@@ -922,7 +924,7 @@ public partial class GeneratorTests
     }
 
     [Fact]
-    public void ShouldAllowSimpleTypeInComponentPath()
+    public void ShouldAllowSimpleTypeInConfigPath()
     {
         var source =
             """
@@ -955,7 +957,7 @@ public partial class GeneratorTests
     }
 
     [Fact]
-    public void MergesPropertiesAtSamePath()
+    public void MergesPropertiesAtSameConfigPath()
     {
         var source =
             """
@@ -1001,7 +1003,147 @@ public partial class GeneratorTests
     }
 
     [Fact]
-    public void PreservesExistingComponentTypeWhenSkipped()
+    public void LastUsedCasingOfConfigPathWins()
+    {
+        var source =
+            """
+            [assembly: Aspire.ConfigurationSchema("ONE:two:THREE", typeof(TestSettings1))]
+            [assembly: Aspire.ConfigurationSchema("One:Two:Three", typeof(TestSettings2))]
+            [assembly: Aspire.ConfigurationSchema("one:TWO:three", typeof(Empty))]
+
+            public record TestSettings1
+            {
+                /// <summary>1</summary>
+                public string? TestProperty1 { get; set; }
+            }
+
+            public record TestSettings2
+            {
+                /// <summary>2</summary>
+                public int? TestProperty2 { get; set; }
+            }
+            
+            public record Empty;
+            """;
+
+        var schema = GenerateSchemaFromCode(source, []);
+
+        AssertIsJson(schema,
+            """
+            {
+              "type": "object",
+              "properties": {
+                "One": {
+                  "type": "object",
+                  "properties": {
+                    "Two": {
+                      "type": "object",
+                      "properties": {
+                        "Three": {
+                          "type": "object",
+                          "properties": {
+                            "TestProperty1": {
+                              "type": "string",
+                              "description": "1"
+                            },
+                            "TestProperty2": {
+                              "type": "integer",
+                              "description": "2"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+            """);
+    }
+
+    [Fact]
+    public void LastUsedTypeDocumentationWins()
+    {
+        var source =
+            """
+            [assembly: Aspire.ConfigurationSchema("TestComponent", typeof(testSETTINGS))]
+            [assembly: Aspire.ConfigurationSchema("TestComponent", typeof(TestSettings))]
+
+            /// <summary>Initial documentation.</summary>
+            public class testSETTINGS
+            {
+                public int TestProperty1 { get; set; }
+            }
+
+            /// <summary>Replaced documentation.</summary>
+            public class TestSettings
+            {
+                public bool TestProperty2 { get; set; }
+            }
+            """;
+
+        var schema = GenerateSchemaFromCode(source, []);
+
+        AssertIsJson(schema,
+            """
+            {
+              "type": "object",
+              "properties": {
+                "TestComponent": {
+                  "type": "object",
+                  "properties": {
+                    "TestProperty1": {
+                      "type": "integer"
+                    },
+                    "TestProperty2": {
+                      "type": "boolean"
+                    }
+                  },
+                  "description": "Replaced documentation."
+                }
+              }
+            }
+            """);
+    }
+
+    [Fact]
+    public void LastUsedCasingOfPropertyWins()
+    {
+        var source =
+            """
+            [assembly: Aspire.ConfigurationSchema("TestComponent", typeof(TestSettings))]
+
+            public class TestSettings
+            {
+                /// <summary>Discarded documentation.</summary>
+                public int testPROPERTY { get; set; }
+                
+                public string? TestProperty { get; set; }
+            }
+            """;
+
+        var schema = GenerateSchemaFromCode(source, []);
+
+        AssertIsJson(schema,
+            """
+            {
+              "type": "object",
+              "properties": {
+                "TestComponent": {
+                  "type": "object",
+                  "properties": {
+                    "TestProperty": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+            """);
+    }
+
+    [Fact]
+    public void PreservesExistingTypeWhenConfigPathSkipped()
     {
         var source =
             """
@@ -1301,6 +1443,122 @@ public partial class GeneratorTests
             """);
     }
 
+    [Fact]
+    public void LastUsedCasingOfLogCategoryWins()
+    {
+        var source =
+            """
+            [assembly: Aspire.LoggingCategories("ONE", "one.TWO.three", "One.Two.Three")]
+            """;
+
+        var schema = GenerateSchemaFromCode(source, []);
+
+        AssertIsJson(schema,
+            """
+            {
+              "definitions": {
+                "logLevel": {
+                  "properties": {
+                    "ONE": {
+                      "$ref": "#/definitions/logLevelThreshold"
+                    },
+                    "One.Two.Three": {
+                      "$ref": "#/definitions/logLevelThreshold"
+                    }
+                  }
+                }
+              }
+            }
+            """);
+    }
+
+    [Fact]
+    public void GeneratesSchemaForNamedOptionsOnAsterisk()
+    {
+        var source =
+            """
+            [assembly: Aspire.ConfigurationSchema("Certificates:*", typeof(CertificateSettings))]
+            
+            public class CertificateSettings
+            {
+                /// <summary>
+                /// The private key of the certificate, in base64 format.
+                /// </summary>
+                public string? PrivateKey { get; set; }
+            }
+            """;
+
+        var schema = GenerateSchemaFromCode(source, []);
+
+        AssertIsJson(schema,
+            """
+            {
+              "type": "object",
+              "properties": {
+                "Certificates": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "object",
+                    "properties": {
+                      "PrivateKey": {
+                        "type": "string",
+                        "description": "The private key of the certificate, in base64 format."
+                      }
+                    }
+                  }
+                }
+              }
+            }
+            """);
+    }
+
+    [Fact]
+    public void CanGenerateSchemaForNamedOptionsWithDefaultOptions()
+    {
+        var source =
+            """
+            [assembly: Aspire.ConfigurationSchema("Certificates", typeof(CertificateSettings))]
+            [assembly: Aspire.ConfigurationSchema("Certificates:*", typeof(CertificateSettings))]
+
+            public class CertificateSettings
+            {
+                /// <summary>
+                /// The private key of the certificate, in base64 format.
+                /// </summary>
+                public string? PrivateKey { get; set; }
+            }
+            """;
+
+        var schema = GenerateSchemaFromCode(source, []);
+
+        AssertIsJson(schema,
+            """
+            {
+              "type": "object",
+              "properties": {
+                "Certificates": {
+                  "type": "object",
+                  "properties": {
+                    "PrivateKey": {
+                      "type": "string",
+                      "description": "The private key of the certificate, in base64 format."
+                    }
+                  },
+                  "additionalProperties": {
+                    "type": "object",
+                    "properties": {
+                      "PrivateKey": {
+                        "type": "string",
+                        "description": "The private key of the certificate, in base64 format."
+                      }
+                    }
+                  }
+                }
+              }
+            }
+            """);
+    }
+
     private static string GenerateSchemaFromCode(string sourceText, IEnumerable<MetadataReference> references)
     {
         var sourceSyntaxTree = SyntaxFactory.ParseSyntaxTree(SourceText.From(sourceText));
@@ -1324,9 +1582,8 @@ public partial class GeneratorTests
         var actualJson = JsonNode.Parse(actual)!;
         var expectedJson = JsonNode.Parse(expected)!;
 
-        var serializerOptions = new JsonSerializerOptions { WriteIndented = true };
-        var expectedText = expectedJson.ToJsonString(serializerOptions);
-        var actualText = actualJson.ToJsonString(serializerOptions);
+        var expectedText = expectedJson.ToJsonString(s_testSerializerOptions);
+        var actualText = actualJson.ToJsonString(s_testSerializerOptions);
 
         Assert.Equal(expectedText, actualText);
     }


### PR DESCRIPTION
## Description

Add support for named options in JSON Configuration schemas.

## Quality checklist

- [x] Your code complies with our [Coding Style](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-code-style.md).
- [x] You've updated unit and/or integration tests for your change, where applicable.
- [ ] You've updated documentation for your change, where applicable.
      If your change affects other repositories, such as [Documentation](https://github.com/SteeltoeOSS/Documentation), [Samples](https://github.com/SteeltoeOSS/Samples) and/or [MainSite](https://github.com/SteeltoeOSS/MainSite), add linked PRs here.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
- [ ] You've added required license files and/or file headers (explaining where the code came from with proper attribution), where code is copied from StackOverflow, a blog, or OSS.
