### PR TITLE
Remove redundant null suppressions

### DIFF
--- a/src/Common/test/Certificates.Test/ConfigureCertificateOptionsTest.cs
+++ b/src/Common/test/Certificates.Test/ConfigureCertificateOptionsTest.cs
@@ -89,7 +89,7 @@ public sealed class ConfigureCertificateOptionsTest
         configureOptions.Configure(CertificateName, options);
 
         options.Certificate.Should().NotBeNull();
-        options.Certificate!.HasPrivateKey.Should().BeTrue();
+        options.Certificate.HasPrivateKey.Should().BeTrue();
     }
 
     [Fact]
@@ -102,7 +102,7 @@ public sealed class ConfigureCertificateOptionsTest
         configureOptions.Configure(CertificateName, options);
 
         options.Certificate.Should().NotBeNull();
-        options.Certificate!.HasPrivateKey.Should().BeTrue();
+        options.Certificate.HasPrivateKey.Should().BeTrue();
     }
 
     [Fact]

--- a/src/Configuration/test/CloudFoundry.Test/CloudFoundryApplicationOptionsTest.cs
+++ b/src/Configuration/test/CloudFoundry.Test/CloudFoundryApplicationOptionsTest.cs
@@ -123,9 +123,9 @@ public sealed class CloudFoundryApplicationOptionsTest
         options.ApplicationVersion.Should().Be("fb8fbcc6-8d58-479e-bcc7-3b4ce5a7f0ca");
         options.Api.Should().Be("https://api.system.test-cloud.com");
         options.Limits.Should().NotBeNull();
-        options.Limits!.Disk.Should().Be(1024);
-        options.Limits!.FileDescriptor.Should().Be(16384);
-        options.Limits!.Memory.Should().Be(256);
+        options.Limits.Disk.Should().Be(1024);
+        options.Limits.FileDescriptor.Should().Be(16384);
+        options.Limits.Memory.Should().Be(256);
         options.OrganizationId.Should().BeNull();
         options.OrganizationName.Should().BeNull();
         options.ProcessId.Should().BeNull();

--- a/src/Configuration/test/ConfigServer.Test/ConfigServerHostBuilderExtensionsTest.cs
+++ b/src/Configuration/test/ConfigServer.Test/ConfigServerHostBuilderExtensionsTest.cs
@@ -197,7 +197,7 @@ public sealed class ConfigServerHostBuilderExtensionsTest
         ConfigServerConfigurationProvider? provider = configuration.EnumerateProviders<ConfigServerConfigurationProvider>().SingleOrDefault();
 
         provider.Should().NotBeNull();
-        provider!.ClientOptions.Name.Should().Be("myApp");
+        provider.ClientOptions.Name.Should().Be("myApp");
     }
 
     [Fact]
@@ -219,7 +219,7 @@ public sealed class ConfigServerHostBuilderExtensionsTest
         ConfigServerConfigurationProvider? provider = configuration.EnumerateProviders<ConfigServerConfigurationProvider>().SingleOrDefault();
 
         provider.Should().NotBeNull();
-        provider!.ClientOptions.Name.Should().Be("myApp");
+        provider.ClientOptions.Name.Should().Be("myApp");
     }
 
     [Fact]
@@ -241,7 +241,7 @@ public sealed class ConfigServerHostBuilderExtensionsTest
         ConfigServerConfigurationProvider? provider = configuration.EnumerateProviders<ConfigServerConfigurationProvider>().SingleOrDefault();
 
         provider.Should().NotBeNull();
-        provider!.ClientOptions.Name.Should().Be("myApp");
+        provider.ClientOptions.Name.Should().Be("myApp");
     }
 
     [Fact]
@@ -265,7 +265,7 @@ public sealed class ConfigServerHostBuilderExtensionsTest
         ConfigServerConfigurationProvider? provider = configuration.EnumerateProviders<ConfigServerConfigurationProvider>().SingleOrDefault();
 
         provider.Should().NotBeNull();
-        provider!.ClientOptions.Name.Should().Be("myApp");
+        provider.ClientOptions.Name.Should().Be("myApp");
     }
 
     [Fact]
@@ -287,7 +287,7 @@ public sealed class ConfigServerHostBuilderExtensionsTest
         ConfigServerConfigurationProvider? provider = configuration.EnumerateProviders<ConfigServerConfigurationProvider>().SingleOrDefault();
 
         provider.Should().NotBeNull();
-        provider!.ClientOptions.Environment.Should().Be("TestEnv");
+        provider.ClientOptions.Environment.Should().Be("TestEnv");
     }
 
     [Fact]
@@ -309,6 +309,6 @@ public sealed class ConfigServerHostBuilderExtensionsTest
         ConfigServerConfigurationProvider? provider = configuration.EnumerateProviders<ConfigServerConfigurationProvider>().SingleOrDefault();
 
         provider.Should().NotBeNull();
-        provider!.ClientOptions.Environment.Should().Be("TestEnv");
+        provider.ClientOptions.Environment.Should().Be("TestEnv");
     }
 }

--- a/src/Configuration/test/Kubernetes.ServiceBindings.Test/ServiceBindingMapperTest.cs
+++ b/src/Configuration/test/Kubernetes.ServiceBindings.Test/ServiceBindingMapperTest.cs
@@ -109,9 +109,9 @@ public sealed class ServiceBindingMapperTest
 
         tempPath.Should().NotBeNull();
         source["test-destination-key"].Should().Be(tempPath);
-        File.ReadAllText(tempPath!).Should().Be("test-source-value");
+        File.ReadAllText(tempPath).Should().Be("test-source-value");
 
-        File.Delete(tempPath!);
+        File.Delete(tempPath);
     }
 
     [Fact]

--- a/src/Configuration/test/Placeholder.Test/PlaceholderConfigurationTest.cs
+++ b/src/Configuration/test/Placeholder.Test/PlaceholderConfigurationTest.cs
@@ -62,8 +62,8 @@ public sealed class PlaceholderConfigurationTest : IDisposable
         testSourceA.LastProvider.Should().NotBeNull().And.BeOfType<TestConfigurationProvider>();
         testSourceB.LastProvider.Should().NotBeNull().And.BeOfType<TestConfigurationProvider>();
 
