### PR TITLE
Optimize volatile usage

### DIFF
--- a/src/Discovery/test/Eureka.Test/GatedActionTest.cs
+++ b/src/Discovery/test/Eureka.Test/GatedActionTest.cs
@@ -6,12 +6,12 @@ namespace Steeltoe.Discovery.Eureka.Test;
 
 public sealed class GatedActionTest
 {
-    private volatile int _timerFuncCount;
+    private int _timerFuncCount;
 
     [Fact]
     public async Task Run_Enforces_SingleActiveTask()
     {
-        _timerFuncCount = 0;
+        Interlocked.Exchange(ref _timerFuncCount, 0);
         var timedTask = new GatedAction(TimerFunc);
         await using var timer = new Timer(_ => timedTask.Run(), null, 10, 100);
         await Task.Delay(1000);

--- a/src/Management/src/Abstractions/Diagnostics/DiagnosticsManager.cs
+++ b/src/Management/src/Abstractions/Diagnostics/DiagnosticsManager.cs
@@ -23,7 +23,7 @@ internal sealed class DiagnosticsManager : IObserver<DiagnosticListener>, IDispo
     private IDisposable? _listenersSubscription;
 #pragma warning restore S1450 // Private fields only used as local variables in methods should become local variables
 
-    private volatile int _started;
+    private int _started;
 
     public DiagnosticsManager(IOptionsMonitor<MetricsObserverOptions> observerOptions, IEnumerable<IRuntimeDiagnosticSource> runtimeSources,
         IEnumerable<IDiagnosticObserver> observers, IEnumerable<EventListener> eventListeners, ILogger<DiagnosticsManager> logger)


### PR DESCRIPTION
## Description

Remove redundant `volatile` keyword on private fields that are exclusively accessed via `Interlocked` class.

Fixes #1265.

## Quality checklist

<!-- Please run through the checklist below to ensure a smooth review and merge process for your PR. -->

- [x] Your code complies with our [Coding Style](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-code-style.md).
- [x] You've updated unit and/or integration tests for your change, where applicable.
- [ ] You've updated documentation for your change, where applicable.
      If your change affects other repositories, such as [Documentation](https://github.com/SteeltoeOSS/Documentation), [Samples](https://github.com/SteeltoeOSS/Samples) and/or [MainSite](https://github.com/SteeltoeOSS/MainSite), add linked PRs here.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
- [ ] You've added required license files and/or file headers (explaining where the code came from with proper attribution), where code is copied from StackOverflow, a blog, or OSS.
