### PR TITLE
Formatting: place call to base in primary constructor on separate line

### DIFF
--- a/src/Common/src/Common/DynamicTypeAccess/TaskShim.cs
+++ b/src/Common/src/Common/DynamicTypeAccess/TaskShim.cs
@@ -11,7 +11,8 @@ namespace Steeltoe.Common.DynamicTypeAccess;
 /// <typeparam name="TResult">
 /// The type of the result produced by the underlying task.
 /// </typeparam>
-internal sealed class TaskShim<TResult>(object instance) : Shim(Wrap(instance)), IDisposable
+internal sealed class TaskShim<TResult>(object instance)
+    : Shim(Wrap(instance)), IDisposable
 {
     public override Task Instance => (Task)base.Instance;
 

--- a/src/Common/src/Common/DynamicTypeAccess/TypeAccessor.cs
+++ b/src/Common/src/Common/DynamicTypeAccess/TypeAccessor.cs
@@ -7,7 +7,8 @@ namespace Steeltoe.Common.DynamicTypeAccess;
 /// <summary>
 /// Provides reflection-based access to static members of a <see cref="System.Type" />.
 /// </summary>
-internal sealed class TypeAccessor(Type type) : ReflectionAccessor(type)
+internal sealed class TypeAccessor(Type type)
+    : ReflectionAccessor(type)
 {
     public Type Type { get; } = type;
 

--- a/src/Configuration/test/CloudFoundry.Test/ServiceBindings/BasePostProcessorsTest.cs
+++ b/src/Configuration/test/CloudFoundry.Test/ServiceBindings/BasePostProcessorsTest.cs
@@ -67,7 +67,8 @@ public abstract class BasePostProcessorsTest
         return null;
     }
 
-    private sealed class TestPostProcessorConfigurationProvider(PostProcessorConfigurationSource source) : PostProcessorConfigurationProvider(source);
+    private sealed class TestPostProcessorConfigurationProvider(PostProcessorConfigurationSource source)
+        : PostProcessorConfigurationProvider(source);
 
     private sealed class TestPostProcessorConfigurationSource : PostProcessorConfigurationSource;
 }

--- a/src/Configuration/test/Kubernetes.ServiceBindings.Test/BasePostProcessorsTest.cs
+++ b/src/Configuration/test/Kubernetes.ServiceBindings.Test/BasePostProcessorsTest.cs
@@ -50,7 +50,8 @@ public abstract class BasePostProcessorsTest
         return new TestPostProcessorConfigurationProvider(source);
     }
 
-    private sealed class TestPostProcessorConfigurationProvider(PostProcessorConfigurationSource source) : PostProcessorConfigurationProvider(source);
+    private sealed class TestPostProcessorConfigurationProvider(PostProcessorConfigurationSource source)
+        : PostProcessorConfigurationProvider(source);
 
     private sealed class TestPostProcessorConfigurationSource : PostProcessorConfigurationSource;
 }

--- a/src/Connectors/src/Connectors/DynamicTypeAccess/ConnectorShim.cs
+++ b/src/Connectors/src/Connectors/DynamicTypeAccess/ConnectorShim.cs
@@ -6,7 +6,8 @@ using Steeltoe.Common.DynamicTypeAccess;
 
 namespace Steeltoe.Connectors.DynamicTypeAccess;
 
-internal sealed class ConnectorShim<TOptions>(Type connectionType, object instance) : Shim(CreateAccessor(connectionType, instance)), IDisposable
+internal sealed class ConnectorShim<TOptions>(Type connectionType, object instance)
+    : Shim(CreateAccessor(connectionType, instance)), IDisposable
     where TOptions : ConnectionStringOptions
 {
     public override IDisposable Instance => (IDisposable)base.Instance;

--- a/src/Connectors/test/EntityFrameworkCore.Test/GoodDbContext.cs
+++ b/src/Connectors/test/EntityFrameworkCore.Test/GoodDbContext.cs
@@ -6,4 +6,5 @@ using Microsoft.EntityFrameworkCore;
 
 namespace Steeltoe.Connectors.EntityFrameworkCore.Test;
 
-internal sealed class GoodDbContext(DbContextOptions<GoodDbContext> options) : DbContext(options);
+internal sealed class GoodDbContext(DbContextOptions<GoodDbContext> options)
+    : DbContext(options);

--- a/src/Connectors/test/EntityFrameworkCore.Test/MigrateDbContextTaskTest.cs
+++ b/src/Connectors/test/EntityFrameworkCore.Test/MigrateDbContextTaskTest.cs
@@ -31,7 +31,8 @@ public sealed class MigrateDbContextTaskTest
         TestMigrator.HasMigrated.Should().BeTrue();
     }
 
