### PR TITLE
Refactor actuator middleware (separation of concerns)

### DIFF
--- a/shared-package.props
+++ b/shared-package.props
@@ -7,7 +7,7 @@
       Taking the suggestion TODAY produces List<string>(), but the spec doesn't require that, so the compiler may change it over time.
       As a result, callers that cast back to List<string> will face a breaking change.
      -->
-    <NoWarn>$(NoWarn);CS1591;IDE0028;IDE0300;IDE0301;IDE0302;IDE0303;IDE0304;IDE0305</NoWarn>
+    <NoWarn>$(NoWarn);CS1591;IDE0028;IDE0300;IDE0301;IDE0302;IDE0303;IDE0304;IDE0305;IDE0306</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 

--- a/src/Bootstrap/test/AutoConfiguration.Test/HostBuilderExtensionsTest.cs
+++ b/src/Bootstrap/test/AutoConfiguration.Test/HostBuilderExtensionsTest.cs
@@ -351,7 +351,7 @@ public sealed class HostBuilderExtensionsTest
 
     private static async Task AssertAllActuatorsAreAutowiredAsync(HostWrapper hostWrapper, bool expectHealthy)
     {
-        hostWrapper.Services.GetServices<IActuatorEndpointHandler>().Should().ContainSingle();
+        hostWrapper.Services.GetServices<IHypermediaEndpointHandler>().Should().ContainSingle();
         hostWrapper.Services.GetServices<IStartupFilter>().OfType<ConfigureActuatorsMiddlewareStartupFilter>().Should().ContainSingle();
 
         if (hostWrapper.Services.GetService<IServer>() != null)

--- a/src/Management/src/Endpoint/Actuators/DbMigrations/DbMigrationsEndpointMiddleware.cs
+++ b/src/Management/src/Endpoint/Actuators/DbMigrations/DbMigrationsEndpointMiddleware.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Steeltoe.Management.Endpoint.Configuration;
@@ -14,9 +13,8 @@ internal sealed class DbMigrationsEndpointMiddleware(
     IDbMigrationsEndpointHandler endpointHandler, IOptionsMonitor<ManagementOptions> managementOptionsMonitor, ILoggerFactory loggerFactory)
     : EndpointMiddleware<object?, Dictionary<string, DbMigrationsDescriptor>>(endpointHandler, managementOptionsMonitor, loggerFactory)
 {
-    protected override async Task<Dictionary<string, DbMigrationsDescriptor>> InvokeEndpointHandlerAsync(HttpContext context,
-        CancellationToken cancellationToken)
+    protected override async Task<Dictionary<string, DbMigrationsDescriptor>> InvokeEndpointHandlerAsync(object? request, CancellationToken cancellationToken)
     {
-        return await EndpointHandler.InvokeAsync(null, cancellationToken);
+        return await EndpointHandler.InvokeAsync(request, cancellationToken);
     }
 }

--- a/src/Management/src/Endpoint/Actuators/Environment/EnvironmentEndpointMiddleware.cs
+++ b/src/Management/src/Endpoint/Actuators/Environment/EnvironmentEndpointMiddleware.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Steeltoe.Management.Endpoint.Configuration;
@@ -14,8 +13,8 @@ internal sealed class EnvironmentEndpointMiddleware(
     IEnvironmentEndpointHandler endpointHandler, IOptionsMonitor<ManagementOptions> managementOptionsMonitor, ILoggerFactory loggerFactory)
     : EndpointMiddleware<object?, EnvironmentResponse>(endpointHandler, managementOptionsMonitor, loggerFactory)
 {
-    protected override async Task<EnvironmentResponse> InvokeEndpointHandlerAsync(HttpContext context, CancellationToken cancellationToken)
+    protected override async Task<EnvironmentResponse> InvokeEndpointHandlerAsync(object? request, CancellationToken cancellationToken)
     {
-        return await EndpointHandler.InvokeAsync(null, context.RequestAborted);
+        return await EndpointHandler.InvokeAsync(request, cancellationToken);
     }
 }

--- a/src/Management/src/Endpoint/Actuators/Health/Availability/LivenessStateHealthContributor.cs
+++ b/src/Management/src/Endpoint/Actuators/Health/Availability/LivenessStateHealthContributor.cs
@@ -8,7 +8,7 @@ using Steeltoe.Common.HealthChecks;
 
 namespace Steeltoe.Management.Endpoint.Actuators.Health.Availability;
 
-internal sealed class LivenessStateContributor : AvailabilityStateHealthContributor
+internal sealed class LivenessStateHealthContributor : AvailabilityStateHealthContributor
 {
     private readonly ApplicationAvailability _availability;
     private readonly IOptionsMonitor<LivenessStateContributorOptions> _optionsMonitor;
@@ -17,7 +17,7 @@ internal sealed class LivenessStateContributor : AvailabilityStateHealthContribu
 
     public override string Id => "livenessState";
 
-    public LivenessStateContributor(ApplicationAvailability availability, IOptionsMonitor<LivenessStateContributorOptions> optionsMonitor,
+    public LivenessStateHealthContributor(ApplicationAvailability availability, IOptionsMonitor<LivenessStateContributorOptions> optionsMonitor,
         ILoggerFactory loggerFactory)
         : base(new Dictionary<AvailabilityState, HealthStatus>
         {

--- a/src/Management/src/Endpoint/Actuators/Health/Availability/ReadinessStateHealthContributor.cs
+++ b/src/Management/src/Endpoint/Actuators/Health/Availability/ReadinessStateHealthContributor.cs
@@ -8,7 +8,7 @@ using Steeltoe.Common.HealthChecks;
 
 namespace Steeltoe.Management.Endpoint.Actuators.Health.Availability;
 
-internal sealed class ReadinessStateContributor : AvailabilityStateHealthContributor
+internal sealed class ReadinessStateHealthContributor : AvailabilityStateHealthContributor
 {
     private readonly ApplicationAvailability _availability;
     private readonly IOptionsMonitor<ReadinessStateContributorOptions> _optionsMonitor;
@@ -17,7 +17,7 @@ internal sealed class ReadinessStateContributor : AvailabilityStateHealthContrib
 
     public override string Id => "readinessState";
 
-    public ReadinessStateContributor(ApplicationAvailability availability, IOptionsMonitor<ReadinessStateContributorOptions> optionsMonitor,
+    public ReadinessStateHealthContributor(ApplicationAvailability availability, IOptionsMonitor<ReadinessStateContributorOptions> optionsMonitor,
         ILoggerFactory loggerFactory)
         : base(new Dictionary<AvailabilityState, HealthStatus>
         {

--- a/src/Management/src/Endpoint/Actuators/Health/Contributors/DiskSpaceHealthContributor.cs
+++ b/src/Management/src/Endpoint/Actuators/Health/Contributors/DiskSpaceHealthContributor.cs
@@ -7,13 +7,13 @@ using Steeltoe.Common.HealthChecks;
 
 namespace Steeltoe.Management.Endpoint.Actuators.Health.Contributors;
 
-internal sealed class DiskSpaceContributor : IHealthContributor
+internal sealed class DiskSpaceHealthContributor : IHealthContributor
 {
     private readonly IOptionsMonitor<DiskSpaceContributorOptions> _optionsMonitor;
 
     public string Id => "diskSpace";
 
-    public DiskSpaceContributor(IOptionsMonitor<DiskSpaceContributorOptions> optionsMonitor)
+    public DiskSpaceHealthContributor(IOptionsMonitor<DiskSpaceContributorOptions> optionsMonitor)
     {
         ArgumentNullException.ThrowIfNull(optionsMonitor);
 

--- a/src/Management/src/Endpoint/Actuators/Health/Contributors/PingHealthContributor.cs
+++ b/src/Management/src/Endpoint/Actuators/Health/Contributors/PingHealthContributor.cs
@@ -7,13 +7,13 @@ using Steeltoe.Common.HealthChecks;
 
 namespace Steeltoe.Management.Endpoint.Actuators.Health.Contributors;
 
-internal sealed class PingContributor : IHealthContributor
+internal sealed class PingHealthContributor : IHealthContributor
 {
     private readonly IOptionsMonitor<PingContributorOptions> _optionsMonitor;
 
     public string Id => "ping";
 
-    public PingContributor(IOptionsMonitor<PingContributorOptions> optionsMonitor)
+    public PingHealthContributor(IOptionsMonitor<PingContributorOptions> optionsMonitor)
     {
         ArgumentNullException.ThrowIfNull(optionsMonitor);
 

--- a/src/Management/src/Endpoint/Actuators/Health/EndpointServiceCollectionExtensions.cs
+++ b/src/Management/src/Endpoint/Actuators/Health/EndpointServiceCollectionExtensions.cs
@@ -58,19 +58,19 @@ public static class EndpointServiceCollectionExtensions
     private static void RegisterDefaultHealthContributors(IServiceCollection services)
     {
         services.ConfigureOptionsWithChangeTokenSource<DiskSpaceContributorOptions, ConfigureDiskSpaceContributorOptions>();
-        AddHealthContributor<DiskSpaceContributor>(services);
+        AddHealthContributor<DiskSpaceHealthContributor>(services);
 
         services.ConfigureOptionsWithChangeTokenSource<PingContributorOptions, ConfigurePingContributorOptions>();
-        AddHealthContributor<PingContributor>(services);
+        AddHealthContributor<PingHealthContributor>(services);
 
         services.TryAddSingleton<ApplicationAvailability>();
         services.TryAddEnumerable(ServiceDescriptor.Transient<IStartupFilter, AvailabilityStartupFilter>());
 
         services.ConfigureOptionsWithChangeTokenSource<LivenessStateContributorOptions, ConfigureLivenessStateContributorOptions>();
-        AddHealthContributor<LivenessStateContributor>(services);
+        AddHealthContributor<LivenessStateHealthContributor>(services);
 
         services.ConfigureOptionsWithChangeTokenSource<ReadinessStateContributorOptions, ConfigureReadinessStateContributorOptions>();
-        AddHealthContributor<ReadinessStateContributor>(services);
+        AddHealthContributor<ReadinessStateHealthContributor>(services);
     }
 
     /// <summary>

--- a/src/Management/src/Endpoint/Actuators/HttpExchanges/HttpExchangesEndpointMiddleware.cs
+++ b/src/Management/src/Endpoint/Actuators/HttpExchanges/HttpExchangesEndpointMiddleware.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Steeltoe.Management.Endpoint.Configuration;
@@ -14,8 +13,8 @@ internal sealed class HttpExchangesEndpointMiddleware(
     IHttpExchangesEndpointHandler endpointHandler, IOptionsMonitor<ManagementOptions> managementOptionsMonitor, ILoggerFactory loggerFactory)
     : EndpointMiddleware<object?, HttpExchangesResult>(endpointHandler, managementOptionsMonitor, loggerFactory)
 {
-    protected override async Task<HttpExchangesResult> InvokeEndpointHandlerAsync(HttpContext context, CancellationToken cancellationToken)
+    protected override async Task<HttpExchangesResult> InvokeEndpointHandlerAsync(object? request, CancellationToken cancellationToken)
     {
-        return await EndpointHandler.InvokeAsync(null, cancellationToken);
+        return await EndpointHandler.InvokeAsync(request, cancellationToken);
     }
 }

--- a/src/Management/src/Endpoint/Actuators/Hypermedia/EndpointServiceCollectionExtensions.cs
+++ b/src/Management/src/Endpoint/Actuators/Hypermedia/EndpointServiceCollectionExtensions.cs
@@ -40,7 +40,7 @@ public static class EndpointServiceCollectionExtensions
         ArgumentNullException.ThrowIfNull(services);
 
         services.AddCoreActuatorServices<HypermediaEndpointOptions, ConfigureHypermediaEndpointOptions, HypermediaEndpointMiddleware,
-            IActuatorEndpointHandler, ActuatorEndpointHandler, string, Links>(configureMiddleware);
+            IHypermediaEndpointHandler, HypermediaEndpointHandler, string, Links>(configureMiddleware);
 
         return services;
     }

--- a/src/Management/src/Endpoint/Actuators/Hypermedia/HypermediaEndpointHandler.cs
+++ b/src/Management/src/Endpoint/Actuators/Hypermedia/HypermediaEndpointHandler.cs
@@ -13,7 +13,7 @@ namespace Steeltoe.Management.Endpoint.Actuators.Hypermedia;
 /// <summary>
 /// Provides the hypermedia link collection for all registered and enabled actuators.
 /// </summary>
-internal sealed class ActuatorEndpointHandler : IActuatorEndpointHandler
+internal sealed class HypermediaEndpointHandler : IHypermediaEndpointHandler
 {
     private readonly IOptionsMonitor<ManagementOptions> _managementOptionsMonitor;
     private readonly IOptionsMonitor<HypermediaEndpointOptions> _endpointOptionsMonitor;
@@ -22,7 +22,7 @@ internal sealed class ActuatorEndpointHandler : IActuatorEndpointHandler
 
     public EndpointOptions Options => _endpointOptionsMonitor.CurrentValue;
 
-    public ActuatorEndpointHandler(IOptionsMonitor<ManagementOptions> managementOptionsMonitor,
+    public HypermediaEndpointHandler(IOptionsMonitor<ManagementOptions> managementOptionsMonitor,
         IOptionsMonitor<HypermediaEndpointOptions> endpointOptionsMonitor, IEnumerable<IEndpointOptionsMonitorProvider> endpointOptionsMonitorProviders,
         ILoggerFactory loggerFactory)
     {

--- a/src/Management/src/Endpoint/Actuators/Hypermedia/HypermediaEndpointMiddleware.cs
+++ b/src/Management/src/Endpoint/Actuators/Hypermedia/HypermediaEndpointMiddleware.cs
@@ -12,7 +12,7 @@ using Steeltoe.Management.Endpoint.Middleware;
 namespace Steeltoe.Management.Endpoint.Actuators.Hypermedia;
 
 internal sealed class HypermediaEndpointMiddleware(
-    IActuatorEndpointHandler endpointHandler, IOptionsMonitor<ManagementOptions> managementOptionsMonitor, ILoggerFactory loggerFactory)
+    IHypermediaEndpointHandler endpointHandler, IOptionsMonitor<ManagementOptions> managementOptionsMonitor, ILoggerFactory loggerFactory)
     : EndpointMiddleware<string, Links>(endpointHandler, managementOptionsMonitor, loggerFactory)
 {
     protected override Task<string?> ParseRequestAsync(HttpContext httpContext, CancellationToken cancellationToken)

--- a/src/Management/src/Endpoint/Actuators/Hypermedia/IHypermediaEndpointHandler.cs
+++ b/src/Management/src/Endpoint/Actuators/Hypermedia/IHypermediaEndpointHandler.cs
@@ -4,4 +4,4 @@
 
 namespace Steeltoe.Management.Endpoint.Actuators.Hypermedia;
 
-public interface IActuatorEndpointHandler : IEndpointHandler<string, Links>;
+public interface IHypermediaEndpointHandler : IEndpointHandler<string, Links>;

--- a/src/Management/src/Endpoint/Actuators/Info/InfoEndpointMiddleware.cs
+++ b/src/Management/src/Endpoint/Actuators/Info/InfoEndpointMiddleware.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Steeltoe.Management.Endpoint.Configuration;
@@ -14,8 +13,8 @@ internal sealed class InfoEndpointMiddleware(
     IInfoEndpointHandler endpointHandler, IOptionsMonitor<ManagementOptions> managementOptionsMonitor, ILoggerFactory loggerFactory)
     : EndpointMiddleware<object?, IDictionary<string, object>>(endpointHandler, managementOptionsMonitor, loggerFactory)
 {
-    protected override async Task<IDictionary<string, object>> InvokeEndpointHandlerAsync(HttpContext context, CancellationToken cancellationToken)
+    protected override async Task<IDictionary<string, object>> InvokeEndpointHandlerAsync(object? request, CancellationToken cancellationToken)
     {
-        return await EndpointHandler.InvokeAsync(null, cancellationToken);
+        return await EndpointHandler.InvokeAsync(request, cancellationToken);
     }
 }

--- a/src/Management/src/Endpoint/Actuators/Refresh/RefreshEndpointMiddleware.cs
+++ b/src/Management/src/Endpoint/Actuators/Refresh/RefreshEndpointMiddleware.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Steeltoe.Management.Endpoint.Configuration;
@@ -19,8 +18,8 @@ internal sealed class RefreshEndpointMiddleware(
         return new RefreshActuatorMetadataProvider(ContentType);
     }
 
-    protected override async Task<IList<string>> InvokeEndpointHandlerAsync(HttpContext context, CancellationToken cancellationToken)
+    protected override async Task<IList<string>> InvokeEndpointHandlerAsync(object? request, CancellationToken cancellationToken)
     {
-        return await EndpointHandler.InvokeAsync(null, cancellationToken);
+        return await EndpointHandler.InvokeAsync(request, cancellationToken);
     }
 }

--- a/src/Management/src/Endpoint/Actuators/RouteMappings/RouteMappingsEndpointMiddleware.cs
+++ b/src/Management/src/Endpoint/Actuators/RouteMappings/RouteMappingsEndpointMiddleware.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Steeltoe.Management.Endpoint.Actuators.RouteMappings.ResponseTypes;
@@ -19,10 +18,10 @@ internal sealed class RouteMappingsEndpointMiddleware(
     : EndpointMiddleware<object?, RouteMappingsResponse>(endpointHandler, managementOptionsMonitor, loggerFactory)
 {
     // There is no difference between v2 and v3 responses. This override is a workaround for Spring Boot Admin: https://github.com/codecentric/spring-boot-admin/issues/4001.
-    private protected override string ContentType { get; } = "application/vnd.spring-boot.actuator.v2+json";
+    private protected override string ContentType => "application/vnd.spring-boot.actuator.v2+json";
 
-    protected override async Task<RouteMappingsResponse> InvokeEndpointHandlerAsync(HttpContext context, CancellationToken cancellationToken)
+    protected override async Task<RouteMappingsResponse> InvokeEndpointHandlerAsync(object? request, CancellationToken cancellationToken)
     {
-        return await EndpointHandler.InvokeAsync(null, context.RequestAborted);
+        return await EndpointHandler.InvokeAsync(request, cancellationToken);
     }
 }

--- a/src/Management/src/Endpoint/Actuators/Services/ServicesEndpointMiddleware.cs
+++ b/src/Management/src/Endpoint/Actuators/Services/ServicesEndpointMiddleware.cs
@@ -9,7 +9,7 @@ using Steeltoe.Management.Endpoint.Middleware;
 
 namespace Steeltoe.Management.Endpoint.Actuators.Services;
 
-public sealed class ServicesEndpointMiddleware(
+internal sealed class ServicesEndpointMiddleware(
     IServicesEndpointHandler endpointHandler, IOptionsMonitor<ManagementOptions> managementOptionsMonitor, ILoggerFactory loggerFactory)
     : EndpointMiddleware<object?, IList<ServiceRegistration>>(endpointHandler, managementOptionsMonitor, loggerFactory)
 {

--- a/src/Management/src/Endpoint/Actuators/Services/ServicesEndpointMiddleware.cs
+++ b/src/Management/src/Endpoint/Actuators/Services/ServicesEndpointMiddleware.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Steeltoe.Management.Endpoint.Configuration;
@@ -14,8 +13,8 @@ public sealed class ServicesEndpointMiddleware(
     IServicesEndpointHandler endpointHandler, IOptionsMonitor<ManagementOptions> managementOptionsMonitor, ILoggerFactory loggerFactory)
     : EndpointMiddleware<object?, IList<ServiceRegistration>>(endpointHandler, managementOptionsMonitor, loggerFactory)
 {
-    protected override async Task<IList<ServiceRegistration>> InvokeEndpointHandlerAsync(HttpContext context, CancellationToken cancellationToken)
+    protected override async Task<IList<ServiceRegistration>> InvokeEndpointHandlerAsync(object? request, CancellationToken cancellationToken)
     {
-        return await EndpointHandler.InvokeAsync(null, cancellationToken);
+        return await EndpointHandler.InvokeAsync(request, cancellationToken);
     }
 }

--- a/src/Management/src/Endpoint/Actuators/ThreadDump/EventPipeThreadDumper.cs
+++ b/src/Management/src/Endpoint/Actuators/ThreadDump/EventPipeThreadDumper.cs
@@ -19,7 +19,7 @@ namespace Steeltoe.Management.Endpoint.Actuators.ThreadDump;
 /// <summary>
 /// Thread dumper that uses the EventPipe to acquire the call stacks of all the running threads.
 /// </summary>
-public sealed class EventPipeThreadDumper
+internal sealed class EventPipeThreadDumper
 {
     private static readonly StackTraceElement UnknownStackTraceElement = new()
     {

--- a/src/Management/src/Endpoint/Actuators/ThreadDump/ThreadDumpEndpointMiddleware.cs
+++ b/src/Management/src/Endpoint/Actuators/ThreadDump/ThreadDumpEndpointMiddleware.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Steeltoe.Management.Endpoint.Configuration;
@@ -14,12 +13,8 @@ internal sealed class ThreadDumpEndpointMiddleware(
     IThreadDumpEndpointHandler endpointHandler, IOptionsMonitor<ManagementOptions> managementOptionsMonitor, ILoggerFactory loggerFactory)
     : EndpointMiddleware<object?, IList<ThreadInfo>>(endpointHandler, managementOptionsMonitor, loggerFactory)
 {
-    private readonly ILogger<ThreadDumpEndpointMiddleware> _logger = loggerFactory.CreateLogger<ThreadDumpEndpointMiddleware>();
-
-    protected override async Task<IList<ThreadInfo>> InvokeEndpointHandlerAsync(HttpContext context, CancellationToken cancellationToken)
+    protected override async Task<IList<ThreadInfo>> InvokeEndpointHandlerAsync(object? request, CancellationToken cancellationToken)
     {
-        _logger.LogDebug("Executing ThreadDumpHandler");
-
-        return await EndpointHandler.InvokeAsync(null, cancellationToken);
+        return await EndpointHandler.InvokeAsync(request, cancellationToken);
     }
 }

--- a/src/Management/src/Endpoint/CoreActuatorServiceCollectionExtensions.cs
+++ b/src/Management/src/Endpoint/CoreActuatorServiceCollectionExtensions.cs
@@ -33,15 +33,15 @@ public static class CoreActuatorServiceCollectionExtensions
     /// The actuator-specific <see cref="IEndpointMiddleware" />.
     /// </typeparam>
     /// <typeparam name="TEndpointHandlerInterface">
-    /// The actuator-specific <see cref="IEndpointHandler{TArgument, TResult}" /> interface.
+    /// The actuator-specific <see cref="IEndpointHandler{TRequest, TResponse}" /> interface.
     /// </typeparam>
     /// <typeparam name="TEndpointHandler">
-    /// The actuator-specific <see cref="IEndpointHandler{TArgument, TResult}" /> implementation.
+    /// The actuator-specific <see cref="IEndpointHandler{TRequest, TResponse}" /> implementation.
     /// </typeparam>
-    /// <typeparam name="TArgument">
+    /// <typeparam name="TRequest">
     /// The actuator-specific endpoint handler input type.
     /// </typeparam>
-    /// <typeparam name="TResult">
+    /// <typeparam name="TResponse">
     /// The actuator-specific endpoint handler output type.
     /// </typeparam>
     /// <param name="services">
@@ -55,11 +55,11 @@ public static class CoreActuatorServiceCollectionExtensions
     /// The incoming <paramref name="services" /> so that additional calls can be chained.
     /// </returns>
     public static IServiceCollection AddCoreActuatorServices<TEndpointOptions, TConfigureEndpointOptions, TMiddleware, TEndpointHandlerInterface,
-        TEndpointHandler, TArgument, TResult>(this IServiceCollection services, bool configureMiddleware)
+        TEndpointHandler, TRequest, TResponse>(this IServiceCollection services, bool configureMiddleware)
         where TEndpointOptions : EndpointOptions
         where TConfigureEndpointOptions : class, IConfigureOptionsWithKey<TEndpointOptions>
         where TMiddleware : class, IEndpointMiddleware
-        where TEndpointHandlerInterface : class, IEndpointHandler<TArgument, TResult>
+        where TEndpointHandlerInterface : class, IEndpointHandler<TRequest, TResponse>
         where TEndpointHandler : class, TEndpointHandlerInterface
     {
         ArgumentNullException.ThrowIfNull(services);

--- a/src/Management/src/Endpoint/IEndpointHandler.cs
+++ b/src/Management/src/Endpoint/IEndpointHandler.cs
@@ -6,9 +6,9 @@ using Steeltoe.Management.Configuration;
 
 namespace Steeltoe.Management.Endpoint;
 
-public interface IEndpointHandler<in TArgument, TResult>
+public interface IEndpointHandler<in TRequest, TResponse>
 {
     EndpointOptions Options { get; }
 
-    Task<TResult> InvokeAsync(TArgument argument, CancellationToken cancellationToken);
+    Task<TResponse> InvokeAsync(TRequest argument, CancellationToken cancellationToken);
 }

--- a/src/Management/src/Endpoint/PublicAPI.Unshipped.txt
+++ b/src/Management/src/Endpoint/PublicAPI.Unshipped.txt
@@ -362,9 +362,6 @@ Steeltoe.Management.Endpoint.Actuators.Services.ServicesEndpointMiddleware.Servi
 Steeltoe.Management.Endpoint.Actuators.Services.ServicesEndpointOptions
 Steeltoe.Management.Endpoint.Actuators.Services.ServicesEndpointOptions.ServicesEndpointOptions() -> void
 Steeltoe.Management.Endpoint.Actuators.ThreadDump.EndpointServiceCollectionExtensions
-Steeltoe.Management.Endpoint.Actuators.ThreadDump.EventPipeThreadDumper
-Steeltoe.Management.Endpoint.Actuators.ThreadDump.EventPipeThreadDumper.DumpThreadsAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IList<Steeltoe.Management.Endpoint.Actuators.ThreadDump.ThreadInfo!>!>!
-Steeltoe.Management.Endpoint.Actuators.ThreadDump.EventPipeThreadDumper.EventPipeThreadDumper(Microsoft.Extensions.Options.IOptionsMonitor<Steeltoe.Management.Endpoint.Actuators.ThreadDump.ThreadDumpEndpointOptions!>! optionsMonitor, Microsoft.Extensions.Logging.ILogger<Steeltoe.Management.Endpoint.Actuators.ThreadDump.EventPipeThreadDumper!>! logger) -> void
 Steeltoe.Management.Endpoint.Actuators.ThreadDump.IThreadDumpEndpointHandler
 Steeltoe.Management.Endpoint.Actuators.ThreadDump.StackTraceElement
 Steeltoe.Management.Endpoint.Actuators.ThreadDump.StackTraceElement.ClassName.get -> string?

--- a/src/Management/src/Endpoint/PublicAPI.Unshipped.txt
+++ b/src/Management/src/Endpoint/PublicAPI.Unshipped.txt
@@ -357,8 +357,6 @@ Steeltoe.Management.Endpoint.Actuators.Services.ServiceRegistration.Key.get -> s
 Steeltoe.Management.Endpoint.Actuators.Services.ServiceRegistration.Scope.get -> string!
 Steeltoe.Management.Endpoint.Actuators.Services.ServiceRegistration.ServiceRegistration(Microsoft.Extensions.DependencyInjection.ServiceDescriptor! descriptor) -> void
 Steeltoe.Management.Endpoint.Actuators.Services.ServiceRegistration.Type.get -> string!
-Steeltoe.Management.Endpoint.Actuators.Services.ServicesEndpointMiddleware
-Steeltoe.Management.Endpoint.Actuators.Services.ServicesEndpointMiddleware.ServicesEndpointMiddleware(Steeltoe.Management.Endpoint.Actuators.Services.IServicesEndpointHandler! endpointHandler, Microsoft.Extensions.Options.IOptionsMonitor<Steeltoe.Management.Endpoint.Configuration.ManagementOptions!>! managementOptionsMonitor, Microsoft.Extensions.Logging.ILoggerFactory! loggerFactory) -> void
 Steeltoe.Management.Endpoint.Actuators.Services.ServicesEndpointOptions
 Steeltoe.Management.Endpoint.Actuators.Services.ServicesEndpointOptions.ServicesEndpointOptions() -> void
 Steeltoe.Management.Endpoint.Actuators.ThreadDump.EndpointServiceCollectionExtensions

--- a/src/Management/src/Endpoint/PublicAPI.Unshipped.txt
+++ b/src/Management/src/Endpoint/PublicAPI.Unshipped.txt
@@ -1,5 +1,5 @@
 #nullable enable
-abstract Steeltoe.Management.Endpoint.Middleware.EndpointMiddleware<TArgument, TResult>.InvokeEndpointHandlerAsync(Microsoft.AspNetCore.Http.HttpContext! context, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<TResult>!
+abstract Steeltoe.Management.Endpoint.Middleware.EndpointMiddleware<TRequest, TResponse>.InvokeEndpointHandlerAsync(TRequest? request, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<TResponse>!
 const Steeltoe.Management.Endpoint.Actuators.Health.Availability.ApplicationAvailability.LivenessKey = "Liveness" -> string!
 const Steeltoe.Management.Endpoint.Actuators.Health.Availability.ApplicationAvailability.ReadinessKey = "Readiness" -> string!
 override Steeltoe.Management.Endpoint.Actuators.Health.Availability.AvailabilityState.ToString() -> string!
@@ -53,7 +53,7 @@ static Steeltoe.Management.Endpoint.ApplicationBuilderExtensions.UseActuatorEndp
 static Steeltoe.Management.Endpoint.ApplicationBuilderExtensions.UseActuatorEndpoints(this Microsoft.AspNetCore.Builder.IApplicationBuilder! builder, System.Action<Microsoft.AspNetCore.Builder.IEndpointConventionBuilder!>? configureEndpoints) -> Microsoft.AspNetCore.Builder.IApplicationBuilder!
 static Steeltoe.Management.Endpoint.ApplicationBuilderExtensions.UseActuatorsCorsPolicy(this Microsoft.AspNetCore.Builder.IApplicationBuilder! builder) -> Microsoft.AspNetCore.Builder.IApplicationBuilder!
 static Steeltoe.Management.Endpoint.ApplicationBuilderExtensions.UseManagementPort(this Microsoft.AspNetCore.Builder.IApplicationBuilder! builder) -> Microsoft.AspNetCore.Builder.IApplicationBuilder!
-static Steeltoe.Management.Endpoint.CoreActuatorServiceCollectionExtensions.AddCoreActuatorServices<TEndpointOptions, TConfigureEndpointOptions, TMiddleware, TEndpointHandlerInterface, TEndpointHandler, TArgument, TResult>(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services, bool configureMiddleware) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
+static Steeltoe.Management.Endpoint.CoreActuatorServiceCollectionExtensions.AddCoreActuatorServices<TEndpointOptions, TConfigureEndpointOptions, TMiddleware, TEndpointHandlerInterface, TEndpointHandler, TRequest, TResponse>(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services, bool configureMiddleware) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
 static Steeltoe.Management.Endpoint.CoreActuatorServiceCollectionExtensions.ConfigureActuatorEndpoints(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services, System.Action<Microsoft.AspNetCore.Builder.IEndpointConventionBuilder!>! configureEndpoints) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
 static Steeltoe.Management.Endpoint.CoreActuatorServiceCollectionExtensions.ConfigureActuatorsCorsPolicy(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services, System.Action<Microsoft.AspNetCore.Cors.Infrastructure.CorsPolicyBuilder!>! configureCorsPolicy) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
 static Steeltoe.Management.Endpoint.SpringBootAdminClient.ServiceCollectionExtensions.AddSpringBootAdminClient(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
@@ -446,18 +446,18 @@ Steeltoe.Management.Endpoint.Configuration.ManagementOptions.SslEnabled.set -> v
 Steeltoe.Management.Endpoint.Configuration.ManagementOptions.UseStatusCodeFromResponse.get -> bool
 Steeltoe.Management.Endpoint.Configuration.ManagementOptions.UseStatusCodeFromResponse.set -> void
 Steeltoe.Management.Endpoint.CoreActuatorServiceCollectionExtensions
-Steeltoe.Management.Endpoint.IEndpointHandler<TArgument, TResult>
-Steeltoe.Management.Endpoint.IEndpointHandler<TArgument, TResult>.InvokeAsync(TArgument argument, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<TResult>!
-Steeltoe.Management.Endpoint.IEndpointHandler<TArgument, TResult>.Options.get -> Steeltoe.Management.Configuration.EndpointOptions!
+Steeltoe.Management.Endpoint.IEndpointHandler<TRequest, TResponse>
+Steeltoe.Management.Endpoint.IEndpointHandler<TRequest, TResponse>.InvokeAsync(TRequest argument, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<TResponse>!
+Steeltoe.Management.Endpoint.IEndpointHandler<TRequest, TResponse>.Options.get -> Steeltoe.Management.Configuration.EndpointOptions!
 Steeltoe.Management.Endpoint.Middleware.ActuatorMetadataProvider
 Steeltoe.Management.Endpoint.Middleware.ActuatorMetadataProvider.ActuatorMetadataProvider(string! defaultContentType) -> void
 Steeltoe.Management.Endpoint.Middleware.ActuatorMetadataProvider.DefaultContentType.get -> string!
-Steeltoe.Management.Endpoint.Middleware.EndpointMiddleware<TArgument, TResult>
-Steeltoe.Management.Endpoint.Middleware.EndpointMiddleware<TArgument, TResult>.EndpointHandler.get -> Steeltoe.Management.Endpoint.IEndpointHandler<TArgument, TResult>!
-Steeltoe.Management.Endpoint.Middleware.EndpointMiddleware<TArgument, TResult>.EndpointMiddleware(Steeltoe.Management.Endpoint.IEndpointHandler<TArgument, TResult>! endpointHandler, Microsoft.Extensions.Options.IOptionsMonitor<Steeltoe.Management.Endpoint.Configuration.ManagementOptions!>! managementOptionsMonitor, Microsoft.Extensions.Logging.ILoggerFactory! loggerFactory) -> void
-Steeltoe.Management.Endpoint.Middleware.EndpointMiddleware<TArgument, TResult>.EndpointOptions.get -> Steeltoe.Management.Configuration.EndpointOptions!
-Steeltoe.Management.Endpoint.Middleware.EndpointMiddleware<TArgument, TResult>.InvokeAsync(Microsoft.AspNetCore.Http.HttpContext! context, Microsoft.AspNetCore.Http.RequestDelegate? next) -> System.Threading.Tasks.Task!
-Steeltoe.Management.Endpoint.Middleware.EndpointMiddleware<TArgument, TResult>.ManagementOptionsMonitor.get -> Microsoft.Extensions.Options.IOptionsMonitor<Steeltoe.Management.Endpoint.Configuration.ManagementOptions!>!
+Steeltoe.Management.Endpoint.Middleware.EndpointMiddleware<TRequest, TResponse>
+Steeltoe.Management.Endpoint.Middleware.EndpointMiddleware<TRequest, TResponse>.EndpointHandler.get -> Steeltoe.Management.Endpoint.IEndpointHandler<TRequest, TResponse>!
+Steeltoe.Management.Endpoint.Middleware.EndpointMiddleware<TRequest, TResponse>.EndpointMiddleware(Steeltoe.Management.Endpoint.IEndpointHandler<TRequest, TResponse>! endpointHandler, Microsoft.Extensions.Options.IOptionsMonitor<Steeltoe.Management.Endpoint.Configuration.ManagementOptions!>! managementOptionsMonitor, Microsoft.Extensions.Logging.ILoggerFactory! loggerFactory) -> void
+Steeltoe.Management.Endpoint.Middleware.EndpointMiddleware<TRequest, TResponse>.EndpointOptions.get -> Steeltoe.Management.Configuration.EndpointOptions!
+Steeltoe.Management.Endpoint.Middleware.EndpointMiddleware<TRequest, TResponse>.InvokeAsync(Microsoft.AspNetCore.Http.HttpContext! context, Microsoft.AspNetCore.Http.RequestDelegate? next) -> System.Threading.Tasks.Task!
+Steeltoe.Management.Endpoint.Middleware.EndpointMiddleware<TRequest, TResponse>.ManagementOptionsMonitor.get -> Microsoft.Extensions.Options.IOptionsMonitor<Steeltoe.Management.Endpoint.Configuration.ManagementOptions!>!
 Steeltoe.Management.Endpoint.Middleware.IEndpointMiddleware
 Steeltoe.Management.Endpoint.Middleware.IEndpointMiddleware.EndpointOptions.get -> Steeltoe.Management.Configuration.EndpointOptions!
 Steeltoe.Management.Endpoint.Middleware.IEndpointMiddleware.GetMetadataProvider() -> Steeltoe.Management.Endpoint.Middleware.ActuatorMetadataProvider!
@@ -477,6 +477,7 @@ Steeltoe.Management.Endpoint.SpringBootAdminClient.SpringBootAdminClientOptions.
 Steeltoe.Management.Endpoint.SpringBootAdminClient.SpringBootAdminClientOptions.ValidateCertificates.set -> void
 virtual Steeltoe.Management.Endpoint.Configuration.ConfigureEndpointOptions<TOptions>.Configure(TOptions! options) -> void
 virtual Steeltoe.Management.Endpoint.Middleware.ActuatorMetadataProvider.GetMetadata(string! httpMethod) -> Microsoft.AspNetCore.Http.EndpointMetadataCollection!
-virtual Steeltoe.Management.Endpoint.Middleware.EndpointMiddleware<TArgument, TResult>.CanInvoke(Microsoft.AspNetCore.Http.PathString requestPath) -> bool
-virtual Steeltoe.Management.Endpoint.Middleware.EndpointMiddleware<TArgument, TResult>.GetMetadataProvider() -> Steeltoe.Management.Endpoint.Middleware.ActuatorMetadataProvider!
-virtual Steeltoe.Management.Endpoint.Middleware.EndpointMiddleware<TArgument, TResult>.WriteResponseAsync(TResult result, Microsoft.AspNetCore.Http.HttpContext! context, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
+virtual Steeltoe.Management.Endpoint.Middleware.EndpointMiddleware<TRequest, TResponse>.CanInvoke(Microsoft.AspNetCore.Http.PathString requestPath) -> bool
+virtual Steeltoe.Management.Endpoint.Middleware.EndpointMiddleware<TRequest, TResponse>.GetMetadataProvider() -> Steeltoe.Management.Endpoint.Middleware.ActuatorMetadataProvider!
+virtual Steeltoe.Management.Endpoint.Middleware.EndpointMiddleware<TRequest, TResponse>.ParseRequestAsync(Microsoft.AspNetCore.Http.HttpContext! httpContext, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<TRequest?>!
+virtual Steeltoe.Management.Endpoint.Middleware.EndpointMiddleware<TRequest, TResponse>.WriteResponseAsync(TResponse response, Microsoft.AspNetCore.Http.HttpContext! httpContext, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!

--- a/src/Management/src/Endpoint/PublicAPI.Unshipped.txt
+++ b/src/Management/src/Endpoint/PublicAPI.Unshipped.txt
@@ -238,7 +238,7 @@ Steeltoe.Management.Endpoint.Actuators.HttpExchanges.IHttpExchangesRepository.Ge
 Steeltoe.Management.Endpoint.Actuators.Hypermedia.EndpointServiceCollectionExtensions
 Steeltoe.Management.Endpoint.Actuators.Hypermedia.HypermediaEndpointOptions
 Steeltoe.Management.Endpoint.Actuators.Hypermedia.HypermediaEndpointOptions.HypermediaEndpointOptions() -> void
-Steeltoe.Management.Endpoint.Actuators.Hypermedia.IActuatorEndpointHandler
+Steeltoe.Management.Endpoint.Actuators.Hypermedia.IHypermediaEndpointHandler
 Steeltoe.Management.Endpoint.Actuators.Hypermedia.Link
 Steeltoe.Management.Endpoint.Actuators.Hypermedia.Link.Href.get -> string!
 Steeltoe.Management.Endpoint.Actuators.Hypermedia.Link.Href.set -> void

--- a/src/Management/test/Endpoint.Test/Actuators/Health/Availability/LivenessStateHealthContributorTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/Health/Availability/LivenessStateHealthContributorTest.cs
@@ -9,7 +9,7 @@ using Steeltoe.Management.Endpoint.Actuators.Health.Availability;
 
 namespace Steeltoe.Management.Endpoint.Test.Actuators.Health.Availability;
 
-public sealed class LivenessStateContributorTest
+public sealed class LivenessStateHealthContributorTest
 {
     private readonly ApplicationAvailability _availability = new(NullLogger<ApplicationAvailability>.Instance);
 
@@ -21,7 +21,7 @@ public sealed class LivenessStateContributorTest
     [Fact]
     public async Task HandlesUnknown()
     {
-        var contributor = new LivenessStateContributor(_availability, _optionsMonitor, NullLoggerFactory.Instance);
+        var contributor = new LivenessStateHealthContributor(_availability, _optionsMonitor, NullLoggerFactory.Instance);
 
         HealthCheckResult? result = await contributor.CheckHealthAsync(CancellationToken.None);
 
@@ -33,7 +33,7 @@ public sealed class LivenessStateContributorTest
     public async Task HandlesCorrect()
     {
         _availability.SetAvailabilityState(ApplicationAvailability.LivenessKey, LivenessState.Correct, "tests");
-        var contributor = new LivenessStateContributor(_availability, _optionsMonitor, NullLoggerFactory.Instance);
+        var contributor = new LivenessStateHealthContributor(_availability, _optionsMonitor, NullLoggerFactory.Instance);
 
         HealthCheckResult? result = await contributor.CheckHealthAsync(CancellationToken.None);
 
@@ -45,7 +45,7 @@ public sealed class LivenessStateContributorTest
     public async Task HandlesBroken()
     {
         _availability.SetAvailabilityState(ApplicationAvailability.LivenessKey, LivenessState.Broken, "tests");
-        var contributor = new LivenessStateContributor(_availability, _optionsMonitor, NullLoggerFactory.Instance);
+        var contributor = new LivenessStateHealthContributor(_availability, _optionsMonitor, NullLoggerFactory.Instance);
 
         HealthCheckResult? result = await contributor.CheckHealthAsync(CancellationToken.None);
 

--- a/src/Management/test/Endpoint.Test/Actuators/Health/Availability/ReadinessStateHealthContributorTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/Health/Availability/ReadinessStateHealthContributorTest.cs
@@ -9,7 +9,7 @@ using Steeltoe.Management.Endpoint.Actuators.Health.Availability;
 
 namespace Steeltoe.Management.Endpoint.Test.Actuators.Health.Availability;
 
-public sealed class ReadinessStateContributorTest
+public sealed class ReadinessStateHealthContributorTest
 {
     private readonly ApplicationAvailability _availability = new(NullLogger<ApplicationAvailability>.Instance);
 
@@ -21,7 +21,7 @@ public sealed class ReadinessStateContributorTest
     [Fact]
     public async Task HandlesUnknown()
     {
-        var contributor = new ReadinessStateContributor(_availability, _optionsMonitor, NullLoggerFactory.Instance);
+        var contributor = new ReadinessStateHealthContributor(_availability, _optionsMonitor, NullLoggerFactory.Instance);
 
         HealthCheckResult? result = await contributor.CheckHealthAsync(CancellationToken.None);
 
@@ -33,7 +33,7 @@ public sealed class ReadinessStateContributorTest
     public async Task HandlesAccepting()
     {
         _availability.SetAvailabilityState(ApplicationAvailability.ReadinessKey, ReadinessState.AcceptingTraffic, "tests");
-        var contributor = new ReadinessStateContributor(_availability, _optionsMonitor, NullLoggerFactory.Instance);
+        var contributor = new ReadinessStateHealthContributor(_availability, _optionsMonitor, NullLoggerFactory.Instance);
 
         HealthCheckResult? result = await contributor.CheckHealthAsync(CancellationToken.None);
 
@@ -45,7 +45,7 @@ public sealed class ReadinessStateContributorTest
     public async Task HandlesRefusing()
     {
         _availability.SetAvailabilityState(ApplicationAvailability.ReadinessKey, ReadinessState.RefusingTraffic, "tests");
-        var contributor = new ReadinessStateContributor(_availability, _optionsMonitor, NullLoggerFactory.Instance);
+        var contributor = new ReadinessStateHealthContributor(_availability, _optionsMonitor, NullLoggerFactory.Instance);
 
         HealthCheckResult? result = await contributor.CheckHealthAsync(CancellationToken.None);
 

--- a/src/Management/test/Endpoint.Test/Actuators/Health/Contributors/DiskSpaceHealthContributorTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/Health/Contributors/DiskSpaceHealthContributorTest.cs
@@ -9,13 +9,13 @@ using Steeltoe.Management.Endpoint.Actuators.Health.Contributors;
 
 namespace Steeltoe.Management.Endpoint.Test.Actuators.Health.Contributors;
 
-public sealed class DiskSpaceContributorTest : BaseTest
+public sealed class DiskSpaceHealthContributorTest : BaseTest
 {
     [Fact]
     public void Constructor_InitializesWithDefaults()
     {
         IOptionsMonitor<DiskSpaceContributorOptions> optionsMonitor = GetOptionsMonitorFromSettings<DiskSpaceContributorOptions>();
-        var contributor = new DiskSpaceContributor(optionsMonitor);
+        var contributor = new DiskSpaceHealthContributor(optionsMonitor);
         Assert.Equal("diskSpace", contributor.Id);
     }
 
@@ -23,7 +23,7 @@ public sealed class DiskSpaceContributorTest : BaseTest
     public async Task Health_InitializedWithDefaults_ReturnsExpected()
     {
         IOptionsMonitor<DiskSpaceContributorOptions> optionsMonitor = GetOptionsMonitorFromSettings<DiskSpaceContributorOptions>();
-        var contributor = new DiskSpaceContributor(optionsMonitor);
+        var contributor = new DiskSpaceHealthContributor(optionsMonitor);
         Assert.Equal("diskSpace", contributor.Id);
         HealthCheckResult? result = await contributor.CheckHealthAsync(CancellationToken.None);
         Assert.NotNull(result);
@@ -44,7 +44,7 @@ public sealed class DiskSpaceContributorTest : BaseTest
             Path = OperatingSystem.IsWindows() ? @"C:\does-not-exist" : "/does/not/exist"
         });
 
-        var contributor = new DiskSpaceContributor(optionsMonitor);
+        var contributor = new DiskSpaceHealthContributor(optionsMonitor);
 
         HealthCheckResult? result = await contributor.CheckHealthAsync(CancellationToken.None);
 
@@ -98,7 +98,7 @@ public sealed class DiskSpaceContributorTest : BaseTest
                 new DriveInfo("/dev/shm")
             ];
 
-        DriveInfo? drive = DiskSpaceContributor.FindVolume(path, systemDrives);
+        DriveInfo? drive = DiskSpaceHealthContributor.FindVolume(path, systemDrives);
 
         if (expected == null)
         {

--- a/src/Management/test/Endpoint.Test/Actuators/Health/HealthEndpointTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/Health/HealthEndpointTest.cs
@@ -139,7 +139,7 @@ public sealed class HealthEndpointTest(ITestOutputHelper testOutputHelper) : Bas
     {
         using var testContext = new TestContext(_testOutputHelper);
 
-        List<IHealthContributor> contributors = [new DiskSpaceContributor(GetOptionsMonitorFromSettings<DiskSpaceContributorOptions>())];
+        List<IHealthContributor> contributors = [new DiskSpaceHealthContributor(GetOptionsMonitorFromSettings<DiskSpaceContributorOptions>())];
 
         testContext.AdditionalServices = (services, _) =>
         {
@@ -189,8 +189,8 @@ public sealed class HealthEndpointTest(ITestOutputHelper testOutputHelper) : Bas
 
         List<IHealthContributor> contributors =
         [
-            new DiskSpaceContributor(GetOptionsMonitorFromSettings<DiskSpaceContributorOptions>()),
-            new LivenessStateContributor(appAvailability, optionsMonitor, NullLoggerFactory.Instance)
+            new DiskSpaceHealthContributor(GetOptionsMonitorFromSettings<DiskSpaceContributorOptions>()),
+            new LivenessStateHealthContributor(appAvailability, optionsMonitor, NullLoggerFactory.Instance)
         ];
 
         testContext.AdditionalServices = (services, _) =>
@@ -236,7 +236,7 @@ public sealed class HealthEndpointTest(ITestOutputHelper testOutputHelper) : Bas
             new UnknownContributor(),
             new DisabledContributor(),
             new UpContributor(),
-            new ReadinessStateContributor(appAvailability, optionsMonitor, NullLoggerFactory.Instance)
+            new ReadinessStateHealthContributor(appAvailability, optionsMonitor, NullLoggerFactory.Instance)
         ];
 
         testContext.AdditionalServices = (services, _) =>

--- a/src/Management/test/Endpoint.Test/Actuators/Hypermedia/EndpointServiceCollectionTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/Hypermedia/EndpointServiceCollectionTest.cs
@@ -21,7 +21,7 @@ public sealed class EndpointServiceCollectionTest : BaseTest
         services.AddHypermediaActuator();
 
         await using ServiceProvider serviceProvider = services.BuildServiceProvider(true);
-        var handler = serviceProvider.GetService<IActuatorEndpointHandler>();
+        var handler = serviceProvider.GetService<IHypermediaEndpointHandler>();
         Assert.NotNull(handler);
     }
 }

--- a/src/Management/test/Endpoint.Test/Actuators/Hypermedia/HypermediaEndpointTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/Hypermedia/HypermediaEndpointTest.cs
@@ -32,7 +32,7 @@ public sealed class HypermediaEndpointTest(ITestOutputHelper testOutputHelper) :
             });
         };
 
-        var handler = testContext.GetRequiredService<IActuatorEndpointHandler>();
+        var handler = testContext.GetRequiredService<IHypermediaEndpointHandler>();
 
         Links links = await handler.InvokeAsync("http://localhost:5000/foobar", CancellationToken.None);
         links.Entries.Should().Contain(entry => entry.Key == "self" && entry.Value.Href == "http://localhost:5000/foobar");
@@ -50,7 +50,7 @@ public sealed class HypermediaEndpointTest(ITestOutputHelper testOutputHelper) :
             services.AddHypermediaActuator();
         };
 
-        var handler = testContext.GetRequiredService<IActuatorEndpointHandler>();
+        var handler = testContext.GetRequiredService<IHypermediaEndpointHandler>();
 
         Links links = await handler.InvokeAsync("http://localhost:5000/foobar", CancellationToken.None);
         links.Entries.Should().Contain(entry => entry.Key == "self" && entry.Value.Href == "http://localhost:5000/foobar");
@@ -76,7 +76,7 @@ public sealed class HypermediaEndpointTest(ITestOutputHelper testOutputHelper) :
             });
         };
 
-        var handler = testContext.GetRequiredService<IActuatorEndpointHandler>();
+        var handler = testContext.GetRequiredService<IHypermediaEndpointHandler>();
 
         Links links = await handler.InvokeAsync("http://localhost:5000/foobar", CancellationToken.None);
         links.Entries.Should().Contain(entry => entry.Key == "self" && entry.Value.Href == "http://localhost:5000/foobar");
@@ -103,7 +103,7 @@ public sealed class HypermediaEndpointTest(ITestOutputHelper testOutputHelper) :
             });
         };
 
-        var handler = testContext.GetRequiredService<IActuatorEndpointHandler>();
+        var handler = testContext.GetRequiredService<IHypermediaEndpointHandler>();
 
         Links links = await handler.InvokeAsync("http://localhost:5000/foobar", CancellationToken.None);
         links.Entries.Should().BeEmpty();

--- a/src/Management/test/Endpoint.Test/SpringBootAdminClient/TestMiddleware.cs
+++ b/src/Management/test/Endpoint.Test/SpringBootAdminClient/TestMiddleware.cs
@@ -22,7 +22,7 @@ public sealed class TestMiddleware : IMiddleware
     {
         if (context.Request.Path.Value?.EndsWith("instances", StringComparison.Ordinal) == true)
         {
-            var dictionary = await JsonSerializer.DeserializeAsync<Dictionary<string, object>>(context.Request.Body);
+            var dictionary = await JsonSerializer.DeserializeAsync<Dictionary<string, object>>(context.Request.Body, cancellationToken: context.RequestAborted);
             context.Response.Headers.Append("Content-Type", "application/json");
 
             bool isValid = dictionary != null && KeyNames.All(dictionary.ContainsKey);


### PR DESCRIPTION
## Description

Refactor actuator middleware: move parsing of request (body) into separate virtual method, so that handler invocation is agnostic of `HttpContext`.

`EndpointMiddleware.InvokeEndpointHandlerAsync` used to take an `HttpContext` parameter, which has changed to `TRequest`. The newly added method `ParseRequestAsync` takes `HttpContext` as input and returns a `TRequest`.

The public API diff is minimal; this is mostly about aligning internals for a better separation of concerns.

Additionally, this PR includes several commits regarding naming consistency that I've found while documenting public API changes.

## Quality checklist

- [x] Your code complies with our [Coding Style](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-code-style.md).
- [x] You've updated unit and/or integration tests for your change, where applicable.
- [ ] You've updated documentation for your change, where applicable.
      If your change affects other repositories, such as [Documentation](https://github.com/SteeltoeOSS/Documentation), [Samples](https://github.com/SteeltoeOSS/Samples) and/or [MainSite](https://github.com/SteeltoeOSS/MainSite), add linked PRs here.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
- [ ] You've added required license files and/or file headers (explaining where the code came from with proper attribution), where code is copied from StackOverflow, a blog, or OSS.
