### PR TITLE
Fix ThreadState capitalization

### DIFF
--- a/src/Management/src/Endpoint/Actuators/ThreadDump/State.cs
+++ b/src/Management/src/Endpoint/Actuators/ThreadDump/State.cs
@@ -2,16 +2,12 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-using System.Text.Json.Serialization;
-using Steeltoe.Common.CasingConventions;
-
 #if !DEBUG
 #pragma warning disable SA1602 // Enumeration items should be documented
 #endif
 
 namespace Steeltoe.Management.Endpoint.Actuators.ThreadDump;
 
-[JsonConverter(typeof(SnakeCaseAllCapsEnumMemberJsonConverter))]
 public enum State
 {
     New,

--- a/src/Management/src/Endpoint/Actuators/ThreadDump/ThreadInfo.cs
+++ b/src/Management/src/Endpoint/Actuators/ThreadDump/ThreadInfo.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Text.Json.Serialization;
+using Steeltoe.Common.CasingConventions;
 
 namespace Steeltoe.Management.Endpoint.Actuators.ThreadDump;
 
@@ -44,6 +45,7 @@ public sealed class ThreadInfo
     public string? ThreadName { get; set; }
 
     [JsonPropertyName("threadState")]
+    [JsonConverter(typeof(SnakeCaseAllCapsEnumMemberJsonConverter))]
     public State ThreadState { get; set; }
 
     [JsonPropertyName("waitedCount")]


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->

<!-- If this is your first PR in this repo, please read our [Contributing Guidelines (https://github.com/SteeltoeOSS/.github/blob/master/CONTRIBUTING.md) and remember to sign the [Contributor License Agreement](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-license.md). Our bot will notify you shortly after the PR has been created. -->

## Description

In manual testing I was able to confirm that Apps Manager expects ThreadState in a thread dump to be ALLCAPS

Fixes #1400 

![image](https://github.com/user-attachments/assets/abcebb29-55b8-4dc5-b888-2ad0c2f0329e)

## Quality checklist

<!-- Please run through the checklist below to ensure a smooth review and merge process for your PR. -->

- [ ] Your code complies with our [Coding Style](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-code-style.md).
- [ ] You've updated unit and/or integration tests for your change, where applicable.
- [ ] You've updated documentation for your change, where applicable.
      If your change affects other repositories, such as [Documentation](https://github.com/SteeltoeOSS/Documentation), [Samples](https://github.com/SteeltoeOSS/Samples) and/or [MainSite](https://github.com/SteeltoeOSS/MainSite), add linked PRs here.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
- [ ] You've added required license files and/or file headers (explaining where the code came from with proper attribution), where code is copied from StackOverflow, a blog, or OSS.