-        testSourceA.LastProvider!.LoadCount.Should().Be(1);
-        testSourceB.LastProvider!.LoadCount.Should().Be(1);
+        testSourceA.LastProvider.LoadCount.Should().Be(1);
+        testSourceB.LastProvider.LoadCount.Should().Be(1);
 
         Guid lastProviderIdA = testSourceA.LastProvider.Id;
         Guid lastProviderIdB = testSourceB.LastProvider.Id;
@@ -101,8 +101,8 @@ public sealed class PlaceholderConfigurationTest : IDisposable
         testSourceA.LastProvider.Should().NotBeNull();
         testSourceB.LastProvider.Should().NotBeNull();
 
-        testSourceA.LastProvider!.DisposeCount.Should().Be(0);
-        testSourceB.LastProvider!.DisposeCount.Should().Be(0);
+        testSourceA.LastProvider.DisposeCount.Should().Be(0);
+        testSourceB.LastProvider.DisposeCount.Should().Be(0);
 
         configurationRoot.Dispose();
 
@@ -130,19 +130,25 @@ public sealed class PlaceholderConfigurationTest : IDisposable
         builder.Add(testSourceB);
         builder.AddPlaceholderResolver(_loggerFactory);
 
-        TestConfigurationProvider previousProviderA;
-        TestConfigurationProvider previousProviderB;
+        TestConfigurationProvider? previousProviderA;
+        TestConfigurationProvider? previousProviderB;
 
         using ((ConfigurationRoot)builder.Build())
         {
-            previousProviderA = testSourceA.LastProvider!;
-            previousProviderB = testSourceA.LastProvider!;
+            previousProviderA = testSourceA.LastProvider;
+            previousProviderB = testSourceA.LastProvider;
         }
 
         _ = builder.Build();
 
-        TestConfigurationProvider nextProviderA = testSourceA.LastProvider!;
-        TestConfigurationProvider nextProviderB = testSourceA.LastProvider!;
+        TestConfigurationProvider? nextProviderA = testSourceA.LastProvider;
+        TestConfigurationProvider? nextProviderB = testSourceA.LastProvider;
+
+        previousProviderA.Should().NotBeNull();
+        previousProviderB.Should().NotBeNull();
+
+        nextProviderA.Should().NotBeNull();
+        nextProviderB.Should().NotBeNull();
 
         previousProviderA.Id.Should().NotBe(nextProviderA.Id);
         previousProviderB.Id.Should().NotBe(nextProviderB.Id);
@@ -178,8 +184,8 @@ public sealed class PlaceholderConfigurationTest : IDisposable
         testSourceA.LastProvider.Should().NotBeNull();
         testSourceB.LastProvider.Should().NotBeNull();
 
-        testSourceA.LastProvider!.Set("testRoot:keyA", "valueA");
-        testSourceB.LastProvider!.Set("testRoot:keyB", "valueB");
+        testSourceA.LastProvider.Set("testRoot:keyA", "valueA");
+        testSourceB.LastProvider.Set("testRoot:keyB", "valueB");
 
         configurationRoot["testRoot:keyA"].Should().Be("valueA");
         configurationRoot["testRoot:keyB"].Should().Be("valueB");

--- a/src/Connectors/test/Connectors.Test/CosmosDb/CosmosDbHealthContributorTest.cs
+++ b/src/Connectors/test/Connectors.Test/CosmosDb/CosmosDbHealthContributorTest.cs
@@ -40,7 +40,7 @@ public sealed class CosmosDbHealthContributorTest
         HealthCheckResult? result = await healthContributor.CheckHealthAsync(CancellationToken.None);
 
         result.Should().NotBeNull();
-        result!.Status.Should().Be(HealthStatus.Down);
+        result.Status.Should().Be(HealthStatus.Down);
         result.Description.Should().Be("CosmosDB health check failed");
         result.Details.Should().Contain("host", "localhost");
         result.Details.Should().Contain("service", serviceName);
@@ -65,7 +65,7 @@ public sealed class CosmosDbHealthContributorTest
         HealthCheckResult? result = await healthContributor.CheckHealthAsync(CancellationToken.None);
 
         result.Should().NotBeNull();
-        result!.Status.Should().Be(HealthStatus.Down);
+        result.Status.Should().Be(HealthStatus.Down);
         result.Description.Should().Be("CosmosDB health check failed");
         result.Details.Should().Contain("host", "localhost");
         result.Details.Should().Contain("service", serviceName);
@@ -88,7 +88,7 @@ public sealed class CosmosDbHealthContributorTest
         HealthCheckResult? result = await healthContributor.CheckHealthAsync(CancellationToken.None);
 
         result.Should().NotBeNull();
-        result!.Status.Should().Be(HealthStatus.Up);
+        result.Status.Should().Be(HealthStatus.Up);
         result.Details.Should().Contain("host", "localhost");
         result.Details.Should().Contain("service", "Example");
         result.Details.Should().NotContainKey("error");
@@ -139,7 +139,7 @@ public sealed class CosmosDbHealthContributorTest
         HealthCheckResult? result = await healthContributor.CheckHealthAsync(CancellationToken.None);
 
         result.Should().NotBeNull();
-        result!.Status.Should().Be(HealthStatus.Up);
+        result.Status.Should().Be(HealthStatus.Up);
         result.Details.Should().Contain("host", "localhost");
         result.Details.Should().Contain("service", "Example");
         result.Details.Should().NotContainKey("error");

--- a/src/Connectors/test/Connectors.Test/MongoDb/MongoDbHealthContributorTest.cs
+++ b/src/Connectors/test/Connectors.Test/MongoDb/MongoDbHealthContributorTest.cs
@@ -34,7 +34,7 @@ public sealed class MongoDbHealthContributorTest
         HealthCheckResult? result = await healthContributor.CheckHealthAsync(CancellationToken.None);
 
         result.Should().NotBeNull();
