### PR TITLE
Check exposure/enabled for HTTP verb match in management endpoints

### DIFF
--- a/src/Management/test/Endpoint.Test/Actuators/Refresh/HttpVerbInConventionalRoutingTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/Refresh/HttpVerbInConventionalRoutingTest.cs
@@ -35,10 +35,65 @@ public sealed class HttpVerbInConventionalRoutingTest
         var requestUri = new Uri("/actuator/refresh", UriKind.Relative);
 
         HttpResponseMessage getResponse = await httpClient.GetAsync(requestUri);
-        getResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        getResponse.StatusCode.Should().Be(HttpStatusCode.MethodNotAllowed);
 
         HttpResponseMessage postResponse = await httpClient.PostAsync(requestUri, null);
         postResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task Can_be_configured_to_unexposed()
+    {
+        var appSettings = new Dictionary<string, string?>
+        {
+            ["Management:Endpoints:Actuator:Exposure:Include:0"] = string.Empty
+        };
+
+        WebApplicationBuilder builder = TestWebApplicationBuilderFactory.Create();
+        builder.Configuration.AddInMemoryCollection(appSettings);
+        builder.Services.AddControllersWithViews(options => options.EnableEndpointRouting = false);
+        builder.Services.AddRefreshActuator();
+
+        await using WebApplication app = builder.Build();
+        app.UseMvc(routes => routes.MapRoute("default", "{controller=Home}/{action=Index}/{id?}"));
+        await app.StartAsync();
+
+        using HttpClient httpClient = app.GetTestClient();
+        var requestUri = new Uri("/actuator/refresh", UriKind.Relative);
+
+        HttpResponseMessage getResponse = await httpClient.GetAsync(requestUri);
+        getResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
+
+        HttpResponseMessage postResponse = await httpClient.PostAsync(requestUri, null);
+        postResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task Can_be_configured_to_disabled()
+    {
+        var appSettings = new Dictionary<string, string?>
+        {
+            ["Management:Endpoints:Actuator:Exposure:Include:0"] = "refresh",
+            ["Management:Endpoints:Refresh:Enabled"] = "false"
+        };
+
+        WebApplicationBuilder builder = TestWebApplicationBuilderFactory.Create();
+        builder.Configuration.AddInMemoryCollection(appSettings);
+        builder.Services.AddControllersWithViews(options => options.EnableEndpointRouting = false);
+        builder.Services.AddRefreshActuator();
+
+        await using WebApplication app = builder.Build();
+        app.UseMvc(routes => routes.MapRoute("default", "{controller=Home}/{action=Index}/{id?}"));
+        await app.StartAsync();
+
+        using HttpClient httpClient = app.GetTestClient();
+        var requestUri = new Uri("/actuator/refresh", UriKind.Relative);
+
+        HttpResponseMessage getResponse = await httpClient.GetAsync(requestUri);
+        getResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
+
+        HttpResponseMessage postResponse = await httpClient.PostAsync(requestUri, null);
+        postResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
     }
 
     [Fact]
@@ -94,7 +149,7 @@ public sealed class HttpVerbInConventionalRoutingTest
         getResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
         HttpResponseMessage postResponse = await httpClient.PostAsync(requestUri, null);
-        postResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        postResponse.StatusCode.Should().Be(HttpStatusCode.MethodNotAllowed);
     }
 
     [Fact]
@@ -124,5 +179,69 @@ public sealed class HttpVerbInConventionalRoutingTest
 
         HttpResponseMessage postResponse = await httpClient.PostAsync(requestUri, null);
         postResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task Can_change_allowed_verbs_at_runtime()
