### PR TITLE
Fix ignored authorization callbacks in management endpoints

### DIFF
--- a/src/Management/src/Endpoint/ActuatorConventionBuilder.cs
+++ b/src/Management/src/Endpoint/ActuatorConventionBuilder.cs
@@ -6,24 +6,25 @@ using Microsoft.AspNetCore.Builder;
 
 namespace Steeltoe.Management.Endpoint;
 
-public sealed class ActuatorConventionBuilder : IEndpointConventionBuilder
+/// <summary>
+/// Captures conventions for actuator endpoints and applies them to the builders returned from ASP.NET MapMethods() calls.
+/// </summary>
+internal abstract class ActuatorConventionBuilder : IEndpointConventionBuilder
 {
-    private readonly List<IEndpointConventionBuilder> _builders = [];
+    /// <summary>
+    /// Adds a convention to the builder. This interface implementation is called by ASP.NET extension methods, such as
+    /// <see cref="AuthorizationEndpointConventionBuilderExtensions.RequireAuthorization{TBuilder}(TBuilder)" />.
+    /// </summary>
+    /// <param name="convention">
+    /// The convention to add.
+    /// </param>
+    public abstract void Add(Action<EndpointBuilder> convention);
 
-    public void Add(Action<EndpointBuilder> convention)
-    {
-        ArgumentNullException.ThrowIfNull(convention);
-
-        foreach (IEndpointConventionBuilder builder in _builders)
-        {
-            builder.Add(convention);
-        }
-    }
-
-    public void Add(IEndpointConventionBuilder builder)
-    {
-        ArgumentNullException.ThrowIfNull(builder);
-
-        _builders.Add(builder);
-    }
+    /// <summary>
+    /// Captures a convention builder, which is returned from ASP.NET MapMethods() for a single actuator endpoint.
+    /// </summary>
+    /// <param name="builder">
+    /// The builder returned from MapMethods().
+    /// </param>
+    public abstract void TrackTarget(IEndpointConventionBuilder builder);
 }

--- a/src/Management/src/Endpoint/ActuatorEndpointMapper.cs
+++ b/src/Management/src/Endpoint/ActuatorEndpointMapper.cs
@@ -37,10 +37,10 @@ internal sealed class ActuatorEndpointMapper
         _logger = logger;
     }
 
-    public void Map(IEndpointRouteBuilder endpointRouteBuilder, ActuatorConventionBuilder conventionBuilder)
+    public void Map(IEndpointRouteBuilder endpointRouteBuilder, ActuatorConventionBuilder actuatorConventionBuilder)
     {
         ArgumentNullException.ThrowIfNull(endpointRouteBuilder);
-        ArgumentNullException.ThrowIfNull(conventionBuilder);
+        ArgumentNullException.ThrowIfNull(actuatorConventionBuilder);
 
         InnerMap(middleware => endpointRouteBuilder.CreateApplicationBuilder().UseMiddleware(middleware.GetType()).Build(),
             (middleware, requestPath, pipeline) =>
@@ -50,7 +50,7 @@ internal sealed class ActuatorEndpointMapper
                 if (allowedVerbs.Count > 0)
                 {
                     IEndpointConventionBuilder endpointConventionBuilder = endpointRouteBuilder.MapMethods(requestPath, allowedVerbs, pipeline);
-                    conventionBuilder.Add(endpointConventionBuilder);
+                    actuatorConventionBuilder.TrackTarget(endpointConventionBuilder);
                 }
             });
     }

--- a/src/Management/src/Endpoint/ActuatorRouteBuilderExtensions.cs
+++ b/src/Management/src/Endpoint/ActuatorRouteBuilderExtensions.cs
@@ -17,7 +17,7 @@ public static class ActuatorRouteBuilderExtensions
     /// The <see cref="IEndpointRouteBuilder" /> to add routes to.
     /// </param>
     /// <returns>
