### PR TITLE
Allow to clear default entries in collections in options

### DIFF
--- a/src/Management/src/Abstractions/Configuration/EndpointOptions.cs
+++ b/src/Management/src/Abstractions/Configuration/EndpointOptions.cs
@@ -45,14 +45,11 @@ public abstract class EndpointOptions
     /// <summary>
     /// Gets the list of HTTP verbs that are allowed for this endpoint.
     /// </summary>
-    public IList<string> AllowedVerbs { get; }
+    public IList<string> AllowedVerbs { get; private set; } = new List<string>();
 
-    protected EndpointOptions()
+    internal void ApplyDefaultAllowedVerbs()
     {
-        // ReSharper disable once VirtualMemberCallInConstructor
-#pragma warning disable S1699 // Constructors should only call non-overridable methods
         AllowedVerbs = GetDefaultAllowedVerbs();
-#pragma warning restore S1699 // Constructors should only call non-overridable methods
     }
 
     /// <summary>

--- a/src/Management/src/Abstractions/Configuration/EndpointOptions.cs
+++ b/src/Management/src/Abstractions/Configuration/EndpointOptions.cs
@@ -47,6 +47,13 @@ public abstract class EndpointOptions
     /// </summary>
     public IList<string> AllowedVerbs { get; private set; } = new List<string>();
 
+    internal HashSet<string> GetSafeAllowedVerbs()
+    {
+        // Caution: Mapping with an empty string in the list results in exposing the endpoint at ALL verbs.
+        // And duplicate verbs that only differ in case result in an ambiguous match error when mapping routes.
+        return AllowedVerbs.Where(verb => verb.Length > 0).ToHashSet(StringComparer.OrdinalIgnoreCase);
+    }
+
     internal void ApplyDefaultAllowedVerbs()
     {
         AllowedVerbs = GetDefaultAllowedVerbs();

--- a/src/Management/src/Endpoint/ActuatorEndpointMapper.cs
+++ b/src/Management/src/Endpoint/ActuatorEndpointMapper.cs
@@ -45,8 +45,10 @@ internal sealed class ActuatorEndpointMapper
         InnerMap(middleware => endpointRouteBuilder.CreateApplicationBuilder().UseMiddleware(middleware.GetType()).Build(),
             (middleware, requestPath, pipeline) =>
             {
-                IEndpointConventionBuilder builder = endpointRouteBuilder.MapMethods(requestPath, middleware.EndpointOptions.AllowedVerbs, pipeline);
-                conventionBuilder.Add(builder);
+                HashSet<string> allowedVerbs = middleware.EndpointOptions.AllowedVerbs.ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+                IEndpointConventionBuilder endpointConventionBuilder = endpointRouteBuilder.MapMethods(requestPath, allowedVerbs, pipeline);
+                conventionBuilder.Add(endpointConventionBuilder);
             });
     }
 
@@ -56,7 +58,9 @@ internal sealed class ActuatorEndpointMapper
 
         InnerMap(middleware => routeBuilder.ApplicationBuilder.UseMiddleware(middleware.GetType()).Build(), (middleware, requestPath, pipeline) =>
         {
-            foreach (string verb in middleware.EndpointOptions.AllowedVerbs)
+            HashSet<string> allowedVerbs = middleware.EndpointOptions.AllowedVerbs.ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+            foreach (string verb in allowedVerbs)
             {
                 routeBuilder.MapVerb(verb, requestPath, pipeline);
             }

--- a/src/Management/src/Endpoint/ActuatorServiceCollectionExtensions.cs
+++ b/src/Management/src/Endpoint/ActuatorServiceCollectionExtensions.cs
@@ -50,9 +50,7 @@ public static class ActuatorServiceCollectionExtensions
         ArgumentNullException.ThrowIfNull(services);
 
         services.ConfigureOptionsWithChangeTokenSource<TOptions, TConfigureOptions>();
-
-        services.TryAddEnumerable(
-            ServiceDescriptor.Singleton<EndpointOptions, TOptions>(provider => provider.GetRequiredService<IOptionsMonitor<TOptions>>().CurrentValue));
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<IEndpointOptionsMonitorProvider, EndpointOptionsMonitorProvider<TOptions>>());
     }
 
     internal static void ConfigureOptionsWithChangeTokenSource<TOptions, TConfigureOptions>(this IServiceCollection services)

--- a/src/Management/src/Endpoint/Actuators/CloudFoundry/CloudFoundryEndpointHandler.cs
+++ b/src/Management/src/Endpoint/Actuators/CloudFoundry/CloudFoundryEndpointHandler.cs
@@ -19,26 +19,26 @@ internal sealed class CloudFoundryEndpointHandler : ICloudFoundryEndpointHandler
 {
     private readonly IOptionsMonitor<ManagementOptions> _managementOptionsMonitor;
     private readonly IOptionsMonitor<CloudFoundryEndpointOptions> _endpointOptionsMonitor;
-    private readonly EndpointOptions[] _endpointOptionsArray;
+    private readonly IEndpointOptionsMonitorProvider[] _optionsMonitorProviderArray;
     private readonly ILogger<HypermediaService> _hypermediaServiceLogger;
 
     public EndpointOptions Options => _endpointOptionsMonitor.CurrentValue;
 
     public CloudFoundryEndpointHandler(IOptionsMonitor<ManagementOptions> managementOptionsMonitor,
-        IOptionsMonitor<CloudFoundryEndpointOptions> endpointOptionsMonitor, IEnumerable<EndpointOptions> endpointOptionsCollection,
+        IOptionsMonitor<CloudFoundryEndpointOptions> endpointOptionsMonitor, IEnumerable<IEndpointOptionsMonitorProvider> endpointOptionsMonitorProviders,
         ILoggerFactory loggerFactory)
     {
         ArgumentNullException.ThrowIfNull(managementOptionsMonitor);
         ArgumentNullException.ThrowIfNull(endpointOptionsMonitor);
-        ArgumentNullException.ThrowIfNull(endpointOptionsCollection);
+        ArgumentNullException.ThrowIfNull(endpointOptionsMonitorProviders);
         ArgumentNullException.ThrowIfNull(loggerFactory);
 
-        EndpointOptions[] endpointOptionsArray = endpointOptionsCollection.ToArray();
-        ArgumentGuard.ElementsNotNull(endpointOptionsArray);
+        IEndpointOptionsMonitorProvider[] optionsMonitorProviderArray = endpointOptionsMonitorProviders.ToArray();
+        ArgumentGuard.ElementsNotNull(optionsMonitorProviderArray);
 
         _managementOptionsMonitor = managementOptionsMonitor;
         _endpointOptionsMonitor = endpointOptionsMonitor;
-        _endpointOptionsArray = endpointOptionsArray;
+        _optionsMonitorProviderArray = optionsMonitorProviderArray;
         _hypermediaServiceLogger = loggerFactory.CreateLogger<HypermediaService>();
     }
 
@@ -46,7 +46,9 @@ internal sealed class CloudFoundryEndpointHandler : ICloudFoundryEndpointHandler
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(baseUrl);
 
-        var hypermediaService = new HypermediaService(_managementOptionsMonitor, _endpointOptionsMonitor, _endpointOptionsArray, _hypermediaServiceLogger);
+        var hypermediaService =
+            new HypermediaService(_managementOptionsMonitor, _endpointOptionsMonitor, _optionsMonitorProviderArray, _hypermediaServiceLogger);
+
         Links result = hypermediaService.Invoke(baseUrl);
         return await Task.FromResult(result);
     }

