### PR TITLE
Fixes in health actuator

### DIFF
--- a/src/Management/src/Endpoint/Actuators/Health/Availability/AvailabilityHealthContributor.cs
+++ b/src/Management/src/Endpoint/Actuators/Health/Availability/AvailabilityHealthContributor.cs
@@ -12,6 +12,8 @@ public abstract class AvailabilityHealthContributor : IHealthContributor
     private readonly IDictionary<AvailabilityState, HealthStatus> _stateMappings;
     private readonly ILogger _logger;
 
+    protected abstract bool IsEnabled { get; }
+
     public abstract string Id { get; }
 
     protected AvailabilityHealthContributor(IDictionary<AvailabilityState, HealthStatus> stateMappings, ILoggerFactory loggerFactory)
@@ -25,8 +27,8 @@ public abstract class AvailabilityHealthContributor : IHealthContributor
 
     public Task<HealthCheckResult?> CheckHealthAsync(CancellationToken cancellationToken)
     {
-        HealthCheckResult result = Health();
-        return Task.FromResult<HealthCheckResult?>(result);
+        HealthCheckResult? result = IsEnabled ? Health() : null;
+        return Task.FromResult(result);
     }
 
     private HealthCheckResult Health()

--- a/src/Management/src/Endpoint/Actuators/Health/Availability/ConfigureLivenessHealthContributorOptions.cs
+++ b/src/Management/src/Endpoint/Actuators/Health/Availability/ConfigureLivenessHealthContributorOptions.cs
@@ -1,0 +1,29 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Extensions.Configuration;
+using Steeltoe.Management.Endpoint.Configuration;
+
+namespace Steeltoe.Management.Endpoint.Actuators.Health.Availability;
+
+internal sealed class ConfigureLivenessHealthContributorOptions : IConfigureOptionsWithKey<LivenessHealthContributorOptions>
+{
+    private readonly IConfiguration _configuration;
+
+    public string ConfigurationKey => "management:endpoints:health:liveness";
+
+    public ConfigureLivenessHealthContributorOptions(IConfiguration configuration)
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        _configuration = configuration;
+    }
+
+    public void Configure(LivenessHealthContributorOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        _configuration.GetSection(ConfigurationKey).Bind(options);
+    }
+}

--- a/src/Management/src/Endpoint/Actuators/Health/Availability/ConfigureReadinessHealthContributorOptions.cs
+++ b/src/Management/src/Endpoint/Actuators/Health/Availability/ConfigureReadinessHealthContributorOptions.cs
@@ -1,0 +1,29 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Extensions.Configuration;
+using Steeltoe.Management.Endpoint.Configuration;
+
+namespace Steeltoe.Management.Endpoint.Actuators.Health.Availability;
+
+internal sealed class ConfigureReadinessHealthContributorOptions : IConfigureOptionsWithKey<ReadinessHealthContributorOptions>
+{
+    private readonly IConfiguration _configuration;
+
+    public string ConfigurationKey => "management:endpoints:health:readiness";
+
+    public ConfigureReadinessHealthContributorOptions(IConfiguration configuration)
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        _configuration = configuration;
+    }
+
+    public void Configure(ReadinessHealthContributorOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        _configuration.GetSection(ConfigurationKey).Bind(options);
+    }
+}

--- a/src/Management/src/Endpoint/Actuators/Health/Availability/LivenessHealthContributor.cs
+++ b/src/Management/src/Endpoint/Actuators/Health/Availability/LivenessHealthContributor.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Steeltoe.Common.HealthChecks;
 
 namespace Steeltoe.Management.Endpoint.Actuators.Health.Availability;