-    /// A <see cref="IEndpointConventionBuilder" /> that can be used to further customize the actuator endpoints.
+    /// An <see cref="IEndpointConventionBuilder" /> that can be used to further customize the actuator endpoints.
     /// </returns>
     public static IEndpointConventionBuilder MapAllActuators(this IEndpointRouteBuilder builder)
     {

--- a/src/Management/src/Endpoint/ActuatorRouteBuilderExtensions.cs
+++ b/src/Management/src/Endpoint/ActuatorRouteBuilderExtensions.cs
@@ -17,11 +17,11 @@ public static class ActuatorRouteBuilderExtensions
     /// The <see cref="IEndpointRouteBuilder" /> to add routes to.
     /// </param>
     /// <returns>
-    /// The incoming <paramref name="builder" /> so that additional calls can be chained.
+    /// A <see cref="IEndpointConventionBuilder" /> that can be used to further customize the actuator endpoints.
     /// </returns>
     public static IEndpointConventionBuilder MapAllActuators(this IEndpointRouteBuilder builder)
     {
-        return MapAllActuators(builder, null);
+        return MapAllActuators(builder, new ImmediateActuatorConventionBuilder());
     }
 
     /// <summary>
@@ -31,20 +31,20 @@ public static class ActuatorRouteBuilderExtensions
     /// The <see cref="IEndpointRouteBuilder" /> to add routes to.
     /// </param>
     /// <param name="conventionBuilder">
-    /// An optional builder to customize endpoints.
+    /// The builder to customize all mapped endpoints.
     /// </param>
     /// <returns>
-    /// The incoming <paramref name="routeBuilder" /> so that additional calls can be chained.
+    /// The incoming <paramref name="conventionBuilder" /> that can be used to further customize the actuator endpoints.
     /// </returns>
-    public static IEndpointConventionBuilder MapAllActuators(this IEndpointRouteBuilder routeBuilder, ActuatorConventionBuilder? conventionBuilder)
+    internal static IEndpointConventionBuilder MapAllActuators(this IEndpointRouteBuilder routeBuilder, ActuatorConventionBuilder conventionBuilder)
     {
         ArgumentNullException.ThrowIfNull(routeBuilder);
+        ArgumentNullException.ThrowIfNull(conventionBuilder);
 
         IServiceProvider serviceProvider = routeBuilder.ServiceProvider;
 
         using IServiceScope scope = serviceProvider.CreateScope();
         var mapper = scope.ServiceProvider.GetRequiredService<ActuatorEndpointMapper>();
-        conventionBuilder ??= new ActuatorConventionBuilder();
 
         mapper.Map(routeBuilder, conventionBuilder);
         return conventionBuilder;

--- a/src/Management/src/Endpoint/ActuatorServiceCollectionExtensions.cs
+++ b/src/Management/src/Endpoint/ActuatorServiceCollectionExtensions.cs
@@ -141,7 +141,7 @@ public static class ActuatorServiceCollectionExtensions
     /// The <see cref="IServiceCollection" /> to add services to.
     /// </param>
     /// <returns>
-    /// A <see cref="IEndpointConventionBuilder" /> that can be used to further customize the actuator endpoints.
+    /// An <see cref="IEndpointConventionBuilder" /> that can be used to further customize the actuator endpoints.
     /// </returns>
     public static IEndpointConventionBuilder ActivateActuatorEndpoints(this IServiceCollection services)
     {

--- a/src/Management/src/Endpoint/ActuatorServiceCollectionExtensions.cs
+++ b/src/Management/src/Endpoint/ActuatorServiceCollectionExtensions.cs
@@ -141,13 +141,18 @@ public static class ActuatorServiceCollectionExtensions
     /// The <see cref="IServiceCollection" /> to add services to.
     /// </param>
     /// <returns>
-    /// The incoming <paramref name="services" /> so that additional calls can be chained.
+    /// A <see cref="IEndpointConventionBuilder" /> that can be used to further customize the actuator endpoints.
     /// </returns>
     public static IEndpointConventionBuilder ActivateActuatorEndpoints(this IServiceCollection services)
     {
+        return InnerActivateActuatorEndpoints(services);
+    }
+
+    internal static DeferredActuatorConventionBuilder InnerActivateActuatorEndpoints(this IServiceCollection services)
+    {
         ArgumentNullException.ThrowIfNull(services);
 
-        var actuatorConventionBuilder = new ActuatorConventionBuilder();
+        var actuatorConventionBuilder = new DeferredActuatorConventionBuilder();
 
         services.TryAddEnumerable(
             ServiceDescriptor.Transient<IStartupFilter, AllActuatorsStartupFilter>(_ => new AllActuatorsStartupFilter(actuatorConventionBuilder)));

--- a/src/Management/src/Endpoint/AllActuatorsStartupFilter.cs
+++ b/src/Management/src/Endpoint/AllActuatorsStartupFilter.cs
@@ -17,9 +17,9 @@ namespace Steeltoe.Management.Endpoint;
 
 public sealed class AllActuatorsStartupFilter : IStartupFilter
 {
-    private readonly ActuatorConventionBuilder _conventionBuilder;
+    private readonly DeferredActuatorConventionBuilder _conventionBuilder;
 
-    public AllActuatorsStartupFilter(ActuatorConventionBuilder conventionBuilder)
+    internal AllActuatorsStartupFilter(DeferredActuatorConventionBuilder conventionBuilder)
     {
         ArgumentNullException.ThrowIfNull(conventionBuilder);
 

--- a/src/Management/src/Endpoint/DeferredActuatorConventionBuilder.cs
+++ b/src/Management/src/Endpoint/DeferredActuatorConventionBuilder.cs
@@ -1,0 +1,54 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.AspNetCore.Builder;
+
+namespace Steeltoe.Management.Endpoint;
+
+/// <summary>
+/// Used by IServiceCollection.ActivateActuatorEndpoints() and host builder extension methods. <see cref="TrackTarget" /> executes AFTER all
+/// <see cref="Add" /> and <see cref="AddConfigure" /> calls.
+/// </summary>
+internal sealed class DeferredActuatorConventionBuilder : ActuatorConventionBuilder
+{
+    private readonly List<Action<EndpointBuilder>> _conventions = [];
+    private readonly List<Action<IEndpointConventionBuilder>> _configureActions = [];
+
+    /// <inheritdoc />
+    public override void Add(Action<EndpointBuilder> convention)
+    {
+        ArgumentNullException.ThrowIfNull(convention);
+
+        _conventions.Add(convention);
+    }
+
+    /// <inheritdoc />
+    public override void TrackTarget(IEndpointConventionBuilder builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        foreach (Action<IEndpointConventionBuilder> configureAction in _configureActions)
+        {
+            configureAction(builder);
+        }
+
+        foreach (Action<EndpointBuilder> convention in _conventions)
+        {
+            builder.Add(convention);
+        }
+    }
+
+    /// <summary>
+    /// Captures a callback to configure endpoint conventions.
+    /// </summary>
+    /// <param name="configureConvention">
+    /// A callback to configure endpoint conventions, for example: configureEndpoints => configureEndpoints.RequireAuthorization().
+    /// </param>
+    public void AddConfigure(Action<IEndpointConventionBuilder> configureConvention)
+    {
+        ArgumentNullException.ThrowIfNull(configureConvention);
+
+        _configureActions.Add(configureConvention);
+    }
+}

--- a/src/Management/src/Endpoint/HostBuilderWrapperExtensions.cs
+++ b/src/Management/src/Endpoint/HostBuilderWrapperExtensions.cs
@@ -127,8 +127,12 @@ internal static class HostBuilderWrapperExtensions
     {
         wrapper.ConfigureServices(services =>
         {
-            IEndpointConventionBuilder conventionBuilder = services.ActivateActuatorEndpoints();
-            configureEndpoints?.Invoke(conventionBuilder);
+            DeferredActuatorConventionBuilder conventionBuilder = services.InnerActivateActuatorEndpoints();
+
+            if (configureEndpoints != null)
+            {
+                conventionBuilder.AddConfigure(configureEndpoints);
+            }
         });
     }
 }

--- a/src/Management/src/Endpoint/ImmediateActuatorConventionBuilder.cs
+++ b/src/Management/src/Endpoint/ImmediateActuatorConventionBuilder.cs
@@ -1,0 +1,34 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.AspNetCore.Builder;
+
+namespace Steeltoe.Management.Endpoint;
+
+/// <summary>
+/// Used by IEndpointRouteBuilder.MapAllActuators(). <see cref="TrackTarget" /> executes BEFORE any optional <see cref="Add" /> calls.
+/// </summary>
+internal sealed class ImmediateActuatorConventionBuilder : ActuatorConventionBuilder
+{
+    private readonly List<IEndpointConventionBuilder> _builders = [];
+
+    /// <inheritdoc />
+    public override void Add(Action<EndpointBuilder> convention)
+    {
+        ArgumentNullException.ThrowIfNull(convention);
+
+        foreach (IEndpointConventionBuilder builder in _builders)
+        {
+            builder.Add(convention);
+        }
+    }
+
+    /// <inheritdoc />
+    public override void TrackTarget(IEndpointConventionBuilder builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        _builders.Add(builder);
+    }
+}

--- a/src/Management/src/Endpoint/PublicAPI.Unshipped.txt
+++ b/src/Management/src/Endpoint/PublicAPI.Unshipped.txt
@@ -20,7 +20,6 @@ static readonly Steeltoe.Management.Endpoint.Actuators.Health.Availability.Liven
 static readonly Steeltoe.Management.Endpoint.Actuators.Health.Availability.ReadinessState.AcceptingTraffic -> Steeltoe.Management.Endpoint.Actuators.Health.Availability.ReadinessState!
 static readonly Steeltoe.Management.Endpoint.Actuators.Health.Availability.ReadinessState.RefusingTraffic -> Steeltoe.Management.Endpoint.Actuators.Health.Availability.ReadinessState!
 static Steeltoe.Management.Endpoint.ActuatorRouteBuilderExtensions.MapAllActuators(this Microsoft.AspNetCore.Routing.IEndpointRouteBuilder! builder) -> Microsoft.AspNetCore.Builder.IEndpointConventionBuilder!
-static Steeltoe.Management.Endpoint.ActuatorRouteBuilderExtensions.MapAllActuators(this Microsoft.AspNetCore.Routing.IEndpointRouteBuilder! routeBuilder, Steeltoe.Management.Endpoint.ActuatorConventionBuilder? conventionBuilder) -> Microsoft.AspNetCore.Builder.IEndpointConventionBuilder!
 static Steeltoe.Management.Endpoint.ActuatorRouteBuilderExtensions.MapAllActuators(this Microsoft.AspNetCore.Routing.IRouteBuilder! builder) -> Microsoft.AspNetCore.Routing.IRouteBuilder!
 static Steeltoe.Management.Endpoint.Actuators.CloudFoundry.CloudFoundrySecurityServiceCollectionExtensions.AddCloudFoundrySecurity(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
 static Steeltoe.Management.Endpoint.Actuators.CloudFoundry.EndpointApplicationBuilderExtensions.UseCloudFoundrySecurity(this Microsoft.AspNetCore.Builder.IApplicationBuilder! builder) -> Microsoft.AspNetCore.Builder.IApplicationBuilder!
@@ -107,10 +106,6 @@ static Steeltoe.Management.Endpoint.ManagementWebHostBuilderExtensions.AddServic
 static Steeltoe.Management.Endpoint.ManagementWebHostBuilderExtensions.AddThreadDumpActuator(this Microsoft.AspNetCore.Hosting.IWebHostBuilder! builder) -> Microsoft.AspNetCore.Hosting.IWebHostBuilder!
 static Steeltoe.Management.Endpoint.ManagementWebHostBuilderExtensions.AddThreadDumpActuator(this Microsoft.AspNetCore.Hosting.IWebHostBuilder! builder, Steeltoe.Management.Endpoint.MediaTypeVersion mediaTypeVersion) -> Microsoft.AspNetCore.Hosting.IWebHostBuilder!
 static Steeltoe.Management.Endpoint.SpringBootAdminClient.ServiceCollectionExtensions.AddSpringBootAdminClient(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
-Steeltoe.Management.Endpoint.ActuatorConventionBuilder
-Steeltoe.Management.Endpoint.ActuatorConventionBuilder.ActuatorConventionBuilder() -> void
-Steeltoe.Management.Endpoint.ActuatorConventionBuilder.Add(Microsoft.AspNetCore.Builder.IEndpointConventionBuilder! builder) -> void
-Steeltoe.Management.Endpoint.ActuatorConventionBuilder.Add(System.Action<Microsoft.AspNetCore.Builder.EndpointBuilder!>! convention) -> void
 Steeltoe.Management.Endpoint.ActuatorRouteBuilderExtensions
 Steeltoe.Management.Endpoint.Actuators.CloudFoundry.CloudFoundryEndpointOptions
 Steeltoe.Management.Endpoint.Actuators.CloudFoundry.CloudFoundryEndpointOptions.Api.get -> string?
@@ -497,7 +492,6 @@ Steeltoe.Management.Endpoint.Actuators.ThreadDump.ThreadInfo.WaitedTime.get -> l
 Steeltoe.Management.Endpoint.Actuators.ThreadDump.ThreadInfo.WaitedTime.set -> void
 Steeltoe.Management.Endpoint.ActuatorServiceCollectionExtensions
 Steeltoe.Management.Endpoint.AllActuatorsStartupFilter
-Steeltoe.Management.Endpoint.AllActuatorsStartupFilter.AllActuatorsStartupFilter(Steeltoe.Management.Endpoint.ActuatorConventionBuilder! conventionBuilder) -> void
 Steeltoe.Management.Endpoint.AllActuatorsStartupFilter.Configure(System.Action<Microsoft.AspNetCore.Builder.IApplicationBuilder!>? next) -> System.Action<Microsoft.AspNetCore.Builder.IApplicationBuilder!>!
 Steeltoe.Management.Endpoint.Configuration.Exposure
 Steeltoe.Management.Endpoint.Configuration.Exposure.Exclude.get -> System.Collections.Generic.IList<string!>!


### PR DESCRIPTION
## Description

Bugfix: when using `AddAllActuators` on a host builder with a callback to require authorization, the callback is ignored. For example:

```c#
hostBuilder.AddAllActuators(configureEndpoints =>
{
    configureEndpoints.RequireAuthorization("TestAuth"); // auth check does not run
});
```

Bugfix: when using `ActivateActuatorEndpoints` on service collection with a continuation to require authorization, the callback is ignored. For example:

```c#
services.AddAllActuators();
services.ActivateActuatorEndpoints().RequireAuthorization("TestAuth"); // auth check does not run
```

## Quality checklist

- [x] Your code complies with our [Coding Style](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-code-style.md).
- [x] You've updated unit and/or integration tests for your change, where applicable.
- [ ] You've updated documentation for your change, where applicable.
      If your change affects other repositories, such as [Documentation](https://github.com/SteeltoeOSS/Documentation), [Samples](https://github.com/SteeltoeOSS/Samples) and/or [MainSite](https://github.com/SteeltoeOSS/MainSite), add linked PRs here.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
- [ ] You've added required license files and/or file headers (explaining where the code came from with proper attribution), where code is copied from StackOverflow, a blog, or OSS.
