### PR TITLE
Run all tests against .NET 8 and 9

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "jetbrains.resharper.globaltools": {
-      "version": "2024.3.3",
+      "version": "2024.3.5",
       "commands": [
         "jb"
       ],

--- a/.editorconfig
+++ b/.editorconfig
@@ -78,6 +78,7 @@ dotnet_diagnostic.IDE0058.severity = silent
 
 # Collection expression preferences (note: turned off in shared-package.props)
 dotnet_style_prefer_collection_expression = when_types_exactly_match
+dotnet_diagnostic.IDE0306.severity = silent # Workaround for https://github.com/dotnet/roslyn/issues/77177
 
 # Parameter preferences
 dotnet_code_quality_unused_parameters = non_public

--- a/Steeltoe.Debug.ruleset
+++ b/Steeltoe.Debug.ruleset
@@ -51,14 +51,12 @@
     <Rule Id="S2148" Action="Warning" />
     <Rule Id="S2156" Action="Warning" />
     <Rule Id="S2187" Action="None" />
+    <Rule Id="S2325" Action="None" />
     <Rule Id="S2327" Action="Warning" />
     <Rule Id="S2342" Action="Warning" />
     <Rule Id="S2360" Action="Warning" />
     <Rule Id="S2387" Action="Warning" />
     <Rule Id="S2437" Action="Warning" />
-    <Rule Id="S2583" Action="Info" />
-    <Rule Id="S2589" Action="Info" />
-    <Rule Id="S2674" Action="Warning" />
     <Rule Id="S2699" Action="Info" />
     <Rule Id="S2737" Action="Info" />
     <Rule Id="S2931" Action="Warning" />
@@ -86,7 +84,6 @@
     <Rule Id="S3937" Action="Warning" />
     <Rule Id="S3956" Action="Warning" />
     <Rule Id="S3962" Action="Warning" />
-    <Rule Id="S3993" Action="Warning" />
     <Rule Id="S3997" Action="Warning" />
     <Rule Id="S3998" Action="None" />
     <Rule Id="S4004" Action="Warning" />
@@ -113,7 +110,6 @@
     <Rule Id="S4487" Action="Info" />
     <Rule Id="S4583" Action="None" />
     <Rule Id="S4663" Action="Info" />
-    <Rule Id="S5773" Action="None" />
     <Rule Id="S6419" Action="None" />
     <Rule Id="S6420" Action="None" />
     <Rule Id="S6422" Action="None" />
@@ -121,6 +117,9 @@
     <Rule Id="S6507" Action="Warning" />
     <Rule Id="S6513" Action="Warning" />
     <Rule Id="S6563" Action="Warning" />
+    <Rule Id="S6602" Action="Warning" />
+    <Rule Id="S6603" Action="Warning" />
+    <Rule Id="S6605" Action="Warning" />
     <Rule Id="S6610" Action="None" />
     <Rule Id="S6797" Action="None" />
     <Rule Id="S6798" Action="None" />

--- a/Steeltoe.Release.ruleset
+++ b/Steeltoe.Release.ruleset
@@ -7,6 +7,7 @@
   </Rules>
   <Rules AnalyzerId="Microsoft.CodeAnalysis.NetAnalyzers" RuleNamespace="Microsoft.CodeAnalysis.NetAnalyzers">
     <Rule Id="CA1018" Action="Warning" />
+    <Rule Id="CA1062" Action="Warning" />
     <Rule Id="CA1068" Action="Warning" />
     <Rule Id="CA1305" Action="None" />
     <Rule Id="CA1724" Action="Warning" />
@@ -42,12 +43,12 @@
     <Rule Id="S2148" Action="Warning" />
     <Rule Id="S2156" Action="Warning" />
     <Rule Id="S2187" Action="None" />
+    <Rule Id="S2325" Action="None" />
     <Rule Id="S2327" Action="Warning" />
     <Rule Id="S2342" Action="Warning" />
     <Rule Id="S2360" Action="Warning" />
     <Rule Id="S2387" Action="Warning" />
     <Rule Id="S2437" Action="Warning" />
-    <Rule Id="S2674" Action="Warning" />
     <Rule Id="S2931" Action="Warning" />
     <Rule Id="S3011" Action="None" />
     <Rule Id="S3052" Action="Warning" />
@@ -62,7 +63,6 @@
     <Rule Id="S3878" Action="None" />
     <Rule Id="S3889" Action="None" />
     <Rule Id="S3898" Action="Warning" />
-    <Rule Id="S3900" Action="Warning" />
     <Rule Id="S3906" Action="Warning" />
     <Rule Id="S3908" Action="Warning" />
     <Rule Id="S3925" Action="None" />
@@ -71,7 +71,6 @@
     <Rule Id="S3937" Action="Warning" />
     <Rule Id="S3956" Action="Warning" />
     <Rule Id="S3962" Action="Warning" />
-    <Rule Id="S3993" Action="Warning" />
     <Rule Id="S3997" Action="Warning" />
     <Rule Id="S3998" Action="None" />
     <Rule Id="S4004" Action="Warning" />
@@ -96,7 +95,6 @@
     <Rule Id="S4428" Action="None" />
     <Rule Id="S4433" Action="None" />
     <Rule Id="S4583" Action="None" />
-    <Rule Id="S5773" Action="None" />
     <Rule Id="S6419" Action="None" />
     <Rule Id="S6420" Action="None" />
     <Rule Id="S6422" Action="None" />
@@ -104,6 +102,9 @@
     <Rule Id="S6507" Action="Warning" />
     <Rule Id="S6513" Action="Warning" />
     <Rule Id="S6563" Action="Warning" />
+    <Rule Id="S6602" Action="Warning" />
+    <Rule Id="S6603" Action="Warning" />
+    <Rule Id="S6605" Action="Warning" />
     <Rule Id="S6610" Action="None" />
     <Rule Id="S6797" Action="None" />
     <Rule Id="S6798" Action="None" />

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -57,6 +57,10 @@ jobs:
     displayName: Install .NET 8
     inputs:
       version: 8.0.x
+  - task: UseDotNet@2
+    displayName: Install .NET 9
+    inputs:
+      version: 9.0.x
   - task: DotNetCoreCLI@2
     displayName: Install Nerdbank.GitVersioning tool
     condition: eq(variables['imageName'], 'macOS-latest')
@@ -101,11 +105,11 @@ jobs:
     condition: eq(variables['integrationTests'], 'true')
     displayName: Start Docker services
   - task: DotNetCoreCLI@2
-    displayName: dotnet test net8.0
+    displayName: dotnet test
     inputs:
       command: test
       projects: '**/*.csproj'
-      arguments: '--blame-hang-timeout 3m -f net8.0 --no-build -c $(buildConfiguration) -maxcpucount:1 $(skipFilter) --collect "XPlat Code Coverage" --settings coverlet.runsettings --logger trx --results-directory $(Build.SourcesDirectory)'
+      arguments: '--blame-hang-timeout 3m --no-build -c $(buildConfiguration) -maxcpucount:1 $(skipFilter) --collect "XPlat Code Coverage" --settings coverlet.runsettings --logger trx --results-directory $(Build.SourcesDirectory)'
       publishTestResults: false
   - task: CopyFiles@2
     condition: failed()

--- a/build/package.yml
+++ b/build/package.yml
@@ -23,6 +23,10 @@ jobs:
     displayName: Install .NET 8
     inputs:
       version: 8.0.x
+  - task: UseDotNet@2
+    displayName: Install .NET 9
+    inputs:
+      version: 9.0.x
   - task: PowerShell@2
     displayName: Set package version
     env:

--- a/build/pr-code-cleanup.yml
+++ b/build/pr-code-cleanup.yml
@@ -21,6 +21,10 @@ jobs:
     displayName: Install .NET 8
     inputs:
       version: 8.0.x
+  - task: UseDotNet@2
+    displayName: Install .NET 9
+    inputs:
+      version: 9.0.x
   - checkout: self
     fetchDepth: 0
     persistCredentials: true

--- a/build/sonar-analyze.yml
+++ b/build/sonar-analyze.yml
@@ -20,6 +20,10 @@ jobs:
     displayName: Install .NET 8
     inputs:
       version: 8.0.x
+  - task: UseDotNet@2
+    displayName: Install .NET 9
+    inputs:
+      version: 9.0.x
   - task: DotNetCoreCLI@2
     displayName: dotnet restore
     inputs:
@@ -55,11 +59,11 @@ jobs:
       docker run -d --name rabbitmq -p 5672:5672 -p 15672:15672 rabbitmq:3-management
     displayName: Start Docker services
   - task: DotNetCoreCLI@2
-    displayName: dotnet test net8.0
+    displayName: dotnet test
     inputs:
       command: test
       projects: '**/*.csproj'
-      arguments: '--blame-hang-timeout 3m -f net8.0 --no-build -c $(buildConfiguration) -maxcpucount:1 --filter "Category!=SkipOnLinux" --collect "XPlat Code Coverage" --settings coverlet.runsettings --logger trx --results-directory $(Build.SourcesDirectory)'
+      arguments: '--blame-hang-timeout 3m --no-build -c $(buildConfiguration) -maxcpucount:1 --filter "Category!=SkipOnLinux" --collect "XPlat Code Coverage" --settings coverlet.runsettings --logger trx --results-directory $(Build.SourcesDirectory)'
       publishTestResults: false
   - task: CopyFiles@2
     condition: failed()

--- a/build/templates/component-build.yaml
+++ b/build/templates/component-build.yaml
@@ -30,6 +30,10 @@ jobs:
     displayName: Install .NET 8
     inputs:
       version: 8.0.x
+  - task: UseDotNet@2
+    displayName: Install .NET 9
+    inputs:
+      version: 9.0.x
   - task: DotNetCoreCLI@2
     displayName: Install Nerdbank.GitVersioning tool
     condition: eq('${{parameters.OS}}', 'macOS')
@@ -64,11 +68,11 @@ jobs:
     condition: eq(${{parameters.runConfigServer}}, 'true')
     displayName: Start Config Server
   - task: DotNetCoreCLI@2
-    displayName: dotnet test net8.0
+    displayName: dotnet test
     inputs:
       command: test
       projects: $(SolutionFile)
-      arguments: -f net8.0 ${{parameters.skipFilter}} $(CommonTestArgs)
+      arguments: ${{parameters.skipFilter}} $(CommonTestArgs)
       publishTestResults: false
   - task: CopyFiles@2
     condition: failed()

--- a/build/verify-code-style.yml
+++ b/build/verify-code-style.yml
@@ -17,6 +17,10 @@ jobs:
     displayName: Install .NET 8
     inputs:
       version: 8.0.x
+  - task: UseDotNet@2
+    displayName: Install .NET 9
+    inputs:
+      version: 9.0.x
   - checkout: self
     persistCredentials: true
     fetchDepth: 0

--- a/shared-test.props
+++ b/shared-test.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <NoWarn>$(NoWarn);S2094;S3900;SA1602;CA1707;NU5104</NoWarn>
+    <NoWarn>$(NoWarn);S2094;SA1602;CA1062;CA1707;NU5104</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Bootstrap/test/AutoConfiguration.Test/HostBuilderExtensionsTest.cs
+++ b/src/Bootstrap/test/AutoConfiguration.Test/HostBuilderExtensionsTest.cs
@@ -336,7 +336,7 @@ public sealed class HostBuilderExtensionsTest
 
     private static void AssertServiceDiscoveryClientsAreAutowired(HostWrapper hostWrapper)
     {
-        IDiscoveryClient[] discoveryClients = hostWrapper.Services.GetServices<IDiscoveryClient>().ToArray();
+        IDiscoveryClient[] discoveryClients = [.. hostWrapper.Services.GetServices<IDiscoveryClient>()];
 
         discoveryClients.Should().HaveCount(3);
         discoveryClients.Should().ContainSingle(discoveryClient => discoveryClient is ConfigurationDiscoveryClient);

--- a/src/Bootstrap/test/AutoConfiguration.Test/Steeltoe.Bootstrap.AutoConfiguration.Test.csproj
+++ b/src/Bootstrap/test/AutoConfiguration.Test/Steeltoe.Bootstrap.AutoConfiguration.Test.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\shared.props" />

--- a/src/Bootstrap/test/EmptyAutoConfiguration.Test/EmptyAutoConfigurationTest.cs
+++ b/src/Bootstrap/test/EmptyAutoConfiguration.Test/EmptyAutoConfigurationTest.cs
@@ -27,8 +27,11 @@ public sealed class EmptyAutoConfigurationTest
             "Steeltoe.Common.TestResources.dll"
         };
 
-        string[] files = Directory.GetFiles(AppDomain.CurrentDomain.BaseDirectory, "Steeltoe*.dll").Select(Path.GetFileName).Select(fileName => fileName!)
-            .Where(fileName => !whitelist.Contains(fileName)).ToArray();
+        string[] files =
+        [
+            .. Directory.GetFiles(AppDomain.CurrentDomain.BaseDirectory, "Steeltoe*.dll").Select(Path.GetFileName).Select(fileName => fileName!)
+                .Where(fileName => !whitelist.Contains(fileName))
+        ];
 
         files.Should().BeEmpty();
     }

--- a/src/Bootstrap/test/EmptyAutoConfiguration.Test/Steeltoe.Bootstrap.EmptyAutoConfiguration.Test.csproj
+++ b/src/Bootstrap/test/EmptyAutoConfiguration.Test/Steeltoe.Bootstrap.EmptyAutoConfiguration.Test.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\shared.props" />

--- a/src/Common/src/Common/Steeltoe.Common.csproj
+++ b/src/Common/src/Common/Steeltoe.Common.csproj
@@ -13,5 +13,6 @@
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="$(MatchTargetFrameworkVersion)" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="$(FoundationalVersion)" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="$(FoundationalVersion)" />
+    <PackageReference Include="System.Text.Json" Version="$(FoundationalVersion)" />
   </ItemGroup>
 </Project>

--- a/src/Common/test/Certificates.Test/ConfigureCertificateOptionsTest.cs
+++ b/src/Common/test/Certificates.Test/ConfigureCertificateOptionsTest.cs
@@ -169,7 +169,7 @@ public sealed class ConfigureCertificateOptionsTest
         var optionsMonitor = serviceProvider.GetRequiredService<IOptionsMonitor<CertificateOptions>>();
         optionsMonitor.Get(CertificateName).Certificate.Should().BeEquivalentTo(firstX509);
 
-        IOptionsChangeTokenSource<CertificateOptions>[] tokenSources = serviceProvider.GetServices<IOptionsChangeTokenSource<CertificateOptions>>().ToArray();
+        IOptionsChangeTokenSource<CertificateOptions>[] tokenSources = [.. serviceProvider.GetServices<IOptionsChangeTokenSource<CertificateOptions>>()];
         tokenSources.OfType<FilePathInOptionsChangeTokenSource<CertificateOptions>>().Should().HaveCount(2);
         IChangeToken changeToken = tokenSources.OfType<ConfigurationChangeTokenSource<CertificateOptions>>().Single().GetChangeToken();
 

--- a/src/Common/test/Certificates.Test/LocalCertificateWriterTest.cs
+++ b/src/Common/test/Certificates.Test/LocalCertificateWriterTest.cs
@@ -5,6 +5,10 @@
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 
+#if NET9_0_OR_GREATER
+#pragma warning disable SYSLIB0057 // Type or member is obsolete
+#endif
+
 namespace Steeltoe.Common.Certificates.Test;
 
 public sealed class LocalCertificateWriterTest