-        result!.Status.Should().Be(HealthStatus.Down);
+        result.Status.Should().Be(HealthStatus.Down);
         result.Description.Should().Be("MongoDB health check failed");
         result.Details.Should().Contain("host", "localhost");
         result.Details.Should().Contain("service", "Example");
@@ -57,7 +57,7 @@ public sealed class MongoDbHealthContributorTest
         HealthCheckResult? result = await healthContributor.CheckHealthAsync(CancellationToken.None);
 
         result.Should().NotBeNull();
-        result!.Status.Should().Be(HealthStatus.Up);
+        result.Status.Should().Be(HealthStatus.Up);
         result.Details.Should().Contain("host", "localhost");
         result.Details.Should().Contain("service", "Example");
         result.Details.Should().NotContainKey("error");
@@ -110,7 +110,7 @@ public sealed class MongoDbHealthContributorTest
         HealthCheckResult? result = await healthContributor.CheckHealthAsync(CancellationToken.None);
 
         result.Should().NotBeNull();
-        result!.Status.Should().Be(HealthStatus.Up);
+        result.Status.Should().Be(HealthStatus.Up);
         result.Details.Should().Contain("host", "localhost");
         result.Details.Should().Contain("service", "Example");
         result.Details.Should().NotContainKey("error");

--- a/src/Connectors/test/Connectors.Test/RabbitMQ/RabbitMQHealthContributorTest.cs
+++ b/src/Connectors/test/Connectors.Test/RabbitMQ/RabbitMQHealthContributorTest.cs
@@ -30,7 +30,7 @@ public sealed class RabbitMQHealthContributorTest
         HealthCheckResult? result = await healthContributor.CheckHealthAsync(CancellationToken.None);
 
         result.Should().NotBeNull();
-        result!.Status.Should().Be(HealthStatus.Down);
+        result.Status.Should().Be(HealthStatus.Down);
         result.Description.Should().Be("RabbitMQ health check failed");
         result.Details.Should().Contain("host", "localhost");
         result.Details.Should().Contain("service", "Example");
@@ -59,7 +59,7 @@ public sealed class RabbitMQHealthContributorTest
         HealthCheckResult? result = await healthContributor.CheckHealthAsync(CancellationToken.None);
 
         result.Should().NotBeNull();
-        result!.Status.Should().Be(HealthStatus.Up);
+        result.Status.Should().Be(HealthStatus.Up);
         result.Details.Should().Contain("host", "localhost");
         result.Details.Should().Contain("service", "Example");
         result.Details.Should().NotContainKey("error");
@@ -93,7 +93,7 @@ public sealed class RabbitMQHealthContributorTest
         HealthCheckResult? result = await healthContributor.CheckHealthAsync(CancellationToken.None);
 
         result.Should().NotBeNull();
-        result!.Status.Should().Be(HealthStatus.Down);
+        result.Status.Should().Be(HealthStatus.Down);
         result.Description.Should().Be("RabbitMQ health check failed");
         result.Details.Should().Contain("host", "localhost");
         result.Details.Should().Contain("service", "Example");
@@ -130,7 +130,7 @@ public sealed class RabbitMQHealthContributorTest
         HealthCheckResult? result = await healthContributor.CheckHealthAsync(CancellationToken.None);
 
         result.Should().NotBeNull();
-        result!.Status.Should().Be(HealthStatus.Up);
+        result.Status.Should().Be(HealthStatus.Up);
         result.Details.Should().Contain("host", "localhost");
         result.Details.Should().Contain("service", "Example");
         result.Details.Should().NotContainKey("error");

--- a/src/Connectors/test/Connectors.Test/Redis/RedisHealthContributorTest.cs
+++ b/src/Connectors/test/Connectors.Test/Redis/RedisHealthContributorTest.cs
@@ -31,7 +31,7 @@ public sealed class RedisHealthContributorTest
         HealthCheckResult? result = await healthContributor.CheckHealthAsync(CancellationToken.None);
 
         result.Should().NotBeNull();
-        result!.Status.Should().Be(HealthStatus.Down);
+        result.Status.Should().Be(HealthStatus.Down);
         result.Description.Should().Be("Redis health check failed");
         result.Details.Should().Contain("host", "localhost");
         result.Details.Should().Contain("service", "Example");
@@ -59,7 +59,7 @@ public sealed class RedisHealthContributorTest
         HealthCheckResult? result = await healthContributor.CheckHealthAsync(CancellationToken.None);
 
         result.Should().NotBeNull();
-        result!.Status.Should().Be(HealthStatus.Up);
+        result.Status.Should().Be(HealthStatus.Up);
         result.Details.Should().Contain("host", "localhost");
         result.Details.Should().Contain("service", "Example");
         result.Details.Should().NotContainKey("error");
@@ -92,7 +92,7 @@ public sealed class RedisHealthContributorTest
         HealthCheckResult? result = await healthContributor.CheckHealthAsync(CancellationToken.None);
 
         result.Should().NotBeNull();
-        result!.Status.Should().Be(HealthStatus.Up);
+        result.Status.Should().Be(HealthStatus.Up);
         result.Details.Should().Contain("host", "localhost");
         result.Details.Should().Contain("service", "Example");
         result.Details.Should().NotContainKey("error");

--- a/src/Connectors/test/Connectors.Test/RelationalDatabaseHealthContributorTest.cs
+++ b/src/Connectors/test/Connectors.Test/RelationalDatabaseHealthContributorTest.cs
@@ -28,7 +28,7 @@ public sealed class RelationalDatabaseHealthContributorTest
         HealthCheckResult? result = await healthContributor.CheckHealthAsync(CancellationToken.None);
 
         result.Should().NotBeNull();
