### PR TITLE
Configuration schema generator: fix missing cref inside para tag

### DIFF
--- a/src/Tools/src/ConfigurationSchemaGenerator/ConfigSchemaEmitter.cs
+++ b/src/Tools/src/ConfigurationSchemaGenerator/ConfigSchemaEmitter.cs
@@ -548,7 +548,8 @@ internal sealed partial class ConfigSchemaEmitter(SchemaGenerationSpec spec, Com
     {
         if (element.Name == "para" || element.Name == "p")
         {
-            return $"<br/><br/>{element.Value}<br/><br/>";
+            var innerText = string.Join(string.Empty, element.Nodes().Select(node => GetNodeText(node)));
+            return $"<br/><br/>{innerText}<br/><br/>";
         }
 
         if (element.Name == "br")

--- a/src/Tools/test/ConfigurationSchemaGenerator.Tests/GeneratorTests.cs
+++ b/src/Tools/test/ConfigurationSchemaGenerator.Tests/GeneratorTests.cs
@@ -127,6 +127,7 @@ public partial class GeneratorTests
     [InlineData("<see cref=\"M:System.Diagnostics.Debug.Assert(bool)\"/>", "'System.Diagnostics.Debug.Assert(bool)'")]
     [InlineData("<see cref=\"E:System.Windows.Input.ICommand.CanExecuteChanged\"/>", "'System.Windows.Input.ICommand.CanExecuteChanged'")]
     [InlineData("<exception cref=\"T:System.InvalidOperationException\" />", "'System.InvalidOperationException'")]
+    [InlineData("<para><exception cref=\"T:System.InvalidOperationException\" /></para>", "'System.InvalidOperationException'")]
     public void ShouldQuoteCrefAttributes(string input, string expected)
     {
         var summaryElement = ConvertToSummaryElement(input);


### PR DESCRIPTION
## Description

Configuration schema generator: fix missing cref inside para tag.
Fixes https://github.com/SteeltoeOSS/Steeltoe/pull/1356#discussion_r1759077189.

Example output from `GetDocComment(ISymbol)`:
```xml
<member name="P:Steeltoe.Management.Endpoint.Actuators.HttpExchanges.HttpExchangesEndpointOptions.RequestHeaders">
  <summary>
            Gets request header values that are allowed to be logged.
            <para>
            If a request header is not present in the <see cref="P:Steeltoe.Management.Endpoint.Actuators.HttpExchanges.HttpExchangesEndpointOptions.RequestHeaders" />, the header name will be logged with a redacted value. Request headers can
            contain authentication tokens, or private information which may have regulatory concerns under GDPR and other laws. Arbitrary request headers should
            not be logged unless logs are secure and access controlled and the privacy impact assessed.
            </para>
  </summary>
</member>
```

## Quality checklist

- [x] Your code complies with our [Coding Style](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-code-style.md).
- [x] You've updated unit and/or integration tests for your change, where applicable.
- [ ] You've updated documentation for your change, where applicable.
      If your change affects other repositories, such as [Documentation](https://github.com/SteeltoeOSS/Documentation), [Samples](https://github.com/SteeltoeOSS/Samples) and/or [MainSite](https://github.com/SteeltoeOSS/MainSite), add linked PRs here.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
- [ ] You've added required license files and/or file headers (explaining where the code came from with proper attribution), where code is copied from StackOverflow, a blog, or OSS.