--- a/src/Common/test/Certificates.Test/Steeltoe.Common.Certificates.Test.csproj
+++ b/src/Common/test/Certificates.Test/Steeltoe.Common.Certificates.Test.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\shared.props" />

--- a/src/Common/test/Common.Test/Steeltoe.Common.Test.csproj
+++ b/src/Common/test/Common.Test/Steeltoe.Common.Test.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\shared.props" />

--- a/src/Common/test/Hosting.Test/Steeltoe.Common.Hosting.Test.csproj
+++ b/src/Common/test/Hosting.Test/Steeltoe.Common.Hosting.Test.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\shared.props" />

--- a/src/Common/test/Http.Test/Steeltoe.Common.Http.Test.csproj
+++ b/src/Common/test/Http.Test/Steeltoe.Common.Http.Test.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\shared.props" />

--- a/src/Common/test/Logging.Test/Steeltoe.Common.Logging.Test.csproj
+++ b/src/Common/test/Logging.Test/Steeltoe.Common.Logging.Test.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\shared.props" />

--- a/src/Common/test/Net.Test/Steeltoe.Common.Net.Test.csproj
+++ b/src/Common/test/Net.Test/Steeltoe.Common.Net.Test.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\shared.props" />

--- a/src/Common/test/TestResources/CapturingLoggerProvider.cs
+++ b/src/Common/test/TestResources/CapturingLoggerProvider.cs
@@ -15,7 +15,12 @@ public sealed class CapturingLoggerProvider : ILoggerProvider
     private static readonly Func<string, LogLevel, bool> DefaultFilter = (_, _) => true;
     private readonly Func<string, LogLevel, bool> _filter;
 
+#if NET9_0_OR_GREATER
+    private readonly Lock _lockObject = new();
+#else
     private readonly object _lockObject = new();
+#endif
+
     private readonly List<string> _messages = [];
 
     public CapturingLoggerProvider()

--- a/src/Common/test/TestResources/Steeltoe.Common.TestResources.csproj
+++ b/src/Common/test/TestResources/Steeltoe.Common.TestResources.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/Configuration/src/Encryption/Cryptography/AesTextDecryptor.cs
+++ b/src/Configuration/src/Encryption/Cryptography/AesTextDecryptor.cs
@@ -36,7 +36,10 @@ internal sealed class AesTextDecryptor : ITextDecryptor
 
         byte[] saltBytes = GetSaltBytes(salt);
 
+#pragma warning disable S5344 // Use at least 100,000 iterations here.
+        // Justification: Changing the iteration count breaks compatibility with Spring Cloud Config Server.
         _key = KeyDerivation.Pbkdf2(key, saltBytes, KeyDerivationPrf.HMACSHA1, 1024, KeySize / 8);
+#pragma warning restore S5344 // Use at least 100,000 iterations here.
     }
 
     private static byte[] GetSaltBytes(string salt)

--- a/src/Configuration/test/CloudFoundry.Test/Steeltoe.Configuration.CloudFoundry.Test.csproj
+++ b/src/Configuration/test/CloudFoundry.Test/Steeltoe.Configuration.CloudFoundry.Test.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\shared.props" />

--- a/src/Configuration/test/ConfigServer.Discovery.Test/Steeltoe.Configuration.ConfigServer.Discovery.Test.csproj
+++ b/src/Configuration/test/ConfigServer.Discovery.Test/Steeltoe.Configuration.ConfigServer.Discovery.Test.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\shared.props" />

--- a/src/Configuration/test/ConfigServer.Integration.Test/Steeltoe.Configuration.ConfigServer.Integration.Test.csproj
+++ b/src/Configuration/test/ConfigServer.Integration.Test/Steeltoe.Configuration.ConfigServer.Integration.Test.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\shared.props" />

--- a/src/Configuration/test/ConfigServer.Test/ConfigServerConfigurationProviderTest.Loading.cs
+++ b/src/Configuration/test/ConfigServer.Test/ConfigServerConfigurationProviderTest.Loading.cs
@@ -109,7 +109,7 @@ public sealed partial class ConfigServerConfigurationProviderTest
 
         TestConfigServerStartup.Reset();
         TestConfigServerStartup.Response = environment;
-        TestConfigServerStartup.ReturnStatus = Enumerable.Repeat(200, 100).ToArray();
+        TestConfigServerStartup.ReturnStatus = [.. Enumerable.Repeat(200, 100)];
         TestConfigServerStartup.Label = "test-label";
         WebHostBuilder builder = TestWebHostBuilderFactory.Create();
         builder.UseStartup<TestConfigServerStartup>();
@@ -157,7 +157,7 @@ public sealed partial class ConfigServerConfigurationProviderTest
         TestConfigServerStartup.Response = environment;
 
         // Initial requests succeed, but later requests return 400 status code so that an exception is thrown during polling
-        TestConfigServerStartup.ReturnStatus = Enumerable.Repeat(200, 2).Concat(Enumerable.Repeat(400, 100)).ToArray();
+        TestConfigServerStartup.ReturnStatus = [.. Enumerable.Repeat(200, 2).Concat(Enumerable.Repeat(400, 100))];
         TestConfigServerStartup.Label = "test-label";
         WebHostBuilder builder = TestWebHostBuilderFactory.Create();
         builder.UseStartup<TestConfigServerStartup>();
@@ -205,7 +205,7 @@ public sealed partial class ConfigServerConfigurationProviderTest
 
         TestConfigServerStartup.Reset();
         TestConfigServerStartup.Response = environment;
-        TestConfigServerStartup.ReturnStatus = Enumerable.Repeat(200, 100).ToArray();
+        TestConfigServerStartup.ReturnStatus = [.. Enumerable.Repeat(200, 100)];
         TestConfigServerStartup.Label = "test-label";
         WebHostBuilder builder = TestWebHostBuilderFactory.Create();
         builder.UseStartup<TestConfigServerStartup>();

--- a/src/Configuration/test/ConfigServer.Test/Steeltoe.Configuration.ConfigServer.Test.csproj
+++ b/src/Configuration/test/ConfigServer.Test/Steeltoe.Configuration.ConfigServer.Test.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\shared.props" />

--- a/src/Configuration/test/Encryption.Test/Steeltoe.Configuration.Encryption.Test.csproj
+++ b/src/Configuration/test/Encryption.Test/Steeltoe.Configuration.Encryption.Test.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\shared.props" />

--- a/src/Configuration/test/Kubernetes.ServiceBindings.Test/Steeltoe.Configuration.Kubernetes.ServiceBindings.Test.csproj
+++ b/src/Configuration/test/Kubernetes.ServiceBindings.Test/Steeltoe.Configuration.Kubernetes.ServiceBindings.Test.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\shared.props" />

--- a/src/Configuration/test/Placeholder.Test/Steeltoe.Configuration.Placeholder.Test.csproj
+++ b/src/Configuration/test/Placeholder.Test/Steeltoe.Configuration.Placeholder.Test.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\shared.props" />

--- a/src/Configuration/test/RandomValue.Test/Steeltoe.Configuration.RandomValue.Test.csproj
+++ b/src/Configuration/test/RandomValue.Test/Steeltoe.Configuration.RandomValue.Test.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\shared.props" />

--- a/src/Configuration/test/SpringBoot.Test/Steeltoe.Configuration.SpringBoot.Test.csproj
+++ b/src/Configuration/test/SpringBoot.Test/Steeltoe.Configuration.SpringBoot.Test.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\shared.props" />

--- a/src/Connectors/src/Connectors/RabbitMQ/DynamicTypeAccess/ConnectionFactoryInterfaceShim.cs
+++ b/src/Connectors/src/Connectors/RabbitMQ/DynamicTypeAccess/ConnectionFactoryInterfaceShim.cs
@@ -11,9 +11,13 @@ internal sealed class ConnectionFactoryInterfaceShim(RabbitMQPackageResolver pac
 {
     private readonly RabbitMQPackageResolver _packageResolver = packageResolver;
 
-    public ConnectionInterfaceShim CreateConnection()
+    public async Task<ConnectionInterfaceShim> CreateConnectionAsync(CancellationToken cancellationToken)
     {
-        object connectionInstance = InstanceAccessor.InvokeMethodOverload("CreateConnection", true, Type.EmptyTypes)!;
-        return new ConnectionInterfaceShim(_packageResolver, connectionInstance);
+        var task = (Task)InstanceAccessor.InvokeMethodOverload("CreateConnectionAsync", true, [typeof(CancellationToken)], cancellationToken)!;
+
+        await task;
+
+        using var taskShim = new TaskShim<IDisposable>(task);
+        return new ConnectionInterfaceShim(_packageResolver, taskShim.Result);
     }
 }

--- a/src/Connectors/src/Connectors/RabbitMQ/RabbitMQHealthContributor.cs
+++ b/src/Connectors/src/Connectors/RabbitMQ/RabbitMQHealthContributor.cs
@@ -32,7 +32,7 @@ internal sealed class RabbitMQHealthContributor : IHealthContributor, IDisposabl
         _logger = logger;
     }
 
-    public Task<HealthCheckResult?> CheckHealthAsync(CancellationToken cancellationToken)
+    public async Task<HealthCheckResult?> CheckHealthAsync(CancellationToken cancellationToken)
     {
         _logger.LogTrace("Checking {DbConnection} health at {Host}", Id, Host);
 
@@ -53,7 +53,7 @@ internal sealed class RabbitMQHealthContributor : IHealthContributor, IDisposabl
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            _connectionInterfaceShim ??= _connectionFactoryInterfaceShim.CreateConnection();
+            _connectionInterfaceShim ??= await _connectionFactoryInterfaceShim.CreateConnectionAsync(cancellationToken);
 
             if (!_connectionInterfaceShim.IsOpen)
             {
@@ -86,7 +86,7 @@ internal sealed class RabbitMQHealthContributor : IHealthContributor, IDisposabl
             result.Details.Add("error", $"{exception.GetType().Name}: {exception.Message}");
         }
 
-        return Task.FromResult<HealthCheckResult?>(result);
+        return result;
     }
 
     public void Dispose()

--- a/src/Connectors/src/Connectors/RabbitMQ/RabbitMQServiceCollectionExtensions.cs
+++ b/src/Connectors/src/Connectors/RabbitMQ/RabbitMQServiceCollectionExtensions.cs
@@ -63,7 +63,7 @@ public static class RabbitMQServiceCollectionExtensions
         if (!ConnectorFactoryShim<RabbitMQOptions>.IsRegistered(packageResolver.ConnectionInterface.Type, services))
         {
             var optionsBuilder = new ConnectorAddOptionsBuilder(
-                (serviceProvider, serviceBindingName) => CreateConnection(serviceProvider, serviceBindingName, packageResolver),
+                (serviceProvider, serviceBindingName) => CreateConnectionAsync(serviceProvider, serviceBindingName, packageResolver, CancellationToken.None),
                 (serviceProvider, serviceBindingName) => CreateHealthContributor(serviceProvider, serviceBindingName, packageResolver))
             {
                 // From https://www.rabbitmq.com/dotnet-api-guide.html#connection-and-channel-lifespan:
@@ -120,7 +120,8 @@ public static class RabbitMQServiceCollectionExtensions
         return (string?)builder["host"] ?? "localhost";
     }
 
-    private static IDisposable CreateConnection(IServiceProvider serviceProvider, string serviceBindingName, RabbitMQPackageResolver packageResolver)
+    private static async Task<IDisposable> CreateConnectionAsync(IServiceProvider serviceProvider, string serviceBindingName,
+        RabbitMQPackageResolver packageResolver, CancellationToken cancellationToken)
     {
         var optionsMonitor = serviceProvider.GetRequiredService<IOptionsMonitor<RabbitMQOptions>>();
         RabbitMQOptions options = optionsMonitor.Get(serviceBindingName);
@@ -133,7 +134,7 @@ public static class RabbitMQServiceCollectionExtensions
         }
 
         ConnectionFactoryInterfaceShim connectionFactoryInterfaceShim = connectionFactoryShim.AsInterface();
-        ConnectionInterfaceShim connectionInterfaceShim = connectionFactoryInterfaceShim.CreateConnection();
+        ConnectionInterfaceShim connectionInterfaceShim = await connectionFactoryInterfaceShim.CreateConnectionAsync(cancellationToken);
         return connectionInterfaceShim.Instance;
     }
 }

--- a/src/Connectors/test/Connectors.Test/CosmosDb/CosmosDbConnectorTest.cs
+++ b/src/Connectors/test/Connectors.Test/CosmosDb/CosmosDbConnectorTest.cs
@@ -247,8 +247,8 @@ public sealed class CosmosDbConnectorTest
 
         await using WebApplication app = builder.Build();
 
-        IHealthContributor[] healthContributors = app.Services.GetServices<IHealthContributor>().ToArray();
-        CosmosDbHealthContributor[] cosmosDbHealthContributors = healthContributors.Should().AllBeOfType<CosmosDbHealthContributor>().Subject.ToArray();
+        IHealthContributor[] healthContributors = [.. app.Services.GetServices<IHealthContributor>()];
+        CosmosDbHealthContributor[] cosmosDbHealthContributors = [.. healthContributors.Should().AllBeOfType<CosmosDbHealthContributor>().Subject];
         cosmosDbHealthContributors.Should().HaveCount(2);
 
         cosmosDbHealthContributors[0].Id.Should().Be("CosmosDB");

--- a/src/Connectors/test/Connectors.Test/MongoDb/MongoDbConnectorTest.cs
+++ b/src/Connectors/test/Connectors.Test/MongoDb/MongoDbConnectorTest.cs
@@ -255,8 +255,8 @@ public sealed class MongoDbConnectorTest
 
         await using WebApplication app = builder.Build();
 
-        IHealthContributor[] healthContributors = app.Services.GetServices<IHealthContributor>().ToArray();
-        MongoDbHealthContributor[] mongoDbHealthContributors = healthContributors.Should().AllBeOfType<MongoDbHealthContributor>().Subject.ToArray();
+        IHealthContributor[] healthContributors = [.. app.Services.GetServices<IHealthContributor>()];
+        MongoDbHealthContributor[] mongoDbHealthContributors = [.. healthContributors.Should().AllBeOfType<MongoDbHealthContributor>().Subject];
         mongoDbHealthContributors.Should().HaveCount(2);
 
         mongoDbHealthContributors[0].Id.Should().Be("MongoDB");

--- a/src/Connectors/test/Connectors.Test/MySql/MySqlConnector/MySqlConnectorTest.cs
+++ b/src/Connectors/test/Connectors.Test/MySql/MySqlConnector/MySqlConnectorTest.cs
@@ -268,8 +268,8 @@ public sealed class MySqlConnectorTest
 
         await using WebApplication app = builder.Build();
 
-        IHealthContributor[] healthContributors = app.Services.GetServices<IHealthContributor>().ToArray();
-        RelationalDatabaseHealthContributor[] contributors = healthContributors.Should().AllBeOfType<RelationalDatabaseHealthContributor>().Subject.ToArray();
+        IHealthContributor[] healthContributors = [.. app.Services.GetServices<IHealthContributor>()];
+        RelationalDatabaseHealthContributor[] contributors = [.. healthContributors.Should().AllBeOfType<RelationalDatabaseHealthContributor>().Subject];
         contributors.Should().HaveCount(2);
 
         contributors[0].Id.Should().Be("MySQL");

