### PR TITLE
ApplicationAvailability: Use typed event handler

### DIFF
--- a/src/Management/src/Endpoint/Actuators/Health/Availability/ApplicationAvailability.cs
+++ b/src/Management/src/Endpoint/Actuators/Health/Availability/ApplicationAvailability.cs
@@ -14,8 +14,8 @@ public sealed class ApplicationAvailability
     private readonly Dictionary<string, AvailabilityState> _availabilityStates = [];
     private readonly ILogger<ApplicationAvailability> _logger;
 
-    public event EventHandler? LivenessChanged;
-    public event EventHandler? ReadinessChanged;
+    public event EventHandler<AvailabilityEventArgs>? LivenessChanged;
+    public event EventHandler<AvailabilityEventArgs>? ReadinessChanged;
 
     public ApplicationAvailability(ILogger<ApplicationAvailability> logger)
     {

--- a/src/Management/src/Endpoint/PublicAPI.Unshipped.txt
+++ b/src/Management/src/Endpoint/PublicAPI.Unshipped.txt
@@ -112,8 +112,8 @@ Steeltoe.Management.Endpoint.Actuators.Health.Availability.ApplicationAvailabili
 Steeltoe.Management.Endpoint.Actuators.Health.Availability.ApplicationAvailability.GetAvailabilityState(string! availabilityType) -> Steeltoe.Management.Endpoint.Actuators.Health.Availability.AvailabilityState?
 Steeltoe.Management.Endpoint.Actuators.Health.Availability.ApplicationAvailability.GetLivenessState() -> Steeltoe.Management.Endpoint.Actuators.Health.Availability.AvailabilityState?
 Steeltoe.Management.Endpoint.Actuators.Health.Availability.ApplicationAvailability.GetReadinessState() -> Steeltoe.Management.Endpoint.Actuators.Health.Availability.AvailabilityState?
-Steeltoe.Management.Endpoint.Actuators.Health.Availability.ApplicationAvailability.LivenessChanged -> System.EventHandler?
-Steeltoe.Management.Endpoint.Actuators.Health.Availability.ApplicationAvailability.ReadinessChanged -> System.EventHandler?
+Steeltoe.Management.Endpoint.Actuators.Health.Availability.ApplicationAvailability.LivenessChanged -> System.EventHandler<Steeltoe.Management.Endpoint.Actuators.Health.Availability.AvailabilityEventArgs!>?
+Steeltoe.Management.Endpoint.Actuators.Health.Availability.ApplicationAvailability.ReadinessChanged -> System.EventHandler<Steeltoe.Management.Endpoint.Actuators.Health.Availability.AvailabilityEventArgs!>?
 Steeltoe.Management.Endpoint.Actuators.Health.Availability.ApplicationAvailability.SetAvailabilityState(string! availabilityType, Steeltoe.Management.Endpoint.Actuators.Health.Availability.AvailabilityState! newState, string? caller) -> void
 Steeltoe.Management.Endpoint.Actuators.Health.Availability.AvailabilityEventArgs
 Steeltoe.Management.Endpoint.Actuators.Health.Availability.AvailabilityEventArgs.AvailabilityEventArgs(Steeltoe.Management.Endpoint.Actuators.Health.Availability.AvailabilityState! availabilityState) -> void

--- a/src/Management/test/Endpoint.Test/Actuators/Health/Availability/ApplicationAvailabilityTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/Health/Availability/ApplicationAvailabilityTest.cs
@@ -72,15 +72,15 @@ public sealed class ApplicationAvailabilityTest
         Assert.Equal(ReadinessState.AcceptingTraffic, _lastReadinessState);
     }
 
-    private void Availability_ReadinessChanged(object? sender, EventArgs args)
+    private void Availability_ReadinessChanged(object? sender, AvailabilityEventArgs args)
     {
         _readinessChanges++;
-        _lastReadinessState = (ReadinessState)((AvailabilityEventArgs)args).NewState;
+        _lastReadinessState = (ReadinessState)args.NewState;
     }
 
-    private void Availability_LivenessChanged(object? sender, EventArgs args)
+    private void Availability_LivenessChanged(object? sender, AvailabilityEventArgs args)
     {
         _livenessChanges++;
-        _lastLivenessState = (LivenessState)((AvailabilityEventArgs)args).NewState;
+        _lastLivenessState = (LivenessState)args.NewState;
     }
 }


### PR DESCRIPTION
## Description

Changes the `ApplicationAvailability` event handler signatures so that callers don't need to cast.

## Quality checklist

- [x] Your code complies with our [Coding Style](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-code-style.md).
- [x] You've updated unit and/or integration tests for your change, where applicable.
- [ ] You've updated documentation for your change, where applicable.
      If your change affects other repositories, such as [Documentation](https://github.com/SteeltoeOSS/Documentation), [Samples](https://github.com/SteeltoeOSS/Samples) and/or [MainSite](https://github.com/SteeltoeOSS/MainSite), add linked PRs here.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
- [ ] You've added required license files and/or file headers (explaining where the code came from with proper attribution), where code is copied from StackOverflow, a blog, or OSS.