--- a/src/Management/src/Endpoint/Actuators/Environment/ConfigureEnvironmentEndpointOptions.cs
+++ b/src/Management/src/Endpoint/Actuators/Environment/ConfigureEnvironmentEndpointOptions.cs
@@ -30,12 +30,17 @@ internal sealed class ConfigureEnvironmentEndpointOptions(IConfiguration configu
 
         // It's not possible to distinguish between null and an empty list in configuration.
         // See https://github.com/dotnet/extensions/issues/1341.
+        // As a workaround, we interpret a single empty string element to clear the defaults.
         if (options.KeysToSanitize.Count == 0)
         {
             foreach (string defaultKey in DefaultKeysToSanitize)
             {
                 options.KeysToSanitize.Add(defaultKey);
             }
+        }
+        else if (options.KeysToSanitize is [""])
+        {
+            options.KeysToSanitize.Clear();
         }
     }
 }

--- a/src/Management/src/Endpoint/Actuators/Environment/EnvironmentEndpointOptions.cs
+++ b/src/Management/src/Endpoint/Actuators/Environment/EnvironmentEndpointOptions.cs
@@ -9,7 +9,7 @@ namespace Steeltoe.Management.Endpoint.Actuators.Environment;
 public sealed class EnvironmentEndpointOptions : EndpointOptions
 {
     /// <summary>
-    /// Gets the list of keys to sanitize.
+    /// Gets the list of keys to sanitize. Allows regular expressions.
     /// </summary>
     public IList<string> KeysToSanitize { get; } = new List<string>();
 }

--- a/src/Management/src/Endpoint/Actuators/Health/ConfigureHealthEndpointOptions.cs
+++ b/src/Management/src/Endpoint/Actuators/Health/ConfigureHealthEndpointOptions.cs
@@ -28,14 +28,21 @@ internal sealed class ConfigureHealthEndpointOptions(IConfiguration configuratio
             };
         }
 
-        options.Groups.TryAdd("liveness", new HealthGroupOptions
+        if (options.Groups.Count == 0)
         {
-            Include = "liveness"
-        });
+            options.Groups["liveness"] = new HealthGroupOptions
+            {
+                Include = "liveness"
+            };
 
-        options.Groups.TryAdd("readiness", new HealthGroupOptions
+            options.Groups["readiness"] = new HealthGroupOptions
+            {
+                Include = "readiness"
+            };
+        }
+        else if (options.Groups.Count == 1 && options.Groups.TryGetValue(string.Empty, out HealthGroupOptions? group) && string.IsNullOrEmpty(group.Include))
         {
-            Include = "readiness"
-        });
+            options.Groups.Clear();
+        }
     }
 }

--- a/src/Management/src/Endpoint/Actuators/Hypermedia/ActuatorEndpointHandler.cs
+++ b/src/Management/src/Endpoint/Actuators/Hypermedia/ActuatorEndpointHandler.cs
@@ -17,25 +17,26 @@ internal sealed class ActuatorEndpointHandler : IActuatorEndpointHandler
 {
     private readonly IOptionsMonitor<ManagementOptions> _managementOptionsMonitor;
     private readonly IOptionsMonitor<HypermediaEndpointOptions> _endpointOptionsMonitor;
-    private readonly EndpointOptions[] _endpointOptionsArray;
+    private readonly IEndpointOptionsMonitorProvider[] _endpointOptionsMonitorProviderArray;
     private readonly ILogger<HypermediaService> _hypermediaServiceLogger;
 
     public EndpointOptions Options => _endpointOptionsMonitor.CurrentValue;
 
     public ActuatorEndpointHandler(IOptionsMonitor<ManagementOptions> managementOptionsMonitor,
-        IOptionsMonitor<HypermediaEndpointOptions> endpointOptionsMonitor, IEnumerable<EndpointOptions> endpointOptionsCollection, ILoggerFactory loggerFactory)
+        IOptionsMonitor<HypermediaEndpointOptions> endpointOptionsMonitor, IEnumerable<IEndpointOptionsMonitorProvider> endpointOptionsMonitorProviders,
+        ILoggerFactory loggerFactory)
     {
         ArgumentNullException.ThrowIfNull(managementOptionsMonitor);
         ArgumentNullException.ThrowIfNull(endpointOptionsMonitor);
-        ArgumentNullException.ThrowIfNull(endpointOptionsCollection);
+        ArgumentNullException.ThrowIfNull(endpointOptionsMonitorProviders);
         ArgumentNullException.ThrowIfNull(loggerFactory);
 
-        EndpointOptions[] endpointOptionsArray = endpointOptionsCollection.ToArray();
-        ArgumentGuard.ElementsNotNull(endpointOptionsArray);
+        IEndpointOptionsMonitorProvider[] endpointOptionsMonitorProviderArray = endpointOptionsMonitorProviders.ToArray();
+        ArgumentGuard.ElementsNotNull(endpointOptionsMonitorProviderArray);
 
         _managementOptionsMonitor = managementOptionsMonitor;
         _endpointOptionsMonitor = endpointOptionsMonitor;
-        _endpointOptionsArray = endpointOptionsArray;
+        _endpointOptionsMonitorProviderArray = endpointOptionsMonitorProviderArray;
         _hypermediaServiceLogger = loggerFactory.CreateLogger<HypermediaService>();
     }
 
