### PR TITLE
Update pipeline tasks

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -78,7 +78,7 @@ jobs:
       projects: src/Steeltoe.All.sln
       feedsToUse: config
       nugetConfigPath: nuget.config
-  - task: SonarCloudPrepare@1
+  - task: SonarCloudPrepare@3
     condition: eq(variables['sonarAnalyze'], 'true')
     displayName: Prepare analysis on SonarCloud
     inputs:
@@ -130,7 +130,7 @@ jobs:
       testResultsFormat: VSTest
       testResultsFiles: '*.trx'
       mergeTestResults: true
-  - task: Palmmedia.reportgenerator.reportgenerator-build-release-task.reportgenerator@4
+  - task: Palmmedia.reportgenerator.reportgenerator-build-release-task.reportgenerator@5
     condition: and(succeededOrFailed(), or(eq(variables['Agent.OS'], 'Windows_NT'), eq(variables['integrationTests'], 'true')))
     displayName: Consolidate coverage for this job
     inputs:
@@ -141,10 +141,10 @@ jobs:
     condition: and(succeeded(), or(eq(variables['Agent.OS'], 'Windows_NT'), eq(variables['integrationTests'], 'true')))
     displayName: Publish code coverage artifacts
     artifact: coverageResults-$(Agent.JobName)
-  - task: SonarCloudAnalyze@1
+  - task: SonarCloudAnalyze@3
     condition: and(succeededOrFailed(), eq(variables['sonarAnalyze'], 'true'))
     displayName: Run code analysis
-  - task: SonarCloudPublish@1
+  - task: SonarCloudPublish@3
     condition: and(succeededOrFailed(), eq(variables['sonarAnalyze'], 'true'))
     displayName: Publish quality gate result
 - job: Wrap_up
@@ -163,14 +163,14 @@ jobs:
     condition: succeededOrFailed()
     displayName: Download test coverage results from Windows
     continueOnError: true
-  - task: Palmmedia.reportgenerator.reportgenerator-build-release-task.reportgenerator@4
+  - task: Palmmedia.reportgenerator.reportgenerator-build-release-task.reportgenerator@5
     condition: succeededOrFailed()
     displayName: Consolidate code coverage results
     inputs:
       reports: $(Pipeline.Workspace)/**/Cobertura.xml
       targetdir: $(Build.ArtifactStagingDirectory)/CodeCoverage
       reporttypes: Cobertura
-  - task: PublishCodeCoverageResults@1
+  - task: PublishCodeCoverageResults@2
     condition: succeededOrFailed()
     displayName: Publish code coverage to Azure DevOps
     inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -170,7 +170,7 @@ jobs:
       reports: $(Pipeline.Workspace)/**/Cobertura.xml
       targetdir: $(Build.ArtifactStagingDirectory)/CodeCoverage
       reporttypes: Cobertura
-  - task: PublishCodeCoverageResults@2
+  - task: PublishCodeCoverageResults@1
     condition: succeededOrFailed()
     displayName: Publish code coverage to Azure DevOps
     inputs:


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->

<!-- If this is your first PR in this repo, please read our [Contributing Guidelines (https://github.com/SteeltoeOSS/.github/blob/master/CONTRIBUTING.md) and remember to sign the [Contributor License Agreement](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-license.md). Our bot will notify you shortly after the PR has been created. -->

## Description

Resolve these build warnings:
```
##[warning]Task 'Prepare Analysis Configuration' version 1 (SonarCloudPrepare@1) is deprecated.
##[warning]This task is deprecated. Please upgrade to the latest version. For more information, refer to https://docs.sonarsource.com/sonarcloud/advanced-setup/ci-based-analysis/sonarcloud-extension-for-azure-devops/
##[warning]Task 'Prepare Analysis Configuration' version 1 (SonarCloudPrepare@1) is dependent on a Node version (10) that is end-of-life. Contact the extension owner for an updated version of the task. Task maintainers should review Node upgrade guidance: https://aka.ms/node-runner-guidance

##[warning]Task 'ReportGenerator' version 4 (reportgenerator@4) is dependent on a Node version (6) that is end-of-life. Contact the extension owner for an updated version of the task. Task maintainers should review Node upgrade guidance: https://aka.ms/node-runner-guidance

##[warning]Task 'Run Code Analysis' version 1 (SonarCloudAnalyze@1) is deprecated.
##[warning]This task is deprecated. Please upgrade to the latest version. For more information, refer to https://docs.sonarsource.com/sonarcloud/advanced-setup/ci-based-analysis/sonarcloud-extension-for-azure-devops/
##[warning]Task 'Run Code Analysis' version 1 (SonarCloudAnalyze@1) is dependent on a Node version (10) that is end-of-life. Contact the extension owner for an updated version of the task. Task maintainers should review Node upgrade guidance: https://aka.ms/node-runner-guidance

##[warning]Task 'Publish Quality Gate Result' version 1 (SonarCloudPublish@1) is deprecated.
##[warning]This task is deprecated. Please upgrade to the latest version. For more information, refer to https://docs.sonarsource.com/sonarcloud/advanced-setup/ci-based-analysis/sonarcloud-extension-for-azure-devops/
##[warning]Task 'Publish Quality Gate Result' version 1 (SonarCloudPublish@1) is dependent on a Node version (10) that is end-of-life. Contact the extension owner for an updated version of the task. Task maintainers should review Node upgrade guidance: https://aka.ms/node-runner-guidance
```