### PR TITLE
Add support for keyed services in beans/services actuator

### DIFF
--- a/src/Common/src/Common/Properties/AssemblyInfo.cs
+++ b/src/Common/src/Common/Properties/AssemblyInfo.cs
@@ -29,6 +29,7 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("Steeltoe.Discovery.HttpClients")]
 [assembly: InternalsVisibleTo("Steeltoe.Discovery.HttpClients.Test")]
 [assembly: InternalsVisibleTo("Steeltoe.Logging.Abstractions")]
+[assembly: InternalsVisibleTo("Steeltoe.Logging.DynamicLogger")]
 [assembly: InternalsVisibleTo("Steeltoe.Logging.DynamicSerilog")]
 [assembly: InternalsVisibleTo("Steeltoe.Management.Abstractions")]
 [assembly: InternalsVisibleTo("Steeltoe.Management.Endpoint")]

--- a/src/Common/src/Common/ServiceDescriptorExtensions.cs
+++ b/src/Common/src/Common/ServiceDescriptorExtensions.cs
@@ -1,0 +1,24 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Steeltoe.Common;
+
+/// <summary>
+/// Provides a workaround for https://github.com/dotnet/runtime/issues/95789. This breaking change was patched in later .NET 8 versions, but users may
+/// still be using an old version.
+/// </summary>
+internal static class ServiceDescriptorExtensions
+{
+    public static Type? SafeGetImplementationType(this ServiceDescriptor descriptor)
+    {
+        return descriptor.IsKeyedService ? descriptor.KeyedImplementationType : descriptor.ImplementationType;
+    }
+
+    public static object? SafeGetImplementationInstance(this ServiceDescriptor descriptor)
+    {
+        return descriptor.IsKeyedService ? descriptor.KeyedImplementationInstance : descriptor.ImplementationInstance;
+    }
+}

--- a/src/Discovery/src/Eureka/EurekaServiceCollectionExtensions.cs
+++ b/src/Discovery/src/Eureka/EurekaServiceCollectionExtensions.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
+using Steeltoe.Common;
 using Steeltoe.Common.Certificates;
 using Steeltoe.Common.Discovery;
 using Steeltoe.Common.Extensions;
