### PR TITLE
don't mask unauthorized as server error, set a claims id if user has …

### DIFF
--- a/src/Management/src/Endpoint/Actuators/CloudFoundry/EndpointServiceCollectionExtensions.cs
+++ b/src/Management/src/Endpoint/Actuators/CloudFoundry/EndpointServiceCollectionExtensions.cs
@@ -62,10 +62,7 @@ public static class EndpointServiceCollectionExtensions
         services.TryAddSingleton<HttpClientHandlerFactory>();
         services.TryAddSingleton<ValidateCertificatesHttpClientHandlerConfigurer<CloudFoundryEndpointOptions>>();
 
-        IHttpClientBuilder httpClientBuilder = services.AddHttpClient(PermissionsProvider.HttpClientName).RedactLoggedHeaders(new List<string>
-        {
-            "Authorization"
-        });
+        IHttpClientBuilder httpClientBuilder = services.AddHttpClient(PermissionsProvider.HttpClientName).RedactLoggedHeaders(["Authorization"]);
 
         httpClientBuilder.ConfigurePrimaryHttpMessageHandler(serviceProvider =>
         {

--- a/src/Management/src/Endpoint/Actuators/CloudFoundry/EndpointServiceCollectionExtensions.cs
+++ b/src/Management/src/Endpoint/Actuators/CloudFoundry/EndpointServiceCollectionExtensions.cs
@@ -62,7 +62,10 @@ public static class EndpointServiceCollectionExtensions
         services.TryAddSingleton<HttpClientHandlerFactory>();
         services.TryAddSingleton<ValidateCertificatesHttpClientHandlerConfigurer<CloudFoundryEndpointOptions>>();
 
-        IHttpClientBuilder httpClientBuilder = services.AddHttpClient(PermissionsProvider.HttpClientName);
+        IHttpClientBuilder httpClientBuilder = services.AddHttpClient(PermissionsProvider.HttpClientName).RedactLoggedHeaders(new List<string>
+        {
+            "Authorization"
+        });
 
         httpClientBuilder.ConfigurePrimaryHttpMessageHandler(serviceProvider =>
         {

--- a/src/Management/src/Endpoint/Actuators/CloudFoundry/PermissionsProvider.cs
+++ b/src/Management/src/Endpoint/Actuators/CloudFoundry/PermissionsProvider.cs
@@ -67,7 +67,7 @@ internal sealed class PermissionsProvider
 
         try
         {
-            _logger.LogDebug("GetPermissionsAsync({Uri}, {AccessToken})", checkPermissionsUri, SecurityUtilities.SanitizeInput(accessToken));
+            _logger.LogDebug("GetPermissionsAsync({Uri})", checkPermissionsUri);
             using HttpClient httpClient = CreateHttpClient();
             using HttpResponseMessage response = await httpClient.SendAsync(request, cancellationToken);
 

--- a/src/Management/src/Endpoint/Actuators/CloudFoundry/PermissionsProvider.cs
+++ b/src/Management/src/Endpoint/Actuators/CloudFoundry/PermissionsProvider.cs
@@ -76,7 +76,7 @@ internal sealed class PermissionsProvider
                 _logger.LogInformation("Cloud Foundry returned status: {HttpStatus} while obtaining permissions from: {PermissionsUri}", response.StatusCode,
                     checkPermissionsUri);
 
-                return response.StatusCode == HttpStatusCode.Forbidden
+                return response.StatusCode is HttpStatusCode.Forbidden or HttpStatusCode.Unauthorized
                     ? new SecurityResult(HttpStatusCode.Forbidden, AccessDeniedMessage)
                     : new SecurityResult(HttpStatusCode.ServiceUnavailable, CloudfoundryNotReachableMessage);
             }

--- a/src/Management/src/Endpoint/Steeltoe.Management.Endpoint.csproj
+++ b/src/Management/src/Endpoint/Steeltoe.Management.Endpoint.csproj
@@ -13,6 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="$(DiagnosticsTracingVersion)" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="$(SystemIdentityModelVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Management/test/Endpoint.Test/ActuatorsHostBuilderTest.cs
+++ b/src/Management/test/Endpoint.Test/ActuatorsHostBuilderTest.cs
@@ -51,6 +51,9 @@ public sealed class ActuatorsHostBuilderTest
     [InlineData(HostBuilderType.WebApplication)]
     public async Task CloudFoundryActuator(HostBuilderType hostBuilderType)
     {
+        const string token =
+            "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwczovL3VhYS5jbG91ZC5jb20vb2F1dGgvdG9rZW4iLCJpYXQiOjE3MzcwNjMxNzYsImV4cCI6MTc2ODU5OTE3NiwiYXVkIjoiYWN0dWF0b3IiLCJzdWIiOiJ1c2VyQGVtYWlsLmNvbSIsInNjb3BlIjpbImFjdHVhdG9yLnJlYWQiLCJjbG91ZF9jb250cm9sbGVyLnVzZXIiXSwiRW1haWwiOiJ1c2VyQGVtYWlsLmNvbSIsImNsaWVudF9pZCI6ImFwcHNfbWFuYWdlcl9qcyIsInVzZXJfbmFtZSI6InVzZXJAZW1haWwuY29tIiwidXNlcl9pZCI6InVzZXIifQ.bfCtDFxcWF8Yuie2p89S8_fTuUkAOd3i9M8PyKDV-N0";
+
         using var scope = new EnvironmentVariableScope("VCAP_APPLICATION", """
             {
                 "cf_api": "https://api.cloud.com",
@@ -71,7 +74,7 @@ public sealed class ActuatorsHostBuilderTest
         var handler = new DelegateToMockHttpClientHandler();
 
         handler.Mock.Expect(HttpMethod.Get, "https://api.cloud.com/v2/apps/fa05c1a9-0fc1-4fbd-bae1-139850dec7a3/permissions")
-            .WithHeaders("Authorization", "bearer test-token").Respond("application/json", """
+            .WithHeaders("Authorization", $"bearer {token}").Respond("application/json", """
                 {
                     "read_sensitive_data": true
                 }
@@ -83,7 +86,7 @@ public sealed class ActuatorsHostBuilderTest
         using HttpClient httpClient = host.GetTestClient();
 
         var request = new HttpRequestMessage(HttpMethod.Get, new Uri("http://localhost/cloudfoundryapplication"));
-        request.Headers.Authorization = AuthenticationHeaderValue.Parse("Bearer test-token");
+        request.Headers.Authorization = AuthenticationHeaderValue.Parse($"bearer {token}");
 
         HttpResponseMessage response = await httpClient.SendAsync(request);
         response.StatusCode.Should().Be(HttpStatusCode.OK);

--- a/versions.props
+++ b/versions.props
@@ -29,6 +29,7 @@
     <SourceLinkGitHubVersion>8.0.*</SourceLinkGitHubVersion>
     <StyleCopVersion>1.2.0-beta.556</StyleCopVersion>
     <SystemCommandLineVersion>2.0.0-beta4.24324.3</SystemCommandLineVersion>
+    <SystemIdentityModelVersion>8.3.0</SystemIdentityModelVersion>
     <SystemSqlClientVersion>4.8.*</SystemSqlClientVersion>
     <SystemTextJsonToolsVersion>9.0.*</SystemTextJsonToolsVersion>
     <TestSdkVersion>17.10.*</TestSdkVersion>


### PR DESCRIPTION
# Description

This PR removes masking of HTTP403 as HTTP503 and sets a user identity if the JWT has some level of app permissions
also removes ability to trace-log all (unredacted) request headers

Fixes #1441, Fixes #1442

## Quality checklist

<!-- Please run through the checklist below to ensure a smooth review and merge process for your PR. -->

- [ ] Your code complies with our [Coding Style](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-code-style.md).
- [ ] You've updated unit and/or integration tests for your change, where applicable.
- [ ] You've updated documentation for your change, where applicable.
      If your change affects other repositories, such as [Documentation](https://github.com/SteeltoeOSS/Documentation), [Samples](https://github.com/SteeltoeOSS/Samples) and/or [MainSite](https://github.com/SteeltoeOSS/MainSite), add linked PRs here.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
- [ ] You've added required license files and/or file headers (explaining where the code came from with proper attribution), where code is copied from StackOverflow, a blog, or OSS.
