### PR TITLE
Move Diagnostics types from Management.Abstractions to Management.Endpoint

### DIFF
--- a/src/Management/src/Abstractions/PublicAPI.Unshipped.txt
+++ b/src/Management/src/Abstractions/PublicAPI.Unshipped.txt
@@ -1,5 +1,4 @@
 #nullable enable
-abstract Steeltoe.Management.Diagnostics.DiagnosticObserver.ProcessEvent(string! eventName, object? value) -> void
 Steeltoe.Management.Configuration.EndpointOptions
 Steeltoe.Management.Configuration.EndpointOptions.AllowedVerbs.get -> System.Collections.Generic.IList<string!>!
 Steeltoe.Management.Configuration.EndpointOptions.EndpointOptions() -> void
@@ -9,42 +8,6 @@ Steeltoe.Management.Configuration.EndpointPermissions
 Steeltoe.Management.Configuration.EndpointPermissions.Full = 2 -> Steeltoe.Management.Configuration.EndpointPermissions
 Steeltoe.Management.Configuration.EndpointPermissions.None = 0 -> Steeltoe.Management.Configuration.EndpointPermissions
 Steeltoe.Management.Configuration.EndpointPermissions.Restricted = 1 -> Steeltoe.Management.Configuration.EndpointPermissions
-Steeltoe.Management.Diagnostics.DiagnosticObserver
-Steeltoe.Management.Diagnostics.DiagnosticObserver.DiagnosticObserver(string! name, string! listenerName, Microsoft.Extensions.Logging.ILoggerFactory! loggerFactory) -> void
-Steeltoe.Management.Diagnostics.DiagnosticObserver.Dispose() -> void
-Steeltoe.Management.Diagnostics.DiagnosticObserver.ListenerName.get -> string!
-Steeltoe.Management.Diagnostics.DiagnosticObserver.ObserverName.get -> string!
-Steeltoe.Management.Diagnostics.DiagnosticObserver.Subscribe(System.Diagnostics.DiagnosticListener! listener) -> void
-Steeltoe.Management.Diagnostics.IDiagnosticObserver
-Steeltoe.Management.Diagnostics.IDiagnosticObserver.ObserverName.get -> string!
-Steeltoe.Management.Diagnostics.IDiagnosticObserver.Subscribe(System.Diagnostics.DiagnosticListener! listener) -> void
-Steeltoe.Management.Diagnostics.IDiagnosticsManager
-Steeltoe.Management.Diagnostics.IDiagnosticsManager.Start() -> void
-Steeltoe.Management.Diagnostics.IDiagnosticsManager.Stop() -> void
-Steeltoe.Management.Diagnostics.IRuntimeDiagnosticSource
-Steeltoe.Management.Diagnostics.IRuntimeDiagnosticSource.AddInstrumentation() -> void
-Steeltoe.Management.Diagnostics.MetricsObserverOptions
-Steeltoe.Management.Diagnostics.MetricsObserverOptions.AspNetCoreHosting.get -> bool
-Steeltoe.Management.Diagnostics.MetricsObserverOptions.AspNetCoreHosting.set -> void
-Steeltoe.Management.Diagnostics.MetricsObserverOptions.EgressIgnorePattern.get -> string?
-Steeltoe.Management.Diagnostics.MetricsObserverOptions.EgressIgnorePattern.set -> void
-Steeltoe.Management.Diagnostics.MetricsObserverOptions.EventCounterEvents.get -> bool
-Steeltoe.Management.Diagnostics.MetricsObserverOptions.EventCounterEvents.set -> void
-Steeltoe.Management.Diagnostics.MetricsObserverOptions.EventCounterIntervalSec.get -> int?
-Steeltoe.Management.Diagnostics.MetricsObserverOptions.EventCounterIntervalSec.set -> void
-Steeltoe.Management.Diagnostics.MetricsObserverOptions.ExcludedMetrics.get -> System.Collections.Generic.IList<string!>!
-Steeltoe.Management.Diagnostics.MetricsObserverOptions.GCEvents.get -> bool
-Steeltoe.Management.Diagnostics.MetricsObserverOptions.GCEvents.set -> void
-Steeltoe.Management.Diagnostics.MetricsObserverOptions.HttpClientCore.get -> bool
-Steeltoe.Management.Diagnostics.MetricsObserverOptions.HttpClientCore.set -> void
-Steeltoe.Management.Diagnostics.MetricsObserverOptions.HttpClientDesktop.get -> bool
-Steeltoe.Management.Diagnostics.MetricsObserverOptions.HttpClientDesktop.set -> void
-Steeltoe.Management.Diagnostics.MetricsObserverOptions.IncludedMetrics.get -> System.Collections.Generic.IList<string!>!
-Steeltoe.Management.Diagnostics.MetricsObserverOptions.IngressIgnorePattern.get -> string?
-Steeltoe.Management.Diagnostics.MetricsObserverOptions.IngressIgnorePattern.set -> void
-Steeltoe.Management.Diagnostics.MetricsObserverOptions.MetricsObserverOptions() -> void
-Steeltoe.Management.Diagnostics.MetricsObserverOptions.ThreadPoolEvents.get -> bool
-Steeltoe.Management.Diagnostics.MetricsObserverOptions.ThreadPoolEvents.set -> void
 virtual Steeltoe.Management.Configuration.EndpointOptions.Enabled.get -> bool?
 virtual Steeltoe.Management.Configuration.EndpointOptions.Enabled.set -> void
 virtual Steeltoe.Management.Configuration.EndpointOptions.GetDefaultAllowedVerbs() -> System.Collections.Generic.IList<string!>!