-        result!.Status.Should().Be(HealthStatus.Down);
+        result.Status.Should().Be(HealthStatus.Down);
         result.Description.Should().Be("PostgreSQL health check failed");
         result.Details.Should().Contain("host", "localhost");
         result.Details.Should().Contain("service", "Example");
@@ -48,7 +48,7 @@ public sealed class RelationalDatabaseHealthContributorTest
         HealthCheckResult? result = await healthContributor.CheckHealthAsync(CancellationToken.None);
 
         result.Should().NotBeNull();
-        result!.Status.Should().Be(HealthStatus.Up);
+        result.Status.Should().Be(HealthStatus.Up);
         result.Details.Should().Contain("host", "localhost");
         result.Details.Should().Contain("service", "Example");
         result.Details.Should().NotContainKey("error");
@@ -67,7 +67,7 @@ public sealed class RelationalDatabaseHealthContributorTest
         HealthCheckResult? result = await healthContributor.CheckHealthAsync(CancellationToken.None);
 
         result.Should().NotBeNull();
-        result!.Status.Should().Be(HealthStatus.Down);
+        result.Status.Should().Be(HealthStatus.Down);
         result.Description.Should().Be("MySQL health check failed");
         result.Details.Should().Contain("host", "localhost");
         result.Details.Should().Contain("service", "Example");
@@ -87,7 +87,7 @@ public sealed class RelationalDatabaseHealthContributorTest
         HealthCheckResult? result = await healthContributor.CheckHealthAsync(CancellationToken.None);
 
         result.Should().NotBeNull();
-        result!.Status.Should().Be(HealthStatus.Up);
+        result.Status.Should().Be(HealthStatus.Up);
         result.Details.Should().Contain("host", "localhost");
         result.Details.Should().Contain("service", "Example");
         result.Details.Should().NotContainKey("error");
@@ -107,7 +107,7 @@ public sealed class RelationalDatabaseHealthContributorTest
         HealthCheckResult? result = await healthContributor.CheckHealthAsync(CancellationToken.None);
 
         result.Should().NotBeNull();
-        result!.Status.Should().Be(HealthStatus.Down);
+        result.Status.Should().Be(HealthStatus.Down);
         result.Description.Should().Be("SQL Server health check failed");
         result.Details.Should().Contain("host", "localhost");
         result.Details.Should().Contain("service", "Example");
@@ -127,7 +127,7 @@ public sealed class RelationalDatabaseHealthContributorTest
         HealthCheckResult? result = await healthContributor.CheckHealthAsync(CancellationToken.None);
 
         result.Should().NotBeNull();
-        result!.Status.Should().Be(HealthStatus.Up);
+        result.Status.Should().Be(HealthStatus.Up);
         result.Details.Should().Contain("host", "localhost");
         result.Details.Should().Contain("service", "Example");
         result.Details.Should().NotContainKey("error");
@@ -152,7 +152,7 @@ public sealed class RelationalDatabaseHealthContributorTest
         HealthCheckResult? result = await healthContributor.CheckHealthAsync(CancellationToken.None);
 
         result.Should().NotBeNull();
-        result!.Status.Should().Be(HealthStatus.Up);
+        result.Status.Should().Be(HealthStatus.Up);
         result.Details.Should().Contain("host", "localhost");
         result.Details.Should().Contain("service", "Example");
         result.Details.Should().NotContainKey("error");

--- a/src/Discovery/test/Eureka.Test/EurekaApplicationInfoManagerTest.cs
+++ b/src/Discovery/test/Eureka.Test/EurekaApplicationInfoManagerTest.cs
@@ -41,7 +41,7 @@ public sealed class EurekaApplicationInfoManagerTest
         appManager.Instance.IsDirty.Should().BeTrue();
 
         eventMonitor.EventArgs.Should().NotBeNull();
-        eventMonitor.EventArgs!.PreviousInstance.Status.Should().Be(previousStatus);
+        eventMonitor.EventArgs.PreviousInstance.Status.Should().Be(previousStatus);
         eventMonitor.EventArgs.NewInstance.Status.Should().Be(InstanceStatus.OutOfService);
     }
 
@@ -136,7 +136,7 @@ public sealed class EurekaApplicationInfoManagerTest
         appManager.Instance.IsDirty.Should().BeTrue();
 
         eventMonitor.EventArgs.Should().NotBeNull();
-        eventMonitor.EventArgs!.PreviousInstance.VipAddress.Should().Be("some");
+        eventMonitor.EventArgs.PreviousInstance.VipAddress.Should().Be("some");
         eventMonitor.EventArgs.NewInstance.VipAddress.Should().Be("other");
     }
 
@@ -237,13 +237,13 @@ public sealed class EurekaApplicationInfoManagerTest
         appManager.Instance.IPAddress.Should().Be("192.168.0.2");
 
         eventMonitor.EventArgs.Should().NotBeNull();
-        eventMonitor.EventArgs!.PreviousInstance.InstanceId.Should().Be("some");
+        eventMonitor.EventArgs.PreviousInstance.InstanceId.Should().Be("some");
         eventMonitor.EventArgs.NewInstance.InstanceId.Should().Be("some");
-        eventMonitor.EventArgs!.PreviousInstance.AppName.Should().Be("DEMO");
+        eventMonitor.EventArgs.PreviousInstance.AppName.Should().Be("DEMO");
         eventMonitor.EventArgs.NewInstance.AppName.Should().Be("DEMO");
-        eventMonitor.EventArgs!.PreviousInstance.HostName.Should().Be("localhost");
+        eventMonitor.EventArgs.PreviousInstance.HostName.Should().Be("localhost");
         eventMonitor.EventArgs.NewInstance.HostName.Should().Be("new-host");
-        eventMonitor.EventArgs!.PreviousInstance.IPAddress.Should().Be("192.168.0.1");
+        eventMonitor.EventArgs.PreviousInstance.IPAddress.Should().Be("192.168.0.1");
         eventMonitor.EventArgs.NewInstance.IPAddress.Should().Be("192.168.0.2");
     }
 

