### PR TITLE
Add test to resolve placeholder in default

### DIFF
--- a/src/Configuration/test/Placeholder.Test/PropertyPlaceholderHelperTest.cs
+++ b/src/Configuration/test/Placeholder.Test/PropertyPlaceholderHelperTest.cs
@@ -64,6 +64,26 @@ public sealed class PropertyPlaceholderHelperTest
     }
 
     [Fact]
+    public void ResolvePlaceholders_ResolvesSinglePlaceholder_ResolvesPlaceholderInDefault()
+    {
+        const string text = "foo=${foo?${myDefault}}";
+
+        var appSettings = new Dictionary<string, string?>
+        {
+            ["myDefault"] = "empty"
+        };
+
+        var builder = new ConfigurationBuilder();
+        builder.AddInMemoryCollection(appSettings);
+        IConfiguration configuration = builder.Build();
+
+        var helper = new PropertyPlaceholderHelper(NullLogger<PropertyPlaceholderHelper>.Instance);
+
+        string? result = helper.ResolvePlaceholders(text, configuration);
+        Assert.Equal("foo=empty", result);
+    }
+
+    [Fact]
     public void ResolvePlaceholders_ResolvesSingleSpringPlaceholder()
     {
         const string text = "foo=${foo.bar}";


### PR DESCRIPTION
## Description

Add test coverage for resolving a placeholder in the default value (for example: `${ref}?${defaultRef}`), which is documented at: https://docs.steeltoe.io/api/v3/configuration/placeholder-provider.html:

> A placeholder takes the form of `${key:subkey1:subkey2?default_value}`, where
> ...
> Note that placeholder defaults (for example, `default_value`) can be defined to be placeholders as well and those are resolved as well.

## Quality checklist

- [x] Your code complies with our [Coding Style](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-code-style.md).
- [x] You've updated unit and/or integration tests for your change, where applicable.
- [ ] You've updated documentation for your change, where applicable.
      If your change affects other repositories, such as [Documentation](https://github.com/SteeltoeOSS/Documentation), [Samples](https://github.com/SteeltoeOSS/Samples) and/or [MainSite](https://github.com/SteeltoeOSS/MainSite), add linked PRs here.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
- [ ] You've added required license files and/or file headers (explaining where the code came from with proper attribution), where code is copied from StackOverflow, a blog, or OSS.