--- a/src/Connectors/test/Connectors.Test/MySql/Oracle/MySqlConnectorTest.cs
+++ b/src/Connectors/test/Connectors.Test/MySql/Oracle/MySqlConnectorTest.cs
@@ -268,8 +268,8 @@ public sealed class MySqlConnectorTest
 
         await using WebApplication app = builder.Build();
 
-        IHealthContributor[] healthContributors = app.Services.GetServices<IHealthContributor>().ToArray();
-        RelationalDatabaseHealthContributor[] contributors = healthContributors.Should().AllBeOfType<RelationalDatabaseHealthContributor>().Subject.ToArray();
+        IHealthContributor[] healthContributors = [.. app.Services.GetServices<IHealthContributor>()];
+        RelationalDatabaseHealthContributor[] contributors = [.. healthContributors.Should().AllBeOfType<RelationalDatabaseHealthContributor>().Subject];
         contributors.Should().HaveCount(2);
 
         contributors[0].Id.Should().Be("MySQL");

--- a/src/Connectors/test/Connectors.Test/PostgreSql/PostgreSqlConnectorTest.cs
+++ b/src/Connectors/test/Connectors.Test/PostgreSql/PostgreSqlConnectorTest.cs
@@ -438,8 +438,8 @@ public sealed class PostgreSqlConnectorTest
 
         await using WebApplication app = builder.Build();
 
-        IHealthContributor[] healthContributors = app.Services.GetServices<IHealthContributor>().ToArray();
-        RelationalDatabaseHealthContributor[] contributors = healthContributors.Should().AllBeOfType<RelationalDatabaseHealthContributor>().Subject.ToArray();
+        IHealthContributor[] healthContributors = [.. app.Services.GetServices<IHealthContributor>()];
+        RelationalDatabaseHealthContributor[] contributors = [.. healthContributors.Should().AllBeOfType<RelationalDatabaseHealthContributor>().Subject];
         contributors.Should().HaveCount(2);
 
         contributors[0].Id.Should().Be("PostgreSQL");
@@ -468,7 +468,7 @@ public sealed class PostgreSqlConnectorTest
 
         await using WebApplication app = builder.Build();
 
-        IHealthContributor[] healthContributors = app.Services.GetServices<IHealthContributor>().ToArray();
+        IHealthContributor[] healthContributors = [.. app.Services.GetServices<IHealthContributor>()];
         healthContributors.Should().BeEmpty();
     }
 
@@ -490,7 +490,7 @@ public sealed class PostgreSqlConnectorTest
 
         await using WebApplication app = builder.Build();
 
-        IHealthContributor[] healthContributors = app.Services.GetServices<IHealthContributor>().ToArray();
+        IHealthContributor[] healthContributors = [.. app.Services.GetServices<IHealthContributor>()];
         healthContributors.Should().BeEmpty();
     }
 

--- a/src/Connectors/test/Connectors.Test/RabbitMQ/RabbitMQConnectorTest.cs
+++ b/src/Connectors/test/Connectors.Test/RabbitMQ/RabbitMQConnectorTest.cs
@@ -332,8 +332,8 @@ public sealed class RabbitMQConnectorTest
 
         await using WebApplication app = builder.Build();
 
-        IHealthContributor[] healthContributors = app.Services.GetServices<IHealthContributor>().ToArray();
-        RabbitMQHealthContributor[] rabbitMQHealthContributors = healthContributors.Should().AllBeOfType<RabbitMQHealthContributor>().Subject.ToArray();
+        IHealthContributor[] healthContributors = [.. app.Services.GetServices<IHealthContributor>()];
+        RabbitMQHealthContributor[] rabbitMQHealthContributors = [.. healthContributors.Should().AllBeOfType<RabbitMQHealthContributor>().Subject];
         rabbitMQHealthContributors.Should().HaveCount(2);
 
         rabbitMQHealthContributors[0].Id.Should().Be("RabbitMQ");

--- a/src/Connectors/test/Connectors.Test/RabbitMQ/RabbitMQConnectorTest.cs
+++ b/src/Connectors/test/Connectors.Test/RabbitMQ/RabbitMQConnectorTest.cs
@@ -451,102 +451,91 @@ public sealed class RabbitMQConnectorTest
         public int LocalPort => throw new NotImplementedException();
         public int RemotePort => throw new NotImplementedException();
         public ushort ChannelMax => throw new NotImplementedException();
-        public IDictionary<string, object> ClientProperties => throw new NotImplementedException();
+        public IDictionary<string, object?> ClientProperties => throw new NotImplementedException();
         public ShutdownEventArgs CloseReason => throw new NotImplementedException();
         public AmqpTcpEndpoint Endpoint => throw new NotImplementedException();
         public uint FrameMax => throw new NotImplementedException();
         public TimeSpan Heartbeat => throw new NotImplementedException();
         public bool IsOpen => throw new NotImplementedException();
-        public AmqpTcpEndpoint[] KnownHosts => throw new NotImplementedException();
         public IProtocol Protocol => throw new NotImplementedException();
-        public IDictionary<string, object> ServerProperties => throw new NotImplementedException();
-        public IList<ShutdownReportEntry> ShutdownReport => throw new NotImplementedException();
+        public IDictionary<string, object?> ServerProperties => throw new NotImplementedException();
+        public IEnumerable<ShutdownReportEntry> ShutdownReport => throw new NotImplementedException();
         public string ClientProvidedName => throw new NotImplementedException();
 
-        public event EventHandler<CallbackExceptionEventArgs> CallbackException
+        public event AsyncEventHandler<CallbackExceptionEventArgs>? CallbackExceptionAsync
         {
             add => throw new NotImplementedException();
             remove => throw new NotImplementedException();
         }
 
-        public event EventHandler<ConnectionBlockedEventArgs> ConnectionBlocked
+        public event AsyncEventHandler<ShutdownEventArgs>? ConnectionShutdownAsync
         {
             add => throw new NotImplementedException();
             remove => throw new NotImplementedException();
         }
 
-        public event EventHandler<ShutdownEventArgs> ConnectionShutdown
+        public event AsyncEventHandler<AsyncEventArgs>? RecoverySucceededAsync
         {
             add => throw new NotImplementedException();
             remove => throw new NotImplementedException();
         }
 
-        public event EventHandler<EventArgs> ConnectionUnblocked
+        public event AsyncEventHandler<ConnectionRecoveryErrorEventArgs>? ConnectionRecoveryErrorAsync
         {
             add => throw new NotImplementedException();
             remove => throw new NotImplementedException();
+        }
+
+        public event AsyncEventHandler<ConsumerTagChangedAfterRecoveryEventArgs>? ConsumerTagChangeAfterRecoveryAsync
+        {
+            add => throw new NotImplementedException();
+            remove => throw new NotImplementedException();
+        }
+
+        public event AsyncEventHandler<QueueNameChangedAfterRecoveryEventArgs>? QueueNameChangedAfterRecoveryAsync
+        {
+            add => throw new NotImplementedException();
+            remove => throw new NotImplementedException();
+        }
+
+        public event AsyncEventHandler<RecoveringConsumerEventArgs>? RecoveringConsumerAsync
+        {
+            add => throw new NotImplementedException();
+            remove => throw new NotImplementedException();
+        }
+
+        public event AsyncEventHandler<ConnectionBlockedEventArgs>? ConnectionBlockedAsync
+        {
+            add => throw new NotImplementedException();
+            remove => throw new NotImplementedException();
+        }
+
+        public event AsyncEventHandler<AsyncEventArgs>? ConnectionUnblockedAsync
+        {
+            add => throw new NotImplementedException();
+            remove => throw new NotImplementedException();
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            return ValueTask.CompletedTask;
         }
 
         public void Dispose()
         {
         }
 
-        public void UpdateSecret(string newSecret, string reason)
+        public Task UpdateSecretAsync(string newSecret, string reason, CancellationToken cancellationToken = default)
         {
             throw new NotImplementedException();
         }
 
-        public void Abort()
+        public Task CloseAsync(ushort reasonCode, string reasonText, TimeSpan timeout, bool abort, CancellationToken cancellationToken = default)
         {
             throw new NotImplementedException();
         }
 
-        public void Abort(ushort reasonCode, string reasonText)
-        {
-            throw new NotImplementedException();
-        }
-
-        public void Abort(TimeSpan timeout)
-        {
-            throw new NotImplementedException();
-        }
-
-        public void Abort(ushort reasonCode, string reasonText, TimeSpan timeout)
-        {
-            throw new NotImplementedException();
-        }
-
-        public void Close()
-        {
-            throw new NotImplementedException();
-        }
-
-        public void Close(ushort reasonCode, string reasonText)
-        {
-            throw new NotImplementedException();
-        }
-
-        public void Close(TimeSpan timeout)
-        {
-            throw new NotImplementedException();
-        }
-
-        public void Close(ushort reasonCode, string reasonText, TimeSpan timeout)
-        {
-            throw new NotImplementedException();
-        }
-
-        public IModel CreateModel()
-        {
-            throw new NotImplementedException();
-        }
-
-        public void HandleConnectionBlocked(string reason)
-        {
-            throw new NotImplementedException();
-        }
-
-        public void HandleConnectionUnblocked()
+        public Task<IChannel> CreateChannelAsync(CreateChannelOptions? options = null, CancellationToken cancellationToken = default)
         {
             throw new NotImplementedException();
         }

--- a/src/Connectors/test/Connectors.Test/RabbitMQ/RabbitMQHealthContributorTest.cs
+++ b/src/Connectors/test/Connectors.Test/RabbitMQ/RabbitMQHealthContributorTest.cs
@@ -43,13 +43,13 @@ public sealed class RabbitMQHealthContributorTest
         var connectionMock = new Mock<IConnection>();
         connectionMock.Setup(connection => connection.IsOpen).Returns(true);
 
-        connectionMock.Setup(connection => connection.ServerProperties).Returns(new Dictionary<string, object>
+        connectionMock.Setup(connection => connection.ServerProperties).Returns(new Dictionary<string, object?>
         {
             { "version", "1.2.3"u8.ToArray() }
         });
 
         var connectionFactoryMock = new Mock<IConnectionFactory>();
-        connectionFactoryMock.Setup(factory => factory.CreateConnection()).Returns(connectionMock.Object);
+        connectionFactoryMock.Setup(factory => factory.CreateConnectionAsync(It.IsAny<CancellationToken>())).Returns(Task.FromResult(connectionMock.Object));
 
         using var healthContributor = new RabbitMQHealthContributor(connectionFactoryMock.Object, "localhost", NullLogger<RabbitMQHealthContributor>.Instance)
         {
@@ -72,13 +72,13 @@ public sealed class RabbitMQHealthContributorTest
         var connectionMock = new Mock<IConnection>();
         connectionMock.Setup(connection => connection.IsOpen).Returns(true);
 
-        connectionMock.Setup(connection => connection.ServerProperties).Returns(new Dictionary<string, object>
+        connectionMock.Setup(connection => connection.ServerProperties).Returns(new Dictionary<string, object?>
         {
             { "version", "1.2.3"u8.ToArray() }
         });
 
         var connectionFactoryMock = new Mock<IConnectionFactory>();
-        connectionFactoryMock.Setup(factory => factory.CreateConnection()).Returns(connectionMock.Object);
+        connectionFactoryMock.Setup(factory => factory.CreateConnectionAsync(It.IsAny<CancellationToken>())).Returns(Task.FromResult(connectionMock.Object));
 
         using var healthContributor = new RabbitMQHealthContributor(connectionFactoryMock.Object, "localhost", NullLogger<RabbitMQHealthContributor>.Instance)
         {

--- a/src/Connectors/test/Connectors.Test/Redis/RedisConnectorTest.cs
+++ b/src/Connectors/test/Connectors.Test/Redis/RedisConnectorTest.cs
@@ -282,8 +282,8 @@ public sealed class RedisConnectorTest
 
         await using WebApplication app = builder.Build();
 
-        IHealthContributor[] healthContributors = app.Services.GetServices<IHealthContributor>().ToArray();
-        RedisHealthContributor[] redisHealthContributors = healthContributors.Should().AllBeOfType<RedisHealthContributor>().Subject.ToArray();
+        IHealthContributor[] healthContributors = [.. app.Services.GetServices<IHealthContributor>()];
+        RedisHealthContributor[] redisHealthContributors = [.. healthContributors.Should().AllBeOfType<RedisHealthContributor>().Subject];
         redisHealthContributors.Should().HaveCount(2);
 
         redisHealthContributors[0].Id.Should().Be("Redis");

--- a/src/Connectors/test/Connectors.Test/SqlServer/MicrosoftData/SqlServerConnectorTest.cs
+++ b/src/Connectors/test/Connectors.Test/SqlServer/MicrosoftData/SqlServerConnectorTest.cs
@@ -257,8 +257,8 @@ public sealed class SqlServerConnectorTest
 
         await using WebApplication app = builder.Build();
 
-        IHealthContributor[] healthContributors = app.Services.GetServices<IHealthContributor>().ToArray();
-        RelationalDatabaseHealthContributor[] contributors = healthContributors.Should().AllBeOfType<RelationalDatabaseHealthContributor>().Subject.ToArray();
+        IHealthContributor[] healthContributors = [.. app.Services.GetServices<IHealthContributor>()];
+        RelationalDatabaseHealthContributor[] contributors = [.. healthContributors.Should().AllBeOfType<RelationalDatabaseHealthContributor>().Subject];
         contributors.Should().HaveCount(2);
 
         contributors[0].Id.Should().Be("SQL Server");

--- a/src/Connectors/test/Connectors.Test/SqlServer/SystemData/SqlServerConnectorTest.cs
+++ b/src/Connectors/test/Connectors.Test/SqlServer/SystemData/SqlServerConnectorTest.cs
@@ -259,8 +259,8 @@ public sealed class SqlServerConnectorTest
 
         await using WebApplication app = builder.Build();
 
-        IHealthContributor[] healthContributors = app.Services.GetServices<IHealthContributor>().ToArray();
-        RelationalDatabaseHealthContributor[] contributors = healthContributors.Should().AllBeOfType<RelationalDatabaseHealthContributor>().Subject.ToArray();
+        IHealthContributor[] healthContributors = [.. app.Services.GetServices<IHealthContributor>()];
+        RelationalDatabaseHealthContributor[] contributors = [.. healthContributors.Should().AllBeOfType<RelationalDatabaseHealthContributor>().Subject];
         contributors.Should().HaveCount(2);
 
         contributors[0].Id.Should().Be("SQL Server");

--- a/src/Connectors/test/Connectors.Test/SqlServer/SystemData/SqlServerConnectorTest.cs
+++ b/src/Connectors/test/Connectors.Test/SqlServer/SystemData/SqlServerConnectorTest.cs
@@ -13,6 +13,8 @@ using Steeltoe.Configuration.CloudFoundry.ServiceBindings;
 using Steeltoe.Connectors.SqlServer;
 using Steeltoe.Connectors.SqlServer.RuntimeTypeAccess;
 
+#pragma warning disable CS0618 // Type or member is obsolete
+
 namespace Steeltoe.Connectors.Test.SqlServer.SystemData;
 
 public sealed class SqlServerConnectorTest

--- a/src/Connectors/test/Connectors.Test/Steeltoe.Connectors.Test.csproj
+++ b/src/Connectors/test/Connectors.Test/Steeltoe.Connectors.Test.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\shared.props" />

--- a/src/Connectors/test/EntityFrameworkCore.Test/MigrateDbContextTaskTest.cs
+++ b/src/Connectors/test/EntityFrameworkCore.Test/MigrateDbContextTaskTest.cs
@@ -60,5 +60,12 @@ public sealed class MigrateDbContextTaskTest
         {
             throw new NotImplementedException();
         }
+
+#if NET9_0_OR_GREATER
+        public bool HasPendingModelChanges()
+        {
+            throw new NotImplementedException();
+        }
+#endif
     }
 }

--- a/src/Connectors/test/EntityFrameworkCore.Test/Steeltoe.Connectors.EntityFrameworkCore.Test.csproj
+++ b/src/Connectors/test/EntityFrameworkCore.Test/Steeltoe.Connectors.EntityFrameworkCore.Test.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\shared.props" />

--- a/src/Connectors/test/EntityFrameworkCore.Test/Steeltoe.Connectors.EntityFrameworkCore.Test.csproj
+++ b/src/Connectors/test/EntityFrameworkCore.Test/Steeltoe.Connectors.EntityFrameworkCore.Test.csproj
@@ -9,7 +9,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="$(EntityFrameworkCoreTestVersion)" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="$(EntityFrameworkCoreTestVersion)" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="$(EntityFrameworkCoreTestVersion)" />
-    <PackageReference Include="MySql.EntityFrameworkCore" Version="$(EntityFrameworkCoreMySqlTestVersion)" />
+    <PackageReference Include="MySql.EntityFrameworkCore" Version="$(EntityFrameworkCoreTestVersion)" />
     <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="$(EntityFrameworkCoreTestVersion)" />
     <PackageReference Include="System.Text.Json" Version="$(FoundationalVersion)" />
   </ItemGroup>

--- a/src/Discovery/test/Configuration.Test/ConfigurationDiscoveryClientTest.cs
+++ b/src/Discovery/test/Configuration.Test/ConfigurationDiscoveryClientTest.cs
@@ -136,7 +136,7 @@ public sealed class ConfigurationDiscoveryClientTest
         await using ServiceProvider serviceProvider = services.BuildServiceProvider(true);
 
         // by getting the client, we're confirming that the options are also available in the container
-        IDiscoveryClient[] discoveryClients = serviceProvider.GetServices<IDiscoveryClient>().ToArray();
+        IDiscoveryClient[] discoveryClients = [.. serviceProvider.GetServices<IDiscoveryClient>()];
 
         Assert.Single(discoveryClients);
         Assert.IsType<ConfigurationDiscoveryClient>(discoveryClients[0]);
@@ -164,10 +164,10 @@ public sealed class ConfigurationDiscoveryClientTest
 
         await using ServiceProvider serviceProvider = services.BuildServiceProvider(true);
 
-        IDiscoveryClient[] discoveryClients = serviceProvider.GetServices<IDiscoveryClient>().ToArray();
+        IDiscoveryClient[] discoveryClients = [.. serviceProvider.GetServices<IDiscoveryClient>()];
         discoveryClients.OfType<ConfigurationDiscoveryClient>().Should().ContainSingle();
 
-        ConfigurationDiscoveryClient[] configurationDiscoveryClients = serviceProvider.GetServices<ConfigurationDiscoveryClient>().ToArray();
+        ConfigurationDiscoveryClient[] configurationDiscoveryClients = [.. serviceProvider.GetServices<ConfigurationDiscoveryClient>()];
         configurationDiscoveryClients.Should().BeEmpty();
     }
 
@@ -183,7 +183,7 @@ public sealed class ConfigurationDiscoveryClientTest
 
         await using ServiceProvider serviceProvider = services.BuildServiceProvider(true);
 
-        IHostedService[] hostedServices = serviceProvider.GetServices<IHostedService>().ToArray();
+        IHostedService[] hostedServices = [.. serviceProvider.GetServices<IHostedService>()];
         hostedServices.OfType<DiscoveryClientHostedService>().Should().ContainSingle();
     }
 }