-    private sealed class TestMigrateDbContext(DbContextOptions options) : DbContext(options)
+    private sealed class TestMigrateDbContext(DbContextOptions options)
+        : DbContext(options)
     {
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
         {

--- a/src/Logging/src/DynamicSerilog/DynamicTypeAccess/LoggerConfigurationShim.cs
+++ b/src/Logging/src/DynamicSerilog/DynamicTypeAccess/LoggerConfigurationShim.cs
@@ -9,7 +9,8 @@ using Steeltoe.Common.DynamicTypeAccess;
 
 namespace Steeltoe.Logging.DynamicSerilog.DynamicTypeAccess;
 
-internal sealed class LoggerConfigurationShim(object instance) : Shim(new InstanceAccessor(new TypeAccessor(typeof(LoggerConfiguration)), instance))
+internal sealed class LoggerConfigurationShim(object instance)
+    : Shim(new InstanceAccessor(new TypeAccessor(typeof(LoggerConfiguration)), instance))
 {
     public LogEventLevel MinimumLevel => InstanceAccessor.GetPrivateFieldValue<LogEventLevel>("_minimumLevel");
 

--- a/src/Management/src/Endpoint/Actuators/Info/Contributors/AppSettingsInfoContributor.cs
+++ b/src/Management/src/Endpoint/Actuators/Info/Contributors/AppSettingsInfoContributor.cs
@@ -6,7 +6,8 @@ using Microsoft.Extensions.Configuration;
 
 namespace Steeltoe.Management.Endpoint.Actuators.Info.Contributors;
 
-internal sealed class AppSettingsInfoContributor(IConfiguration? configuration) : ConfigurationContributor(configuration), IInfoContributor
+internal sealed class AppSettingsInfoContributor(IConfiguration? configuration)
+    : ConfigurationContributor(configuration), IInfoContributor
 {
     private const string AppsettingsPrefix = "info";
 

--- a/src/Management/src/Endpoint/Actuators/Metrics/Observers/MetricsObserver.cs
+++ b/src/Management/src/Endpoint/Actuators/Metrics/Observers/MetricsObserver.cs
@@ -8,8 +8,8 @@ using Steeltoe.Management.Diagnostics;
 
 namespace Steeltoe.Management.Endpoint.Actuators.Metrics.Observers;
 
-internal abstract class MetricsObserver(string observerName, string diagnosticName, ILoggerFactory loggerFactory) : DiagnosticObserver(observerName,
-    diagnosticName, loggerFactory)
+internal abstract class MetricsObserver(string observerName, string diagnosticName, ILoggerFactory loggerFactory)
+    : DiagnosticObserver(observerName, diagnosticName, loggerFactory)
 {
     private Regex? _pathMatcher;
 

--- a/src/Management/test/Endpoint.Test/Actuators/DbMigrations/TestDatabaseMigrationScanner.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/DbMigrations/TestDatabaseMigrationScanner.cs
@@ -33,5 +33,6 @@ internal sealed class TestDatabaseMigrationScanner : IDatabaseMigrationScanner
         return ["migration"];
     }
 
-    private sealed class TestDbException(string message) : DbException(message);
+    private sealed class TestDbException(string message)
+        : DbException(message);
 }

--- a/src/Steeltoe.All.sln.DotSettings
+++ b/src/Steeltoe.All.sln.DotSettings
@@ -142,6 +142,7 @@
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_ACCESSORHOLDER_ATTRIBUTE_ON_SAME_LINE_EX/@EntryValue">NEVER</s:String>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_CONSTRUCTOR_INITIALIZER_ON_SAME_LINE/@EntryValue">False</s:Boolean>
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_FIELD_ATTRIBUTE_ON_SAME_LINE_EX/@EntryValue">NEVER</s:String>
+	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_PRIMARY_CONSTRUCTOR_INITIALIZER_ON_SAME_LINE/@EntryValue">False</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_SIMPLE_ACCESSOR_ON_SINGLE_LINE/@EntryValue">False</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_SIMPLE_ANONYMOUSMETHOD_ON_SINGLE_LINE/@EntryValue">False</s:Boolean>
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_SIMPLE_EMBEDDED_STATEMENT_ON_SAME_LINE/@EntryValue">NEVER</s:String>


### PR DESCRIPTION
## Description

This PR updates formatting rules to place the call to base in a primary constructor on a separate line. It uses the Resharper formatter option introduced in https://youtrack.jetbrains.com/issue/RSRP-495410/Wrapping-and-line-breaks-in-primary-constructor-base-calls.

## Quality checklist

- [x] Your code complies with our [Coding Style](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-code-style.md).
- [x] You've updated unit and/or integration tests for your change, where applicable.
- [ ] You've updated documentation for your change, where applicable.
      If your change affects other repositories, such as [Documentation](https://github.com/SteeltoeOSS/Documentation), [Samples](https://github.com/SteeltoeOSS/Samples) and/or [MainSite](https://github.com/SteeltoeOSS/MainSite), add linked PRs here.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
- [ ] You've added required license files and/or file headers (explaining where the code came from with proper attribution), where code is copied from StackOverflow, a blog, or OSS.