--- a/src/Discovery/test/Eureka.Test/Transport/EurekaClientTest.cs
+++ b/src/Discovery/test/Eureka.Test/Transport/EurekaClientTest.cs
@@ -591,7 +591,7 @@ public sealed class EurekaClientTest
         ApplicationInfo? app = apps.GetRegisteredApplication("foo");
 
         app.Should().NotBeNull();
-        app!.Name.Should().Be("FOO");
+        app.Name.Should().Be("FOO");
 
         app.Instances.Should().ContainSingle();
         app.Instances[0].InstanceId.Should().Be("localhost:foo");
@@ -665,7 +665,7 @@ public sealed class EurekaClientTest
         ApplicationInfo? app = apps.GetRegisteredApplication("foo");
 
         app.Should().NotBeNull();
-        app!.Name.Should().Be("FOO");
+        app.Name.Should().Be("FOO");
 
         app.Instances.Should().ContainSingle();
         app.Instances[0].InstanceId.Should().Be("localhost:foo");
@@ -702,7 +702,7 @@ public sealed class EurekaClientTest
         ApplicationInfo? app = apps.GetRegisteredApplication("foo");
 
         app.Should().NotBeNull();
-        app!.Name.Should().Be("FOO");
+        app.Name.Should().Be("FOO");
 
         app.Instances.Should().ContainSingle();
         app.Instances[0].InstanceId.Should().Be("localhost:foo");

--- a/src/Logging/test/DynamicSerilog.Test/HostBuilderTests.cs
+++ b/src/Logging/test/DynamicSerilog.Test/HostBuilderTests.cs
@@ -121,7 +121,7 @@ public sealed class HostBuilderTests : IDisposable
         var optionsMonitor = host.Services.GetRequiredService<IOptionsMonitor<SerilogOptions>>();
         MinimumLevel? minimumLevel = optionsMonitor.CurrentValue.MinimumLevel;
         minimumLevel.Should().NotBeNull();
-        minimumLevel!.Default.Should().Be(LogEventLevel.Information);
+        minimumLevel.Default.Should().Be(LogEventLevel.Information);
         minimumLevel.Override.Should().BeEmpty();
 
         var logger = host.Services.GetRequiredService<ILogger<HostBuilderTests>>();
@@ -156,7 +156,7 @@ public sealed class HostBuilderTests : IDisposable
         var optionsMonitor = host.Services.GetRequiredService<IOptionsMonitor<SerilogOptions>>();
         MinimumLevel? minimumLevel = optionsMonitor.CurrentValue.MinimumLevel;
         minimumLevel.Should().NotBeNull();
-        minimumLevel!.Default.Should().Be(LogEventLevel.Error);
+        minimumLevel.Default.Should().Be(LogEventLevel.Error);
         minimumLevel.Override.Should().BeEmpty();
 
         var logger = host.Services.GetRequiredService<ILogger<HostBuilderTests>>();
@@ -190,7 +190,7 @@ public sealed class HostBuilderTests : IDisposable
         var optionsMonitor = host.Services.GetRequiredService<IOptionsMonitor<SerilogOptions>>();
         MinimumLevel? minimumLevel = optionsMonitor.CurrentValue.MinimumLevel;
         minimumLevel.Should().NotBeNull();
-        minimumLevel!.Default.Should().Be(LogEventLevel.Error);
+        minimumLevel.Default.Should().Be(LogEventLevel.Error);
         minimumLevel.Override.Should().BeEmpty();
 
         var logger = host.Services.GetRequiredService<ILogger<HostBuilderTests>>();
@@ -224,7 +224,7 @@ public sealed class HostBuilderTests : IDisposable
         var optionsMonitor = host.Services.GetRequiredService<IOptionsMonitor<SerilogOptions>>();
         MinimumLevel? minimumLevel = optionsMonitor.CurrentValue.MinimumLevel;
         minimumLevel.Should().NotBeNull();
-        minimumLevel!.Default.Should().Be(LogEventLevel.Information);
+        minimumLevel.Default.Should().Be(LogEventLevel.Information);
         minimumLevel.Override.Should().ContainSingle();
         minimumLevel.Override.Should().Contain("Steeltoe", LogEventLevel.Error);
 
@@ -262,7 +262,7 @@ public sealed class HostBuilderTests : IDisposable
         var optionsMonitor = host.Services.GetRequiredService<IOptionsMonitor<SerilogOptions>>();
         MinimumLevel? minimumLevel = optionsMonitor.CurrentValue.MinimumLevel;
         minimumLevel.Should().NotBeNull();
-        minimumLevel!.Default.Should().Be(LogEventLevel.Error);
+        minimumLevel.Default.Should().Be(LogEventLevel.Error);
         minimumLevel.Override.Should().BeEmpty();
 
         var logger = host.Services.GetRequiredService<ILogger<HostBuilderTests>>();
@@ -299,7 +299,7 @@ public sealed class HostBuilderTests : IDisposable
         var optionsMonitor = host.Services.GetRequiredService<IOptionsMonitor<SerilogOptions>>();
         MinimumLevel? minimumLevel = optionsMonitor.CurrentValue.MinimumLevel;
         minimumLevel.Should().NotBeNull();
-        minimumLevel!.Default.Should().Be(LogEventLevel.Information);
+        minimumLevel.Default.Should().Be(LogEventLevel.Information);
         minimumLevel.Override.Should().ContainSingle();
         minimumLevel.Override.Should().Contain("Steeltoe", LogEventLevel.Error);
 

--- a/src/Management/test/Endpoint.Test/ActuatorContentNegotiationTests.cs
+++ b/src/Management/test/Endpoint.Test/ActuatorContentNegotiationTests.cs
@@ -67,7 +67,7 @@ public sealed class ActuatorContentNegotiationTests
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         response.Content.Headers.ContentType.Should().NotBeNull();
-        response.Content.Headers.ContentType!.MediaType.Should().Be(responseContentType);
+        response.Content.Headers.ContentType.MediaType.Should().Be(responseContentType);
     }
 
     // Values captured from Spring Boot Admin 3.4.1