@@ -10,10 +11,14 @@ namespace Steeltoe.Management.Endpoint.Actuators.Health.Availability;
 public sealed class LivenessHealthContributor : AvailabilityHealthContributor
 {
     private readonly ApplicationAvailability _availability;
+    private readonly IOptionsMonitor<LivenessHealthContributorOptions> _optionsMonitor;
+
+    protected override bool IsEnabled => _optionsMonitor.CurrentValue.Enabled;
 
     public override string Id => "liveness";
 
-    public LivenessHealthContributor(ApplicationAvailability availability, ILoggerFactory loggerFactory)
+    public LivenessHealthContributor(ApplicationAvailability availability, IOptionsMonitor<LivenessHealthContributorOptions> optionsMonitor,
+        ILoggerFactory loggerFactory)
         : base(new Dictionary<AvailabilityState, HealthStatus>
         {
             { LivenessState.Correct, HealthStatus.Up },
@@ -21,8 +26,10 @@ public sealed class LivenessHealthContributor : AvailabilityHealthContributor
         }, loggerFactory)
     {
         ArgumentNullException.ThrowIfNull(availability);
+        ArgumentNullException.ThrowIfNull(optionsMonitor);
 
         _availability = availability;
+        _optionsMonitor = optionsMonitor;
     }
 
     protected override AvailabilityState? GetState()

--- a/src/Management/src/Endpoint/Actuators/Health/Availability/LivenessHealthContributorOptions.cs
+++ b/src/Management/src/Endpoint/Actuators/Health/Availability/LivenessHealthContributorOptions.cs
@@ -1,0 +1,13 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+namespace Steeltoe.Management.Endpoint.Actuators.Health.Availability;
+
+public sealed class LivenessHealthContributorOptions
+{
+    /// <summary>
+    /// Gets or sets a value indicating whether to enable the liveness contributor. Default value: true.
+    /// </summary>
+    public bool Enabled { get; set; } = true;
+}

--- a/src/Management/src/Endpoint/Actuators/Health/Availability/ReadinessHealthContributor.cs
+++ b/src/Management/src/Endpoint/Actuators/Health/Availability/ReadinessHealthContributor.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Steeltoe.Common.HealthChecks;
 
 namespace Steeltoe.Management.Endpoint.Actuators.Health.Availability;
@@ -10,10 +11,14 @@ namespace Steeltoe.Management.Endpoint.Actuators.Health.Availability;
 public sealed class ReadinessHealthContributor : AvailabilityHealthContributor
 {
     private readonly ApplicationAvailability _availability;
+    private readonly IOptionsMonitor<ReadinessHealthContributorOptions> _optionsMonitor;
+
+    protected override bool IsEnabled => _optionsMonitor.CurrentValue.Enabled;
 
     public override string Id => "readiness";
 
-    public ReadinessHealthContributor(ApplicationAvailability availability, ILoggerFactory loggerFactory)
+    public ReadinessHealthContributor(ApplicationAvailability availability, IOptionsMonitor<ReadinessHealthContributorOptions> optionsMonitor,
+        ILoggerFactory loggerFactory)
         : base(new Dictionary<AvailabilityState, HealthStatus>
         {
             { ReadinessState.AcceptingTraffic, HealthStatus.Up },
@@ -21,8 +26,10 @@ public sealed class ReadinessHealthContributor : AvailabilityHealthContributor
         }, loggerFactory)
     {
         ArgumentNullException.ThrowIfNull(availability);
+        ArgumentNullException.ThrowIfNull(optionsMonitor);
 
         _availability = availability;
+        _optionsMonitor = optionsMonitor;
     }
 
     protected override AvailabilityState? GetState()

--- a/src/Management/src/Endpoint/Actuators/Health/Availability/ReadinessHealthContributorOptions.cs
+++ b/src/Management/src/Endpoint/Actuators/Health/Availability/ReadinessHealthContributorOptions.cs
@@ -1,0 +1,13 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+namespace Steeltoe.Management.Endpoint.Actuators.Health.Availability;
+
+public sealed class ReadinessHealthContributorOptions
+{
+    /// <summary>
+    /// Gets or sets a value indicating whether to enable the readiness contributor. Default value: true.
+    /// </summary>
+    public bool Enabled { get; set; } = true;
+}

--- a/src/Management/src/Endpoint/Actuators/Health/EndpointServiceCollectionExtensions.cs
+++ b/src/Management/src/Endpoint/Actuators/Health/EndpointServiceCollectionExtensions.cs
@@ -74,7 +74,11 @@ public static class EndpointServiceCollectionExtensions
 
         services.TryAddSingleton<ApplicationAvailability>();
         services.TryAddEnumerable(ServiceDescriptor.Transient<IStartupFilter, AvailabilityStartupFilter>());
+
+        services.ConfigureOptionsWithChangeTokenSource<LivenessHealthContributorOptions, ConfigureLivenessHealthContributorOptions>();
         AddHealthContributor<LivenessHealthContributor>(services);
+
+        services.ConfigureOptionsWithChangeTokenSource<ReadinessHealthContributorOptions, ConfigureReadinessHealthContributorOptions>();
         AddHealthContributor<ReadinessHealthContributor>(services);
     }
 

--- a/src/Management/src/Endpoint/Actuators/Health/HealthConverter.cs
+++ b/src/Management/src/Endpoint/Actuators/Health/HealthConverter.cs
@@ -33,17 +33,32 @@ internal sealed class HealthConverter : JsonConverter<HealthEndpointResponse>
             writer.WritePropertyName("details");
             writer.WriteStartObject();
 
-            foreach (KeyValuePair<string, object> detail in value.Details)
+            foreach ((string detailKey, object detailValue) in value.Details)
             {
-                writer.WritePropertyName(detail.Key);
+                writer.WritePropertyName(detailKey);
 
-                if (detail.Value is HealthCheckResult detailValue)
+                if (detailValue is HealthCheckResult result)
                 {
-                    JsonSerializer.Serialize(writer, detailValue.Details, options);
+                    var details = new Dictionary<string, object>
+                    {
+                        ["status"] = result.Status.ToSnakeCaseString(SnakeCaseStyle.AllCaps)
+                    };
+
+                    if (result.Description != null)
+                    {
+                        details["description"] = result.Description;
+                    }
+
+                    foreach ((string resultKey, object resultValue) in result.Details)
+                    {
+                        details[resultKey] = resultValue;
+                    }
+
+                    JsonSerializer.Serialize(writer, details, options);
                 }
                 else
                 {
-                    JsonSerializer.Serialize(writer, detail.Value, options);
+                    JsonSerializer.Serialize(writer, detailValue, options);
                 }
             }
 

--- a/src/Management/src/Endpoint/ConfigurationSchema.json
+++ b/src/Management/src/Endpoint/ConfigurationSchema.json
@@ -302,9 +302,27 @@
                   "type": "string",
                   "description": "Gets or sets the unique ID of this endpoint."
                 },