@@ -53,7 +16,3 @@ virtual Steeltoe.Management.Configuration.EndpointOptions.Id.set -> void
 virtual Steeltoe.Management.Configuration.EndpointOptions.Path.get -> string?
 virtual Steeltoe.Management.Configuration.EndpointOptions.Path.set -> void
 virtual Steeltoe.Management.Configuration.EndpointOptions.RequiresExactMatch() -> bool
-virtual Steeltoe.Management.Diagnostics.DiagnosticObserver.Dispose(bool disposing) -> void
-virtual Steeltoe.Management.Diagnostics.DiagnosticObserver.OnCompleted() -> void
-virtual Steeltoe.Management.Diagnostics.DiagnosticObserver.OnError(System.Exception! error) -> void
-virtual Steeltoe.Management.Diagnostics.DiagnosticObserver.OnNext(System.Collections.Generic.KeyValuePair<string!, object?> value) -> void

--- a/src/Management/src/Endpoint/Actuators/HttpExchanges/EndpointServiceCollectionExtensions.cs
+++ b/src/Management/src/Endpoint/Actuators/HttpExchanges/EndpointServiceCollectionExtensions.cs
@@ -4,7 +4,7 @@
 
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
-using Steeltoe.Management.Diagnostics;
+using Steeltoe.Management.Endpoint.Actuators.Metrics.Diagnostics;
 
 namespace Steeltoe.Management.Endpoint.Actuators.HttpExchanges;
 

--- a/src/Management/src/Endpoint/Actuators/HttpExchanges/HttpExchangesDiagnosticObserver.cs
+++ b/src/Management/src/Endpoint/Actuators/HttpExchanges/HttpExchangesDiagnosticObserver.cs
@@ -10,7 +10,7 @@ using Microsoft.AspNetCore.Http.Features;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Primitives;
-using Steeltoe.Management.Diagnostics;
+using Steeltoe.Management.Endpoint.Actuators.Metrics.Diagnostics;
 
 namespace Steeltoe.Management.Endpoint.Actuators.HttpExchanges;
 

--- a/src/Management/src/Endpoint/Actuators/Metrics/ConfigureMetricsObserverOptions.cs
+++ b/src/Management/src/Endpoint/Actuators/Metrics/ConfigureMetricsObserverOptions.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.Extensions.Configuration;
-using Steeltoe.Management.Diagnostics;
 using Steeltoe.Management.Endpoint.Configuration;
 
 namespace Steeltoe.Management.Endpoint.Actuators.Metrics;

