### PR TITLE
Backport fixes for warnings reported by code analyzers in .NET 9

### DIFF
--- a/src/Configuration/src/ConfigServer/ConfigServerServiceCollectionExtensions.cs
+++ b/src/Configuration/src/ConfigServer/ConfigServerServiceCollectionExtensions.cs
@@ -47,7 +47,7 @@ public static class ConfigServerServiceCollectionExtensions
     {
         ArgumentNullException.ThrowIfNull(services);
 
-        services.TryAddEnumerable(ServiceDescriptor.Singleton(typeof(IHealthContributor), typeof(ConfigServerHealthContributor)));
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<IHealthContributor, ConfigServerHealthContributor>());
 
         return services;
     }

--- a/src/Configuration/src/RandomValue/RandomValueProvider.cs
+++ b/src/Configuration/src/RandomValue/RandomValueProvider.cs
@@ -197,6 +197,6 @@ internal sealed class RandomValueProvider : ConfigurationProvider
     {
         byte[] bytes = new byte[16];
         Random.Shared.NextBytes(bytes);
-        return BitConverter.ToString(bytes).Replace("-", string.Empty, StringComparison.Ordinal);
+        return Convert.ToHexString(bytes);
     }
 }

--- a/src/Discovery/src/Configuration/ConfigurationServiceCollectionExtensions.cs
+++ b/src/Discovery/src/Configuration/ConfigurationServiceCollectionExtensions.cs
@@ -51,7 +51,7 @@ public static class ConfigurationServiceCollectionExtensions
 
         services.AddOptions<ConfigurationDiscoveryOptions>().BindConfiguration(ConfigurationDiscoveryOptions.ConfigurationPrefix);
 
-        services.TryAddEnumerable(ServiceDescriptor.Singleton(typeof(IDiscoveryClient), typeof(ConfigurationDiscoveryClient)));
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<IDiscoveryClient, ConfigurationDiscoveryClient>());
         services.AddHostedService<DiscoveryClientHostedService>();
 
         return services;

--- a/src/Discovery/src/Consul/ConsulServiceCollectionExtensions.cs
+++ b/src/Discovery/src/Consul/ConsulServiceCollectionExtensions.cs
@@ -93,8 +93,8 @@ public static class ConsulServiceCollectionExtensions
         });
 
         services.AddSingleton<ConsulServiceRegistrar>();
-        services.TryAddEnumerable(ServiceDescriptor.Singleton(typeof(IDiscoveryClient), typeof(ConsulDiscoveryClient)));
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<IDiscoveryClient, ConsulDiscoveryClient>());
         services.AddHostedService<DiscoveryClientHostedService>();
-        services.TryAddEnumerable(ServiceDescriptor.Singleton(typeof(IHealthContributor), typeof(ConsulHealthContributor)));
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<IHealthContributor, ConsulHealthContributor>());
     }
 }

--- a/src/Discovery/src/Eureka/EurekaServiceCollectionExtensions.cs
+++ b/src/Discovery/src/Eureka/EurekaServiceCollectionExtensions.cs
@@ -84,7 +84,7 @@ public static class EurekaServiceCollectionExtensions
     private static void AddEurekaServices(IServiceCollection services)
     {
         services.AddSingleton<HealthCheckHandlerProvider>();
-        services.TryAddEnumerable(ServiceDescriptor.Singleton(typeof(IHealthContributor), typeof(EurekaServerHealthContributor)));
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<IHealthContributor, EurekaServerHealthContributor>());
         services.AddSingleton<EurekaApplicationInfoManager>();
 
         services.TryAddSingleton<EurekaDiscoveryClient>();