--- a/src/Management/test/Endpoint.Test/Actuators/CloudFoundry/EndpointMiddlewareTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/CloudFoundry/EndpointMiddlewareTest.cs
@@ -43,7 +43,7 @@ public sealed class EndpointMiddlewareTest : BaseTest
         var links = await client.GetFromJsonAsync<Links>("http://localhost/cloudfoundryapplication", SerializerOptions);
 
         links.Should().NotBeNull();
-        links!.Entries["beans"].Href.Should().Be("http://localhost/cloudfoundryapplication/beans");
+        links.Entries["beans"].Href.Should().Be("http://localhost/cloudfoundryapplication/beans");
         links.Entries["dbmigrations"].Href.Should().Be("http://localhost/cloudfoundryapplication/dbmigrations");
         links.Entries["env"].Href.Should().Be("http://localhost/cloudfoundryapplication/env");
         links.Entries["health"].Href.Should().Be("http://localhost/cloudfoundryapplication/health");

--- a/src/Management/test/Endpoint.Test/Actuators/Health/Contributors/DiskSpaceHealthContributorTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/Health/Contributors/DiskSpaceHealthContributorTest.cs
@@ -49,7 +49,7 @@ public sealed class DiskSpaceHealthContributorTest : BaseTest
         HealthCheckResult? result = await contributor.CheckHealthAsync(CancellationToken.None);
 
         result.Should().NotBeNull();
-        result!.Status.Should().Be(HealthStatus.Unknown);
+        result.Status.Should().Be(HealthStatus.Unknown);
         result.Description.Should().Be("Failed to determine free disk space.");
         result.Details.Should().Contain("error", "The configured path is invalid or does not exist.");
     }
@@ -107,7 +107,7 @@ public sealed class DiskSpaceHealthContributorTest : BaseTest
         else
         {
             drive.Should().NotBeNull();
-            drive!.RootDirectory.FullName.Should().Be(expected);
+            drive.RootDirectory.FullName.Should().Be(expected);
         }
     }
 }

--- a/src/Management/test/Endpoint.Test/Actuators/Health/EndpointMiddlewareTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/Health/EndpointMiddlewareTest.cs
@@ -98,7 +98,7 @@ public sealed class EndpointMiddlewareTest : BaseTest
         health.Should().NotBeNull();
         health.Should().ContainKey("status");
         health.Should().ContainKey("components");
-        health!["components"].ToString().Should().Contain("diskSpace").And.NotContain("details");
+        health["components"].ToString().Should().Contain("diskSpace").And.NotContain("details");
     }
 
     [Fact]
@@ -128,7 +128,7 @@ public sealed class EndpointMiddlewareTest : BaseTest
         health.Should().NotBeNull();
         health.Should().ContainKey("status");
         health.Should().ContainKey("components");
-        string componentString = health!["components"].ToString() ?? string.Empty;
+        string componentString = health["components"].ToString() ?? string.Empty;
         componentString.Should().Contain("diskSpace");
         componentString.Should().Contain("details");
     }
@@ -160,10 +160,10 @@ public sealed class EndpointMiddlewareTest : BaseTest
         health.Should().NotBeNull();
         health.Should().ContainKey("status");
         health.Should().ContainKey("components");
-        var components = JsonSerializer.Deserialize<Dictionary<string, object>>(health!["components"].ToString()!);
+        var components = JsonSerializer.Deserialize<Dictionary<string, object>>(health["components"].ToString()!);
         components.Should().ContainKey("diskSpace");
         components.Should().ContainKey("test-registration");
-        components!["test-registration"].ToString().Should().NotContain("\"tags\":[\"test-tag-1\",\"test-tag-2\"]");
+        components["test-registration"].ToString().Should().NotContain("\"tags\":[\"test-tag-1\",\"test-tag-2\"]");
     }
 
     [Fact]
@@ -194,10 +194,10 @@ public sealed class EndpointMiddlewareTest : BaseTest
         health.Should().NotBeNull();
         health.Should().ContainKey("status");
         health.Should().ContainKey("components");
-        var components = JsonSerializer.Deserialize<Dictionary<string, object>>(health!["components"].ToString()!);
+        var components = JsonSerializer.Deserialize<Dictionary<string, object>>(health["components"].ToString()!);
         components.Should().ContainKey("diskSpace");
         components.Should().ContainKey("test-registration");
-        components!["test-registration"].ToString().Should().Contain("\"tags\":[\"test-tag-1\",\"test-tag-2\"]");
+        components["test-registration"].ToString().Should().Contain("\"tags\":[\"test-tag-1\",\"test-tag-2\"]");
     }
 
     [Fact]
@@ -227,7 +227,7 @@ public sealed class EndpointMiddlewareTest : BaseTest
         health.Should().NotBeNull();
         health.Should().ContainKey("status");
         health.Should().ContainKey("components");
-        health!["components"].ToString().Should().NotContain("diskSpace");
+        health["components"].ToString().Should().NotContain("diskSpace");
     }
 
     [Fact]

--- a/src/Management/test/Endpoint.Test/Actuators/HttpExchanges/HttpExchangesDiagnosticObserverTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/HttpExchanges/HttpExchangesDiagnosticObserverTest.cs
@@ -187,10 +187,10 @@ public sealed class HttpExchangesDiagnosticObserverTest : BaseTest
         queuedExchange.Response.Headers["HeaderB"][0].Should().Be("headerBValue");
         queuedExchange.Response.Headers[HeaderNames.SetCookie][0].Should().Be("some-value-that-should-be-redacted");
         queuedExchange.Principal.Should().NotBeNull();
-        queuedExchange.Principal!.Name.Should().Be("MyTestName");
+        queuedExchange.Principal.Name.Should().Be("MyTestName");
         queuedExchange.Request.RemoteAddress.Should().Be("127.0.0.1");
         queuedExchange.Session.Should().NotBeNull();