@@ -33,7 +34,7 @@ public static class EurekaServiceCollectionExtensions
     {
         ArgumentNullException.ThrowIfNull(services);
 
-        if (services.All(descriptor => descriptor.ImplementationType != typeof(EurekaDiscoveryClient)))
+        if (services.All(descriptor => descriptor.SafeGetImplementationType() != typeof(EurekaDiscoveryClient)))
         {
             ConfigureEurekaServices(services);
             AddEurekaServices(services);

--- a/src/Logging/src/DynamicLogger/LoggingBuilderExtensions.cs
+++ b/src/Logging/src/DynamicLogger/LoggingBuilderExtensions.cs
@@ -49,7 +49,7 @@ public static class LoggingBuilderExtensions
 
     private static void EnsureConsoleLoggingIsRegistered(ILoggingBuilder builder)
     {
-        if (builder.Services.All(descriptor => descriptor.ImplementationType != typeof(ConsoleLoggerProvider)))
+        if (builder.Services.All(descriptor => descriptor.SafeGetImplementationType() != typeof(ConsoleLoggerProvider)))
         {
             builder.AddConsole();
         }
@@ -58,7 +58,7 @@ public static class LoggingBuilderExtensions
     private static void UpdateConsoleLoggerProviderRegistration(IServiceCollection services)
     {
         // Remove the original ConsoleLoggerProvider registration as ILoggerProvider to prevent duplicate logging.
-        ServiceDescriptor? descriptor = services.FirstOrDefault(descriptor => descriptor.ImplementationType == typeof(ConsoleLoggerProvider));
+        ServiceDescriptor? descriptor = services.FirstOrDefault(descriptor => descriptor.SafeGetImplementationType() == typeof(ConsoleLoggerProvider));
 
         if (descriptor != null)
         {

--- a/src/Management/src/Endpoint/PublicAPI.Unshipped.txt
+++ b/src/Management/src/Endpoint/PublicAPI.Unshipped.txt
@@ -241,6 +241,9 @@ Steeltoe.Management.Endpoint.Actuators.HttpExchanges.HttpExchange.SerializedTime
 Steeltoe.Management.Endpoint.Actuators.HttpExchanges.HttpExchange.Session.get -> Steeltoe.Management.Endpoint.Actuators.HttpExchanges.HttpExchangeSession?
 Steeltoe.Management.Endpoint.Actuators.HttpExchanges.HttpExchange.Timestamp.get -> System.DateTime
 Steeltoe.Management.Endpoint.Actuators.HttpExchanges.HttpExchange.TimeTaken.get -> System.TimeSpan
+Steeltoe.Management.Endpoint.Actuators.HttpExchanges.HttpExchangePrincipal
+Steeltoe.Management.Endpoint.Actuators.HttpExchanges.HttpExchangePrincipal.HttpExchangePrincipal(string! name) -> void
+Steeltoe.Management.Endpoint.Actuators.HttpExchanges.HttpExchangePrincipal.Name.get -> string!
 Steeltoe.Management.Endpoint.Actuators.HttpExchanges.HttpExchangeRequest
 Steeltoe.Management.Endpoint.Actuators.HttpExchanges.HttpExchangeRequest.Headers.get -> System.Collections.Generic.IDictionary<string!, Microsoft.Extensions.Primitives.StringValues>!
 Steeltoe.Management.Endpoint.Actuators.HttpExchanges.HttpExchangeRequest.HttpExchangeRequest(string! method, System.Uri! uri, System.Collections.Generic.IDictionary<string!, Microsoft.Extensions.Primitives.StringValues>! headers, string? remoteAddress) -> void
@@ -284,9 +287,6 @@ Steeltoe.Management.Endpoint.Actuators.HttpExchanges.HttpExchangesResult.HttpExc
 Steeltoe.Management.Endpoint.Actuators.HttpExchanges.IHttpExchangesEndpointHandler
 Steeltoe.Management.Endpoint.Actuators.HttpExchanges.IHttpExchangesRepository
 Steeltoe.Management.Endpoint.Actuators.HttpExchanges.IHttpExchangesRepository.GetHttpExchanges() -> Steeltoe.Management.Endpoint.Actuators.HttpExchanges.HttpExchangesResult!
-Steeltoe.Management.Endpoint.Actuators.HttpExchanges.HttpExchangePrincipal
-Steeltoe.Management.Endpoint.Actuators.HttpExchanges.HttpExchangePrincipal.Name.get -> string!
-Steeltoe.Management.Endpoint.Actuators.HttpExchanges.HttpExchangePrincipal.HttpExchangePrincipal(string! name) -> void
 Steeltoe.Management.Endpoint.Actuators.Hypermedia.EndpointServiceCollectionExtensions
 Steeltoe.Management.Endpoint.Actuators.Hypermedia.HypermediaEndpointOptions
 Steeltoe.Management.Endpoint.Actuators.Hypermedia.HypermediaEndpointOptions.HypermediaEndpointOptions() -> void
@@ -428,6 +428,7 @@ Steeltoe.Management.Endpoint.Actuators.Services.IServicesEndpointHandler
 Steeltoe.Management.Endpoint.Actuators.Services.ServiceRegistration
 Steeltoe.Management.Endpoint.Actuators.Services.ServiceRegistration.AssemblyName.get -> string!
 Steeltoe.Management.Endpoint.Actuators.Services.ServiceRegistration.Dependencies.get -> System.Collections.Generic.ISet<string!>!
+Steeltoe.Management.Endpoint.Actuators.Services.ServiceRegistration.Key.get -> string?
 Steeltoe.Management.Endpoint.Actuators.Services.ServiceRegistration.Scope.get -> string!
 Steeltoe.Management.Endpoint.Actuators.Services.ServiceRegistration.ServiceRegistration(Microsoft.Extensions.DependencyInjection.ServiceDescriptor! descriptor) -> void
 Steeltoe.Management.Endpoint.Actuators.Services.ServiceRegistration.Type.get -> string!

--- a/src/Management/test/Endpoint.Test/Actuators/Services/ServicesEndpointTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/Services/ServicesEndpointTest.cs
@@ -19,6 +19,7 @@ public sealed class ServicesEndpointTest(ITestOutputHelper testOutputHelper) : B
 
         registration.Scope.Should().Be(nameof(ServiceLifetime.Singleton));
         registration.Type.Should().Be(typeof(ServicesEndpointHandler).FullName);
+        registration.Key.Should().BeNull();
         registration.AssemblyName.Should().Be(typeof(ServicesEndpointHandler).Assembly.FullName);
         registration.Dependencies.Should().HaveCount(2);
         registration.Dependencies.ElementAt(0).Should().Be($"Microsoft.Extensions.Options.IOptionsMonitor`1[{typeof(ServicesEndpointOptions).FullName}]");
@@ -32,6 +33,20 @@ public sealed class ServicesEndpointTest(ITestOutputHelper testOutputHelper) : B
 
         registration.Scope.Should().Be(nameof(ServiceLifetime.Transient));
         registration.Type.Should().Be(typeof(ExampleService).FullName);
+        registration.Key.Should().BeNull();
+        registration.AssemblyName.Should().Be(typeof(ExampleService).Assembly.FullName);
+        registration.Dependencies.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Can_resolve_keyed_transient_for_implementation_type()
+    {
+        ServiceRegistration registration =
+            await GetRegistrationForAsync(typeof(ExampleService).FullName, services => services.AddKeyedTransient<ExampleService>("exampleKey"));
+
+        registration.Scope.Should().Be(nameof(ServiceLifetime.Transient));
+        registration.Type.Should().Be(typeof(ExampleService).FullName);
+        registration.Key.Should().Be("exampleKey");
         registration.AssemblyName.Should().Be(typeof(ExampleService).Assembly.FullName);
         registration.Dependencies.Should().BeEmpty();
     }
@@ -44,6 +59,20 @@ public sealed class ServicesEndpointTest(ITestOutputHelper testOutputHelper) : B
 
         registration.Scope.Should().Be(nameof(ServiceLifetime.Transient));
         registration.Type.Should().Be(typeof(ExampleService).FullName);
+        registration.Key.Should().BeNull();
+        registration.AssemblyName.Should().Be(typeof(ExampleService).Assembly.FullName);
+        registration.Dependencies.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Can_resolve_keyed_transient_for_interface_type_with_implementation_type()
+    {
+        ServiceRegistration registration = await GetRegistrationForAsync(typeof(IExampleService).FullName,
+            services => services.AddKeyedTransient<IExampleService, ExampleService>("exampleKey"));
+
+        registration.Scope.Should().Be(nameof(ServiceLifetime.Transient));
+        registration.Type.Should().Be(typeof(ExampleService).FullName);
+        registration.Key.Should().Be("exampleKey");
         registration.AssemblyName.Should().Be(typeof(ExampleService).Assembly.FullName);
         registration.Dependencies.Should().BeEmpty();
     }
@@ -56,6 +85,20 @@ public sealed class ServicesEndpointTest(ITestOutputHelper testOutputHelper) : B
 
         registration.Scope.Should().Be(nameof(ServiceLifetime.Scoped));
         registration.Type.Should().Be(typeof(ExampleService).FullName);
+        registration.Key.Should().BeNull();
+        registration.AssemblyName.Should().Be(typeof(ExampleService).Assembly.FullName);
+        registration.Dependencies.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Can_resolve_keyed_scoped_for_implementation_factory()
+    {
+        ServiceRegistration registration = await GetRegistrationForAsync(typeof(ExampleService).FullName,
+            services => services.AddKeyedScoped<ExampleService>("exampleKey", (_, _) => new ExampleService()));
+
+        registration.Scope.Should().Be(nameof(ServiceLifetime.Scoped));
+        registration.Type.Should().Be(typeof(ExampleService).FullName);
+        registration.Key.Should().Be("exampleKey");
         registration.AssemblyName.Should().Be(typeof(ExampleService).Assembly.FullName);
         registration.Dependencies.Should().BeEmpty();
     }
@@ -68,6 +111,20 @@ public sealed class ServicesEndpointTest(ITestOutputHelper testOutputHelper) : B
 
         registration.Scope.Should().Be(nameof(ServiceLifetime.Scoped));
         registration.Type.Should().Be(typeof(IExampleService).FullName);
+        registration.Key.Should().BeNull();
+        registration.AssemblyName.Should().Be(typeof(ExampleService).Assembly.FullName);
+        registration.Dependencies.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Can_resolve_keyed_scoped_for_interface_type_with_implementation_factory()
+    {
+        ServiceRegistration registration = await GetRegistrationForAsync(typeof(IExampleService).FullName,
+            services => services.AddKeyedScoped<IExampleService>("exampleKey", (_, _) => new ExampleService()));
+
+        registration.Scope.Should().Be(nameof(ServiceLifetime.Scoped));
+        registration.Type.Should().Be(typeof(IExampleService).FullName);
+        registration.Key.Should().Be("exampleKey");
         registration.AssemblyName.Should().Be(typeof(ExampleService).Assembly.FullName);
         registration.Dependencies.Should().BeEmpty();
     }
@@ -80,6 +137,20 @@ public sealed class ServicesEndpointTest(ITestOutputHelper testOutputHelper) : B
 
         registration.Scope.Should().Be(nameof(ServiceLifetime.Singleton));
         registration.Type.Should().Be(typeof(ExampleService).FullName);
+        registration.Key.Should().BeNull();
+        registration.AssemblyName.Should().Be(typeof(ExampleService).Assembly.FullName);
+        registration.Dependencies.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Can_resolve_keyed_singleton_for_implementation_instance()
+    {
+        ServiceRegistration registration = await GetRegistrationForAsync(typeof(ExampleService).FullName,
+            services => services.AddKeyedSingleton("exampleKey", new ExampleService()));
+
+        registration.Scope.Should().Be(nameof(ServiceLifetime.Singleton));
+        registration.Type.Should().Be(typeof(ExampleService).FullName);
+        registration.Key.Should().Be("exampleKey");
         registration.AssemblyName.Should().Be(typeof(ExampleService).Assembly.FullName);
         registration.Dependencies.Should().BeEmpty();
     }
@@ -92,6 +163,20 @@ public sealed class ServicesEndpointTest(ITestOutputHelper testOutputHelper) : B
 
         registration.Scope.Should().Be(nameof(ServiceLifetime.Singleton));
         registration.Type.Should().Be(typeof(ExampleService).FullName);
+        registration.Key.Should().BeNull();
+        registration.AssemblyName.Should().Be(typeof(ExampleService).Assembly.FullName);
+        registration.Dependencies.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Can_resolve_keyed_singleton_for_interface_with_implementation_instance()
+    {
+        ServiceRegistration registration = await GetRegistrationForAsync(typeof(IExampleService).FullName,
+            services => services.AddKeyedSingleton<IExampleService>("exampleKey", new ExampleService()));
+
+        registration.Scope.Should().Be(nameof(ServiceLifetime.Singleton));
+        registration.Type.Should().Be(typeof(ExampleService).FullName);
+        registration.Key.Should().Be("exampleKey");
         registration.AssemblyName.Should().Be(typeof(ExampleService).Assembly.FullName);
         registration.Dependencies.Should().BeEmpty();
     }


### PR DESCRIPTION
## Description

Adds support for keyed services in the `/actuator/beans` management endpoint. This PR adds a `key` property that is non-null for a keyed service. For test coverage, I've added keyed variants of the existing tests.

I've considered mapping to [Spring aliases](https://docs.spring.io/spring-framework/reference/core/beans/definition.html) instead of introducing `key`, but I believe that's not entirely the same concept.

![image](https://github.com/user-attachments/assets/193f5200-e9e6-4b62-8f13-cb6855e64b84)

Fixes #1377.

## Quality checklist

- [x] Your code complies with our [Coding Style](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-code-style.md).
- [x] You've updated unit and/or integration tests for your change, where applicable.
- [ ] You've updated documentation for your change, where applicable.
      If your change affects other repositories, such as [Documentation](https://github.com/SteeltoeOSS/Documentation), [Samples](https://github.com/SteeltoeOSS/Samples) and/or [MainSite](https://github.com/SteeltoeOSS/MainSite), add linked PRs here.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
- [ ] You've added required license files and/or file headers (explaining where the code came from with proper attribution), where code is copied from StackOverflow, a blog, or OSS.