+                "Liveness": {
+                  "type": "object",
+                  "properties": {
+                    "Enabled": {
+                      "type": "boolean",
+                      "description": "Gets or sets a value indicating whether to enable the liveness contributor. Default value: true."
+                    }
+                  }
+                },
                 "Path": {
                   "type": "string",
                   "description": "Gets or sets the relative path at which this endpoint is exposed."
+                },
+                "Readiness": {
+                  "type": "object",
+                  "properties": {
+                    "Enabled": {
+                      "type": "boolean",
+                      "description": "Gets or sets a value indicating whether to enable the readiness contributor. Default value: true."
+                    }
+                  }
                 },
                 "RequiredPermissions": {
                   "enum": [

--- a/src/Management/src/Endpoint/Properties/AssemblyInfo.cs
+++ b/src/Management/src/Endpoint/Properties/AssemblyInfo.cs
@@ -10,6 +10,7 @@ using Steeltoe.Management.Endpoint.Actuators.CloudFoundry;
 using Steeltoe.Management.Endpoint.Actuators.DbMigrations;
 using Steeltoe.Management.Endpoint.Actuators.Environment;
 using Steeltoe.Management.Endpoint.Actuators.Health;
+using Steeltoe.Management.Endpoint.Actuators.Health.Availability;
 using Steeltoe.Management.Endpoint.Actuators.Health.Contributors;
 using Steeltoe.Management.Endpoint.Actuators.HeapDump;
 using Steeltoe.Management.Endpoint.Actuators.HttpExchanges;
@@ -33,6 +34,8 @@ using Steeltoe.Management.Endpoint.SpringBootAdminClient;
 [assembly: ConfigurationSchema("Management:Endpoints:Env", typeof(EnvironmentEndpointOptions))]
 [assembly: ConfigurationSchema("Management:Endpoints:Health", typeof(HealthEndpointOptions))]
 [assembly: ConfigurationSchema("Management:Endpoints:Health:DiskSpace", typeof(DiskSpaceContributorOptions))]
+[assembly: ConfigurationSchema("Management:Endpoints:Health:Liveness", typeof(LivenessHealthContributorOptions))]
+[assembly: ConfigurationSchema("Management:Endpoints:Health:Readiness", typeof(ReadinessHealthContributorOptions))]
 [assembly: ConfigurationSchema("Management:Endpoints:HeapDump", typeof(HeapDumpEndpointOptions))]
 [assembly: ConfigurationSchema("Management:Endpoints:Info", typeof(InfoEndpointOptions))]
 [assembly: ConfigurationSchema("Management:Endpoints:Loggers", typeof(LoggersEndpointOptions))]

--- a/src/Management/src/Endpoint/PublicAPI.Unshipped.txt
+++ b/src/Management/src/Endpoint/PublicAPI.Unshipped.txt
@@ -1,6 +1,7 @@
 #nullable enable
 abstract Steeltoe.Management.Endpoint.Actuators.Health.Availability.AvailabilityHealthContributor.GetState() -> Steeltoe.Management.Endpoint.Actuators.Health.Availability.AvailabilityState?
 abstract Steeltoe.Management.Endpoint.Actuators.Health.Availability.AvailabilityHealthContributor.Id.get -> string!
+abstract Steeltoe.Management.Endpoint.Actuators.Health.Availability.AvailabilityHealthContributor.IsEnabled.get -> bool
 abstract Steeltoe.Management.Endpoint.Middleware.EndpointMiddleware<TArgument, TResult>.InvokeEndpointHandlerAsync(Microsoft.AspNetCore.Http.HttpContext! context, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<TResult>!
 const Steeltoe.Management.Endpoint.Actuators.Health.Availability.ApplicationAvailability.LivenessKey = "Liveness" -> string!
 const Steeltoe.Management.Endpoint.Actuators.Health.Availability.ApplicationAvailability.ReadinessKey = "Readiness" -> string!
@@ -124,10 +125,18 @@ Steeltoe.Management.Endpoint.Actuators.Health.Availability.AvailabilityHealthCon
 Steeltoe.Management.Endpoint.Actuators.Health.Availability.AvailabilityState
 Steeltoe.Management.Endpoint.Actuators.Health.Availability.AvailabilityState.AvailabilityState(string! value) -> void
 Steeltoe.Management.Endpoint.Actuators.Health.Availability.LivenessHealthContributor
-Steeltoe.Management.Endpoint.Actuators.Health.Availability.LivenessHealthContributor.LivenessHealthContributor(Steeltoe.Management.Endpoint.Actuators.Health.Availability.ApplicationAvailability! availability, Microsoft.Extensions.Logging.ILoggerFactory! loggerFactory) -> void
+Steeltoe.Management.Endpoint.Actuators.Health.Availability.LivenessHealthContributor.LivenessHealthContributor(Steeltoe.Management.Endpoint.Actuators.Health.Availability.ApplicationAvailability! availability, Microsoft.Extensions.Options.IOptionsMonitor<Steeltoe.Management.Endpoint.Actuators.Health.Availability.LivenessHealthContributorOptions!>! optionsMonitor, Microsoft.Extensions.Logging.ILoggerFactory! loggerFactory) -> void
+Steeltoe.Management.Endpoint.Actuators.Health.Availability.LivenessHealthContributorOptions
+Steeltoe.Management.Endpoint.Actuators.Health.Availability.LivenessHealthContributorOptions.Enabled.get -> bool
+Steeltoe.Management.Endpoint.Actuators.Health.Availability.LivenessHealthContributorOptions.Enabled.set -> void
+Steeltoe.Management.Endpoint.Actuators.Health.Availability.LivenessHealthContributorOptions.LivenessHealthContributorOptions() -> void
 Steeltoe.Management.Endpoint.Actuators.Health.Availability.LivenessState
 Steeltoe.Management.Endpoint.Actuators.Health.Availability.ReadinessHealthContributor
-Steeltoe.Management.Endpoint.Actuators.Health.Availability.ReadinessHealthContributor.ReadinessHealthContributor(Steeltoe.Management.Endpoint.Actuators.Health.Availability.ApplicationAvailability! availability, Microsoft.Extensions.Logging.ILoggerFactory! loggerFactory) -> void
+Steeltoe.Management.Endpoint.Actuators.Health.Availability.ReadinessHealthContributor.ReadinessHealthContributor(Steeltoe.Management.Endpoint.Actuators.Health.Availability.ApplicationAvailability! availability, Microsoft.Extensions.Options.IOptionsMonitor<Steeltoe.Management.Endpoint.Actuators.Health.Availability.ReadinessHealthContributorOptions!>! optionsMonitor, Microsoft.Extensions.Logging.ILoggerFactory! loggerFactory) -> void
+Steeltoe.Management.Endpoint.Actuators.Health.Availability.ReadinessHealthContributorOptions
+Steeltoe.Management.Endpoint.Actuators.Health.Availability.ReadinessHealthContributorOptions.Enabled.get -> bool
+Steeltoe.Management.Endpoint.Actuators.Health.Availability.ReadinessHealthContributorOptions.Enabled.set -> void
+Steeltoe.Management.Endpoint.Actuators.Health.Availability.ReadinessHealthContributorOptions.ReadinessHealthContributorOptions() -> void
 Steeltoe.Management.Endpoint.Actuators.Health.Availability.ReadinessState
 Steeltoe.Management.Endpoint.Actuators.Health.Contributors.DiskSpaceContributorOptions
 Steeltoe.Management.Endpoint.Actuators.Health.Contributors.DiskSpaceContributorOptions.DiskSpaceContributorOptions() -> void

--- a/src/Management/test/Endpoint.Test/Actuators/Health/Availability/LivenessHealthContributorTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/Health/Availability/LivenessHealthContributorTest.cs
@@ -4,6 +4,7 @@
 
 using Microsoft.Extensions.Logging.Abstractions;
 using Steeltoe.Common.HealthChecks;
+using Steeltoe.Common.TestResources;
 using Steeltoe.Management.Endpoint.Actuators.Health.Availability;
 
 namespace Steeltoe.Management.Endpoint.Test.Actuators.Health.Availability;
@@ -11,11 +12,12 @@ namespace Steeltoe.Management.Endpoint.Test.Actuators.Health.Availability;
 public sealed class LivenessHealthContributorTest
 {
     private readonly ApplicationAvailability _availability = new(NullLogger<ApplicationAvailability>.Instance);
+    private readonly TestOptionsMonitor<LivenessHealthContributorOptions> _optionsMonitor = new();
 
     [Fact]
     public async Task HandlesUnknown()
     {
-        var contributor = new LivenessHealthContributor(_availability, NullLoggerFactory.Instance);
+        var contributor = new LivenessHealthContributor(_availability, _optionsMonitor, NullLoggerFactory.Instance);
 
         HealthCheckResult? result = await contributor.CheckHealthAsync(CancellationToken.None);
 
@@ -27,7 +29,7 @@ public sealed class LivenessHealthContributorTest
     public async Task HandlesCorrect()
     {
         _availability.SetAvailabilityState(ApplicationAvailability.LivenessKey, LivenessState.Correct, "tests");
-        var contributor = new LivenessHealthContributor(_availability, NullLoggerFactory.Instance);
+        var contributor = new LivenessHealthContributor(_availability, _optionsMonitor, NullLoggerFactory.Instance);
 
         HealthCheckResult? result = await contributor.CheckHealthAsync(CancellationToken.None);
 
@@ -39,7 +41,7 @@ public sealed class LivenessHealthContributorTest
     public async Task HandlesBroken()
     {
         _availability.SetAvailabilityState(ApplicationAvailability.LivenessKey, LivenessState.Broken, "tests");
-        var contributor = new LivenessHealthContributor(_availability, NullLoggerFactory.Instance);
+        var contributor = new LivenessHealthContributor(_availability, _optionsMonitor, NullLoggerFactory.Instance);
 
         HealthCheckResult? result = await contributor.CheckHealthAsync(CancellationToken.None);
 

--- a/src/Management/test/Endpoint.Test/Actuators/Health/Availability/ReadinessHealthContributorTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/Health/Availability/ReadinessHealthContributorTest.cs
@@ -4,6 +4,7 @@
 
 using Microsoft.Extensions.Logging.Abstractions;
 using Steeltoe.Common.HealthChecks;
+using Steeltoe.Common.TestResources;
 using Steeltoe.Management.Endpoint.Actuators.Health.Availability;
 
 namespace Steeltoe.Management.Endpoint.Test.Actuators.Health.Availability;
@@ -11,11 +12,12 @@ namespace Steeltoe.Management.Endpoint.Test.Actuators.Health.Availability;
 public sealed class ReadinessHealthContributorTest
 {
     private readonly ApplicationAvailability _availability = new(NullLogger<ApplicationAvailability>.Instance);
+    private readonly TestOptionsMonitor<ReadinessHealthContributorOptions> _optionsMonitor = new();
 
     [Fact]
     public async Task HandlesUnknown()
     {
-        var contributor = new ReadinessHealthContributor(_availability, NullLoggerFactory.Instance);
+        var contributor = new ReadinessHealthContributor(_availability, _optionsMonitor, NullLoggerFactory.Instance);
 
         HealthCheckResult? result = await contributor.CheckHealthAsync(CancellationToken.None);
 
@@ -27,7 +29,7 @@ public sealed class ReadinessHealthContributorTest
     public async Task HandlesAccepting()
     {
         _availability.SetAvailabilityState(ApplicationAvailability.ReadinessKey, ReadinessState.AcceptingTraffic, "tests");
-        var contributor = new ReadinessHealthContributor(_availability, NullLoggerFactory.Instance);
+        var contributor = new ReadinessHealthContributor(_availability, _optionsMonitor, NullLoggerFactory.Instance);
 
         HealthCheckResult? result = await contributor.CheckHealthAsync(CancellationToken.None);
 
@@ -39,7 +41,7 @@ public sealed class ReadinessHealthContributorTest
     public async Task HandlesRefusing()
     {
         _availability.SetAvailabilityState(ApplicationAvailability.ReadinessKey, ReadinessState.RefusingTraffic, "tests");
-        var contributor = new ReadinessHealthContributor(_availability, NullLoggerFactory.Instance);
+        var contributor = new ReadinessHealthContributor(_availability, _optionsMonitor, NullLoggerFactory.Instance);
 
         HealthCheckResult? result = await contributor.CheckHealthAsync(CancellationToken.None);
 

--- a/src/Management/test/Endpoint.Test/Actuators/Health/HealthEndpointTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/Health/HealthEndpointTest.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Steeltoe.Common.HealthChecks;
+using Steeltoe.Common.TestResources;
 using Steeltoe.Management.Endpoint.Actuators.Health;
 using Steeltoe.Management.Endpoint.Actuators.Health.Availability;
 using Steeltoe.Management.Endpoint.Actuators.Health.Contributors;
@@ -179,11 +180,12 @@ public sealed class HealthEndpointTest(ITestOutputHelper testOutputHelper) : Bas
     {
         using var testContext = new TestContext(_testOutputHelper);
         var appAvailability = new ApplicationAvailability(NullLogger<ApplicationAvailability>.Instance);
+        TestOptionsMonitor<LivenessHealthContributorOptions> optionsMonitor = new();
 
         List<IHealthContributor> contributors =
         [
             new DiskSpaceContributor(GetOptionsMonitorFromSettings<DiskSpaceContributorOptions>()),
-            new LivenessHealthContributor(appAvailability, NullLoggerFactory.Instance)
+            new LivenessHealthContributor(appAvailability, optionsMonitor, NullLoggerFactory.Instance)
         ];
 
         testContext.AdditionalServices = (services, _) =>
@@ -210,13 +212,14 @@ public sealed class HealthEndpointTest(ITestOutputHelper testOutputHelper) : Bas
     {
         using var testContext = new TestContext(_testOutputHelper);
         var appAvailability = new ApplicationAvailability(NullLogger<ApplicationAvailability>.Instance);
+        TestOptionsMonitor<ReadinessHealthContributorOptions> optionsMonitor = new();
 
         List<IHealthContributor> contributors =
         [
             new UnknownContributor(),
             new DisabledContributor(),
             new UpContributor(),
-            new ReadinessHealthContributor(appAvailability, NullLoggerFactory.Instance)
+            new ReadinessHealthContributor(appAvailability, optionsMonitor, NullLoggerFactory.Instance)
         ];
 
         testContext.AdditionalServices = (services, _) =>
@@ -242,13 +245,14 @@ public sealed class HealthEndpointTest(ITestOutputHelper testOutputHelper) : Bas
     public async Task InvokeWithReadinessGroupReturnsGroupResults2()
     {
         var appAvailability = new ApplicationAvailability(NullLogger<ApplicationAvailability>.Instance);
+        TestOptionsMonitor<ReadinessHealthContributorOptions> optionsMonitor = new();
 
         List<IHealthContributor> contributors =
         [
             new UnknownContributor(),
             new DisabledContributor(),
             new UpContributor(),
-            new ReadinessHealthContributor(appAvailability, NullLoggerFactory.Instance)
+            new ReadinessHealthContributor(appAvailability, optionsMonitor, NullLoggerFactory.Instance)
         ];
 
         IOptionsMonitor<HealthEndpointOptions> options = GetOptionsMonitorFromSettings<HealthEndpointOptions, ConfigureHealthEndpointOptions>();

--- a/src/Management/test/Endpoint.Test/Actuators/Health/HealthTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/Health/HealthTest.cs
@@ -67,4 +67,42 @@ public sealed class HealthTest : BaseTest
             }
             """);
     }
+
+    [Fact]
+    public void Serialize_WithHealthCheckResult_ReturnsExpected()
+    {
+        var health = new HealthEndpointResponse
+        {
+            Status = HealthStatus.OutOfService,
+            Description = "Test",
+            Details =
+            {
+                ["ExampleContributor"] = new HealthCheckResult
+                {
+                    Status = HealthStatus.Unknown,
+                    Description = "ExampleDescription",
+                    Details =
+                    {
+                        ["ExampleMessage"] = "ExampleValue"
+                    }
+                }
+            }
+        };
+
+        string json = JsonSerializer.Serialize(health, SerializerOptions);
+
+        json.Should().BeJson("""
+            {
+              "status": "OUT_OF_SERVICE",
+              "description": "Test",
+              "details": {
+                "ExampleContributor": {
+                  "status": "UNKNOWN",
+                  "description": "ExampleDescription",
+                  "ExampleMessage": "ExampleValue"
+                }
+              }
+            }
+            """);
+    }
 }


### PR DESCRIPTION
## Description

According to the documentation at https://docs.steeltoe.io/api/v3/management/health.html#creating-a-custom-health-contributor, it should be possible to set the contributor Status/Description properties, but they don't appear in the output. The first commit fixes that.

The second commit enables turning off the default health contributors from configuration.

## Quality checklist

- [x] Your code complies with our [Coding Style](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-code-style.md).
- [x] You've updated unit and/or integration tests for your change, where applicable.
- [ ] You've updated documentation for your change, where applicable.
      If your change affects other repositories, such as [Documentation](https://github.com/SteeltoeOSS/Documentation), [Samples](https://github.com/SteeltoeOSS/Samples) and/or [MainSite](https://github.com/SteeltoeOSS/MainSite), add linked PRs here.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
- [ ] You've added required license files and/or file headers (explaining where the code came from with proper attribution), where code is copied from StackOverflow, a blog, or OSS.