--- a/src/Discovery/test/Configuration.Test/Steeltoe.Discovery.Configuration.Test.csproj
+++ b/src/Discovery/test/Configuration.Test/Steeltoe.Discovery.Configuration.Test.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\shared.props" />

--- a/src/Discovery/test/Consul.Test/ConsulServiceCollectionExtensionsTest.cs
+++ b/src/Discovery/test/Consul.Test/ConsulServiceCollectionExtensionsTest.cs
@@ -37,7 +37,7 @@ public sealed class ConsulServiceCollectionExtensionsTest
         services.AddConsulDiscoveryClient();
 
         await using ServiceProvider serviceProvider = services.BuildServiceProvider(true);
-        IDiscoveryClient[] discoveryClients = serviceProvider.GetServices<IDiscoveryClient>().ToArray();
+        IDiscoveryClient[] discoveryClients = [.. serviceProvider.GetServices<IDiscoveryClient>()];
 
         Assert.Single(discoveryClients);
         Assert.NotNull(discoveryClients[0]);
@@ -142,7 +142,7 @@ public sealed class ConsulServiceCollectionExtensionsTest
 
         await using ServiceProvider serviceProvider = services.BuildServiceProvider(true);
 
-        IHostedService[] hostedServices = serviceProvider.GetServices<IHostedService>().ToArray();
+        IHostedService[] hostedServices = [.. serviceProvider.GetServices<IHostedService>()];
         hostedServices.OfType<DiscoveryClientHostedService>().Should().ContainSingle();
     }
 

--- a/src/Discovery/test/Consul.Test/Steeltoe.Discovery.Consul.Test.csproj
+++ b/src/Discovery/test/Consul.Test/Steeltoe.Discovery.Consul.Test.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\shared.props" />

--- a/src/Discovery/test/Eureka.Test/EurekaDiscoveryClientTest.cs
+++ b/src/Discovery/test/Eureka.Test/EurekaDiscoveryClientTest.cs
@@ -189,7 +189,7 @@ public sealed class EurekaDiscoveryClientTest
 
         await using WebApplication webApplication = builder.Build();
 
-        EurekaDiscoveryClient[] discoveryClients = webApplication.Services.GetServices<IDiscoveryClient>().OfType<EurekaDiscoveryClient>().ToArray();
+        EurekaDiscoveryClient[] discoveryClients = [.. webApplication.Services.GetServices<IDiscoveryClient>().OfType<EurekaDiscoveryClient>()];
         Assert.Single(discoveryClients);
 
         Assert.False(discoveryClients[0].IsCacheRefreshTimerStarted);

--- a/src/Discovery/test/Eureka.Test/EurekaHealthCheckHandlerTest.cs
+++ b/src/Discovery/test/Eureka.Test/EurekaHealthCheckHandlerTest.cs
@@ -147,7 +147,7 @@ public sealed class EurekaHealthCheckHandlerTest
 
         app.Services.GetRequiredService<HttpClientHandlerFactory>().Using(handler);
 
-        IDiscoveryClient[] discoveryClients = app.Services.GetServices<IDiscoveryClient>().ToArray();
+        IDiscoveryClient[] discoveryClients = [.. app.Services.GetServices<IDiscoveryClient>()];
         Assert.Single(discoveryClients);
 
         await Task.Delay(TimeSpan.FromSeconds(2));

--- a/src/Discovery/test/Eureka.Test/EurekaServiceCollectionExtensionsTest.cs
+++ b/src/Discovery/test/Eureka.Test/EurekaServiceCollectionExtensionsTest.cs
@@ -76,7 +76,7 @@ public sealed class EurekaServiceCollectionExtensionsTest
         var timer = new Stopwatch();
         timer.Start();
 
-        IDiscoveryClient[] discoveryClients = serviceProvider.GetServices<IDiscoveryClient>().ToArray();
+        IDiscoveryClient[] discoveryClients = [.. serviceProvider.GetServices<IDiscoveryClient>()];
         Assert.Single(discoveryClients);
 
         timer.Stop();
@@ -219,7 +219,7 @@ public sealed class EurekaServiceCollectionExtensionsTest
 
         await using ServiceProvider serviceProvider = services.BuildServiceProvider(true);
 
-        IHostedService[] hostedServices = serviceProvider.GetServices<IHostedService>().ToArray();
+        IHostedService[] hostedServices = [.. serviceProvider.GetServices<IHostedService>()];
         hostedServices.OfType<DiscoveryClientHostedService>().Should().ContainSingle();
     }
 }

--- a/src/Discovery/test/Eureka.Test/Steeltoe.Discovery.Eureka.Test.csproj
+++ b/src/Discovery/test/Eureka.Test/Steeltoe.Discovery.Eureka.Test.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\shared.props" />

--- a/src/Discovery/test/HttpClients.Test/DiscoveryHostApplicationBuilderExtensionsTest.cs
+++ b/src/Discovery/test/HttpClients.Test/DiscoveryHostApplicationBuilderExtensionsTest.cs
@@ -38,7 +38,7 @@ public sealed class DiscoveryHostApplicationBuilderExtensionsTest
 
         using IHost host = hostBuilder.Build();
 
-        IDiscoveryClient[] discoveryClients = host.Services.GetServices<IDiscoveryClient>().ToArray();
+        IDiscoveryClient[] discoveryClients = [.. host.Services.GetServices<IDiscoveryClient>()];
         Assert.Single(discoveryClients);
         Assert.IsType<EurekaDiscoveryClient>(discoveryClients[0]);
 
@@ -68,7 +68,7 @@ public sealed class DiscoveryHostApplicationBuilderExtensionsTest
 
         using IHost host = hostBuilder.Build();
 
-        IDiscoveryClient[] discoveryClients = host.Services.GetServices<IDiscoveryClient>().ToArray();
+        IDiscoveryClient[] discoveryClients = [.. host.Services.GetServices<IDiscoveryClient>()];
         Assert.Single(discoveryClients);
         Assert.IsType<ConsulDiscoveryClient>(discoveryClients[0]);
 

--- a/src/Discovery/test/HttpClients.Test/DiscoveryHostBuilderExtensionsTest.cs
+++ b/src/Discovery/test/HttpClients.Test/DiscoveryHostBuilderExtensionsTest.cs
@@ -39,7 +39,7 @@ public sealed class DiscoveryHostBuilderExtensionsTest
 
         using IHost host = hostBuilder.Build();
 
-        IDiscoveryClient[] discoveryClients = host.Services.GetServices<IDiscoveryClient>().ToArray();
+        IDiscoveryClient[] discoveryClients = [.. host.Services.GetServices<IDiscoveryClient>()];
         Assert.Single(discoveryClients);
         Assert.IsType<EurekaDiscoveryClient>(discoveryClients[0]);
 
@@ -69,7 +69,7 @@ public sealed class DiscoveryHostBuilderExtensionsTest
 
         using IHost host = hostBuilder.Build();
 
-        IDiscoveryClient[] discoveryClients = host.Services.GetServices<IDiscoveryClient>().ToArray();
+        IDiscoveryClient[] discoveryClients = [.. host.Services.GetServices<IDiscoveryClient>()];
         Assert.Single(discoveryClients);
         Assert.IsType<ConsulDiscoveryClient>(discoveryClients[0]);
 

--- a/src/Discovery/test/HttpClients.Test/DiscoveryWebApplicationBuilderExtensionsTest.cs
+++ b/src/Discovery/test/HttpClients.Test/DiscoveryWebApplicationBuilderExtensionsTest.cs
@@ -39,7 +39,7 @@ public sealed class DiscoveryWebApplicationBuilderExtensionsTest
         builder.Services.AddEurekaDiscoveryClient();
 
         await using WebApplication host = builder.Build();
-        IDiscoveryClient[] discoveryClients = host.Services.GetServices<IDiscoveryClient>().ToArray();
+        IDiscoveryClient[] discoveryClients = [.. host.Services.GetServices<IDiscoveryClient>()];
 
         Assert.Single(discoveryClients);
         Assert.IsType<EurekaDiscoveryClient>(discoveryClients[0]);
@@ -55,7 +55,7 @@ public sealed class DiscoveryWebApplicationBuilderExtensionsTest
 
         await using WebApplication host = builder.Build();
 
-        IDiscoveryClient[] discoveryClients = host.Services.GetServices<IDiscoveryClient>().ToArray();
+        IDiscoveryClient[] discoveryClients = [.. host.Services.GetServices<IDiscoveryClient>()];
         Assert.Single(discoveryClients);
         Assert.IsType<ConsulDiscoveryClient>(discoveryClients[0]);
         Assert.Single(host.Services.GetServices<IHostedService>().OfType<DiscoveryClientHostedService>());

--- a/src/Discovery/test/HttpClients.Test/DiscoveryWebHostBuilderExtensionsTest.cs
+++ b/src/Discovery/test/HttpClients.Test/DiscoveryWebHostBuilderExtensionsTest.cs
@@ -40,7 +40,7 @@ public sealed class DiscoveryWebHostBuilderExtensionsTest
 
         using IWebHost host = hostBuilder.Build();
 
-        IDiscoveryClient[] discoveryClients = host.Services.GetServices<IDiscoveryClient>().ToArray();
+        IDiscoveryClient[] discoveryClients = [.. host.Services.GetServices<IDiscoveryClient>()];
         Assert.Single(discoveryClients);
         Assert.IsType<EurekaDiscoveryClient>(discoveryClients[0]);
 
@@ -57,7 +57,7 @@ public sealed class DiscoveryWebHostBuilderExtensionsTest
 
         using IWebHost host = hostBuilder.Build();
 
-        IDiscoveryClient[] discoveryClients = host.Services.GetServices<IDiscoveryClient>().ToArray();
+        IDiscoveryClient[] discoveryClients = [.. host.Services.GetServices<IDiscoveryClient>()];
         Assert.Single(discoveryClients);
         Assert.IsType<ConsulDiscoveryClient>(discoveryClients[0]);
 

--- a/src/Discovery/test/HttpClients.Test/RegisterMultipleDiscoveryClientsTest.cs
+++ b/src/Discovery/test/HttpClients.Test/RegisterMultipleDiscoveryClientsTest.cs
@@ -74,7 +74,7 @@ public sealed class RegisterMultipleDiscoveryClientsTest
         services.AddEurekaDiscoveryClient();
 
         await using ServiceProvider serviceProvider = services.BuildServiceProvider(true);
-        IDiscoveryClient[] discoveryClients = serviceProvider.GetServices<IDiscoveryClient>().ToArray();
+        IDiscoveryClient[] discoveryClients = [.. serviceProvider.GetServices<IDiscoveryClient>()];
 
         Assert.Single(discoveryClients);
         Assert.IsType<EurekaDiscoveryClient>(discoveryClients[0]);
@@ -103,7 +103,7 @@ public sealed class RegisterMultipleDiscoveryClientsTest
         services.AddEurekaDiscoveryClient();
 
         await using ServiceProvider serviceProvider = services.BuildServiceProvider(true);
-        IDiscoveryClient[] discoveryClients = serviceProvider.GetServices<IDiscoveryClient>().ToArray();
+        IDiscoveryClient[] discoveryClients = [.. serviceProvider.GetServices<IDiscoveryClient>()];
 
         Assert.Single(discoveryClients);
         Assert.IsType<EurekaDiscoveryClient>(discoveryClients[0]);