+    {
+        const string fileName = "appsettings.json";
+        MemoryFileProvider fileProvider = new();
+
+        fileProvider.IncludeFile(fileName, """
+        {
+          "Management": {
+            "Endpoints": {
+              "Actuator": {
+                "Exposure": {
+                  "Include": ["refresh"]
+                }
+              }
+            }
+          }
+        }
+        """);
+
+        WebApplicationBuilder builder = TestWebApplicationBuilderFactory.Create();
+        builder.Configuration.AddJsonFile(fileProvider, fileName, false, true);
+        builder.Services.AddControllersWithViews(options => options.EnableEndpointRouting = false);
+        builder.Services.AddRefreshActuator();
+
+        await using WebApplication app = builder.Build();
+        app.UseMvc(routes => routes.MapRoute("default", "{controller=Home}/{action=Index}/{id?}"));
+        await app.StartAsync();
+
+        using HttpClient httpClient = app.GetTestClient();
+        var requestUri = new Uri("/actuator/refresh", UriKind.Relative);
+
+        HttpResponseMessage getResponse = await httpClient.GetAsync(requestUri);
+        getResponse.StatusCode.Should().Be(HttpStatusCode.MethodNotAllowed);
+
+        HttpResponseMessage postResponse = await httpClient.PostAsync(requestUri, null);
+        postResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        fileProvider.ReplaceFile(fileName, """
+        {
+          "Management": {
+            "Endpoints": {
+              "Actuator": {
+                "Exposure": {
+                  "Include": ["refresh"]
+                }
+              },
+              "Refresh": {
+                "AllowedVerbs": ["GET"]
+              }
+            }
+          }
+        }
+        """);
+
+        fileProvider.NotifyChanged();
+
+        getResponse = await httpClient.GetAsync(requestUri);
+        getResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        postResponse = await httpClient.PostAsync(requestUri, null);
+        postResponse.StatusCode.Should().Be(HttpStatusCode.MethodNotAllowed);
     }
 }

--- a/src/Management/test/Endpoint.Test/Actuators/RouteMappings/EndpointMiddlewareTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/RouteMappings/EndpointMiddlewareTest.cs
@@ -336,11 +336,11 @@ public sealed class EndpointMiddlewareTest : BaseTest
                         },
                         {
                           "handler": "CoreRouteHandler",
-                          "predicate": "{[/actuator/mappings],methods=[Get]}"
+                          "predicate": "{[/actuator/mappings],methods=[GET || PUT || POST || DELETE || HEAD || OPTIONS]}"
                         },
                         {
                           "handler": "CoreRouteHandler",
-                          "predicate": "{[/actuator/refresh],methods=[Post]}"
+                          "predicate": "{[/actuator/refresh],methods=[GET || PUT || POST || DELETE || HEAD || OPTIONS]}"
                         }            
                       ]
                     }
@@ -351,7 +351,7 @@ public sealed class EndpointMiddlewareTest : BaseTest
             """);
 
         response = await client.GetAsync(new Uri("http://localhost/actuator/refresh"));
-        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        Assert.Equal(HttpStatusCode.MethodNotAllowed, response.StatusCode);
 
         response = await client.PostAsync(new Uri("http://localhost/actuator/refresh"), null);
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -439,8 +439,12 @@ public sealed class EndpointMiddlewareTest : BaseTest
                         },
                         {
                           "handler": "CoreRouteHandler",
-                          "predicate": "{[/actuator/mappings],methods=[Get]}"
-                        }            
+                          "predicate": "{[/actuator/mappings],methods=[GET || PUT || POST || DELETE || HEAD || OPTIONS]}"
+                        },
+                        {
+                          "handler": "CoreRouteHandler",
+                          "predicate": "{[/actuator/refresh],methods=[GET || PUT || POST || DELETE || HEAD || OPTIONS]}"
+                        }
                       ]
                     }
                   }


### PR DESCRIPTION
## Description

Instead of mapping endpoints in ASP.NET routing per verb, always map all verbs and then filter inside middleware.

Advantages:
- Returns 404 when not exposed/enabled with invalid verb, instead of 405
- Can change verbs at runtime

Disadvantages:
- Verb information is lost in route mappings endpoint (always shows all verbs)
- Entries in route mappings with all verbs disabled are no longer hidden

Fixes #1410.

## Quality checklist

<!-- Please run through the checklist below to ensure a smooth review and merge process for your PR. -->

- [x] Your code complies with our [Coding Style](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-code-style.md).
- [x] You've updated unit and/or integration tests for your change, where applicable.
- [ ] You've updated documentation for your change, where applicable.
      If your change affects other repositories, such as [Documentation](https://github.com/SteeltoeOSS/Documentation), [Samples](https://github.com/SteeltoeOSS/Samples) and/or [MainSite](https://github.com/SteeltoeOSS/MainSite), add linked PRs here.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
- [ ] You've added required license files and/or file headers (explaining where the code came from with proper attribution), where code is copied from StackOverflow, a blog, or OSS.