-        queuedExchange.Session!.Id.Should().Be("TestSessionId");
+        queuedExchange.Session.Id.Should().Be("TestSessionId");
 
         HttpExchange filteredHeaders = observer.GetHttpExchanges().Exchanges[0];
         filteredHeaders.Should().NotBeNull();
@@ -205,10 +205,10 @@ public sealed class HttpExchangesDiagnosticObserverTest : BaseTest
         filteredHeaders.Response.Headers["HeaderB"][0].Should().Be("headerBValue");
         filteredHeaders.Response.Headers[HeaderNames.SetCookie][0].Should().Be(HttpExchangesDiagnosticObserver.Redacted);
         filteredHeaders.Principal.Should().NotBeNull();
-        filteredHeaders.Principal!.Name.Should().Be("MyTestName");
+        filteredHeaders.Principal.Name.Should().Be("MyTestName");
         filteredHeaders.Request.RemoteAddress.Should().Be("127.0.0.1");
         filteredHeaders.Session.Should().NotBeNull();
-        filteredHeaders.Session!.Id.Should().Be("TestSessionId");
+        filteredHeaders.Session.Id.Should().Be("TestSessionId");
 
         optionsMonitor.CurrentValue.RequestHeaders.Add(HeaderNames.Authorization);
         optionsMonitor.CurrentValue.RequestHeaders.Add("header1");
@@ -277,7 +277,7 @@ public sealed class HttpExchangesDiagnosticObserverTest : BaseTest
         observer.Queue.Should().ContainSingle();
         observer.Queue.TryPeek(out HttpExchange? result).Should().BeTrue();
         result.Should().NotBeNull();
-        result!.Request.Method.Should().Be("GET");
+        result.Request.Method.Should().Be("GET");
         result.Request.Uri.Should().Be("http://localhost:1111/myPath?foo=bar&bar=foo");
         result.Request.Headers.Should().ContainKeys(HeaderNames.Accept, HeaderNames.Authorization, HeaderNames.UserAgent, "Header1", "Header2");
 

--- a/src/Management/test/Endpoint.Test/Actuators/Hypermedia/EndpointMiddlewareTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/Hypermedia/EndpointMiddlewareTest.cs
@@ -32,7 +32,7 @@ public sealed class EndpointMiddlewareTest : BaseTest
         var links = await client.GetFromJsonAsync<Links>($"{requestUriString}/actuator", SerializerOptions);
 
         links.Should().NotBeNull();
-        links!.Entries.Should().ContainKey("self").WhoseValue.Href.Should().Be($"{calculatedHost}/actuator");
+        links.Entries.Should().ContainKey("self").WhoseValue.Href.Should().Be($"{calculatedHost}/actuator");
         links.Entries.Should().ContainKey("info").WhoseValue.Href.Should().Be($"{calculatedHost}/actuator/info");
     }
 

--- a/src/Management/test/Endpoint.Test/Actuators/Loggers/LoggersEndpointTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/Loggers/LoggersEndpointTest.cs
@@ -44,7 +44,7 @@ public sealed class LoggersEndpointTest(ITestOutputHelper testOutputHelper) : Ba
         LoggersResponse? response = await handler.InvokeAsync(new LoggersRequest(), CancellationToken.None);
 
         response.Should().NotBeNull();
-        response!.HasError.Should().BeFalse();
+        response.HasError.Should().BeFalse();
 
         response.Groups.Should().BeEmpty();
 

--- a/src/Management/test/Endpoint.Test/Actuators/RouteMappings/ActuatorRouteMappingsTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/RouteMappings/ActuatorRouteMappingsTest.cs
@@ -1037,7 +1037,7 @@ public sealed class ActuatorRouteMappingsTest
         var responseNode = await httpClient.GetFromJsonAsync<JsonNode>(new Uri("http://localhost/actuator/mappings"));
         responseNode.Should().NotBeNull();
 
-        return removeMappingsActuatorInResponse ? RemoveMappingsActuatorInResponse(responseNode!) : responseNode!;
+        return removeMappingsActuatorInResponse ? RemoveMappingsActuatorInResponse(responseNode) : responseNode;
     }
 
     private static JsonNode RemoveMappingsActuatorInResponse(JsonNode responseNode)

--- a/src/Management/test/Endpoint.Test/Actuators/Services/ServicesEndpointTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/Services/ServicesEndpointTest.cs
@@ -197,7 +197,7 @@ public sealed class ServicesEndpointTest(ITestOutputHelper testOutputHelper) : B
         ServiceRegistration? registration = registrations.SingleOrDefault(registration => registration.Name == registrationName);
         registration.Should().NotBeNull();
 
-        return registration!;
+        return registration;
     }
 
     private interface IExampleService;

--- a/src/Management/test/Endpoint.Test/CorsPolicyTest.cs
+++ b/src/Management/test/Endpoint.Test/CorsPolicyTest.cs
@@ -32,7 +32,7 @@ public sealed class CorsPolicyTest
         CorsOptions corsOptions = app.Services.GetRequiredService<IOptions<CorsOptions>>().Value;
         CorsPolicy? corsPolicy = corsOptions.GetPolicy(ActuatorsCorsPolicyOptions.PolicyName);
         corsPolicy.Should().NotBeNull();
-        corsPolicy!.AllowAnyOrigin.Should().BeTrue();
+        corsPolicy.AllowAnyOrigin.Should().BeTrue();
         corsPolicy.Methods.Should().ContainSingle();
         corsPolicy.Methods.Should().Contain("GET");
 
@@ -58,7 +58,7 @@ public sealed class CorsPolicyTest
         CorsOptions corsOptions = app.Services.GetRequiredService<IOptions<CorsOptions>>().Value;
         CorsPolicy? corsPolicy = corsOptions.GetPolicy(ActuatorsCorsPolicyOptions.PolicyName);
         corsPolicy.Should().NotBeNull();
