### PR TITLE
Fix broken gzip download from heapdump actuator

### DIFF
--- a/src/Management/src/Endpoint/Actuators/HeapDump/HeapDumpEndpointMiddleware.cs
+++ b/src/Management/src/Endpoint/Actuators/HeapDump/HeapDumpEndpointMiddleware.cs
@@ -39,7 +39,7 @@ internal sealed class HeapDumpEndpointMiddleware(
         try
         {
             await using var inputStream = new FileStream(fileName, FileMode.Open);
-            var outputStream = new GZipStream(context.Response.Body, CompressionLevel.Fastest);
+            await using var outputStream = new GZipStream(context.Response.Body, CompressionLevel.Fastest, true);
             await inputStream.CopyToAsync(outputStream, cancellationToken);
         }
         finally


### PR DESCRIPTION
## Description

The gzip stream wasn't being flushed, resulting in the loss of the last bytes.

![image](https://github.com/user-attachments/assets/0dae4b0d-96d0-4e34-a54a-e0ceba367b33)

Additionally, this PR writes the capture logging from gcdump to `ILogger` instead of `Console.Out`.

## Quality checklist

<!-- Please run through the checklist below to ensure a smooth review and merge process for your PR. -->

- [ ] Your code complies with our [Coding Style](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-code-style.md).
- [ ] You've updated unit and/or integration tests for your change, where applicable.
- [ ] You've updated documentation for your change, where applicable.
      If your change affects other repositories, such as [Documentation](https://github.com/SteeltoeOSS/Documentation), [Samples](https://github.com/SteeltoeOSS/Samples) and/or [MainSite](https://github.com/SteeltoeOSS/MainSite), add linked PRs here.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
- [ ] You've added required license files and/or file headers (explaining where the code came from with proper attribution), where code is copied from StackOverflow, a blog, or OSS.
