### PR TITLE
Config schema generator: Backport latest changes from Aspire

### DIFF
--- a/src/Tools/src/ConfigurationSchemaGenerator/ConfigurationSchemaGenerator.csproj
+++ b/src/Tools/src/ConfigurationSchemaGenerator/ConfigurationSchemaGenerator.csproj
@@ -17,6 +17,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(MicrosoftCodeAnalysisVersion)" />
     <PackageReference Include="System.CommandLine" Version="$(SystemCommandLineVersion)" />
+    <PackageReference Include="System.Text.Json" Version="$(SystemTextJsonToolsVersion)" />
 
     <InternalsVisibleTo Include="$(AssemblyName).Tests" />
   </ItemGroup>

--- a/src/Tools/src/ConfigurationSchemaGenerator/DiagnosticDescriptors.cs
+++ b/src/Tools/src/ConfigurationSchemaGenerator/DiagnosticDescriptors.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration;
 
 /// <summary>
 /// Mocks out the Configuration.Binder.SourceGeneration project's DiagnosticDescriptors class.
-///
+/// 
 /// The real diagnostic descriptors can't be used because they use localized strings, which
 /// would require getting dotnet/runtime's "SR" generator working in this repo.
 /// </summary>

--- a/src/Tools/src/ConfigurationSchemaGenerator/RuntimeSource/Configuration.Binder/Specs/InterceptorInfo.cs
+++ b/src/Tools/src/ConfigurationSchemaGenerator/RuntimeSource/Configuration.Binder/Specs/InterceptorInfo.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 // Steeltoe: This file was copied from the .NET Aspire Configuration Schema generator
@@ -54,9 +54,9 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
 
         internal sealed class Builder
         {
-            private TypedInterceptorInfoBuildler? _configBinder_InfoBuilder_Bind_instance;
-            private TypedInterceptorInfoBuildler? _configBinder_InfoBuilder_Bind_instance_BinderOptions;
-            private TypedInterceptorInfoBuildler? _configBinder_InfoBuilder_Bind_key_instance;
+            private TypedInterceptorInfoBuilder? _configBinder_InfoBuilder_Bind_instance;
+            private TypedInterceptorInfoBuilder? _configBinder_InfoBuilder_Bind_instance_BinderOptions;
+            private TypedInterceptorInfoBuilder? _configBinder_InfoBuilder_Bind_key_instance;
 
             private List<InvocationLocationInfo>? _interceptors_configBinder;
             private List<InvocationLocationInfo>? _interceptors_OptionsBuilderExt;
@@ -83,9 +83,9 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
 
                 MethodsToGen |= overload;
 
-                void RegisterInterceptor(ref TypedInterceptorInfoBuildler? infoBuilder)
+                void RegisterInterceptor(ref TypedInterceptorInfoBuilder? infoBuilder)
                 {
-                    infoBuilder ??= new TypedInterceptorInfoBuildler();
+                    infoBuilder ??= new TypedInterceptorInfoBuilder();
                     infoBuilder.RegisterInterceptor(overload, type, invocation);
                 }
             }
@@ -133,7 +133,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
         }
     }
 
-    internal sealed class TypedInterceptorInfoBuildler
+    internal sealed class TypedInterceptorInfoBuilder
     {
         private readonly Dictionary<ComplexTypeSpec, TypedInterceptorInvocationInfo.Builder> _invocationInfoBuilderCache = new();
 

--- a/src/Tools/src/ConfigurationSchemaGenerator/RuntimeSource/Roslyn/GetBestTypeByMetadataName.cs
+++ b/src/Tools/src/ConfigurationSchemaGenerator/RuntimeSource/Roslyn/GetBestTypeByMetadataName.cs
@@ -103,7 +103,7 @@ namespace Microsoft.CodeAnalysis.DotnetRuntime.Extensions
             switch (symbol.Kind)
             {
                 case SymbolKind.Alias:
-                    // Aliases are uber private.  They're only visible in the same file that they
+                    // Aliases are uber private. They're only visible in the same file that they
                     // were declared in.
                     return SymbolVisibility.Private;
 

--- a/versions.props
+++ b/versions.props
@@ -29,6 +29,7 @@
     <StyleCopVersion>1.2.0-beta.556</StyleCopVersion>
     <SystemCommandLineVersion>2.0.0-beta4.24324.3</SystemCommandLineVersion>
     <SystemSqlClientVersion>4.8.*</SystemSqlClientVersion>
+    <SystemTextJsonToolsVersion>9.0.*</SystemTextJsonToolsVersion>
     <TestSdkVersion>17.10.*</TestSdkVersion>
     <XunitAbstractionsVersion>2.0.*</XunitAbstractionsVersion>
     <XunitVersion>2.8.*</XunitVersion>


### PR DESCRIPTION
## Description

This PR backports the latest changes from the Aspire Configuration Schema Generator.
Based on https://github.com/dotnet/aspire/pull/6312. Targets `System.Text.Json` v9, which contains breaking changes.

## Quality checklist

- [x] Your code complies with our [Coding Style](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-code-style.md).
- [x] You've updated unit and/or integration tests for your change, where applicable.
- [ ] You've updated documentation for your change, where applicable.
      If your change affects other repositories, such as [Documentation](https://github.com/SteeltoeOSS/Documentation), [Samples](https://github.com/SteeltoeOSS/Samples) and/or [MainSite](https://github.com/SteeltoeOSS/MainSite), add linked PRs here.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
- [ ] You've added required license files and/or file headers (explaining where the code came from with proper attribution), where code is copied from StackOverflow, a blog, or OSS.