@@ -250,7 +250,7 @@ public sealed class RegisterMultipleDiscoveryClientsTest
         services.AddEurekaDiscoveryClient();
 
         await using ServiceProvider serviceProvider = services.BuildServiceProvider(true);
-        IDiscoveryClient[] discoveryClients = serviceProvider.GetServices<IDiscoveryClient>().ToArray();
+        IDiscoveryClient[] discoveryClients = [.. serviceProvider.GetServices<IDiscoveryClient>()];
 
         Assert.Single(discoveryClients);
         Assert.IsType<EurekaDiscoveryClient>(discoveryClients[0]);
@@ -349,7 +349,7 @@ public sealed class RegisterMultipleDiscoveryClientsTest
         services.AddEurekaDiscoveryClient();
 
         await using ServiceProvider serviceProvider = services.BuildServiceProvider(true);
-        IDiscoveryClient[] discoveryClients = serviceProvider.GetServices<IDiscoveryClient>().ToArray();
+        IDiscoveryClient[] discoveryClients = [.. serviceProvider.GetServices<IDiscoveryClient>()];
 
         Assert.Single(discoveryClients);
         Assert.IsType<EurekaDiscoveryClient>(discoveryClients[0]);
@@ -686,7 +686,7 @@ public sealed class RegisterMultipleDiscoveryClientsTest
         services.AddConsulDiscoveryClient();
 
         await using ServiceProvider serviceProvider = services.BuildServiceProvider(true);
-        IDiscoveryClient[] discoveryClients = serviceProvider.GetServices<IDiscoveryClient>().ToArray();
+        IDiscoveryClient[] discoveryClients = [.. serviceProvider.GetServices<IDiscoveryClient>()];
 
         Assert.Single(discoveryClients);
         Assert.IsType<ConsulDiscoveryClient>(discoveryClients[0]);
@@ -721,7 +721,7 @@ public sealed class RegisterMultipleDiscoveryClientsTest
         services.AddConsulDiscoveryClient();
 
         await using ServiceProvider serviceProvider = services.BuildServiceProvider(true);
-        IDiscoveryClient[] discoveryClients = serviceProvider.GetServices<IDiscoveryClient>().ToArray();
+        IDiscoveryClient[] discoveryClients = [.. serviceProvider.GetServices<IDiscoveryClient>()];
 
         Assert.Single(discoveryClients);
         Assert.IsType<ConsulDiscoveryClient>(discoveryClients[0]);
@@ -757,7 +757,7 @@ public sealed class RegisterMultipleDiscoveryClientsTest
         services.AddConsulDiscoveryClient();
 
         await using ServiceProvider serviceProvider = services.BuildServiceProvider(true);
-        IDiscoveryClient[] discoveryClients = serviceProvider.GetServices<IDiscoveryClient>().ToArray();
+        IDiscoveryClient[] discoveryClients = [.. serviceProvider.GetServices<IDiscoveryClient>()];
 
         Assert.Single(discoveryClients);
         Assert.IsType<ConsulDiscoveryClient>(discoveryClients[0]);
@@ -860,7 +860,7 @@ public sealed class RegisterMultipleDiscoveryClientsTest
         services.AddConfigurationDiscoveryClient();
 
         await using ServiceProvider serviceProvider = services.BuildServiceProvider(true);
-        IDiscoveryClient[] discoveryClients = serviceProvider.GetServices<IDiscoveryClient>().ToArray();
+        IDiscoveryClient[] discoveryClients = [.. serviceProvider.GetServices<IDiscoveryClient>()];
 
         Assert.Single(discoveryClients);
         Assert.IsType<ConfigurationDiscoveryClient>(discoveryClients[0]);
@@ -887,7 +887,7 @@ public sealed class RegisterMultipleDiscoveryClientsTest
         services.AddEurekaDiscoveryClient();
 
         await using ServiceProvider serviceProvider = services.BuildServiceProvider(true);
-        IDiscoveryClient[] discoveryClients = serviceProvider.GetServices<IDiscoveryClient>().ToArray();
+        IDiscoveryClient[] discoveryClients = [.. serviceProvider.GetServices<IDiscoveryClient>()];
         discoveryClients.Should().HaveCount(3);
 
         serviceProvider.GetServices<IHealthContributor>().OfType<ConsulHealthContributor>().Should().ContainSingle();

--- a/src/Discovery/test/HttpClients.Test/Steeltoe.Discovery.HttpClients.Test.csproj
+++ b/src/Discovery/test/HttpClients.Test/Steeltoe.Discovery.HttpClients.Test.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\shared.props" />

--- a/src/Logging/test/DynamicLogger.Test/DynamicConsoleLoggerProviderTest.cs
+++ b/src/Logging/test/DynamicLogger.Test/DynamicConsoleLoggerProviderTest.cs
@@ -87,7 +87,7 @@ public sealed class DynamicConsoleLoggerProviderTest : IDisposable
         using IDynamicLoggerProvider provider = CreateLoggerProvider(configurationBuilder => configurationBuilder.AddInMemoryCollection(appSettings));
         _ = provider.CreateLogger("A.B.C.D.Example");
 
-        string[] loggerStates = provider.GetLogLevels().Select(state => state.ToString()).ToArray();
+        string[] loggerStates = [.. provider.GetLogLevels().Select(state => state.ToString())];
 
         loggerStates.Should().HaveCount(6);
         loggerStates.Should().Contain("Default: Information");

--- a/src/Logging/test/DynamicLogger.Test/HostBuilderTests.cs
+++ b/src/Logging/test/DynamicLogger.Test/HostBuilderTests.cs
@@ -23,7 +23,7 @@ public sealed class HostBuilderTests
         builder.Logging.AddDynamicConsole();
         await using WebApplication host = builder.Build();
 
-        ILoggerProvider[] loggerProviders = host.Services.GetServices<ILoggerProvider>().ToArray();
+        ILoggerProvider[] loggerProviders = [.. host.Services.GetServices<ILoggerProvider>()];
         loggerProviders.OfType<ConsoleLoggerProvider>().Should().BeEmpty();
         loggerProviders.OfType<DynamicConsoleLoggerProvider>().Should().ContainSingle();
 
@@ -38,7 +38,7 @@ public sealed class HostBuilderTests
         builder.Logging.AddDynamicConsole();
         await using WebApplication host = builder.Build();
 
-        ILoggerProvider[] loggerProviders = host.Services.GetServices<ILoggerProvider>().ToArray();
+        ILoggerProvider[] loggerProviders = [.. host.Services.GetServices<ILoggerProvider>()];
         loggerProviders.OfType<DynamicConsoleLoggerProvider>().Should().ContainSingle();
 
         host.Services.GetService<IDynamicLoggerProvider>().Should().BeOfType<DynamicConsoleLoggerProvider>();

--- a/src/Logging/test/DynamicLogger.Test/Steeltoe.Logging.DynamicLogger.Test.csproj
+++ b/src/Logging/test/DynamicLogger.Test/Steeltoe.Logging.DynamicLogger.Test.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\shared.props" />

--- a/src/Logging/test/DynamicSerilog.Test/DynamicSerilogLoggerProviderTest.cs
+++ b/src/Logging/test/DynamicSerilog.Test/DynamicSerilogLoggerProviderTest.cs
@@ -50,7 +50,7 @@ public sealed class DynamicSerilogLoggerProviderTest : IDisposable
         using IDynamicLoggerProvider provider = CreateLoggerProvider(configurationBuilder => configurationBuilder.AddInMemoryCollection(appSettings));
         _ = provider.CreateLogger("A.B.C.D.Example");
 
-        string[] loggerStates = provider.GetLogLevels().Select(state => state.ToString()).ToArray();
+        string[] loggerStates = [.. provider.GetLogLevels().Select(state => state.ToString())];
 
         loggerStates.Should().HaveCount(6);
         loggerStates.Should().Contain("Default: Information");

--- a/src/Logging/test/DynamicSerilog.Test/HostBuilderTests.cs
+++ b/src/Logging/test/DynamicSerilog.Test/HostBuilderTests.cs
@@ -34,7 +34,7 @@ public sealed class HostBuilderTests : IDisposable
         builder.Logging.AddDynamicSerilog();
         await using WebApplication host = builder.Build();
 
-        ILoggerProvider[] loggerProviders = host.Services.GetServices<ILoggerProvider>().ToArray();
+        ILoggerProvider[] loggerProviders = [.. host.Services.GetServices<ILoggerProvider>()];
         loggerProviders.OfType<ConsoleLoggerProvider>().Should().BeEmpty();
         loggerProviders.OfType<DynamicSerilogLoggerProvider>().Should().ContainSingle();
 
@@ -49,7 +49,7 @@ public sealed class HostBuilderTests : IDisposable
         builder.Logging.AddDynamicSerilog();
         await using WebApplication host = builder.Build();
 
-        ILoggerProvider[] loggerProviders = host.Services.GetServices<ILoggerProvider>().ToArray();
+        ILoggerProvider[] loggerProviders = [.. host.Services.GetServices<ILoggerProvider>()];
         loggerProviders.OfType<DynamicSerilogLoggerProvider>().Should().ContainSingle();
 
         host.Services.GetService<IDynamicLoggerProvider>().Should().BeOfType<DynamicSerilogLoggerProvider>();

--- a/src/Logging/test/DynamicSerilog.Test/Steeltoe.Logging.DynamicSerilog.Test.csproj
+++ b/src/Logging/test/DynamicSerilog.Test/Steeltoe.Logging.DynamicSerilog.Test.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\shared.props" />

--- a/src/Management/src/Endpoint/Actuators/HeapDump/EndpointServiceCollectionExtensions.cs
+++ b/src/Management/src/Endpoint/Actuators/HeapDump/EndpointServiceCollectionExtensions.cs
@@ -43,7 +43,7 @@ public static class EndpointServiceCollectionExtensions
         services.AddCoreActuatorServices<HeapDumpEndpointOptions, ConfigureHeapDumpEndpointOptions, HeapDumpEndpointMiddleware, IHeapDumpEndpointHandler,
             HeapDumpEndpointHandler, object?, string?>(configureMiddleware);
 
-        services.TryAddSingleton<HeapDumper>();
+        services.TryAddSingleton<IHeapDumper, HeapDumper>();
 
         return services;
     }