--- a/src/Management/src/Endpoint/Actuators/Metrics/Diagnostics/DiagnosticObserver.cs
+++ b/src/Management/src/Endpoint/Actuators/Metrics/Diagnostics/DiagnosticObserver.cs
@@ -6,7 +6,7 @@ using System.Diagnostics;
 using System.Reflection;
 using Microsoft.Extensions.Logging;
 
-namespace Steeltoe.Management.Diagnostics;
+namespace Steeltoe.Management.Endpoint.Actuators.Metrics.Diagnostics;
 
 public abstract class DiagnosticObserver : IDiagnosticObserver
 {

--- a/src/Management/src/Endpoint/Actuators/Metrics/Diagnostics/DiagnosticsManager.cs
+++ b/src/Management/src/Endpoint/Actuators/Metrics/Diagnostics/DiagnosticsManager.cs
@@ -8,7 +8,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Steeltoe.Common;
 
-namespace Steeltoe.Management.Diagnostics;
+namespace Steeltoe.Management.Endpoint.Actuators.Metrics.Diagnostics;
 
 internal sealed class DiagnosticsManager : IObserver<DiagnosticListener>, IDisposable, IDiagnosticsManager
 {

--- a/src/Management/src/Endpoint/Actuators/Metrics/Diagnostics/DiagnosticsService.cs
+++ b/src/Management/src/Endpoint/Actuators/Metrics/Diagnostics/DiagnosticsService.cs
@@ -5,7 +5,7 @@
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
-namespace Steeltoe.Management.Diagnostics;
+namespace Steeltoe.Management.Endpoint.Actuators.Metrics.Diagnostics;
 
 internal sealed class DiagnosticsService : IHostedService
 {

--- a/src/Management/src/Endpoint/Actuators/Metrics/Diagnostics/IDiagnosticObserver.cs
+++ b/src/Management/src/Endpoint/Actuators/Metrics/Diagnostics/IDiagnosticObserver.cs
@@ -4,7 +4,7 @@
 
 using System.Diagnostics;
 
-namespace Steeltoe.Management.Diagnostics;
+namespace Steeltoe.Management.Endpoint.Actuators.Metrics.Diagnostics;
 
 public interface IDiagnosticObserver : IObserver<KeyValuePair<string, object?>>, IDisposable
 {

--- a/src/Management/src/Endpoint/Actuators/Metrics/Diagnostics/IDiagnosticsManager.cs
+++ b/src/Management/src/Endpoint/Actuators/Metrics/Diagnostics/IDiagnosticsManager.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-namespace Steeltoe.Management.Diagnostics;
+namespace Steeltoe.Management.Endpoint.Actuators.Metrics.Diagnostics;
 
 public interface IDiagnosticsManager
 {

--- a/src/Management/src/Endpoint/Actuators/Metrics/Diagnostics/IRuntimeDiagnosticSource.cs
+++ b/src/Management/src/Endpoint/Actuators/Metrics/Diagnostics/IRuntimeDiagnosticSource.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-namespace Steeltoe.Management.Diagnostics;
+namespace Steeltoe.Management.Endpoint.Actuators.Metrics.Diagnostics;
 
 public interface IRuntimeDiagnosticSource
 {

--- a/src/Management/src/Endpoint/Actuators/Metrics/Diagnostics/ServiceCollectionExtensions.cs
+++ b/src/Management/src/Endpoint/Actuators/Metrics/Diagnostics/ServiceCollectionExtensions.cs
@@ -5,7 +5,7 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 
-namespace Steeltoe.Management.Diagnostics;
+namespace Steeltoe.Management.Endpoint.Actuators.Metrics.Diagnostics;
 
 internal static class ServiceCollectionExtensions
 {

--- a/src/Management/src/Endpoint/Actuators/Metrics/EndpointServiceCollectionExtensions.cs
+++ b/src/Management/src/Endpoint/Actuators/Metrics/EndpointServiceCollectionExtensions.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using Steeltoe.Management.Diagnostics;
+using Steeltoe.Management.Endpoint.Actuators.Metrics.Diagnostics;
 using Steeltoe.Management.Endpoint.Actuators.Metrics.Observers;
 using Steeltoe.Management.Endpoint.Actuators.Metrics.SystemDiagnosticsMetrics;
 

--- a/src/Management/src/Endpoint/Actuators/Metrics/MetricsObserverOptions.cs
+++ b/src/Management/src/Endpoint/Actuators/Metrics/MetricsObserverOptions.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-namespace Steeltoe.Management.Diagnostics;
+namespace Steeltoe.Management.Endpoint.Actuators.Metrics;
 
 public sealed class MetricsObserverOptions
 {

--- a/src/Management/src/Endpoint/Actuators/Metrics/Observers/AspNetCoreHostingObserver.cs
+++ b/src/Management/src/Endpoint/Actuators/Metrics/Observers/AspNetCoreHostingObserver.cs
@@ -10,7 +10,6 @@ using Microsoft.AspNetCore.Diagnostics;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using Steeltoe.Management.Diagnostics;
 
 namespace Steeltoe.Management.Endpoint.Actuators.Metrics.Observers;
 

--- a/src/Management/src/Endpoint/Actuators/Metrics/Observers/ClrRuntimeObserver.cs
+++ b/src/Management/src/Endpoint/Actuators/Metrics/Observers/ClrRuntimeObserver.cs
@@ -5,7 +5,7 @@
 using System.Diagnostics;
 using System.Diagnostics.Metrics;
 using Microsoft.Extensions.Options;
-using Steeltoe.Management.Diagnostics;
+using Steeltoe.Management.Endpoint.Actuators.Metrics.Diagnostics;
 
 namespace Steeltoe.Management.Endpoint.Actuators.Metrics.Observers;
 

--- a/src/Management/src/Endpoint/Actuators/Metrics/Observers/EventCounterListener.cs
+++ b/src/Management/src/Endpoint/Actuators/Metrics/Observers/EventCounterListener.cs
@@ -8,7 +8,6 @@ using System.Diagnostics.Tracing;
 using System.Globalization;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using Steeltoe.Management.Diagnostics;
 
 namespace Steeltoe.Management.Endpoint.Actuators.Metrics.Observers;
 

--- a/src/Management/src/Endpoint/Actuators/Metrics/Observers/HttpClientObserver.cs
+++ b/src/Management/src/Endpoint/Actuators/Metrics/Observers/HttpClientObserver.cs
@@ -9,7 +9,6 @@ using System.Text.RegularExpressions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Steeltoe.Common;
-using Steeltoe.Management.Diagnostics;
 
 namespace Steeltoe.Management.Endpoint.Actuators.Metrics.Observers;
 

--- a/src/Management/src/Endpoint/Actuators/Metrics/Observers/MetricsObserver.cs
+++ b/src/Management/src/Endpoint/Actuators/Metrics/Observers/MetricsObserver.cs
@@ -4,7 +4,7 @@
 
 using System.Text.RegularExpressions;
 using Microsoft.Extensions.Logging;
-using Steeltoe.Management.Diagnostics;
+using Steeltoe.Management.Endpoint.Actuators.Metrics.Diagnostics;
 
 namespace Steeltoe.Management.Endpoint.Actuators.Metrics.Observers;
 

--- a/src/Management/src/Endpoint/ConfigurationSchema.json
+++ b/src/Management/src/Endpoint/ConfigurationSchema.json
@@ -840,14 +840,14 @@
                 },
                 "EventCounterIntervalSec": {
                   "type": "integer",
-                  "description": "Gets or sets how often to export (in seconds) when 'Steeltoe.Management.Diagnostics.MetricsObserverOptions.EventCounterEvents' is set to true. Default value: 1."
+                  "description": "Gets or sets how often to export (in seconds) when 'Steeltoe.Management.Endpoint.Actuators.Metrics.MetricsObserverOptions.EventCounterEvents' is set to true. Default value: 1."
                 },
                 "ExcludedMetrics": {
                   "type": "array",
                   "items": {
                     "type": "string"
                   },
-                  "description": "Gets a list of metrics that should not be captured. Entries in 'Steeltoe.Management.Diagnostics.MetricsObserverOptions.IncludedMetrics' take precedence in case of conflict."
+                  "description": "Gets a list of metrics that should not be captured. Entries in 'Steeltoe.Management.Endpoint.Actuators.Metrics.MetricsObserverOptions.IncludedMetrics' take precedence in case of conflict."
                 },
                 "GCEvents": {
                   "type": "boolean",
@@ -866,7 +866,7 @@
                   "items": {
                     "type": "string"
                   },
-                  "description": "Gets a list of metrics that should be captured. This takes precedence over 'Steeltoe.Management.Diagnostics.MetricsObserverOptions.ExcludedMetrics' in case of conflict."
+                  "description": "Gets a list of metrics that should be captured. This takes precedence over 'Steeltoe.Management.Endpoint.Actuators.Metrics.MetricsObserverOptions.ExcludedMetrics' in case of conflict."
                 },
                 "IngressIgnorePattern": {
                   "type": "string",

--- a/src/Management/src/Endpoint/Properties/AssemblyInfo.cs
+++ b/src/Management/src/Endpoint/Properties/AssemblyInfo.cs
@@ -5,7 +5,6 @@
 using System.Runtime.CompilerServices;
 using Aspire;
 using Steeltoe.Common.Configuration;
-using Steeltoe.Management.Diagnostics;
 using Steeltoe.Management.Endpoint.Actuators.CloudFoundry;
 using Steeltoe.Management.Endpoint.Actuators.DbMigrations;
 using Steeltoe.Management.Endpoint.Actuators.Environment;

--- a/src/Management/src/Endpoint/PublicAPI.Unshipped.txt
+++ b/src/Management/src/Endpoint/PublicAPI.Unshipped.txt
@@ -1,5 +1,6 @@
 #nullable enable
 abstract Steeltoe.Management.Endpoint.Middleware.EndpointMiddleware<TArgument, TResult>.InvokeEndpointHandlerAsync(Microsoft.AspNetCore.Http.HttpContext! context, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<TResult>!
+abstract Steeltoe.Management.Endpoint.Actuators.Metrics.Diagnostics.DiagnosticObserver.ProcessEvent(string! eventName, object? value) -> void
 const Steeltoe.Management.Endpoint.Actuators.Health.Availability.ApplicationAvailability.LivenessKey = "Liveness" -> string!
 const Steeltoe.Management.Endpoint.Actuators.Health.Availability.ApplicationAvailability.ReadinessKey = "Readiness" -> string!
 override Steeltoe.Management.Endpoint.Actuators.Health.Availability.AvailabilityState.ToString() -> string!
@@ -292,6 +293,20 @@ Steeltoe.Management.Endpoint.Actuators.Loggers.LoggersResponse.HasError.get -> b
 Steeltoe.Management.Endpoint.Actuators.Loggers.LoggersResponse.Levels.get -> System.Collections.Generic.IList<string!>!
 Steeltoe.Management.Endpoint.Actuators.Loggers.LoggersResponse.Loggers.get -> System.Collections.Generic.IDictionary<string!, Steeltoe.Management.Endpoint.Actuators.Loggers.LoggerLevels!>!
 Steeltoe.Management.Endpoint.Actuators.Loggers.LoggersResponse.LoggersResponse(System.Collections.Generic.IList<string!>! levels, System.Collections.Generic.IDictionary<string!, Steeltoe.Management.Endpoint.Actuators.Loggers.LoggerLevels!>! loggers, System.Collections.Generic.IDictionary<string!, Steeltoe.Management.Endpoint.Actuators.Loggers.LoggerGroup!>! groups) -> void
+Steeltoe.Management.Endpoint.Actuators.Metrics.Diagnostics.DiagnosticObserver
+Steeltoe.Management.Endpoint.Actuators.Metrics.Diagnostics.DiagnosticObserver.DiagnosticObserver(string! name, string! listenerName, Microsoft.Extensions.Logging.ILoggerFactory! loggerFactory) -> void
+Steeltoe.Management.Endpoint.Actuators.Metrics.Diagnostics.DiagnosticObserver.Dispose() -> void
+Steeltoe.Management.Endpoint.Actuators.Metrics.Diagnostics.DiagnosticObserver.ListenerName.get -> string!
+Steeltoe.Management.Endpoint.Actuators.Metrics.Diagnostics.DiagnosticObserver.ObserverName.get -> string!
+Steeltoe.Management.Endpoint.Actuators.Metrics.Diagnostics.DiagnosticObserver.Subscribe(System.Diagnostics.DiagnosticListener! listener) -> void
+Steeltoe.Management.Endpoint.Actuators.Metrics.Diagnostics.IDiagnosticObserver
+Steeltoe.Management.Endpoint.Actuators.Metrics.Diagnostics.IDiagnosticObserver.ObserverName.get -> string!
+Steeltoe.Management.Endpoint.Actuators.Metrics.Diagnostics.IDiagnosticObserver.Subscribe(System.Diagnostics.DiagnosticListener! listener) -> void
+Steeltoe.Management.Endpoint.Actuators.Metrics.Diagnostics.IDiagnosticsManager
+Steeltoe.Management.Endpoint.Actuators.Metrics.Diagnostics.IDiagnosticsManager.Start() -> void
+Steeltoe.Management.Endpoint.Actuators.Metrics.Diagnostics.IDiagnosticsManager.Stop() -> void
+Steeltoe.Management.Endpoint.Actuators.Metrics.Diagnostics.IRuntimeDiagnosticSource
+Steeltoe.Management.Endpoint.Actuators.Metrics.Diagnostics.IRuntimeDiagnosticSource.AddInstrumentation() -> void
 Steeltoe.Management.Endpoint.Actuators.Metrics.EndpointServiceCollectionExtensions
 Steeltoe.Management.Endpoint.Actuators.Metrics.IMetricsEndpointHandler
 Steeltoe.Management.Endpoint.Actuators.Metrics.MetricSample
@@ -308,6 +323,28 @@ Steeltoe.Management.Endpoint.Actuators.Metrics.MetricsEndpointOptions.MaxHistogr
 Steeltoe.Management.Endpoint.Actuators.Metrics.MetricsEndpointOptions.MaxTimeSeries.get -> int
 Steeltoe.Management.Endpoint.Actuators.Metrics.MetricsEndpointOptions.MaxTimeSeries.set -> void
 Steeltoe.Management.Endpoint.Actuators.Metrics.MetricsEndpointOptions.MetricsEndpointOptions() -> void
+Steeltoe.Management.Endpoint.Actuators.Metrics.MetricsObserverOptions
+Steeltoe.Management.Endpoint.Actuators.Metrics.MetricsObserverOptions.AspNetCoreHosting.get -> bool
+Steeltoe.Management.Endpoint.Actuators.Metrics.MetricsObserverOptions.AspNetCoreHosting.set -> void
+Steeltoe.Management.Endpoint.Actuators.Metrics.MetricsObserverOptions.EgressIgnorePattern.get -> string?
+Steeltoe.Management.Endpoint.Actuators.Metrics.MetricsObserverOptions.EgressIgnorePattern.set -> void
+Steeltoe.Management.Endpoint.Actuators.Metrics.MetricsObserverOptions.EventCounterEvents.get -> bool
+Steeltoe.Management.Endpoint.Actuators.Metrics.MetricsObserverOptions.EventCounterEvents.set -> void
+Steeltoe.Management.Endpoint.Actuators.Metrics.MetricsObserverOptions.EventCounterIntervalSec.get -> int?
+Steeltoe.Management.Endpoint.Actuators.Metrics.MetricsObserverOptions.EventCounterIntervalSec.set -> void
+Steeltoe.Management.Endpoint.Actuators.Metrics.MetricsObserverOptions.ExcludedMetrics.get -> System.Collections.Generic.IList<string!>!
+Steeltoe.Management.Endpoint.Actuators.Metrics.MetricsObserverOptions.GCEvents.get -> bool
+Steeltoe.Management.Endpoint.Actuators.Metrics.MetricsObserverOptions.GCEvents.set -> void
+Steeltoe.Management.Endpoint.Actuators.Metrics.MetricsObserverOptions.HttpClientCore.get -> bool
+Steeltoe.Management.Endpoint.Actuators.Metrics.MetricsObserverOptions.HttpClientCore.set -> void
+Steeltoe.Management.Endpoint.Actuators.Metrics.MetricsObserverOptions.HttpClientDesktop.get -> bool
+Steeltoe.Management.Endpoint.Actuators.Metrics.MetricsObserverOptions.HttpClientDesktop.set -> void
+Steeltoe.Management.Endpoint.Actuators.Metrics.MetricsObserverOptions.IncludedMetrics.get -> System.Collections.Generic.IList<string!>!
+Steeltoe.Management.Endpoint.Actuators.Metrics.MetricsObserverOptions.IngressIgnorePattern.get -> string?
+Steeltoe.Management.Endpoint.Actuators.Metrics.MetricsObserverOptions.IngressIgnorePattern.set -> void
+Steeltoe.Management.Endpoint.Actuators.Metrics.MetricsObserverOptions.MetricsObserverOptions() -> void
+Steeltoe.Management.Endpoint.Actuators.Metrics.MetricsObserverOptions.ThreadPoolEvents.get -> bool
+Steeltoe.Management.Endpoint.Actuators.Metrics.MetricsObserverOptions.ThreadPoolEvents.set -> void
 Steeltoe.Management.Endpoint.Actuators.Metrics.MetricsRequest
 Steeltoe.Management.Endpoint.Actuators.Metrics.MetricsRequest.MetricName.get -> string!
 Steeltoe.Management.Endpoint.Actuators.Metrics.MetricsRequest.MetricsRequest(string! metricName, System.Collections.Generic.IList<System.Collections.Generic.KeyValuePair<string!, string!>>! tags) -> void
@@ -503,6 +540,10 @@ Steeltoe.Management.Endpoint.SpringBootAdminClient.SpringBootAdminClientOptions.
 Steeltoe.Management.Endpoint.SpringBootAdminClient.SpringBootAdminClientOptions.Url.set -> void
 Steeltoe.Management.Endpoint.SpringBootAdminClient.SpringBootAdminClientOptions.ValidateCertificates.get -> bool
 Steeltoe.Management.Endpoint.SpringBootAdminClient.SpringBootAdminClientOptions.ValidateCertificates.set -> void
+virtual Steeltoe.Management.Endpoint.Actuators.Metrics.Diagnostics.DiagnosticObserver.Dispose(bool disposing) -> void
+virtual Steeltoe.Management.Endpoint.Actuators.Metrics.Diagnostics.DiagnosticObserver.OnCompleted() -> void
+virtual Steeltoe.Management.Endpoint.Actuators.Metrics.Diagnostics.DiagnosticObserver.OnError(System.Exception! error) -> void
+virtual Steeltoe.Management.Endpoint.Actuators.Metrics.Diagnostics.DiagnosticObserver.OnNext(System.Collections.Generic.KeyValuePair<string!, object?> value) -> void
 virtual Steeltoe.Management.Endpoint.Configuration.ConfigureEndpointOptions<TOptions>.Configure(TOptions! options) -> void
 virtual Steeltoe.Management.Endpoint.Middleware.EndpointMiddleware<TArgument, TResult>.ShouldInvoke(Microsoft.AspNetCore.Http.PathString requestPath) -> bool
 virtual Steeltoe.Management.Endpoint.Middleware.EndpointMiddleware<TArgument, TResult>.WriteResponseAsync(TResult result, Microsoft.AspNetCore.Http.HttpContext! context, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!

--- a/src/Management/test/Endpoint.Test/Actuators/HttpExchanges/EndpointServiceCollectionTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/HttpExchanges/EndpointServiceCollectionTest.cs
@@ -5,8 +5,8 @@
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
-using Steeltoe.Management.Diagnostics;
 using Steeltoe.Management.Endpoint.Actuators.HttpExchanges;
+using Steeltoe.Management.Endpoint.Actuators.Metrics.Diagnostics;
 
 namespace Steeltoe.Management.Endpoint.Test.Actuators.HttpExchanges;
 

--- a/src/Management/test/Endpoint.Test/Actuators/Metrics/AspNetCoreHostingObserverTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/Metrics/AspNetCoreHostingObserverTest.cs
@@ -6,7 +6,6 @@ using Microsoft.AspNetCore.Diagnostics;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
-using Steeltoe.Management.Diagnostics;
 using Steeltoe.Management.Endpoint.Actuators.Metrics;
 using Steeltoe.Management.Endpoint.Actuators.Metrics.Observers;
 

--- a/src/Management/test/Endpoint.Test/Actuators/Metrics/EndpointServiceCollectionExtensionsTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/Metrics/EndpointServiceCollectionExtensionsTest.cs
@@ -6,8 +6,8 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
-using Steeltoe.Management.Diagnostics;
 using Steeltoe.Management.Endpoint.Actuators.Metrics;
+using Steeltoe.Management.Endpoint.Actuators.Metrics.Diagnostics;
 
 namespace Steeltoe.Management.Endpoint.Test.Actuators.Metrics;
 

--- a/src/Management/test/Endpoint.Test/Actuators/Metrics/MetricsObserverOptionsTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/Metrics/MetricsObserverOptionsTest.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-using Steeltoe.Management.Diagnostics;
 using Steeltoe.Management.Endpoint.Actuators.Metrics;
 
 namespace Steeltoe.Management.Endpoint.Test.Actuators.Metrics;

--- a/src/Management/test/Endpoint.Test/Actuators/Metrics/Observers/EventCounterListenerTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/Metrics/Observers/EventCounterListenerTest.cs
@@ -4,7 +4,6 @@
 
 using Microsoft.Extensions.Logging.Abstractions;
 using Steeltoe.Common.TestResources;
-using Steeltoe.Management.Diagnostics;
 using Steeltoe.Management.Endpoint.Actuators.Metrics;
 using Steeltoe.Management.Endpoint.Actuators.Metrics.Observers;
 using Steeltoe.Management.Endpoint.Actuators.Metrics.SystemDiagnosticsMetrics;


### PR DESCRIPTION
## Description

This PR moves all types in the namespace `Steeltoe.Management.Diagnostics` in the `Steeltoe.Management.Abstractions` project to the `Steeltoe.Management.Endpoint` project.

Comparing changes with Steeltoe 3.x, I found that some types moved from Endpoint to Abstractions in v4. Upon further inspection, it turns out all of these types are exclusively used by the Metrics actuator. In Steeltoe 3.x, they were shared between Core/Base projects, which required them to live in Abstractions.

## Quality checklist

- [x] Your code complies with our [Coding Style](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-code-style.md).
- [x] You've updated unit and/or integration tests for your change, where applicable.
- [ ] You've updated documentation for your change, where applicable.
      If your change affects other repositories, such as [Documentation](https://github.com/SteeltoeOSS/Documentation), [Samples](https://github.com/SteeltoeOSS/Samples) and/or [MainSite](https://github.com/SteeltoeOSS/MainSite), add linked PRs here.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
- [ ] You've added required license files and/or file headers (explaining where the code came from with proper attribution), where code is copied from StackOverflow, a blog, or OSS.