@@ -43,7 +44,7 @@ internal sealed class ActuatorEndpointHandler : IActuatorEndpointHandler
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(baseUrl);
 
-        var service = new HypermediaService(_managementOptionsMonitor, _endpointOptionsMonitor, _endpointOptionsArray, _hypermediaServiceLogger);
+        var service = new HypermediaService(_managementOptionsMonitor, _endpointOptionsMonitor, _endpointOptionsMonitorProviderArray, _hypermediaServiceLogger);
         Links result = service.Invoke(baseUrl);
         return Task.FromResult(result);
     }

--- a/src/Management/src/Endpoint/Actuators/Hypermedia/HypermediaService.cs
+++ b/src/Management/src/Endpoint/Actuators/Hypermedia/HypermediaService.cs
@@ -15,38 +15,38 @@ internal sealed class HypermediaService
 {
     private readonly IOptionsMonitor<ManagementOptions> _managementOptionsMonitor;
     private readonly EndpointOptions _endpointOptions;
-    private readonly ICollection<EndpointOptions> _endpointOptionsCollection;
+    private readonly ICollection<IEndpointOptionsMonitorProvider> _endpointOptionsMonitorProviders;
     private readonly ILogger<HypermediaService> _logger;
 
     public HypermediaService(IOptionsMonitor<ManagementOptions> managementOptionsMonitor,
-        IOptionsMonitor<HypermediaEndpointOptions> hypermediaEndpointOptionsMonitor, ICollection<EndpointOptions> endpointOptionsCollection,
-        ILogger<HypermediaService> logger)
+        IOptionsMonitor<HypermediaEndpointOptions> hypermediaEndpointOptionsMonitor,
+        ICollection<IEndpointOptionsMonitorProvider> endpointOptionsMonitorProviders, ILogger<HypermediaService> logger)
     {
         ArgumentNullException.ThrowIfNull(managementOptionsMonitor);
         ArgumentNullException.ThrowIfNull(hypermediaEndpointOptionsMonitor);
-        ArgumentNullException.ThrowIfNull(endpointOptionsCollection);
-        ArgumentGuard.ElementsNotNull(endpointOptionsCollection);
+        ArgumentNullException.ThrowIfNull(endpointOptionsMonitorProviders);
+        ArgumentGuard.ElementsNotNull(endpointOptionsMonitorProviders);
         ArgumentNullException.ThrowIfNull(logger);
 
         _managementOptionsMonitor = managementOptionsMonitor;
         _endpointOptions = hypermediaEndpointOptionsMonitor.CurrentValue;
-        _endpointOptionsCollection = endpointOptionsCollection;
+        _endpointOptionsMonitorProviders = endpointOptionsMonitorProviders;
         _logger = logger;
     }
 
     public HypermediaService(IOptionsMonitor<ManagementOptions> managementOptionsMonitor,
-        IOptionsMonitor<CloudFoundryEndpointOptions> cloudFoundryEndpointOptionsMonitor, ICollection<EndpointOptions> endpointOptionsCollection,
-        ILogger<HypermediaService> logger)
+        IOptionsMonitor<CloudFoundryEndpointOptions> cloudFoundryEndpointOptionsMonitor,
+        ICollection<IEndpointOptionsMonitorProvider> endpointOptionsMonitorProviders, ILogger<HypermediaService> logger)
     {
         ArgumentNullException.ThrowIfNull(managementOptionsMonitor);
         ArgumentNullException.ThrowIfNull(cloudFoundryEndpointOptionsMonitor);
-        ArgumentNullException.ThrowIfNull(endpointOptionsCollection);
-        ArgumentGuard.ElementsNotNull(endpointOptionsCollection);
+        ArgumentNullException.ThrowIfNull(endpointOptionsMonitorProviders);
+        ArgumentGuard.ElementsNotNull(endpointOptionsMonitorProviders);
         ArgumentNullException.ThrowIfNull(logger);
 
         _managementOptionsMonitor = managementOptionsMonitor;
         _endpointOptions = cloudFoundryEndpointOptionsMonitor.CurrentValue;
-        _endpointOptionsCollection = endpointOptionsCollection;
+        _endpointOptionsMonitorProviders = endpointOptionsMonitorProviders;
         _logger = logger;
     }
 
@@ -65,7 +65,7 @@ internal sealed class HypermediaService
 
         Link? selfLink = null;
 