--- a/src/Management/src/Endpoint/Actuators/HeapDump/HeapDumpEndpointHandler.cs
+++ b/src/Management/src/Endpoint/Actuators/HeapDump/HeapDumpEndpointHandler.cs
@@ -11,12 +11,12 @@ namespace Steeltoe.Management.Endpoint.Actuators.HeapDump;
 internal sealed class HeapDumpEndpointHandler : IHeapDumpEndpointHandler
 {
     private readonly IOptionsMonitor<HeapDumpEndpointOptions> _optionsMonitor;
-    private readonly HeapDumper _heapDumper;
+    private readonly IHeapDumper _heapDumper;
     private readonly ILogger<HeapDumpEndpointHandler> _logger;
 
     public EndpointOptions Options => _optionsMonitor.CurrentValue;
 
-    public HeapDumpEndpointHandler(IOptionsMonitor<HeapDumpEndpointOptions> optionsMonitor, HeapDumper heapDumper, ILoggerFactory loggerFactory)
+    public HeapDumpEndpointHandler(IOptionsMonitor<HeapDumpEndpointOptions> optionsMonitor, IHeapDumper heapDumper, ILoggerFactory loggerFactory)
     {
         ArgumentNullException.ThrowIfNull(optionsMonitor);
         ArgumentNullException.ThrowIfNull(heapDumper);

--- a/src/Management/src/Endpoint/Actuators/HeapDump/HeapDumper.cs
+++ b/src/Management/src/Endpoint/Actuators/HeapDump/HeapDumper.cs
@@ -10,7 +10,7 @@ using Microsoft.Extensions.Options;
 
 namespace Steeltoe.Management.Endpoint.Actuators.HeapDump;
 
-public sealed class HeapDumper
+internal sealed class HeapDumper : IHeapDumper
 {
     private readonly string? _basePathOverride;
     private readonly IOptionsMonitor<HeapDumpEndpointOptions> _optionsMonitor;

--- a/src/Management/src/Endpoint/Actuators/HeapDump/IHeapDumper.cs
+++ b/src/Management/src/Endpoint/Actuators/HeapDump/IHeapDumper.cs
@@ -1,0 +1,10 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+namespace Steeltoe.Management.Endpoint.Actuators.HeapDump;
+
+internal interface IHeapDumper
+{
+    string? DumpHeapToFile(CancellationToken cancellationToken);
+}

--- a/src/Management/src/Endpoint/ConfigurationSchema.json
+++ b/src/Management/src/Endpoint/ConfigurationSchema.json
@@ -614,6 +614,10 @@
             "SerializerOptions": {
               "type": "object",
               "properties": {
+                "AllowOutOfOrderMetadataProperties": {
+                  "type": "boolean",
+                  "description": "Allows JSON metadata properties to be specified after regular properties in a deserialized JSON object."
+                },
                 "AllowTrailingCommas": {
                   "type": "boolean",
                   "description": "Get or sets a value that indicates whether an extra comma at the end of a list of JSON values in an object or array is allowed (and ignored) within the JSON payload being deserialized."
@@ -637,15 +641,27 @@
                 },
                 "IgnoreReadOnlyProperties": {
                   "type": "boolean",
-                  "description": "Gets a value that indicates whether read-only properties are ignored during serialization. The default value is false."
+                  "description": "Gets or sets a value that indicates whether read-only properties are ignored during serialization. The default value is false."
                 },
                 "IncludeFields": {
                   "type": "boolean",
                   "description": "Gets or sets a value that indicates whether fields are handled during serialization and deserialization. The default value is false."
                 },
+                "IndentCharacter": {
+                  "type": "integer",
+                  "description": "Defines the indentation character being used when 'System.Text.Json.JsonSerializerOptions.WriteIndented' is enabled. Defaults to the space character."
+                },
+                "IndentSize": {
+                  "type": "integer",
+                  "description": "Defines the indentation size being used when 'System.Text.Json.JsonSerializerOptions.WriteIndented' is enabled. Defaults to two."
+                },
                 "MaxDepth": {
                   "type": "integer",
                   "description": "Gets or sets the maximum depth allowed when serializing or deserializing JSON, with the default value of 0 indicating a maximum depth of 64."
+                },
+                "NewLine": {
+                  "type": "string",
+                  "description": "Gets or sets the new line string to use when 'System.Text.Json.JsonSerializerOptions.WriteIndented' is true.\n\nThe default is the value of 'System.Environment.NewLine'."
                 },
                 "NumberHandling": {
                   "enum": [
@@ -674,6 +690,14 @@
                     "Allow"
                   ],
                   "description": "Gets or sets a value that defines how comments are handled during deserialization."
+                },
+                "RespectNullableAnnotations": {
+                  "type": "boolean",
+                  "description": "Gets or sets a value that indicates whether nullability annotations should be respected during serialization and deserialization."
+                },
+                "RespectRequiredConstructorParameters": {
+                  "type": "boolean",
+                  "description": "Gets or sets a value that indicates whether non-optional constructor parameters should be specified during deserialization."
                 },
                 "UnknownTypeHandling": {
                   "enum": [

--- a/src/Management/src/Endpoint/PublicAPI.Unshipped.txt
+++ b/src/Management/src/Endpoint/PublicAPI.Unshipped.txt
@@ -178,10 +178,6 @@ Steeltoe.Management.Endpoint.Actuators.HeapDump.HeapDumpEndpointOptions
 Steeltoe.Management.Endpoint.Actuators.HeapDump.HeapDumpEndpointOptions.HeapDumpEndpointOptions() -> void
 Steeltoe.Management.Endpoint.Actuators.HeapDump.HeapDumpEndpointOptions.HeapDumpType.get -> string?
 Steeltoe.Management.Endpoint.Actuators.HeapDump.HeapDumpEndpointOptions.HeapDumpType.set -> void
-Steeltoe.Management.Endpoint.Actuators.HeapDump.HeapDumper
-Steeltoe.Management.Endpoint.Actuators.HeapDump.HeapDumper.DumpHeapToFile(System.Threading.CancellationToken cancellationToken) -> string?
-Steeltoe.Management.Endpoint.Actuators.HeapDump.HeapDumper.HeapDumper(Microsoft.Extensions.Options.IOptionsMonitor<Steeltoe.Management.Endpoint.Actuators.HeapDump.HeapDumpEndpointOptions!>! optionsMonitor, Microsoft.Extensions.Logging.ILogger<Steeltoe.Management.Endpoint.Actuators.HeapDump.HeapDumper!>! logger) -> void
-Steeltoe.Management.Endpoint.Actuators.HeapDump.HeapDumper.HeapDumper(Microsoft.Extensions.Options.IOptionsMonitor<Steeltoe.Management.Endpoint.Actuators.HeapDump.HeapDumpEndpointOptions!>! optionsMonitor, string? basePathOverride, Microsoft.Extensions.Logging.ILogger<Steeltoe.Management.Endpoint.Actuators.HeapDump.HeapDumper!>! logger) -> void
 Steeltoe.Management.Endpoint.Actuators.HeapDump.IHeapDumpEndpointHandler
 Steeltoe.Management.Endpoint.Actuators.HttpExchanges.EndpointServiceCollectionExtensions
 Steeltoe.Management.Endpoint.Actuators.HttpExchanges.HttpExchange

--- a/src/Management/src/Prometheus/Steeltoe.Management.Prometheus.csproj
+++ b/src/Management/src/Prometheus/Steeltoe.Management.Prometheus.csproj
@@ -9,6 +9,8 @@
   <Import Project="..\..\..\..\shared.props" />
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="$(FoundationalVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="$(FoundationalVersion)" />
     <PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="$(OpenTelemetryExporterPrometheusVersion)" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="$(OpenTelemetryVersion)" />
   </ItemGroup>

--- a/src/Management/test/Endpoint.Test/ActuatorContentNegotiationTests.cs
+++ b/src/Management/test/Endpoint.Test/ActuatorContentNegotiationTests.cs
@@ -7,8 +7,11 @@ using System.Net.Http.Headers;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 using Steeltoe.Common.TestResources;
 using Steeltoe.Management.Endpoint.Actuators.All;
+using Steeltoe.Management.Endpoint.Actuators.HeapDump;
+using Steeltoe.Management.Endpoint.Test.Actuators.HeapDump;
 
 namespace Steeltoe.Management.Endpoint.Test;
 
@@ -43,6 +46,7 @@ public sealed class ActuatorContentNegotiationTests
         WebApplicationBuilder builder = TestWebApplicationBuilderFactory.Create();
         builder.Configuration.AddInMemoryCollection(AppSettings);
         builder.Services.AddAllActuators();
+        builder.Services.AddSingleton<IHeapDumper, FakeHeapDumper>();
 
         await using WebApplication host = builder.Build();
         await host.StartAsync();

--- a/src/Management/test/Endpoint.Test/ActuatorRouteBuilderExtensionsTest.cs
+++ b/src/Management/test/Endpoint.Test/ActuatorRouteBuilderExtensionsTest.cs
@@ -28,8 +28,11 @@ public sealed class ActuatorRouteBuilderExtensionsTest
     {
         get
         {
-            List<Type> endpointOptionsTypes = typeof(ConfigureEndpointOptions<>).Assembly.GetTypes()
-                .Where(type => type.IsAssignableTo(typeof(EndpointOptions)) && type != typeof(CloudFoundryEndpointOptions)).ToList();
+            List<Type> endpointOptionsTypes =
+            [
+                .. typeof(ConfigureEndpointOptions<>).Assembly.GetTypes().Where(type =>
+                    type.IsAssignableTo(typeof(EndpointOptions)) && type != typeof(CloudFoundryEndpointOptions))
+            ];
 
             TheoryData<RegistrationMode, Type> theoryData = [];
 

--- a/src/Management/test/Endpoint.Test/ActuatorRouteBuilderExtensionsTest.cs
+++ b/src/Management/test/Endpoint.Test/ActuatorRouteBuilderExtensionsTest.cs
@@ -16,7 +16,9 @@ using Steeltoe.Common.TestResources;
 using Steeltoe.Management.Configuration;
 using Steeltoe.Management.Endpoint.Actuators.All;
 using Steeltoe.Management.Endpoint.Actuators.CloudFoundry;
+using Steeltoe.Management.Endpoint.Actuators.HeapDump;
 using Steeltoe.Management.Endpoint.Configuration;
+using Steeltoe.Management.Endpoint.Test.Actuators.HeapDump;
 
 namespace Steeltoe.Management.Endpoint.Test;
 
@@ -71,6 +73,8 @@ public sealed class ActuatorRouteBuilderExtensionsTest
 
         hostBuilder.ConfigureServices(services =>
         {
+            services.AddSingleton<IHeapDumper, FakeHeapDumper>();
+
             if (mode == RegistrationMode.Services)
             {
                 services.AddAllActuators();

--- a/src/Management/test/Endpoint.Test/Actuators/Health/EndpointServiceCollectionTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/Health/EndpointServiceCollectionTest.cs
@@ -31,7 +31,7 @@ public sealed class EndpointServiceCollectionTest : BaseTest
         var aggregator = serviceProvider.GetService<IHealthAggregator>();
         Assert.NotNull(aggregator);
 
-        IHealthContributor[] contributors = serviceProvider.GetServices<IHealthContributor>().ToArray();
+        IHealthContributor[] contributors = [.. serviceProvider.GetServices<IHealthContributor>()];
         Assert.Equal(4, contributors.Length);
 
         var availability = serviceProvider.GetService<ApplicationAvailability>();

--- a/src/Management/test/Endpoint.Test/Actuators/HeapDump/EndpointServiceCollectionTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/HeapDump/EndpointServiceCollectionTest.cs
@@ -21,9 +21,8 @@ public sealed class EndpointServiceCollectionTest : BaseTest
         services.AddHeapDumpActuator();
 
         await using ServiceProvider serviceProvider = services.BuildServiceProvider(true);
-        var heapDumper = serviceProvider.GetService<HeapDumper>();
-        Assert.NotNull(heapDumper);
-        var handler = serviceProvider.GetService<IHeapDumpEndpointHandler>();
-        Assert.NotNull(handler);
+
+        serviceProvider.GetService<IHeapDumpEndpointHandler>().Should().BeOfType<HeapDumpEndpointHandler>();
+        serviceProvider.GetService<IHeapDumper>().Should().BeOfType<HeapDumper>();
     }
 }

--- a/src/Management/test/Endpoint.Test/Actuators/HeapDump/FakeHeapDumper.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/HeapDump/FakeHeapDumper.cs
@@ -1,0 +1,32 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+using Steeltoe.Common.TestResources.IO;
+using Steeltoe.Management.Endpoint.Actuators.HeapDump;
+
+namespace Steeltoe.Management.Endpoint.Test.Actuators.HeapDump;
+
+internal sealed class FakeHeapDumper : IHeapDumper, IDisposable
+{
+    private static readonly byte[] FakeFileContent = "FAKEDUMP"u8.ToArray();
+
+    private readonly List<TempFile> _filesCreated = [];
+
+    public string DumpHeapToFile(CancellationToken cancellationToken)
+    {
+        var file = new TempFile();
+        File.WriteAllBytes(file.FullPath, FakeFileContent);
+
+        _filesCreated.Add(file);
+        return file.FullPath;
+    }
+
+    public void Dispose()
+    {
+        foreach (TempFile file in _filesCreated)
+        {
+            file.Dispose();
+        }
+    }
+}

--- a/src/Management/test/Endpoint.Test/Actuators/HttpExchanges/EndpointServiceCollectionTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/HttpExchanges/EndpointServiceCollectionTest.cs
@@ -37,9 +37,8 @@ public sealed class EndpointServiceCollectionTest : BaseTest
         var handler = serviceProvider.GetService<IHttpExchangesEndpointHandler>();
         handler.Should().NotBeNull();
 
-        IEnumerable<DiagnosticObserver> observers = serviceProvider.GetServices<DiagnosticObserver>();
-        List<DiagnosticObserver> list = observers.ToList();
-        list.Should().ContainSingle();
-        list[0].Should().BeOfType<HttpExchangesDiagnosticObserver>();
+        List<DiagnosticObserver> observers = [.. serviceProvider.GetServices<DiagnosticObserver>()];
+        observers.Should().ContainSingle();
+        observers[0].Should().BeOfType<HttpExchangesDiagnosticObserver>();
     }
 }

--- a/src/Management/test/Endpoint.Test/Actuators/Info/EndpointServiceCollectionTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/Info/EndpointServiceCollectionTest.cs
@@ -25,7 +25,7 @@ public sealed class EndpointServiceCollectionTest : BaseTest
 
         await using ServiceProvider serviceProvider = services.BuildServiceProvider(true);
 
-        IInfoContributor[] contributors = serviceProvider.GetServices<IInfoContributor>().ToArray();
+        IInfoContributor[] contributors = [.. serviceProvider.GetServices<IInfoContributor>()];
         contributors.Should().HaveCount(4);
         contributors.OfType<GitInfoContributor>().Should().NotBeEmpty();
         contributors.OfType<AppSettingsInfoContributor>().Should().NotBeEmpty();

--- a/src/Management/test/Endpoint.Test/ActuatorsHostBuilderTest.cs
+++ b/src/Management/test/Endpoint.Test/ActuatorsHostBuilderTest.cs
@@ -657,7 +657,7 @@ public sealed class ActuatorsHostBuilderTest
         host.Services.GetServices<IEndpointOptionsMonitorProvider>().Should().HaveCount(actuatorCount);
         host.Services.GetServices<IEndpointMiddleware>().Should().HaveCount(actuatorCount);
 
-        IStartupFilter[] startupFilters = host.Services.GetServices<IStartupFilter>().ToArray();
+        IStartupFilter[] startupFilters = [.. host.Services.GetServices<IStartupFilter>()];
         startupFilters.Should().ContainSingle(filter => filter is ConfigureActuatorsMiddlewareStartupFilter);
         startupFilters.Should().ContainSingle(filter => filter is ManagementPortStartupFilter);
         startupFilters.Should().ContainSingle(filter => filter is AvailabilityStartupFilter);

--- a/src/Management/test/Endpoint.Test/ActuatorsHostBuilderTest.cs
+++ b/src/Management/test/Endpoint.Test/ActuatorsHostBuilderTest.cs
@@ -33,6 +33,7 @@ using Steeltoe.Management.Endpoint.Configuration;
 using Steeltoe.Management.Endpoint.ManagementPort;
 using Steeltoe.Management.Endpoint.Middleware;
 using Steeltoe.Management.Endpoint.Test.Actuators.Health.TestContributors;
+using Steeltoe.Management.Endpoint.Test.Actuators.HeapDump;
 using Steeltoe.Management.Endpoint.Test.Actuators.Info;
 
 namespace Steeltoe.Management.Endpoint.Test;
@@ -333,7 +334,12 @@ public sealed class ActuatorsHostBuilderTest
         await using HostWrapper host = hostBuilderType.Build(builder =>
         {
             builder.ConfigureAppConfiguration(configurationBuilder => configurationBuilder.AddInMemoryCollection(AppSettings));
-            builder.ConfigureServices(services => services.AddHeapDumpActuator());
+
+            builder.ConfigureServices(services =>
+            {
+                services.AddHeapDumpActuator();
+                services.AddSingleton<IHeapDumper, FakeHeapDumper>();
+            });
         });
 
         await host.StartAsync();

--- a/src/Management/test/Endpoint.Test/ConfigureOptionsTest.cs
+++ b/src/Management/test/Endpoint.Test/ConfigureOptionsTest.cs
@@ -31,10 +31,10 @@ public sealed class ConfigureOptionsTest
 
         await using ServiceProvider serviceProvider = services.BuildServiceProvider(true);
 
-        IConfigureOptions<ManagementOptions>[] configurers = serviceProvider.GetServices<IConfigureOptions<ManagementOptions>>().ToArray();
+        IConfigureOptions<ManagementOptions>[] configurers = [.. serviceProvider.GetServices<IConfigureOptions<ManagementOptions>>()];
         configurers.Should().ContainSingle();
 
-        IOptionsChangeTokenSource<ManagementOptions>[] tokenSources = serviceProvider.GetServices<IOptionsChangeTokenSource<ManagementOptions>>().ToArray();
+        IOptionsChangeTokenSource<ManagementOptions>[] tokenSources = [.. serviceProvider.GetServices<IOptionsChangeTokenSource<ManagementOptions>>()];
         tokenSources.Should().ContainSingle();
     }
 
@@ -51,7 +51,7 @@ public sealed class ConfigureOptionsTest
 
         await using ServiceProvider serviceProvider = services.BuildServiceProvider(true);
 
-        IConfigureOptions<ManagementOptions>[] configurers = serviceProvider.GetServices<IConfigureOptions<ManagementOptions>>().ToArray();
+        IConfigureOptions<ManagementOptions>[] configurers = [.. serviceProvider.GetServices<IConfigureOptions<ManagementOptions>>()];
         configurers.Should().HaveCount(2);
         configurers.OfType<ConfigureManagementOptions>().Should().ContainSingle();
         configurers.OfType<CustomManagementOptionsConfigurer>().Should().ContainSingle();
@@ -73,7 +73,7 @@ public sealed class ConfigureOptionsTest
 
         await using ServiceProvider serviceProvider = services.BuildServiceProvider(true);
 
-        IConfigureOptions<ManagementOptions>[] configurers = serviceProvider.GetServices<IConfigureOptions<ManagementOptions>>().ToArray();
+        IConfigureOptions<ManagementOptions>[] configurers = [.. serviceProvider.GetServices<IConfigureOptions<ManagementOptions>>()];
         configurers.Should().HaveCount(2);
         configurers.OfType<ConfigureManagementOptions>().Should().ContainSingle();
         configurers.OfType<CustomManagementOptionsConfigurer>().Should().ContainSingle();

--- a/src/Management/test/Endpoint.Test/ContentNegotiationTests.cs
+++ b/src/Management/test/Endpoint.Test/ContentNegotiationTests.cs
@@ -7,9 +7,11 @@ using System.Net.Http.Headers;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 using Steeltoe.Common.TestResources;
 using Steeltoe.Management.Endpoint.Actuators.HeapDump;
 using Steeltoe.Management.Endpoint.Actuators.Loggers;
+using Steeltoe.Management.Endpoint.Test.Actuators.HeapDump;
 
 namespace Steeltoe.Management.Endpoint.Test;
 
@@ -218,6 +220,7 @@ public sealed class ContentNegotiationTests
         WebApplicationBuilder builder = TestWebApplicationBuilderFactory.Create();
         builder.Configuration.AddInMemoryCollection(appSettings);
         builder.Services.AddHeapDumpActuator();
+        builder.Services.AddSingleton<IHeapDumper, FakeHeapDumper>();
 
         await using WebApplication host = builder.Build();
         await host.StartAsync();

--- a/src/Management/test/Endpoint.Test/Steeltoe.Management.Endpoint.Test.csproj
+++ b/src/Management/test/Endpoint.Test/Steeltoe.Management.Endpoint.Test.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\shared.props" />

--- a/src/Management/test/Prometheus.Test/Steeltoe.Management.Prometheus.Test.csproj
+++ b/src/Management/test/Prometheus.Test/Steeltoe.Management.Prometheus.Test.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\shared.props" />

--- a/src/Management/test/RazorPagesWebApp.Test/Steeltoe.Management.Endpoint.RazorPagesWebApp.Test.csproj
+++ b/src/Management/test/RazorPagesWebApp.Test/Steeltoe.Management.Endpoint.RazorPagesWebApp.Test.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/src/Management/test/Tasks.Test/Steeltoe.Management.Tasks.Test.csproj
+++ b/src/Management/test/Tasks.Test/Steeltoe.Management.Tasks.Test.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\shared.props" />

--- a/src/Management/test/Tracing.Test/Steeltoe.Management.Tracing.Test.csproj
+++ b/src/Management/test/Tracing.Test/Steeltoe.Management.Tracing.Test.csproj
@@ -6,6 +6,8 @@
   <Import Project="..\..\..\..\shared.props" />
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="$(FoundationalVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="$(FoundationalVersion)" />
     <PackageReference Include="OpenTelemetry" Version="$(OpenTelemetryVersion)" />
   </ItemGroup>
 

--- a/src/Management/test/Tracing.Test/Steeltoe.Management.Tracing.Test.csproj
+++ b/src/Management/test/Tracing.Test/Steeltoe.Management.Tracing.Test.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\shared.props" />

--- a/src/Security/test/Authentication.JwtBearer.Test/Steeltoe.Security.Authentication.JwtBearer.Test.csproj
+++ b/src/Security/test/Authentication.JwtBearer.Test/Steeltoe.Security.Authentication.JwtBearer.Test.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\shared.props" />

--- a/src/Security/test/Authentication.OpenIdConnect.Test/Steeltoe.Security.Authentication.OpenIdConnect.Test.csproj
+++ b/src/Security/test/Authentication.OpenIdConnect.Test/Steeltoe.Security.Authentication.OpenIdConnect.Test.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\shared.props" />

--- a/src/Security/test/Authorization.Certificate.Test/Steeltoe.Security.Authorization.Certificate.Test.csproj
+++ b/src/Security/test/Authorization.Certificate.Test/Steeltoe.Security.Authorization.Certificate.Test.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\shared.props" />

--- a/src/Security/test/DataProtection.Redis.Test/RedisDataProtectionBuilderExtensionsTest.net80.cs
+++ b/src/Security/test/DataProtection.Redis.Test/RedisDataProtectionBuilderExtensionsTest.net80.cs
@@ -1,0 +1,58 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+using Moq;
+using StackExchange.Redis;
+
+namespace Steeltoe.Security.DataProtection.Redis.Test;
+
+partial class RedisDataProtectionBuilderExtensionsTest
+{
+    private static object GetMockedConnectionMultiplexer(string? connectionString)
+    {
+        Dictionary<string, byte[]> innerStore = [];
+        var databaseMock = new Mock<IDatabase>();
+
+        databaseMock.Setup(database => database.HashGet(It.IsAny<RedisKey>(), It.IsAny<RedisValue[]>(), It.IsAny<CommandFlags>()))
+            .Returns((RedisKey key, RedisValue[] _, CommandFlags _) => GetRedisValues(key));
+
+        databaseMock.Setup(database => database.HashGetAsync(It.IsAny<RedisKey>(), It.IsAny<RedisValue[]>(), It.IsAny<CommandFlags>())).Returns(
+            (RedisKey key, RedisValue[] _, CommandFlags _) => Task.FromResult(GetRedisValues(key)));
+
+        databaseMock.Setup(database =>
+            database.ScriptEvaluateAsync(It.IsAny<string>(), It.IsAny<RedisKey[]?>(), It.IsAny<RedisValue[]?>(), It.IsAny<CommandFlags>())).Returns(
+            (string _, RedisKey[]? keys, RedisValue[]? values, CommandFlags _) =>
+            {
+                innerStore[keys![0]!] = values![3]!;
+                return Task.FromResult(RedisResult.Create(keys[0]));
+            });
+
+        var connectionMultiplexerMock = new Mock<IConnectionMultiplexer>();
+        connectionMultiplexerMock.Setup(connectionMultiplexer => connectionMultiplexer.Configuration).Returns(connectionString!);
+
+        connectionMultiplexerMock.Setup(connectionMultiplexer => connectionMultiplexer.GetDatabase(It.IsAny<int>(), It.IsAny<object?>()))
+            .Returns(databaseMock.Object);
+
+        databaseMock.Setup(database => database.Multiplexer).Returns(connectionMultiplexerMock.Object);
+
+        return connectionMultiplexerMock.Object;
+
+        RedisValue[] GetRedisValues(RedisKey key)
+        {
+            return innerStore.TryGetValue(key!, out byte[]? data)
+                ?
+                [
+                    default,
+                    default,
+                    data
+                ]
+                :
+                [
+                    default,
+                    default,
+                    default
+                ];
+        }
+    }
+}

--- a/src/Security/test/DataProtection.Redis.Test/RedisDataProtectionBuilderExtensionsTest.net90.cs
+++ b/src/Security/test/DataProtection.Redis.Test/RedisDataProtectionBuilderExtensionsTest.net90.cs
@@ -1,0 +1,58 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+using Moq;
+using StackExchange.Redis;
+
+namespace Steeltoe.Security.DataProtection.Redis.Test;
+
+partial class RedisDataProtectionBuilderExtensionsTest
+{
+    private static object GetMockedConnectionMultiplexer(string? connectionString)
+    {
+        Dictionary<string, byte[]> innerStore = [];
+        var databaseMock = new Mock<IDatabase>();
+
+        databaseMock.Setup(database => database.HashGet(It.IsAny<RedisKey>(), It.IsAny<RedisValue[]>(), It.IsAny<CommandFlags>()))
+            .Returns((RedisKey key, RedisValue[] _, CommandFlags _) => GetRedisValues(key));
+
+        databaseMock.Setup(database => database.HashGetAsync(It.IsAny<RedisKey>(), It.IsAny<RedisValue[]>(), It.IsAny<CommandFlags>())).Returns(
+            (RedisKey key, RedisValue[] _, CommandFlags _) => Task.FromResult(GetRedisValues(key)));
+
+        databaseMock.Setup(database => database.HashSetAsync(It.IsAny<RedisKey>(), It.IsAny<HashEntry[]>(), It.IsAny<CommandFlags>())).Returns(
+            (RedisKey key, HashEntry[] hashFields, CommandFlags _) =>
+            {
+                byte[] data = hashFields[2].Value!;
+                innerStore[key!] = data;
+                return Task.CompletedTask;
+            });
+
+        var connectionMultiplexerMock = new Mock<IConnectionMultiplexer>();
+        connectionMultiplexerMock.Setup(connectionMultiplexer => connectionMultiplexer.Configuration).Returns(connectionString!);
+
+        connectionMultiplexerMock.Setup(connectionMultiplexer => connectionMultiplexer.GetDatabase(It.IsAny<int>(), It.IsAny<object?>()))
+            .Returns(databaseMock.Object);
+
+        databaseMock.Setup(database => database.Multiplexer).Returns(connectionMultiplexerMock.Object);
+
+        return connectionMultiplexerMock.Object;
+
+        RedisValue[] GetRedisValues(RedisKey key)
+        {
+            return innerStore.TryGetValue(key!, out byte[]? data)
+                ?
+                [
+                    default,
+                    default,
+                    data
+                ]
+                :
+                [
+                    default,
+                    default,
+                    default
+                ];
+        }
+    }
+}

--- a/src/Security/test/DataProtection.Redis.Test/Steeltoe.Security.DataProtection.Redis.Test.csproj
+++ b/src/Security/test/DataProtection.Redis.Test/Steeltoe.Security.DataProtection.Redis.Test.csproj
@@ -21,8 +21,8 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
     <Compile Remove="**/*.net90.cs" />
     <None Include="**/*.net90.cs" />
-
   </ItemGroup>
+
   <ItemGroup Condition=" '$(TargetFramework)' != 'net8.0' ">
     <Compile Remove="**/*.net80.cs" />
     <None Include="**/*.net80.cs" />

--- a/src/Security/test/DataProtection.Redis.Test/Steeltoe.Security.DataProtection.Redis.Test.csproj
+++ b/src/Security/test/DataProtection.Redis.Test/Steeltoe.Security.DataProtection.Redis.Test.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\..\shared.props" />

--- a/src/Security/test/DataProtection.Redis.Test/Steeltoe.Security.DataProtection.Redis.Test.csproj
+++ b/src/Security/test/DataProtection.Redis.Test/Steeltoe.Security.DataProtection.Redis.Test.csproj
@@ -6,6 +6,25 @@
   <Import Project="..\..\..\..\shared.props" />
 
   <ItemGroup>
+    <!--
+      This reference is repeated to use different versions per target framework.
+      In .NET 9, LUA scripting is no longer used, which is a breaking change that requires different mocks.
+      See https://github.com/dotnet/aspnetcore/pull/54689.
+    -->
+    <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="$(MatchTargetFrameworkVersion)" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\src\DataProtection.Redis\Steeltoe.Security.DataProtection.Redis.csproj" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
+    <Compile Remove="**/*.net90.cs" />
+    <None Include="**/*.net90.cs" />
+
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' != 'net8.0' ">
+    <Compile Remove="**/*.net80.cs" />
+    <None Include="**/*.net80.cs" />
   </ItemGroup>
 </Project>

--- a/src/Tools/src/ConfigurationSchemaGenerator/ConfigurationSchemaGenerator.csproj
+++ b/src/Tools/src/ConfigurationSchemaGenerator/ConfigurationSchemaGenerator.csproj
@@ -17,7 +17,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(MicrosoftCodeAnalysisVersion)" />
     <PackageReference Include="System.CommandLine" Version="$(SystemCommandLineVersion)" />
-    <PackageReference Include="System.Text.Json" Version="$(SystemTextJsonToolsVersion)" />
+    <PackageReference Include="System.Text.Json" Version="$(FoundationalVersion)" />
 
     <InternalsVisibleTo Include="$(AssemblyName).Tests" />
   </ItemGroup>

--- a/src/Tools/test/ConfigurationSchemaGenerator.Tests/ConfigurationSchemaGenerator.Tests.csproj
+++ b/src/Tools/test/ConfigurationSchemaGenerator.Tests/ConfigurationSchemaGenerator.Tests.csproj
@@ -22,7 +22,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="$(CoverletVersion)" />
+    <PackageReference Include="coverlet.collector" Version="$(CoverletVersion)" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="$(FoundationalVersion)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />

--- a/src/Tools/test/ConfigurationSchemaGenerator.Tests/ConfigurationSchemaGenerator.Tests.csproj
+++ b/src/Tools/test/ConfigurationSchemaGenerator.Tests/ConfigurationSchemaGenerator.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PreserveCompilationContext>true</PreserveCompilationContext>

--- a/versions.props
+++ b/versions.props
@@ -23,7 +23,7 @@
     <RabbitClientTestVersion>7.0.*</RabbitClientTestVersion>
     <SerilogEnrichersThreadVersion>4.0.*</SerilogEnrichersThreadVersion>
     <SerilogExceptionsVersion>8.4.*</SerilogExceptionsVersion>
-    <SonarAnalyzerVersion>9.25.*</SonarAnalyzerVersion>
+    <SonarAnalyzerVersion>10.6.0.109712</SonarAnalyzerVersion>
     <SourceLinkGitHubVersion>8.0.*</SourceLinkGitHubVersion>
     <StyleCopVersion>1.2.0-beta.556</StyleCopVersion>
     <SystemCommandLineVersion>2.0.0-beta4.24324.3</SystemCommandLineVersion>

--- a/versions.props
+++ b/versions.props
@@ -37,7 +37,11 @@
     <XunitVersion>2.8.*</XunitVersion>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'"></PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net9.0'">
+  </PropertyGroup>
 
   <PropertyGroup>
     <!--
@@ -51,13 +55,6 @@
     <ConsulVersion>1.7.14.*</ConsulVersion>
     <DiagnosticsTracingVersion>3.1.16</DiagnosticsTracingVersion>
     <EntityFrameworkCoreVersion>8.0.*</EntityFrameworkCoreVersion>
-    <FoundationalVersion>
-      <!--
-        Package versions of this category are always safe to update to the latest version, because they multi-target all frameworks.
-        For example, v6 explicitly targets .NET 6; v7 explicitly targets .NET 6 and 7; v8 explicitly targets .NET 6, 7 and 8.
-      -->
-      8.0.*
-    </FoundationalVersion>
     <MicrosoftIdentityModelVersion>7.6.*</MicrosoftIdentityModelVersion>
     <OpenTelemetryExporterPrometheusVersion>1.9.*-*</OpenTelemetryExporterPrometheusVersion>
     <OpenTelemetryVersion>1.9.*</OpenTelemetryVersion>
@@ -66,6 +63,13 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <FoundationalVersion>
+      <!--
+        Package versions of this category are always safe to update to the latest version, because they multi-target all frameworks.
+        For example, v6 explicitly targets .NET 6; v7 explicitly targets .NET 6 and 7; v8 explicitly targets .NET 6, 7 and 8.
+      -->
+      8.0.*
+    </FoundationalVersion>
     <MatchTargetFrameworkVersion>
       <!--
         Package versions of this category are bound to the target framework, so they cannot be updated to the latest version.
@@ -73,6 +77,24 @@
         Caution: some packages additionally target netstandard, but result in compile-time/runtime errors or reduced API surface.
       -->
       8.0.*
+    </MatchTargetFrameworkVersion>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net9.0'">
+    <FoundationalVersion>
+      <!--
+        Package versions of this category are always safe to update to the latest version, because they multi-target all frameworks.
+        For example, v6 explicitly targets .NET 6; v7 explicitly targets .NET 6 and 7; v8 explicitly targets .NET 6, 7 and 8.
+      -->
+      9.0.*
+    </FoundationalVersion>
+    <MatchTargetFrameworkVersion>
+      <!--
+        Package versions of this category are bound to the target framework, so they cannot be updated to the latest version.
+        For example, v6 targets only .NET 6; v7 targets only .NET 7; v8 targets only .NET 8.
+        Caution: some packages additionally target netstandard, but result in compile-time/runtime errors or reduced API surface.
+      -->
+      9.0.*
     </MatchTargetFrameworkVersion>
   </PropertyGroup>
 </Project>

--- a/versions.props
+++ b/versions.props
@@ -5,42 +5,41 @@
       It's safe to update these at any time, so wildcards are allowed.
     -->
 
-    <AspNetCoreHealthChecksVersion>8.0.*</AspNetCoreHealthChecksVersion>
+    <AspNetCoreHealthChecksVersion>9.0.*</AspNetCoreHealthChecksVersion>
     <CoverletVersion>6.0.*</CoverletVersion>
-    <EntityFrameworkCoreTestVersion>8.0.*</EntityFrameworkCoreTestVersion>
-    <EntityFrameworkCoreMySqlTestVersion>8.0.8</EntityFrameworkCoreMySqlTestVersion>
     <FluentAssertionsJsonVersion>6.1.*</FluentAssertionsJsonVersion>
-    <FluentAssertionsVersion>7.0.*</FluentAssertionsVersion>
-    <MicrosoftAzureCosmosVersion>3.41.*</MicrosoftAzureCosmosVersion>
-    <MicrosoftCodeAnalysisVersion>4.11.0</MicrosoftCodeAnalysisVersion>
-    <MicrosoftSqlClientVersion>5.2.*</MicrosoftSqlClientVersion>
+    <FluentAssertionsVersion>7.1.*</FluentAssertionsVersion>
+    <MicrosoftAzureCosmosVersion>3.46.*</MicrosoftAzureCosmosVersion>
+    <MicrosoftCodeAnalysisVersion>4.12.0</MicrosoftCodeAnalysisVersion>
+    <MicrosoftSqlClientVersion>6.0.*</MicrosoftSqlClientVersion>
     <MockHttpVersion>7.0.*</MockHttpVersion>
-    <MongoDbDriverVersion>2.27.*</MongoDbDriverVersion>
+    <MongoDbDriverVersion>3.1.*</MongoDbDriverVersion>
     <MoqVersion>4.20.69</MoqVersion>
-    <MySqlConnectorVersion>2.3.*</MySqlConnectorVersion>
-    <MySqlDataVersion>9.1.*</MySqlDataVersion>
-    <NerdbankGitVersioningVersion>3.6.*</NerdbankGitVersioningVersion>
+    <MySqlConnectorVersion>2.4.*</MySqlConnectorVersion>
+    <MySqlDataVersion>9.2.*</MySqlDataVersion>
+    <NerdbankGitVersioningVersion>3.7.*</NerdbankGitVersioningVersion>
     <NewtonsoftJsonVersion>13.0.3</NewtonsoftJsonVersion>
     <PublicApiAnalyzersVersion>3.3.*</PublicApiAnalyzersVersion>
-    <RabbitClientTestVersion>6.8.*</RabbitClientTestVersion>
+    <RabbitClientTestVersion>7.0.*</RabbitClientTestVersion>
     <SerilogEnrichersThreadVersion>4.0.*</SerilogEnrichersThreadVersion>
     <SerilogExceptionsVersion>8.4.*</SerilogExceptionsVersion>
     <SonarAnalyzerVersion>9.25.*</SonarAnalyzerVersion>
     <SourceLinkGitHubVersion>8.0.*</SourceLinkGitHubVersion>
     <StyleCopVersion>1.2.0-beta.556</StyleCopVersion>
     <SystemCommandLineVersion>2.0.0-beta4.24324.3</SystemCommandLineVersion>
-    <SystemIdentityModelVersion>8.3.0</SystemIdentityModelVersion>
-    <SystemSqlClientVersion>4.8.*</SystemSqlClientVersion>
-    <SystemTextJsonToolsVersion>9.0.*</SystemTextJsonToolsVersion>
-    <TestSdkVersion>17.10.*</TestSdkVersion>
+    <SystemIdentityModelVersion>8.4.0</SystemIdentityModelVersion>
+    <SystemSqlClientVersion>4.9.*</SystemSqlClientVersion>
+    <TestSdkVersion>17.13.*</TestSdkVersion>
     <XunitAbstractionsVersion>2.0.*</XunitAbstractionsVersion>
-    <XunitVersion>2.8.*</XunitVersion>
+    <XunitVersion>2.9.*</XunitVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <EntityFrameworkCoreTestVersion>8.0.*</EntityFrameworkCoreTestVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'net9.0'">
+    <EntityFrameworkCoreTestVersion>9.0.*-*</EntityFrameworkCoreTestVersion>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -55,21 +54,21 @@
     <ConsulVersion>1.7.14.*</ConsulVersion>
     <DiagnosticsTracingVersion>3.1.16</DiagnosticsTracingVersion>
     <EntityFrameworkCoreVersion>8.0.*</EntityFrameworkCoreVersion>
-    <MicrosoftIdentityModelVersion>7.6.*</MicrosoftIdentityModelVersion>
-    <OpenTelemetryExporterPrometheusVersion>1.9.*-*</OpenTelemetryExporterPrometheusVersion>
-    <OpenTelemetryVersion>1.9.*</OpenTelemetryVersion>
-    <SerilogVersion>8.0.*</SerilogVersion>
-    <SerilogSinksConsoleVersion>6.0.*</SerilogSinksConsoleVersion>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <FoundationalVersion>
       <!--
         Package versions of this category are always safe to update to the latest version, because they multi-target all frameworks.
         For example, v6 explicitly targets .NET 6; v7 explicitly targets .NET 6 and 7; v8 explicitly targets .NET 6, 7 and 8.
       -->
-      8.0.*
+      9.0.*
     </FoundationalVersion>
+    <MicrosoftIdentityModelVersion>8.4.*</MicrosoftIdentityModelVersion>
+    <OpenTelemetryExporterPrometheusVersion>1.11.*-*</OpenTelemetryExporterPrometheusVersion>
+    <OpenTelemetryVersion>1.11.*</OpenTelemetryVersion>
+    <SerilogVersion>8.0.*</SerilogVersion>
+    <SerilogSinksConsoleVersion>6.0.*</SerilogSinksConsoleVersion>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <MatchTargetFrameworkVersion>
       <!--
         Package versions of this category are bound to the target framework, so they cannot be updated to the latest version.
@@ -81,13 +80,6 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'net9.0'">
-    <FoundationalVersion>
-      <!--
-        Package versions of this category are always safe to update to the latest version, because they multi-target all frameworks.
-        For example, v6 explicitly targets .NET 6; v7 explicitly targets .NET 6 and 7; v8 explicitly targets .NET 6, 7 and 8.
-      -->
-      9.0.*
-    </FoundationalVersion>
     <MatchTargetFrameworkVersion>
       <!--
         Package versions of this category are bound to the target framework, so they cannot be updated to the latest version.


### PR DESCRIPTION
## Description

Keep Steeltoe targeting .NET 8, but run all tests against both .NET 8 and .NET 9.
Update NuGet packages to latest versions, except for `DiagnosticsTracingVersion`, which has breaking changes.

Changes in Sonar rules between v9.25.0.90414 and v10.6.0.109712:

| Rule                                                              | Title                                                                                     | Sonar v9.25 | Sonar v10.6 | Change   | Steeltoe main | Main uses default? | Steeltoe PR | PR uses default? | Unchanged in PR?      | Comments                                                                                                                                                |
| ----------------------------------------------------------------- | ----------------------------------------------------------------------------------------- | ----------- | ----------- | -------- | ------------- | ------------------ | ----------- | ---------------- | --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
| [S1694](https://sonarsource.github.io/rspec/#/rspec/S1694/csharp) | An abstract class should have both abstract and concrete methods                          | None        | Warning     | Severity | None          | Yes                | Warning     | Yes              | No (severity changed) | Use new default in Debug/Release, no existing violations                                                                                                |
| [S2053](https://sonarsource.github.io/rspec/#/rspec/S2053/csharp) | Password hashing functions should use an unpredictable salt                               | Warning     |             | Removed  | Warning       | Yes                |             |                  | No (removed rule)     |                                                                                                                                                         |
| [S2222](https://sonarsource.github.io/rspec/#/rspec/S2222/csharp) | Locks should be released on all paths                                                     | Warning     |             | Removed  | Warning       | Yes                |             |                  | No (removed rule)     |                                                                                                                                                         |
| [S2259](https://sonarsource.github.io/rspec/#/rspec/S2259/csharp) | Null pointers should not be dereferenced                                                  | Warning     |             | Removed  | Warning       | Yes                |             |                  | No (removed rule)     |                                                                                                                                                         |
| [S2325](https://sonarsource.github.io/rspec/#/rspec/S2325/csharp) | Methods and properties that don't access instance data should be static                   | None        | Warning     | Severity | None          | Yes                | None        | No               | Yes                   | Keep turned off in Debug/Release, silly rule                                                                                                            |
| [S2583](https://sonarsource.github.io/rspec/#/rspec/S2583/csharp) | Conditionally executed code should be reachable                                           | Warning     |             | Removed  | Warning       | Yes                |             |                  | No (removed rule)     | Had severity Info in Debug                                                                                                                              |
| [S2589](https://sonarsource.github.io/rspec/#/rspec/S2589/csharp) | Boolean expressions should not be gratuitous                                              | Warning     |             | Removed  | Warning       | Yes                |             |                  | No (removed rule)     | Had severity Info in Debug                                                                                                                              |
| [S2674](https://sonarsource.github.io/rspec/#/rspec/S2674/csharp) | The length returned from a stream read should be checked                                  | None        | Warning     | Severity | Warning       | No                 | Warning     | Yes              | Yes                   |                                                                                                                                                         |
| [S3329](https://sonarsource.github.io/rspec/#/rspec/S3329/csharp) | Cipher Block Chaining IVs should be unpredictable                                         | Warning     |             | Removed  | Warning       | Yes                |             |                  | No (removed rule)     |                                                                                                                                                         |
| [S3431](https://sonarsource.github.io/rspec/#/rspec/S3431/csharp) | "[ExpectedException]" should not be used                                                  | None        | Warning     | Severity | None          | Yes                | Warning     | Yes              | No (severity changed) | Use new default in Debug/Release, no existing violations                                                                                                |
| [S3655](https://sonarsource.github.io/rspec/#/rspec/S3655/csharp) | Empty nullable value should not be accessed                                               | Warning     |             | Removed  | Warning       | Yes                |             |                  | No (removed rule)     |                                                                                                                                                         |
| [S3900](https://sonarsource.github.io/rspec/#/rspec/S3900/csharp) | Arguments of public methods should be validated against null                              | None        |             | Removed  | Warning       | No                 |             |                  | No (removed rule)     | Had severity None in Debug, replaced with [CA1062](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1062) in Release |
| [S3949](https://sonarsource.github.io/rspec/#/rspec/S3949/csharp) | Calculations should not overflow                                                          | Warning     |             | Removed  | Warning       | Yes                |             |                  | No (removed rule)     |                                                                                                                                                         |
| [S3966](https://sonarsource.github.io/rspec/#/rspec/S3966/csharp) | Objects should not be disposed more than once                                             | Warning     |             | Removed  | Warning       | Yes                |             |                  | No (removed rule)     |                                                                                                                                                         |
| [S3993](https://sonarsource.github.io/rspec/#/rspec/S3993/csharp) | Custom attributes should be marked with "System.AttributeUsageAttribute"                  | None        | Warning     | Severity | Warning       | No                 | Warning     | Yes              | Yes                   |                                                                                                                                                         |
| [S4050](https://sonarsource.github.io/rspec/#/rspec/S4050/csharp) | Operators should be overloaded consistently                                               | None        | Warning     | Severity | None          | Yes                | Warning     | Yes              | No (severity changed) | Use new default in Debug/Release, no existing violations                                                                                                |
| [S4052](https://sonarsource.github.io/rspec/#/rspec/S4052/csharp) | Types should not extend outdated base types                                               | None        | Warning     | Severity | None          | Yes                | Warning     | Yes              | No (severity changed) | Use new default in Debug/Release, no existing violations                                                                                                |
| [S4158](https://sonarsource.github.io/rspec/#/rspec/S4158/csharp) | Empty collections should not be accessed or iterated                                      | Warning     |             | Removed  | Warning       | Yes                |             |                  | No (removed rule)     |                                                                                                                                                         |
| [S5344](https://sonarsource.github.io/rspec/#/rspec/S5344/csharp) | Passwords should not be stored in plaintext or with a fast hashing algorithm              |             | Warning     | Added    |               |                    | Warning     | Yes              | No (new rule)         | Use new default in Debug/Release, suppressed one violation                                                                                              |
| [S5773](https://sonarsource.github.io/rspec/#/rspec/S5773/csharp) | Types allowed to be deserialized should be restricted                                     | Warning     |             | Removed  | None          | No                 |             |                  | No (removed rule)     |                                                                                                                                                         |
| [S6377](https://sonarsource.github.io/rspec/#/rspec/S6377/csharp) | XML signatures should be validated securely                                               |             | Warning     | Added    |               |                    | Warning     | Yes              | No (new rule)         | Use new default in Debug/Release, no existing violations                                                                                                |
| [S6418](https://sonarsource.github.io/rspec/#/rspec/S6418/csharp) | Hard-coded secrets are security-sensitive                                                 |             | Warning     | Added    |               |                    | Warning     | Yes              | No (new rule)         | Use new default in Debug/Release, no existing violations                                                                                                |
| [S6602](https://sonarsource.github.io/rspec/#/rspec/S6602/csharp) | "Find" method should be used instead of the "FirstOrDefault" extension                    | Warning     | None        | Severity | Warning       | Yes                | Warning     | No               | Yes                   | Keep turned on in Debug/Release, rationale doesn't apply to .NET 8                                                                                      |
| [S6603](https://sonarsource.github.io/rspec/#/rspec/S6603/csharp) | The collection-specific "TrueForAll" method should be used instead of the "All" extension | Warning     | None        | Severity | Warning       | Yes                | Warning     | No               | Yes                   | Keep turned on in Debug/Release, rationale doesn't apply to .NET 8                                                                                      |
| [S6605](https://sonarsource.github.io/rspec/#/rspec/S6605/csharp) | Collection-specific "Exists" method should be used instead of the "Any" extension         | Warning     | None        | Severity | Warning       | Yes                | Warning     | No               | Yes                   | Keep turned on in Debug/Release, rationale doesn't apply to .NET 8                                                                                      |
| [S6932](https://sonarsource.github.io/rspec/#/rspec/S6932/csharp) | Use model binding instead of reading raw request data                                     |             | Warning     | Added    |               |                    | Warning     | Yes              | No (new rule)         | Use new default in Debug/Release, no existing violations                                                                                                |
| [S7039](https://sonarsource.github.io/rspec/#/rspec/S7039/csharp) | Content Security Policies should be restrictive                                           |             | Warning     | Added    |               |                    | Warning     | Yes              | No (new rule)         | Use new default in Debug/Release, no existing violations                                                                                                |

Fixes #1456, fixes #924.

## Quality checklist

- [x] Your code complies with our [Coding Style](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-code-style.md).
- [x] You've updated unit and/or integration tests for your change, where applicable.
- [ ] You've updated documentation for your change, where applicable.
      If your change affects other repositories, such as [Documentation](https://github.com/SteeltoeOSS/Documentation), [Samples](https://github.com/SteeltoeOSS/Samples) and/or [MainSite](https://github.com/SteeltoeOSS/MainSite), add linked PRs here.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
- [ ] You've added required license files and/or file headers (explaining where the code came from with proper attribution), where code is copied from StackOverflow, a blog, or OSS.