--- a/src/Discovery/test/HttpClients.Test/LoadBalancers/DiscoveryHttpClientBuilderExtensionsTest.cs
+++ b/src/Discovery/test/HttpClients.Test/LoadBalancers/DiscoveryHttpClientBuilderExtensionsTest.cs
@@ -85,7 +85,7 @@ public sealed class DiscoveryHttpClientBuilderExtensionsTest
     public async Task AddLoadBalancerT_CanBeUsedWithAnHttpClient()
     {
         var services = new ServiceCollection();
-        services.AddSingleton(typeof(FakeLoadBalancer));
+        services.AddSingleton<FakeLoadBalancer>();
         services.AddHttpClient("test").AddServiceDiscovery<FakeLoadBalancer>();
 
         await using ServiceProvider serviceProvider = services.BuildServiceProvider(true);
@@ -103,7 +103,7 @@ public sealed class DiscoveryHttpClientBuilderExtensionsTest
         var services = new ServiceCollection();
         services.AddSingleton(configuration);
         services.AddConfigurationDiscoveryClient();
-        services.AddSingleton(typeof(FakeLoadBalancer));
+        services.AddSingleton<FakeLoadBalancer>();
 
         services.AddHttpClient("testRandom").AddServiceDiscovery<RandomLoadBalancer>();
         services.AddHttpClient("testRandom2").AddServiceDiscovery<RandomLoadBalancer>();

--- a/src/Logging/test/DynamicSerilog.Test/DynamicSerilogLoggerProviderTest.cs
+++ b/src/Logging/test/DynamicSerilog.Test/DynamicSerilogLoggerProviderTest.cs
@@ -25,7 +25,7 @@ public sealed class DynamicSerilogLoggerProviderTest
         using var factory = new LoggerFactory();
         factory.AddProvider(provider);
 
-        ILogger logger = factory.CreateLogger(typeof(TestClass));
+        ILogger logger = factory.CreateLogger<TestClass>();
 
         logger.IsEnabled(LogLevel.Critical).Should().BeTrue();
         logger.IsEnabled(LogLevel.Error).Should().BeTrue();
@@ -43,7 +43,7 @@ public sealed class DynamicSerilogLoggerProviderTest
         using var factory = new LoggerFactory();
         factory.AddProvider(provider);
 
-        _ = factory.CreateLogger(typeof(TestClass));
+        _ = factory.CreateLogger<TestClass>();
 
         string[] configurations = provider.GetLoggerConfigurations().Select(configuration => configuration.ToString()).ToArray();
 
@@ -63,7 +63,7 @@ public sealed class DynamicSerilogLoggerProviderTest
         using var factory = new LoggerFactory();
         factory.AddProvider(provider);
 
-        _ = factory.CreateLogger(typeof(TestClass));
+        _ = factory.CreateLogger<TestClass>();
 
         string[] configurations = provider.GetLoggerConfigurations().Select(configuration => configuration.ToString()).ToArray();
 
@@ -78,7 +78,7 @@ public sealed class DynamicSerilogLoggerProviderTest
         using var factory = new LoggerFactory();
         factory.AddProvider(provider);
 
-        factory.CreateLogger(typeof(TestClass));
+        factory.CreateLogger<TestClass>();
 
         string[] configurations = provider.GetLoggerConfigurations().Select(configuration => configuration.ToString()).ToArray();
 
@@ -109,7 +109,7 @@ public sealed class DynamicSerilogLoggerProviderTest
         using var factory = new LoggerFactory();
         factory.AddProvider(provider);
 
-        ILogger logger = factory.CreateLogger(typeof(TestClass));
+        ILogger logger = factory.CreateLogger<TestClass>();
 
         provider.SetLogLevel("A", LogLevel.Debug);
 
@@ -253,7 +253,7 @@ public sealed class DynamicSerilogLoggerProviderTest
         var provider = new DynamicSerilogLoggerProvider(GetConfigurationFromFile(), []);
         using var factory = new LoggerFactory();
         factory.AddProvider(provider);
-        ILogger logger = factory.CreateLogger(typeof(TestClass));
+        ILogger logger = factory.CreateLogger<TestClass>();
 
         using (LogContext.PushProperty("A", 1))
         {
@@ -288,7 +288,7 @@ public sealed class DynamicSerilogLoggerProviderTest
         var provider = new DynamicSerilogLoggerProvider(GetConfigurationFromFile(), []);
         using var factory = new LoggerFactory();
         factory.AddProvider(provider);
-        ILogger logger = factory.CreateLogger(typeof(TestClass));
+        ILogger logger = factory.CreateLogger<TestClass>();
 
         logger.LogInformation("Info {@TestInfo}", new
         {
@@ -308,7 +308,7 @@ public sealed class DynamicSerilogLoggerProviderTest
         var provider = new DynamicSerilogLoggerProvider(GetConfiguration(), []);
         using var factory = new LoggerFactory();
         factory.AddProvider(provider);
-        ILogger logger = factory.CreateLogger(typeof(TestClass));
+        ILogger logger = factory.CreateLogger<TestClass>();
 
         // act I - log at all levels, expect Info and above to work
         WriteLogEntries(logger);

--- a/src/Management/src/Endpoint/Actuators/Services/ServiceRegistration.cs
+++ b/src/Management/src/Endpoint/Actuators/Services/ServiceRegistration.cs
@@ -60,7 +60,7 @@ public sealed class ServiceRegistration
         ConstructorInfo[] constructors = implementationType.GetConstructors();
 
         ConstructorInfo? preferredConstructor = Array.Find(constructors,
-            constructor => constructor.GetCustomAttribute(typeof(ActivatorUtilitiesConstructorAttribute)) != null);
+            constructor => constructor.GetCustomAttribute<ActivatorUtilitiesConstructorAttribute>() != null);
 
         if (preferredConstructor != null)
         {

--- a/src/Management/test/Endpoint.Test/Actuators/Health/Startup.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/Health/Startup.cs
@@ -32,19 +32,19 @@ public sealed class Startup
         switch (_configuration.GetValue<string?>("HealthCheckType"))
         {
             case "down":
-                services.RemoveAll(typeof(IHealthContributor));
+                services.RemoveAll<IHealthContributor>();
                 services.AddHealthContributor<DownContributor>();
                 break;
             case "out":
-                services.RemoveAll(typeof(IHealthContributor));
+                services.RemoveAll<IHealthContributor>();
                 services.AddHealthContributor<OutOfServiceContributor>();
                 break;
             case "unknown":
-                services.RemoveAll(typeof(IHealthContributor));
+                services.RemoveAll<IHealthContributor>();
                 services.AddHealthContributor<UnknownContributor>();
                 break;
             case "disabled":
-                services.RemoveAll(typeof(IHealthContributor));
+                services.RemoveAll<IHealthContributor>();
                 services.AddHealthContributor<DisabledContributor>();
                 break;
             case "default":


### PR DESCRIPTION
## Description

Backport fixes for warnings reported by code analyzers in .NET 9.

Aside from minuscule performance improvements, this reduces the diff when we're going to build Steeltoe against .NET 9.

## Quality checklist

- [x] Your code complies with our [Coding Style](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-code-style.md).
- [x] You've updated unit and/or integration tests for your change, where applicable.
- [ ] You've updated documentation for your change, where applicable.
      If your change affects other repositories, such as [Documentation](https://github.com/SteeltoeOSS/Documentation), [Samples](https://github.com/SteeltoeOSS/Samples) and/or [MainSite](https://github.com/SteeltoeOSS/MainSite), add linked PRs here.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
- [ ] You've added required license files and/or file headers (explaining where the code came from with proper attribution), where code is copied from StackOverflow, a blog, or OSS.
