### PR TITLE
Fixed: do not package schema generator (dev-only tool)

### DIFF
--- a/src/Tools/src/ConfigurationSchemaGenerator/ConfigurationSchemaGenerator.csproj
+++ b/src/Tools/src/ConfigurationSchemaGenerator/ConfigurationSchemaGenerator.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
     <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>annotations</Nullable>


### PR DESCRIPTION
This should fix the following in the logs for the package pipeline:
```
/opt/hostedtoolcache/dotnet/sdk/8.0.303/Sdks/NuGet.Build.Tasks.Pack/build/NuGet.Build.Tasks.Pack.targets(221,5): warning NU5104: A stable release of a package should not have a prerelease dependency. Either modify the version spec of dependency "System.CommandLine [2.0.0-beta4.24209.3, )" or update the version field in the nuspec. [/home/vsts/work/1/s/src/Tools/src/ConfigurationSchemaGenerator/ConfigurationSchemaGenerator.csproj]
  The package ConfigurationSchemaGenerator.1.0.0 is missing a readme. Go to https://aka.ms/nuget/authoring-best-practices/readme to learn why package readmes are important.
  Successfully created package '/home/vsts/work/1/a/packages/ConfigurationSchemaGenerator.1.0.0.nupkg'.
```