-        corsPolicy!.AllowAnyOrigin.Should().BeTrue();
+        corsPolicy.AllowAnyOrigin.Should().BeTrue();
         corsPolicy.Methods.Should().ContainSingle();
         corsPolicy.Methods.Should().Contain("POST");
 
@@ -88,7 +88,7 @@ public sealed class CorsPolicyTest
         CorsOptions corsOptions = app.Services.GetRequiredService<IOptions<CorsOptions>>().Value;
         CorsPolicy? corsPolicy = corsOptions.GetPolicy(ActuatorsCorsPolicyOptions.PolicyName);
         corsPolicy.Should().NotBeNull();
-        corsPolicy!.AllowAnyOrigin.Should().BeFalse();
+        corsPolicy.AllowAnyOrigin.Should().BeFalse();
         corsPolicy.IsOriginAllowed("http://example.api.com").Should().BeTrue();
         corsPolicy.IsOriginAllowed("http://google.com").Should().BeFalse();
         corsPolicy.Methods.Should().ContainSingle();
@@ -126,7 +126,7 @@ public sealed class CorsPolicyTest
         CorsOptions corsOptions = app.Services.GetRequiredService<IOptions<CorsOptions>>().Value;
         CorsPolicy? corsPolicy = corsOptions.GetPolicy(ActuatorsCorsPolicyOptions.PolicyName);
         corsPolicy.Should().NotBeNull();
-        corsPolicy!.AllowAnyOrigin.Should().BeTrue();
+        corsPolicy.AllowAnyOrigin.Should().BeTrue();
         corsPolicy.PreflightMaxAge.Should().Be(TimeSpan.FromSeconds(preflightMaxAge));
         corsPolicy.Methods.Should().ContainSingle();
         corsPolicy.Methods.Should().Contain("POST");
@@ -200,7 +200,7 @@ public sealed class CorsPolicyTest
         CorsOptions corsOptions = app.Services.GetRequiredService<IOptions<CorsOptions>>().Value;
         CorsPolicy? corsPolicy = corsOptions.GetPolicy(ActuatorsCorsPolicyOptions.PolicyName);
         corsPolicy.Should().NotBeNull();
-        corsPolicy!.AllowAnyOrigin.Should().BeTrue();
+        corsPolicy.AllowAnyOrigin.Should().BeTrue();
         corsPolicy.Methods.Should().ContainSingle();
         corsPolicy.Methods.Should().Contain("GET");
         corsPolicy.Headers.Should().BeEquivalentTo("Authorization", "X-Cf-App-Instance", "Content-Type", "Content-Disposition");

--- a/src/Security/test/Authentication.JwtBearer.Test/TokenKeyResolverTest.cs
+++ b/src/Security/test/Authentication.JwtBearer.Test/TokenKeyResolverTest.cs
@@ -118,7 +118,7 @@ public sealed class TokenKeyResolverTest
         JsonWebKeySet? result = await resolver.FetchKeySetAsync(CancellationToken.None);
 
         result.Should().NotBeNull();
-        result!.Keys.Should().NotBeEmpty();
+        result.Keys.Should().NotBeEmpty();
     }
 
     private sealed class TestMessageHandler : HttpMessageHandler

--- a/src/Security/test/Authentication.OpenIdConnect.Test/TokenKeyResolverTest.cs
+++ b/src/Security/test/Authentication.OpenIdConnect.Test/TokenKeyResolverTest.cs
@@ -118,7 +118,7 @@ public sealed class TokenKeyResolverTest
         JsonWebKeySet? result = await resolver.FetchKeySetAsync(CancellationToken.None);
 
         result.Should().NotBeNull();
-        result!.Keys.Should().NotBeEmpty();
+        result.Keys.Should().NotBeEmpty();
     }
 
     private sealed class TestMessageHandler : HttpMessageHandler

--- a/src/Security/test/Authorization.Certificate.Test/ApplicationInstanceCertificateTest.cs
+++ b/src/Security/test/Authorization.Certificate.Test/ApplicationInstanceCertificateTest.cs
@@ -22,7 +22,7 @@ public sealed class ApplicationInstanceCertificateTest
         if (shouldParse)
         {
             instanceCertificate.Should().NotBeNull();
-            instanceCertificate!.OrgId.Should().Be(expectedOrgId);
+            instanceCertificate.OrgId.Should().Be(expectedOrgId);
             instanceCertificate.SpaceId.Should().Be(expectedSpaceId);
         }
         else

--- a/versions.props
+++ b/versions.props
@@ -8,7 +8,7 @@
     <AspNetCoreHealthChecksVersion>9.0.*</AspNetCoreHealthChecksVersion>
     <CoverletVersion>6.0.*</CoverletVersion>
     <FluentAssertionsJsonVersion>6.1.*</FluentAssertionsJsonVersion>
-    <FluentAssertionsVersion>7.1.*</FluentAssertionsVersion>
+    <FluentAssertionsVersion>7.2.*</FluentAssertionsVersion>
     <MicrosoftAzureCosmosVersion>3.46.*</MicrosoftAzureCosmosVersion>
     <MicrosoftCodeAnalysisVersion>4.12.0</MicrosoftCodeAnalysisVersion>
     <MicrosoftSqlClientVersion>6.0.*</MicrosoftSqlClientVersion>


### PR DESCRIPTION
## Description

Update to [FluentAssertions 7.2](https://github.com/fluentassertions/fluentassertions/releases/tag/7.2.0), which removes the need for null suppressions after `Should()`.

## Quality checklist

- [x] Your code complies with our [Coding Style](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-code-style.md).
- [x] You've updated unit and/or integration tests for your change, where applicable.
- [ ] You've updated documentation for your change, where applicable.
      If your change affects other repositories, such as [Documentation](https://github.com/SteeltoeOSS/Documentation), [Samples](https://github.com/SteeltoeOSS/Samples) and/or [MainSite](https://github.com/SteeltoeOSS/MainSite), add linked PRs here.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
- [ ] You've added required license files and/or file headers (explaining where the code came from with proper attribution), where code is copied from StackOverflow, a blog, or OSS.
