### PR TITLE
Update nbgv to allow pre-releases

### DIFF
--- a/version.json
+++ b/version.json
@@ -3,7 +3,7 @@
   "version": "4.0-beta",
   "publicReleaseRefSpec": [
     "^refs/heads/main$",
-    "^refs/heads/release/\\d+(?:\\.\\d+)?$"
+    "^refs/heads/release/[0-9]+.*$"
   ],
   "cloudBuild": {
     // https://github.com/dotnet/Nerdbank.GitVersioning/blob/main/doc/cloudbuild.md#set-cloud-build-variables-only-once-in-a-build


### PR DESCRIPTION
## Description

This change removes the commit hash from NuGet packages built from release branches, such as `release/4.0-rc`.
Tested locally from a branch named `release/4.0-alpha1`, which produces the file name: `Steeltoe.Common.4.0.576-beta.nupkg`

## Quality checklist

- [x] Your code complies with our [Coding Style](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-code-style.md).
- [ ] You've updated unit and/or integration tests for your change, where applicable.
- [ ] You've updated documentation for your change, where applicable.
      If your change affects other repositories, such as [Documentation](https://github.com/SteeltoeOSS/Documentation), [Samples](https://github.com/SteeltoeOSS/Samples) and/or [MainSite](https://github.com/SteeltoeOSS/MainSite), add linked PRs here.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
- [ ] You've added required license files and/or file headers (explaining where the code came from with proper attribution), where code is copied from StackOverflow, a blog, or OSS.