-        foreach (EndpointOptions endpointOptions in _endpointOptionsCollection)
+        foreach (EndpointOptions endpointOptions in _endpointOptionsMonitorProviders.Select(provider => provider.Get()))
         {
             if (!endpointOptions.IsEnabled(_managementOptionsMonitor.CurrentValue) || !endpointOptions.IsExposed(_managementOptionsMonitor.CurrentValue))
             {

--- a/src/Management/src/Endpoint/Actuators/Trace/ConfigureTraceEndpointOptions.cs
+++ b/src/Management/src/Endpoint/Actuators/Trace/ConfigureTraceEndpointOptions.cs
@@ -8,20 +8,14 @@ using Steeltoe.Management.Endpoint.Configuration;
 
 namespace Steeltoe.Management.Endpoint.Actuators.Trace;
 
-internal sealed class ConfigureTraceEndpointOptions : ConfigureEndpointOptions<TraceEndpointOptions>, IConfigureNamedOptions<TraceEndpointOptions>
+internal sealed class ConfigureTraceEndpointOptions(IConfiguration configuration)
+    : ConfigureEndpointOptions<TraceEndpointOptions>(configuration, ManagementInfoPrefixV2, EndpointIdV2), IConfigureNamedOptions<TraceEndpointOptions>
 {
+    private const string EndpointIdV1 = "trace";
+    private const string EndpointIdV2 = "httptrace";
     private const string ManagementInfoPrefixV1 = "management:endpoints:trace";
-    private const string ManagementInfoPrefix = "management:endpoints:httptrace";
+    private const string ManagementInfoPrefixV2 = "management:endpoints:httptrace";
     private const int DefaultCapacity = 100;
-    private readonly IConfiguration _configuration;
-
-    public ConfigureTraceEndpointOptions(IConfiguration configuration)
-        : base(configuration, ManagementInfoPrefix, "httptrace")
-    {
-        ArgumentNullException.ThrowIfNull(configuration);
-
-        _configuration = configuration;
-    }
 
     public void Configure(string? name, TraceEndpointOptions options)
     {
@@ -29,16 +23,11 @@ internal sealed class ConfigureTraceEndpointOptions : ConfigureEndpointOptions<T
 
         if (name == TraceEndpointOptionNames.V2.ToString() || string.IsNullOrEmpty(name))
         {
-            Configure(options);
+            ConfigureAtKey(Configuration, ManagementInfoPrefixV2, EndpointIdV2, options);
         }
         else
         {
-            _configuration.GetSection(ManagementInfoPrefixV1).Bind(options);
-
-            if (string.IsNullOrEmpty(options.Id))
-            {
-                options.Id = "trace";
-            }
+            ConfigureAtKey(Configuration, ManagementInfoPrefixV1, EndpointIdV1, options);
         }
 
         if (options.Capacity == -1)

--- a/src/Management/src/Endpoint/Configuration/ConfigureEndpointOptions.cs
+++ b/src/Management/src/Endpoint/Configuration/ConfigureEndpointOptions.cs
@@ -30,11 +30,21 @@ internal abstract class ConfigureEndpointOptions<T> : IConfigureOptionsWithKey<T
 
     public virtual void Configure(T options)
     {
+        ConfigureAtKey(Configuration, _prefix, _id, options);
+    }
+
+    protected static void ConfigureAtKey(IConfiguration configuration, string configurationKey, string endpointId, T options)
+    {
         ArgumentNullException.ThrowIfNull(options);
 
-        Configuration.GetSection(_prefix).Bind(options);
+        configuration.GetSection(configurationKey).Bind(options);
 
-        options.Id ??= _id;
+        options.Id ??= endpointId;
+
+        if (options.AllowedVerbs.Count == 0)
+        {
+            options.ApplyDefaultAllowedVerbs();
+        }
 
         if (!Enum.IsDefined(options.RequiredPermissions))
         {

--- a/src/Management/src/Endpoint/Configuration/ConfigureManagementOptions.cs
+++ b/src/Management/src/Endpoint/Configuration/ConfigureManagementOptions.cs
@@ -123,6 +123,18 @@ internal sealed class ConfigureManagementOptions : IConfigureOptionsWithKey<Mana
             {
                 ReplaceCollection(options.Include, DefaultIncludes);
             }
+            else
+            {
+                if (options.Include is [""])
+                {
+                    ReplaceCollection(options.Include, Array.Empty<string>());
+                }
+
+                if (options.Exclude is [""])
+                {
+                    ReplaceCollection(options.Exclude, Array.Empty<string>());
+                }
+            }
         }
 
         private static List<string>? GetListFromConfigurationCsvString(IConfigurationSection section, string key)

--- a/src/Management/src/Endpoint/Configuration/EndpointOptionsMonitorProvider.cs
+++ b/src/Management/src/Endpoint/Configuration/EndpointOptionsMonitorProvider.cs
@@ -1,0 +1,32 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Extensions.Options;
+using Steeltoe.Management.Configuration;
+
+namespace Steeltoe.Management.Endpoint.Configuration;
+
+/// <summary>
+/// Provides access to the latest value for the specified endpoint options type.
+/// </summary>
+/// <typeparam name="T">
+/// The <see cref="EndpointOptions" /> type.
+/// </typeparam>
+internal sealed class EndpointOptionsMonitorProvider<T> : IEndpointOptionsMonitorProvider
+    where T : EndpointOptions
+{
+    private readonly IOptionsMonitor<T> _optionsMonitor;
+
+    public EndpointOptionsMonitorProvider(IOptionsMonitor<T> optionsMonitor)
+    {
+        ArgumentNullException.ThrowIfNull(optionsMonitor);
+
+        _optionsMonitor = optionsMonitor;
+    }
+
+    public EndpointOptions Get()
+    {
+        return _optionsMonitor.CurrentValue;
+    }
+}

--- a/src/Management/src/Endpoint/Configuration/IEndpointOptionsMonitorProvider.cs
+++ b/src/Management/src/Endpoint/Configuration/IEndpointOptionsMonitorProvider.cs
@@ -1,0 +1,17 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Extensions.Options;
+using Steeltoe.Management.Configuration;
+
+namespace Steeltoe.Management.Endpoint.Configuration;
+
+/// <summary>
+/// Enables to register multiple typed providers to enumerate all <see cref="IOptionsMonitor{TOptions}" />s for the various
+/// <see cref="EndpointOptions" /> types.
+/// </summary>
+internal interface IEndpointOptionsMonitorProvider
+{
+    EndpointOptions Get();
+}

--- a/src/Management/src/Endpoint/ConfigurationSchema.json
+++ b/src/Management/src/Endpoint/ConfigurationSchema.json
@@ -228,7 +228,7 @@
                   "items": {
                     "type": "string"
                   },
-                  "description": "Gets the list of keys to sanitize."
+                  "description": "Gets the list of keys to sanitize. Allows regular expressions."
                 },
                 "Path": {
                   "type": "string",

--- a/src/Management/test/Endpoint.Test/Actuators/CloudFoundry/EndpointMiddlewareTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/CloudFoundry/EndpointMiddlewareTest.cs
@@ -36,7 +36,7 @@ public sealed class EndpointMiddlewareTest : BaseTest
     [Fact]
     public void RoutesByPathAndVerb()
     {
-        var endpointOptions = new HypermediaEndpointOptions();
+        HypermediaEndpointOptions endpointOptions = GetOptionsMonitorFromSettings<HypermediaEndpointOptions>().CurrentValue;
         IOptionsMonitor<ManagementOptions> managementOptionsMonitor = GetOptionsMonitorFromSettings<ManagementOptions>();
         Assert.True(endpointOptions.RequiresExactMatch());
 

--- a/src/Management/test/Endpoint.Test/Actuators/Environment/EnvironmentEndpointOptionsTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/Environment/EnvironmentEndpointOptionsTest.cs
@@ -34,7 +34,7 @@ public sealed class EnvironmentEndpointOptionsTest : BaseTest
     {
         var appSettings = new Dictionary<string, string?>
         {
-            ["management:endpoints:env:keysToSanitize:0"] = ""
+            ["management:endpoints:env:keysToSanitize:0"] = string.Empty
         };
 
         EnvironmentEndpointOptions options = GetOptionsFromSettings<EnvironmentEndpointOptions, ConfigureEnvironmentEndpointOptions>(appSettings);

--- a/src/Management/test/Endpoint.Test/Actuators/Environment/EnvironmentEndpointOptionsTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/Environment/EnvironmentEndpointOptionsTest.cs
@@ -20,12 +20,42 @@ public sealed class EnvironmentEndpointOptionsTest : BaseTest
     ];
 
     [Fact]
-    public void Constructor_InitializesWithDefaults()
+    public void AppliesDefaults()
     {
         EnvironmentEndpointOptions options = GetOptionsFromSettings<EnvironmentEndpointOptions, ConfigureEnvironmentEndpointOptions>();
 
-        Assert.Equal("env", options.Id);
-        Assert.Equal(DefaultKeysToSanitize, options.KeysToSanitize);
-        Assert.Equal(EndpointPermissions.Restricted, options.RequiredPermissions);
+        options.Id.Should().Be("env");
+        options.KeysToSanitize.Should().BeEquivalentTo(DefaultKeysToSanitize);
+        options.RequiredPermissions.Should().Be(EndpointPermissions.Restricted);
+    }
+
+    [Fact]
+    public void CanClearDefaults()
+    {
+        var appSettings = new Dictionary<string, string?>
+        {
+            ["management:endpoints:env:keysToSanitize:0"] = ""
+        };
+
+        EnvironmentEndpointOptions options = GetOptionsFromSettings<EnvironmentEndpointOptions, ConfigureEnvironmentEndpointOptions>(appSettings);
+
+        options.Id.Should().Be("env");
+        options.KeysToSanitize.Should().BeEquivalentTo([]);
+        options.RequiredPermissions.Should().Be(EndpointPermissions.Restricted);
+    }
+
+    [Fact]
+    public void CanOverrideDefaults()
+    {
+        var appSettings = new Dictionary<string, string?>
+        {
+            ["management:endpoints:env:keysToSanitize:0"] = "accessToken"
+        };
+
+        EnvironmentEndpointOptions options = GetOptionsFromSettings<EnvironmentEndpointOptions, ConfigureEnvironmentEndpointOptions>(appSettings);
+
+        options.Id.Should().Be("env");
+        options.KeysToSanitize.Should().BeEquivalentTo(["accessToken"]);
+        options.RequiredPermissions.Should().Be(EndpointPermissions.Restricted);
     }
 }

--- a/src/Management/test/Endpoint.Test/Actuators/Environment/EnvironmentEndpointTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/Environment/EnvironmentEndpointTest.cs
@@ -295,7 +295,7 @@ public sealed class EnvironmentEndpointTest(ITestOutputHelper testOutputHelper) 
     {
         var appsettings = new Dictionary<string, string?>
         {
-            ["management:endpoints:env:keystosanitize:0"] = "credentials",
+            ["management:endpoints:env:keysToSanitize:0"] = "credentials",
             ["password"] = "mysecret"
         };
 

--- a/src/Management/test/Endpoint.Test/Actuators/Health/HealthEndpointOptionsTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/Health/HealthEndpointOptionsTest.cs
@@ -74,4 +74,17 @@ public sealed class HealthEndpointOptionsTest : BaseTest
         Assert.Equal(ClaimTypes.Role, options.Claim.Type);
         Assert.Equal("roleclaimvalue", options.Claim.Value);
     }
+
+    [Fact]
+    public void CanClearDefaultGroups()
+    {
+        var appsettings = new Dictionary<string, string?>
+        {
+            ["management:endpoints:health:groups::include"] = ""
+        };
+
+        HealthEndpointOptions options = GetOptionsFromSettings<HealthEndpointOptions, ConfigureHealthEndpointOptions>(appsettings);
+
+        options.Groups.Should().BeEmpty();
+    }
 }

--- a/src/Management/test/Endpoint.Test/Actuators/Health/HealthEndpointOptionsTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/Health/HealthEndpointOptionsTest.cs
@@ -80,7 +80,7 @@ public sealed class HealthEndpointOptionsTest : BaseTest
     {
         var appsettings = new Dictionary<string, string?>
         {
-            ["management:endpoints:health:groups::include"] = ""
+            ["management:endpoints:health:groups::include"] = string.Empty
         };
 
         HealthEndpointOptions options = GetOptionsFromSettings<HealthEndpointOptions, ConfigureHealthEndpointOptions>(appsettings);

--- a/src/Management/test/Endpoint.Test/Actuators/Refresh/EndpointMiddlewareTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/Refresh/EndpointMiddlewareTest.cs
@@ -43,7 +43,7 @@ public sealed class EndpointMiddlewareTest : BaseTest
         var handler = new RefreshEndpointHandler(endpointOptionsMonitor, configurationRoot, NullLoggerFactory.Instance);
         var middleware = new RefreshEndpointMiddleware(handler, managementOptions, NullLoggerFactory.Instance);
 
-        HttpContext context = CreateRequest("GET", "/refresh");
+        HttpContext context = CreateRequest("POST", "/refresh");
         await middleware.InvokeAsync(context, null);
         context.Response.Body.Seek(0, SeekOrigin.Begin);
         var reader = new StreamReader(context.Response.Body, Encoding.UTF8);

--- a/src/Management/test/Endpoint.Test/Actuators/Refresh/HttpVerbInConventionalRoutingTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/Refresh/HttpVerbInConventionalRoutingTest.cs
@@ -1,0 +1,135 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+using System.Net;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Steeltoe.Common.TestResources;
+
+namespace Steeltoe.Management.Endpoint.Test.Actuators.Refresh;
+
+public sealed class HttpVerbInConventionalRoutingTest
+{
+    [Fact]
+    public async Task Allows_only_POST_requests()
+    {
+        var appSettings = new Dictionary<string, string?>
+        {
+            ["Management:Endpoints:Actuator:Exposure:Include:0"] = "refresh"
+        };
+
+        WebApplicationBuilder builder = TestWebApplicationBuilderFactory.Create();
+        builder.Configuration.AddInMemoryCollection(appSettings);
+        builder.Services.AddControllersWithViews(options => options.EnableEndpointRouting = false);
+        builder.AddRefreshActuator();
+
+        await using WebApplication app = builder.Build();
+        app.UseMvc(routes => routes.MapRoute("default", "{controller=Home}/{action=Index}/{id?}"));
+        await app.StartAsync();
+
+        using TestServer testServer = app.GetTestServer();
+        using HttpClient httpClient = testServer.CreateClient();
+
+        var requestUri = new Uri("/actuator/refresh", UriKind.Relative);
+
+        HttpResponseMessage getResponse = await httpClient.GetAsync(requestUri);
+        getResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
+
+        HttpResponseMessage postResponse = await httpClient.PostAsync(requestUri, null);
+        postResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task Can_be_configured_to_allow_no_verbs()
+    {
+        var appSettings = new Dictionary<string, string?>
+        {
+            ["Management:Endpoints:Actuator:Exposure:Include:0"] = "refresh",
+            ["Management:Endpoints:Refresh:AllowedVerbs:0"] = string.Empty
+        };
+
+        WebApplicationBuilder builder = TestWebApplicationBuilderFactory.Create();
+        builder.Configuration.AddInMemoryCollection(appSettings);
+        builder.Services.AddControllersWithViews(options => options.EnableEndpointRouting = false);
+        builder.AddRefreshActuator();
+
+        await using WebApplication app = builder.Build();
+        app.UseMvc(routes => routes.MapRoute("default", "{controller=Home}/{action=Index}/{id?}"));
+        await app.StartAsync();
+
+        using TestServer testServer = app.GetTestServer();
+        using HttpClient httpClient = testServer.CreateClient();
+
+        var requestUri = new Uri("/actuator/refresh", UriKind.Relative);
+
+        HttpResponseMessage getResponse = await httpClient.GetAsync(requestUri);
+        getResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
+
+        HttpResponseMessage postResponse = await httpClient.PostAsync(requestUri, null);
+        postResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task Can_be_configured_to_allow_only_GET_requests()
+    {
+        var appSettings = new Dictionary<string, string?>
+        {
+            ["Management:Endpoints:Actuator:Exposure:Include:0"] = "refresh",
+            ["Management:Endpoints:Refresh:AllowedVerbs:0"] = "GET"
+        };
+
+        WebApplicationBuilder builder = TestWebApplicationBuilderFactory.Create();
+        builder.Configuration.AddInMemoryCollection(appSettings);
+        builder.Services.AddControllersWithViews(options => options.EnableEndpointRouting = false);
+        builder.AddRefreshActuator();
+
+        await using WebApplication app = builder.Build();
+        app.UseMvc(routes => routes.MapRoute("default", "{controller=Home}/{action=Index}/{id?}"));
+        await app.StartAsync();
+
+        using TestServer testServer = app.GetTestServer();
+        using HttpClient httpClient = testServer.CreateClient();
+
+        var requestUri = new Uri("/actuator/refresh", UriKind.Relative);
+
+        HttpResponseMessage getResponse = await httpClient.GetAsync(requestUri);
+        getResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        HttpResponseMessage postResponse = await httpClient.PostAsync(requestUri, null);
+        postResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task Can_be_configured_to_allow_both_GET_and_POST_requests()
+    {
+        var appSettings = new Dictionary<string, string?>
+        {
+            ["Management:Endpoints:Actuator:Exposure:Include:0"] = "refresh",
+            ["Management:Endpoints:Refresh:AllowedVerbs:0"] = "GET",
+            ["Management:Endpoints:Refresh:AllowedVerbs:1"] = "POST"
+        };
+
+        WebApplicationBuilder builder = TestWebApplicationBuilderFactory.Create();
+        builder.Configuration.AddInMemoryCollection(appSettings);
+        builder.Services.AddControllersWithViews(options => options.EnableEndpointRouting = false);
+        builder.AddRefreshActuator();
+
+        await using WebApplication app = builder.Build();
+        app.UseMvc(routes => routes.MapRoute("default", "{controller=Home}/{action=Index}/{id?}"));
+        await app.StartAsync();
+
+        using TestServer testServer = app.GetTestServer();
+        using HttpClient httpClient = testServer.CreateClient();
+
+        var requestUri = new Uri("/actuator/refresh", UriKind.Relative);
+
+        HttpResponseMessage getResponse = await httpClient.GetAsync(requestUri);
+        getResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        HttpResponseMessage postResponse = await httpClient.PostAsync(requestUri, null);
+        postResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+}

--- a/src/Management/test/Endpoint.Test/Actuators/Refresh/HttpVerbInEndpointRoutingTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/Refresh/HttpVerbInEndpointRoutingTest.cs
@@ -6,11 +6,12 @@ using System.Net;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 using Steeltoe.Common.TestResources;
 
 namespace Steeltoe.Management.Endpoint.Test.Actuators.Refresh;
 
-public sealed class HttpVerbTest
+public sealed class HttpVerbInEndpointRoutingTest
 {
     [Fact]
     public async Task Allows_only_POST_requests()
@@ -22,10 +23,12 @@ public sealed class HttpVerbTest
 
         WebApplicationBuilder builder = TestWebApplicationBuilderFactory.Create();
         builder.Configuration.AddInMemoryCollection(appSettings);
+        builder.Services.AddControllersWithViews();
         builder.AddRefreshActuator();
 
         await using WebApplication app = builder.Build();
         app.UseRouting();
+        app.MapDefaultControllerRoute();
         await app.StartAsync();
 
         using TestServer testServer = app.GetTestServer();
@@ -46,15 +49,17 @@ public sealed class HttpVerbTest
         var appSettings = new Dictionary<string, string?>
         {
             ["Management:Endpoints:Actuator:Exposure:Include:0"] = "refresh",
-            ["Management:Endpoints:Refresh:AllowedVerbs:0"] = ""
+            ["Management:Endpoints:Refresh:AllowedVerbs:0"] = string.Empty
         };
 
         WebApplicationBuilder builder = TestWebApplicationBuilderFactory.Create();
         builder.Configuration.AddInMemoryCollection(appSettings);
+        builder.Services.AddControllersWithViews();
         builder.AddRefreshActuator();
 
         await using WebApplication app = builder.Build();
         app.UseRouting();
+        app.MapDefaultControllerRoute();
         await app.StartAsync();
 
         using TestServer testServer = app.GetTestServer();
@@ -63,10 +68,10 @@ public sealed class HttpVerbTest
         var requestUri = new Uri("/actuator/refresh", UriKind.Relative);
 
         HttpResponseMessage getResponse = await httpClient.GetAsync(requestUri);
-        getResponse.StatusCode.Should().Be(HttpStatusCode.MethodNotAllowed);
+        getResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
 
         HttpResponseMessage postResponse = await httpClient.PostAsync(requestUri, null);
-        postResponse.StatusCode.Should().Be(HttpStatusCode.MethodNotAllowed);
+        postResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
     }
 
     [Fact]
@@ -80,10 +85,12 @@ public sealed class HttpVerbTest
 
         WebApplicationBuilder builder = TestWebApplicationBuilderFactory.Create();
         builder.Configuration.AddInMemoryCollection(appSettings);
+        builder.Services.AddControllersWithViews();
         builder.AddRefreshActuator();
 
         await using WebApplication app = builder.Build();
         app.UseRouting();
+        app.MapDefaultControllerRoute();
         await app.StartAsync();
 
         using TestServer testServer = app.GetTestServer();
@@ -110,10 +117,12 @@ public sealed class HttpVerbTest
 
         WebApplicationBuilder builder = TestWebApplicationBuilderFactory.Create();
         builder.Configuration.AddInMemoryCollection(appSettings);
+        builder.Services.AddControllersWithViews();
         builder.AddRefreshActuator();
 
         await using WebApplication app = builder.Build();
         app.UseRouting();
+        app.MapDefaultControllerRoute();
         await app.StartAsync();
 
         using TestServer testServer = app.GetTestServer();

--- a/src/Management/test/Endpoint.Test/Actuators/Refresh/HttpVerbTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/Refresh/HttpVerbTest.cs
@@ -1,0 +1,130 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+using System.Net;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Configuration;
+using Steeltoe.Common.TestResources;
+
+namespace Steeltoe.Management.Endpoint.Test.Actuators.Refresh;
+
+public sealed class HttpVerbTest
+{
+    [Fact]
+    public async Task Allows_only_POST_requests()
+    {
+        var appSettings = new Dictionary<string, string?>
+        {
+            ["Management:Endpoints:Actuator:Exposure:Include:0"] = "refresh"
+        };
+
+        WebApplicationBuilder builder = TestWebApplicationBuilderFactory.Create();
+        builder.Configuration.AddInMemoryCollection(appSettings);
+        builder.AddRefreshActuator();
+
+        await using WebApplication app = builder.Build();
+        app.UseRouting();
+        await app.StartAsync();
+
+        using TestServer testServer = app.GetTestServer();
+        using HttpClient httpClient = testServer.CreateClient();
+
+        var requestUri = new Uri("/actuator/refresh", UriKind.Relative);
+
+        HttpResponseMessage getResponse = await httpClient.GetAsync(requestUri);
+        getResponse.StatusCode.Should().Be(HttpStatusCode.MethodNotAllowed);
+
+        HttpResponseMessage postResponse = await httpClient.PostAsync(requestUri, null);
+        postResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task Can_be_configured_to_allow_no_verbs()
+    {
+        var appSettings = new Dictionary<string, string?>
+        {
+            ["Management:Endpoints:Actuator:Exposure:Include:0"] = "refresh",
+            ["Management:Endpoints:Refresh:AllowedVerbs:0"] = ""
+        };
+
+        WebApplicationBuilder builder = TestWebApplicationBuilderFactory.Create();
+        builder.Configuration.AddInMemoryCollection(appSettings);
+        builder.AddRefreshActuator();
+
+        await using WebApplication app = builder.Build();
+        app.UseRouting();
+        await app.StartAsync();
+
+        using TestServer testServer = app.GetTestServer();
+        using HttpClient httpClient = testServer.CreateClient();
+
+        var requestUri = new Uri("/actuator/refresh", UriKind.Relative);
+
+        HttpResponseMessage getResponse = await httpClient.GetAsync(requestUri);
+        getResponse.StatusCode.Should().Be(HttpStatusCode.MethodNotAllowed);
+
+        HttpResponseMessage postResponse = await httpClient.PostAsync(requestUri, null);
+        postResponse.StatusCode.Should().Be(HttpStatusCode.MethodNotAllowed);
+    }
+
+    [Fact]
+    public async Task Can_be_configured_to_allow_only_GET_requests()
+    {
+        var appSettings = new Dictionary<string, string?>
+        {
+            ["Management:Endpoints:Actuator:Exposure:Include:0"] = "refresh",
+            ["Management:Endpoints:Refresh:AllowedVerbs:0"] = "GET"
+        };
+
+        WebApplicationBuilder builder = TestWebApplicationBuilderFactory.Create();
+        builder.Configuration.AddInMemoryCollection(appSettings);
+        builder.AddRefreshActuator();
+
+        await using WebApplication app = builder.Build();
+        app.UseRouting();
+        await app.StartAsync();
+
+        using TestServer testServer = app.GetTestServer();
+        using HttpClient httpClient = testServer.CreateClient();
+
+        var requestUri = new Uri("/actuator/refresh", UriKind.Relative);
+
+        HttpResponseMessage getResponse = await httpClient.GetAsync(requestUri);
+        getResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        HttpResponseMessage postResponse = await httpClient.PostAsync(requestUri, null);
+        postResponse.StatusCode.Should().Be(HttpStatusCode.MethodNotAllowed);
+    }
+
+    [Fact]
+    public async Task Can_be_configured_to_allow_both_GET_and_POST_requests()
+    {
+        var appSettings = new Dictionary<string, string?>
+        {
+            ["Management:Endpoints:Actuator:Exposure:Include:0"] = "refresh",
+            ["Management:Endpoints:Refresh:AllowedVerbs:0"] = "GET",
+            ["Management:Endpoints:Refresh:AllowedVerbs:1"] = "POST"
+        };
+
+        WebApplicationBuilder builder = TestWebApplicationBuilderFactory.Create();
+        builder.Configuration.AddInMemoryCollection(appSettings);
+        builder.AddRefreshActuator();
+
+        await using WebApplication app = builder.Build();
+        app.UseRouting();
+        await app.StartAsync();
+
+        using TestServer testServer = app.GetTestServer();
+        using HttpClient httpClient = testServer.CreateClient();
+
+        var requestUri = new Uri("/actuator/refresh", UriKind.Relative);
+
+        HttpResponseMessage getResponse = await httpClient.GetAsync(requestUri);
+        getResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        HttpResponseMessage postResponse = await httpClient.PostAsync(requestUri, null);
+        postResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+}

--- a/src/Management/test/Endpoint.Test/Actuators/RouteMappings/Startup.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/RouteMappings/Startup.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Steeltoe.Management.Endpoint.Actuators.CloudFoundry;
+using Steeltoe.Management.Endpoint.Actuators.Refresh;
 using Steeltoe.Management.Endpoint.Actuators.RouteMappings;
 
 namespace Steeltoe.Management.Endpoint.Test.Actuators.RouteMappings;
@@ -27,6 +28,7 @@ public sealed class Startup
     {
         services.AddCloudFoundryActuator();
         services.AddMappingsActuator();
+        services.AddRefreshActuator();
 
         services.AddMvc(options =>
         {
@@ -55,7 +57,6 @@ public sealed class Startup
             {
                 routes.MapRoute("default", "{controller=Home}/{action=Index}/{id?}");
                 routes.MapAllActuators();
-
                 routes.AddRoutesToMappingsActuator();
             });
         }

--- a/src/Management/test/Endpoint.Test/ExposureTest.cs
+++ b/src/Management/test/Endpoint.Test/ExposureTest.cs
@@ -41,6 +41,21 @@ public sealed class ExposureTest : BaseTest
     }
 
     [Fact]
+    public void ExposureCanClearDefaults()
+    {
+        var appSettings = new Dictionary<string, string?>
+        {
+            ["management:endpoints:actuator:exposure:include:0"] = "",
+            ["management:endpoints:actuator:exposure:exclude:0"] = ""
+        };
+
+        var options = GetOptionsFromSettings<ManagementOptions>(appSettings);
+
+        options.Exposure.Include.Should().BeEmpty();
+        options.Exposure.Exclude.Should().BeEmpty();
+    }
+
+    [Fact]
     public void ExposureBindsToSteeltoeSettings()
     {
         var appSettings = new Dictionary<string, string?>

--- a/src/Management/test/Endpoint.Test/ExposureTest.cs
+++ b/src/Management/test/Endpoint.Test/ExposureTest.cs
@@ -45,8 +45,8 @@ public sealed class ExposureTest : BaseTest
     {
         var appSettings = new Dictionary<string, string?>
         {
-            ["management:endpoints:actuator:exposure:include:0"] = "",
-            ["management:endpoints:actuator:exposure:exclude:0"] = ""
+            ["management:endpoints:actuator:exposure:include:0"] = string.Empty,
+            ["management:endpoints:actuator:exposure:exclude:0"] = string.Empty
         };
 
         var options = GetOptionsFromSettings<ManagementOptions>(appSettings);


### PR DESCRIPTION
## Description

As explained at https://github.com/dotnet/extensions/issues/1341, the configuration binder is unable to "see" empty collections in options. This poses a problem when the intent is to clear a collection instead of adding default entries. As a workaround, we allow a single-element empty string to indicate _not_ to add defaults. For example, the following `appsettings.json`:
```json
{
  "Management": {
    "Endpoints": {
      "Env": {
        "keysToSanitize": {
          ""
        }
      }
    }
  }
}
```
will overwrite the default of:
```json
{
  "Management": {
    "Endpoints": {
      "Env": {
        "keysToSanitize": {
          "password",
          "secret",
          ...
        }
      }
    }
  }
}
```

This PR updates all cases where a collection is exposed in options that is non-empty by default.

Fixes #611.

## Quality checklist

- [x] Your code complies with our [Coding Style](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-code-style.md).
- [x] You've updated unit and/or integration tests for your change, where applicable.
- [ ] You've updated documentation for your change, where applicable.
      If your change affects other repositories, such as [Documentation](https://github.com/SteeltoeOSS/Documentation), [Samples](https://github.com/SteeltoeOSS/Samples) and/or [MainSite](https://github.com/SteeltoeOSS/MainSite), add linked PRs here.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
- [ ] You've added required license files and/or file headers (explaining where the code came from with proper attribution), where code is copied from StackOverflow, a blog, or OSS.
