### PR TITLE
Remove checks for Platform.IsWindows in tests

### DIFF
--- a/src/Management/test/Endpoint.Test/Actuators/ThreadDump/EndpointMiddlewareTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/ThreadDump/EndpointMiddlewareTest.cs
@@ -9,7 +9,6 @@ using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
-using Steeltoe.Common;
 using Steeltoe.Common.TestResources;
 using Steeltoe.Management.Endpoint.Actuators.ThreadDump;
 using Steeltoe.Management.Endpoint.Configuration;
@@ -70,25 +69,22 @@ public sealed class EndpointMiddlewareTest : BaseTest
     [Fact]
     public async Task ThreadDumpActuatorV2_ReturnsExpectedData()
     {
-        if (Platform.IsWindows)
-        {
-            IWebHostBuilder builder = TestWebHostBuilderFactory.Create();
-            builder.UseStartup<Startup>();
-            builder.ConfigureAppConfiguration((_, configuration) => configuration.AddInMemoryCollection(AppSettings));
+        IWebHostBuilder builder = TestWebHostBuilderFactory.Create();
+        builder.UseStartup<Startup>();
+        builder.ConfigureAppConfiguration((_, configuration) => configuration.AddInMemoryCollection(AppSettings));
 
-            using IWebHost host = builder.Build();
-            await host.StartAsync();
+        using IWebHost host = builder.Build();
+        await host.StartAsync();
 
-            using HttpClient client = host.GetTestClient();
-            HttpResponseMessage response = await client.GetAsync(new Uri("http://localhost/actuator/threaddump"));
-            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        using HttpClient client = host.GetTestClient();
+        HttpResponseMessage response = await client.GetAsync(new Uri("http://localhost/actuator/threaddump"));
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
-            string json = await response.Content.ReadAsStringAsync();
-            Assert.NotNull(json);
-            Assert.NotEqual("{}", json);
-            Assert.StartsWith("{", json, StringComparison.Ordinal);
-            Assert.EndsWith("}", json, StringComparison.Ordinal);
-        }
+        string json = await response.Content.ReadAsStringAsync();
+        Assert.NotNull(json);
+        Assert.NotEqual("{}", json);
+        Assert.StartsWith("{", json, StringComparison.Ordinal);
+        Assert.EndsWith("}", json, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/src/Management/test/Endpoint.Test/ManagementHostBuilderExtensionsTest.cs
+++ b/src/Management/test/Endpoint.Test/ManagementHostBuilderExtensionsTest.cs
@@ -10,7 +10,6 @@ using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using Steeltoe.Common;
 using Steeltoe.Common.HealthChecks;
 using Steeltoe.Common.TestResources;
 using Steeltoe.Logging.DynamicLogger;
@@ -187,32 +186,26 @@ public sealed class ManagementHostBuilderExtensionsTest
     [Fact]
     public void AddHeapDumpActuator_IHostBuilder()
     {
-        if (Platform.IsWindows)
-        {
-            IHostBuilder hostBuilder = TestHostBuilderFactory.Create();
-            hostBuilder.AddHeapDumpActuator();
-            using IHost host = hostBuilder.Build();
+        IHostBuilder hostBuilder = TestHostBuilderFactory.Create();
+        hostBuilder.AddHeapDumpActuator();
+        using IHost host = hostBuilder.Build();
 
-            host.Services.GetService<IHeapDumpEndpointHandler>().Should().NotBeNull();
-            host.Services.GetServices<IStartupFilter>().OfType<AllActuatorsStartupFilter>().Should().ContainSingle();
-        }
+        host.Services.GetService<IHeapDumpEndpointHandler>().Should().NotBeNull();
+        host.Services.GetServices<IStartupFilter>().OfType<AllActuatorsStartupFilter>().Should().ContainSingle();
     }
 
     [Fact]
     public async Task AddHeapDumpActuator_IHostBuilder_IStartupFilterFires()
     {
-        if (Platform.IsWindows)
-        {
-            IHostBuilder hostBuilder = TestHostBuilderFactory.CreateWeb();
-            hostBuilder.ConfigureWebHost(ConfigureWebHostWithAllActuatorsExposed);
-            hostBuilder.AddHeapDumpActuator();
+        IHostBuilder hostBuilder = TestHostBuilderFactory.CreateWeb();
+        hostBuilder.ConfigureWebHost(ConfigureWebHostWithAllActuatorsExposed);
+        hostBuilder.AddHeapDumpActuator();
 
-            using IHost host = await hostBuilder.StartAsync();
+        using IHost host = await hostBuilder.StartAsync();
 
-            var requestUri = new Uri("/actuator/heapdump", UriKind.Relative);
-            HttpResponseMessage response = await host.GetTestServer().CreateClient().GetAsync(requestUri);
-            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        }
+        var requestUri = new Uri("/actuator/heapdump", UriKind.Relative);
+        HttpResponseMessage response = await host.GetTestServer().CreateClient().GetAsync(requestUri);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
     }
 
     [Fact]
@@ -408,32 +401,26 @@ public sealed class ManagementHostBuilderExtensionsTest
     [Fact]
     public void AddThreadDumpActuator_IHostBuilder()
     {
-        if (Platform.IsWindows)
-        {
-            IHostBuilder hostBuilder = TestHostBuilderFactory.Create();
-            hostBuilder.AddThreadDumpActuator();
-            using IHost host = hostBuilder.Build();
+        IHostBuilder hostBuilder = TestHostBuilderFactory.Create();
+        hostBuilder.AddThreadDumpActuator();
+        using IHost host = hostBuilder.Build();
 
-            host.Services.GetService<IThreadDumpEndpointHandler>().Should().NotBeNull();
-            host.Services.GetServices<IStartupFilter>().OfType<AllActuatorsStartupFilter>().Should().ContainSingle();
-        }
+        host.Services.GetService<IThreadDumpEndpointHandler>().Should().NotBeNull();
+        host.Services.GetServices<IStartupFilter>().OfType<AllActuatorsStartupFilter>().Should().ContainSingle();
     }
 
     [Fact]
     public async Task AddThreadDumpActuator_IHostBuilder_IStartupFilterFires()
     {
-        if (Platform.IsWindows)
-        {
-            IHostBuilder hostBuilder = TestHostBuilderFactory.CreateWeb();
-            hostBuilder.ConfigureWebHost(ConfigureWebHostWithAllActuatorsExposed);
-            hostBuilder.AddThreadDumpActuator();
+        IHostBuilder hostBuilder = TestHostBuilderFactory.CreateWeb();
+        hostBuilder.ConfigureWebHost(ConfigureWebHostWithAllActuatorsExposed);
+        hostBuilder.AddThreadDumpActuator();
 
-            using IHost host = await hostBuilder.StartAsync();
+        using IHost host = await hostBuilder.StartAsync();
 
-            var requestUri = new Uri("/actuator/threaddump", UriKind.Relative);
-            HttpResponseMessage response = await host.GetTestServer().CreateClient().GetAsync(requestUri);
-            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        }
+        var requestUri = new Uri("/actuator/threaddump", UriKind.Relative);
+        HttpResponseMessage response = await host.GetTestServer().CreateClient().GetAsync(requestUri);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
     }
 
     [Fact]

--- a/src/Management/test/Endpoint.Test/ManagementWebApplicationBuilderExtensionsTest.cs
+++ b/src/Management/test/Endpoint.Test/ManagementWebApplicationBuilderExtensionsTest.cs
@@ -9,7 +9,6 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Steeltoe.Common;
 using Steeltoe.Common.HealthChecks;
 using Steeltoe.Common.TestResources;
 using Steeltoe.Logging.DynamicLogger;
@@ -141,20 +140,17 @@ public sealed class ManagementWebApplicationBuilderExtensionsTest
     [Fact]
     public async Task AddHeapDumpActuator_WebApplicationBuilder_IStartupFilterFires()
     {
-        if (Platform.IsWindows)
-        {
-            WebApplicationBuilder hostBuilder = GetTestServerWithAllActuatorsExposed();
-            hostBuilder.AddHeapDumpActuator();
+        WebApplicationBuilder hostBuilder = GetTestServerWithAllActuatorsExposed();
+        hostBuilder.AddHeapDumpActuator();
 
-            await using WebApplication host = hostBuilder.Build();
-            host.UseRouting();
-            await host.StartAsync();
+        await using WebApplication host = hostBuilder.Build();
+        host.UseRouting();
+        await host.StartAsync();
 
-            Assert.Single(host.Services.GetServices<IHeapDumpEndpointHandler>());
-            Assert.Single(host.Services.GetServices<IStartupFilter>().Where(filter => filter is AllActuatorsStartupFilter));
-            HttpResponseMessage response = await host.GetTestClient().GetAsync(new Uri("/actuator/heapdump", UriKind.Relative));
-            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        }
+        Assert.Single(host.Services.GetServices<IHeapDumpEndpointHandler>());
+        Assert.Single(host.Services.GetServices<IStartupFilter>().Where(filter => filter is AllActuatorsStartupFilter));
+        HttpResponseMessage response = await host.GetTestClient().GetAsync(new Uri("/actuator/heapdump", UriKind.Relative));
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
     }
 
     [Fact]
@@ -275,20 +271,17 @@ public sealed class ManagementWebApplicationBuilderExtensionsTest
     [Fact]
     public async Task AddThreadDumpActuator_WebApplicationBuilder_IStartupFilterFires()
     {
-        if (Platform.IsWindows)
-        {
-            WebApplicationBuilder hostBuilder = GetTestServerWithAllActuatorsExposed();
-            hostBuilder.AddThreadDumpActuator();
+        WebApplicationBuilder hostBuilder = GetTestServerWithAllActuatorsExposed();
+        hostBuilder.AddThreadDumpActuator();
 
-            await using WebApplication host = hostBuilder.Build();
-            host.UseRouting();
-            await host.StartAsync();
+        await using WebApplication host = hostBuilder.Build();
+        host.UseRouting();
+        await host.StartAsync();
 
-            Assert.Single(host.Services.GetServices<IThreadDumpEndpointHandler>());
-            Assert.Single(host.Services.GetServices<IStartupFilter>().Where(filter => filter is AllActuatorsStartupFilter));
-            HttpResponseMessage response = await host.GetTestClient().GetAsync(new Uri("/actuator/threaddump", UriKind.Relative));
-            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        }
+        Assert.Single(host.Services.GetServices<IThreadDumpEndpointHandler>());
+        Assert.Single(host.Services.GetServices<IStartupFilter>().Where(filter => filter is AllActuatorsStartupFilter));
+        HttpResponseMessage response = await host.GetTestClient().GetAsync(new Uri("/actuator/threaddump", UriKind.Relative));
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
     }
 
     [Fact]

--- a/src/Management/test/Endpoint.Test/ManagementWebHostBuilderExtensionsTest.cs
+++ b/src/Management/test/Endpoint.Test/ManagementWebHostBuilderExtensionsTest.cs
@@ -9,7 +9,6 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Steeltoe.Common;
 using Steeltoe.Common.HealthChecks;
 using Steeltoe.Common.TestResources;
 using Steeltoe.Logging.DynamicLogger;
@@ -178,30 +177,24 @@ public sealed class ManagementWebHostBuilderExtensionsTest : BaseTest
     [Fact]
     public void AddHeapDumpActuator_IWebHostBuilder()
     {
-        if (Platform.IsWindows)
-        {
-            IWebHostBuilder hostBuilder = TestWebHostBuilderFactory.Create();
-            hostBuilder.AddHeapDumpActuator();
-            using IWebHost host = hostBuilder.Build();
+        IWebHostBuilder hostBuilder = TestWebHostBuilderFactory.Create();
+        hostBuilder.AddHeapDumpActuator();
+        using IWebHost host = hostBuilder.Build();
 
-            host.Services.GetService<IHeapDumpEndpointHandler>().Should().NotBeNull();
-            host.Services.GetServices<IStartupFilter>().OfType<AllActuatorsStartupFilter>().Should().ContainSingle();
-        }
+        host.Services.GetService<IHeapDumpEndpointHandler>().Should().NotBeNull();
+        host.Services.GetServices<IStartupFilter>().OfType<AllActuatorsStartupFilter>().Should().ContainSingle();
     }
 
     [Fact]
     public async Task AddHeapDumpActuator_IWebHostBuilder_IStartupFilterFires()
     {
-        if (Platform.IsWindows)
-        {
-            IWebHostBuilder hostBuilder = WebHostBuilderWithAllActuatorsExposed;
-            hostBuilder.AddHeapDumpActuator();
-            using IWebHost host = hostBuilder.Start();
+        IWebHostBuilder hostBuilder = WebHostBuilderWithAllActuatorsExposed;
+        hostBuilder.AddHeapDumpActuator();
+        using IWebHost host = hostBuilder.Start();
 
-            var requestUri = new Uri("/actuator/heapdump", UriKind.Relative);
-            HttpResponseMessage response = await host.GetTestServer().CreateClient().GetAsync(requestUri);
-            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        }
+        var requestUri = new Uri("/actuator/heapdump", UriKind.Relative);
+        HttpResponseMessage response = await host.GetTestServer().CreateClient().GetAsync(requestUri);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
     }
 
     [Fact]
@@ -385,30 +378,24 @@ public sealed class ManagementWebHostBuilderExtensionsTest : BaseTest
     [Fact]
     public void AddThreadDumpActuator_IWebHostBuilder()
     {
-        if (Platform.IsWindows)
-        {
-            IWebHostBuilder hostBuilder = TestWebHostBuilderFactory.Create();
-            hostBuilder.AddThreadDumpActuator();
-            using IWebHost host = hostBuilder.Build();
+        IWebHostBuilder hostBuilder = TestWebHostBuilderFactory.Create();
+        hostBuilder.AddThreadDumpActuator();
+        using IWebHost host = hostBuilder.Build();
 
-            host.Services.GetService<IThreadDumpEndpointHandler>().Should().NotBeNull();
-            host.Services.GetServices<IStartupFilter>().OfType<AllActuatorsStartupFilter>().Should().ContainSingle();
-        }
+        host.Services.GetService<IThreadDumpEndpointHandler>().Should().NotBeNull();
+        host.Services.GetServices<IStartupFilter>().OfType<AllActuatorsStartupFilter>().Should().ContainSingle();
     }
 
     [Fact]
     public async Task AddThreadDumpActuator_IWebHostBuilder_IStartupFilterFires()
     {
-        if (Platform.IsWindows)
-        {
-            IWebHostBuilder hostBuilder = WebHostBuilderWithAllActuatorsExposed;
-            hostBuilder.AddThreadDumpActuator();
-            using IWebHost host = hostBuilder.Start();
+        IWebHostBuilder hostBuilder = WebHostBuilderWithAllActuatorsExposed;
+        hostBuilder.AddThreadDumpActuator();
+        using IWebHost host = hostBuilder.Start();
 
-            var requestUri = new Uri("/actuator/threaddump", UriKind.Relative);
-            HttpResponseMessage response = await host.GetTestServer().CreateClient().GetAsync(requestUri);
-            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        }
+        var requestUri = new Uri("/actuator/threaddump", UriKind.Relative);
+        HttpResponseMessage response = await host.GetTestServer().CreateClient().GetAsync(requestUri);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
     }
 
     [Fact]


### PR DESCRIPTION
## Description

This PR removes conditions on `Platform.IsWindows` from tests in `Steeltoe.Management.Endpoint`. Tests from the cibuild are green on Windows/Linux/macOS, so it appears these constraints aren't needed.

The existing logic that checked for ".NET Core" is dead code, see https://learn.microsoft.com/en-us/dotnet/api/system.runtime.interopservices.runtimeinformation.frameworkdescription?view=net-8.0#remarks.

Fixes #1361.

## Quality checklist

- [x] Your code complies with our [Coding Style](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-code-style.md).
- [x] You've updated unit and/or integration tests for your change, where applicable.
- [ ] You've updated documentation for your change, where applicable.
      If your change affects other repositories, such as [Documentation](https://github.com/SteeltoeOSS/Documentation), [Samples](https://github.com/SteeltoeOSS/Samples) and/or [MainSite](https://github.com/SteeltoeOSS/MainSite), add linked PRs here.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
- [ ] You've added required license files and/or file headers (explaining where the code came from with proper attribution), where code is copied from StackOverflow, a blog, or OSS.
