### PR TITLE
Fix SA1602 in IDE

### DIFF
--- a/src/Common/test/TestResources/FastTestConfigurations.cs
+++ b/src/Common/test/TestResources/FastTestConfigurations.cs
@@ -4,11 +4,29 @@
 
 namespace Steeltoe.Common.TestResources;
 
+/// <summary>
+/// Specifies settings to speed up running tests that don't need the full behavior.
+/// </summary>
 [Flags]
 public enum FastTestConfigurations
 {
+    /// <summary>
+    /// Do not connect to Config Server to fetch configuration.
+    /// </summary>
     ConfigServer = 1,
+
+    /// <summary>
+    /// Do not connect to Eureka/Consul to register the local service instance.
+    /// </summary>
     Discovery = 2,
+
+    /// <summary>
+    /// Use connection strings that fail fast, without relying on a network timeout.
+    /// </summary>
     Connectors = 4,
+
+    /// <summary>
+    /// Enables all available options.
+    /// </summary>
     All = ConfigServer | Discovery | Connectors
 }


### PR DESCRIPTION
## Description

This PR makes the following error disappear in Release builds in Visual Studio. Interestingly, the error _doesn't_ show up in command-line builds. While it should, because although [SA1602](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1602.md) is suppressed in `shared-test.props`, it _isn't_ imported from project `Steeltoe.Common.TestResources`.

![image](https://github.com/user-attachments/assets/e2000066-7e9a-4a2e-a6bd-d4d824a9bcb0)

## Quality checklist

- [x] Your code complies with our [Coding Style](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-code-style.md).
- [ ] You've updated unit and/or integration tests for your change, where applicable.
- [ ] You've updated documentation for your change, where applicable.
      If your change affects other repositories, such as [Documentation](https://github.com/SteeltoeOSS/Documentation), [Samples](https://github.com/SteeltoeOSS/Samples) and/or [MainSite](https://github.com/SteeltoeOSS/MainSite), add linked PRs here.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
- [ ] You've added required license files and/or file headers (explaining where the code came from with proper attribution), where code is copied from StackOverflow, a blog, or OSS.
