### PR TITLE
Bugfix when using empty path in EndpointOptions

### DIFF
--- a/src/Management/src/Abstractions/Configuration/EndpointOptions.cs
+++ b/src/Management/src/Abstractions/Configuration/EndpointOptions.cs
@@ -27,7 +27,7 @@ public abstract class EndpointOptions
     {
         get
         {
-            if (!string.IsNullOrEmpty(_path))
+            if (_path != null)
             {
                 return _path;
             }

--- a/src/Management/src/Endpoint/Actuators/Metrics/MetricsEndpointMiddleware.cs
+++ b/src/Management/src/Endpoint/Actuators/Metrics/MetricsEndpointMiddleware.cs
@@ -45,7 +45,7 @@ internal sealed class MetricsEndpointMiddleware(
     internal string GetMetricName(HttpRequest request)
     {
         string? baseRequestPath = ManagementOptionsMonitor.CurrentValue.GetBaseRequestPath(request);
-        string path = $"{baseRequestPath}/{EndpointHandler.Options.Id}".Replace("//", "/", StringComparison.Ordinal);
+        string path = $"{baseRequestPath}/{EndpointHandler.Options.Path}".Replace("//", "/", StringComparison.Ordinal);
 
         return GetMetricName(request, path);
     }

--- a/src/Management/src/Prometheus/PrometheusExtensions.cs
+++ b/src/Management/src/Prometheus/PrometheusExtensions.cs
@@ -48,9 +48,9 @@ public static class PrometheusExtensions
         PrometheusEndpointOptions? prometheusOptions = builder.ApplicationServices.GetServices<EndpointOptions>()
             .OfType<PrometheusEndpointOptions>().FirstOrDefault();
 
-        string root = managementOptions?.Path ?? "/actuator";
-        string id = prometheusOptions?.Id ?? "prometheus";
-        string path = root + "/" + id;
+        string basePath = managementOptions?.Path ?? "/actuator";
+        string endpointPath = prometheusOptions?.Path ?? "prometheus";
+        string path = $"{basePath}/{endpointPath}".Replace("//", "/", StringComparison.Ordinal);
 
         return builder.UseOpenTelemetryPrometheusScrapingEndpoint(path);
     }

--- a/src/Management/test/Endpoint.Test/Actuators/Hypermedia/HypermediaEndpointOptionsTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/Hypermedia/HypermediaEndpointOptionsTest.cs
@@ -37,4 +37,19 @@ public sealed class HypermediaEndpointOptionsTest : BaseTest
         Assert.Equal("info", options.Id);
         Assert.Equal("infopath", options.Path);
     }
+
+    [Fact]
+    public void CanSetEmptyPathWithDifferentId()
+    {
+        var appSettings = new Dictionary<string, string?>
+        {
+            ["Management:Endpoints:Actuator:Id"] = "some",
+            ["Management:Endpoints:Actuator:Path"] = string.Empty
+        };
+
+        HypermediaEndpointOptions options = GetOptionsFromSettings<HypermediaEndpointOptions, ConfigureHypermediaEndpointOptions>(appSettings);
+
+        options.Id.Should().Be("some");
+        options.Path.Should().BeEmpty();
+    }
 }


### PR DESCRIPTION
## Description

Fix: The path value is ignored when configuring endpoint options with an alternative ID and an empty path.

The hypermedia actuator uses an empty ID and an empty path by default, which makes it impossible to reference it in exposure settings. That's probably why Steeltoe skips the exposure check entirely when the ID is empty, effectively resulting in implicit exposure of the hypermedia actuator. To overcome that, a non-empty ID needs to be assigned. In that case, it should be possible to keep the path empty by explicitly configuring it.

```json
{
  "Management": {
    "Endpoints": {
      "Actuator": {
        "Id": "hypermedia",
        "Path": "",
        "Exposure": {
          "Exclude": [ "hypermedia" ]
        }
      }
    }
  }
}
```

## Quality checklist

- [x] Your code complies with our [Coding Style](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-code-style.md).
- [x] You've updated unit and/or integration tests for your change, where applicable.
- [ ] You've updated documentation for your change, where applicable.
      If your change affects other repositories, such as [Documentation](https://github.com/SteeltoeOSS/Documentation), [Samples](https://github.com/SteeltoeOSS/Samples) and/or [MainSite](https://github.com/SteeltoeOSS/MainSite), add linked PRs here.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
- [ ] You've added required license files and/or file headers (explaining where the code came from with proper attribution), where code is copied from StackOverflow, a blog, or OSS.
