### PR TITLE
Ensure HTTP header values are redacted

### DIFF
--- a/src/Common/src/Http/Steeltoe.Common.Http.csproj
+++ b/src/Common/src/Http/Steeltoe.Common.Http.csproj
@@ -9,6 +9,11 @@
   <Import Project="..\..\..\..\shared.props" />
 
   <ItemGroup>
+    <!-- Referencing v9 of Microsoft.Extensions.Http to get HTTP header redaction by default in .NET 8. -->
+    <PackageReference Include="Microsoft.Extensions.Http" Version="$(FoundationalVersion)" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Certificates\Steeltoe.Common.Certificates.csproj" />
     <ProjectReference Include="..\Common\Steeltoe.Common.csproj" />
   </ItemGroup>

--- a/src/Common/test/Http.Test/HeaderRedactionTest.cs
+++ b/src/Common/test/Http.Test/HeaderRedactionTest.cs
@@ -1,0 +1,20 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Extensions.Http;
+
+namespace Steeltoe.Common.Http.Test;
+
+public sealed class HeaderRedactionTest
+{
+    [Fact]
+    public void HttpClientFactory_uses_HTTP_header_redaction_by_default()
+    {
+        // https://learn.microsoft.com/en-us/dotnet/core/compatibility/networking/9.0/redact-headers
+        Version? assemblyVersion = typeof(HttpClientFactoryOptions).Assembly.GetName().Version;
+
+        assemblyVersion.Should().NotBeNull();
+        assemblyVersion.Major.Should().BeGreaterThanOrEqualTo(9);
+    }
+}

--- a/src/Discovery/src/HttpClients/Steeltoe.Discovery.HttpClients.csproj
+++ b/src/Discovery/src/HttpClients/Steeltoe.Discovery.HttpClients.csproj
@@ -10,7 +10,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="$(FoundationalVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="$(FoundationalVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Management/src/Endpoint/Actuators/CloudFoundry/EndpointServiceCollectionExtensions.cs
+++ b/src/Management/src/Endpoint/Actuators/CloudFoundry/EndpointServiceCollectionExtensions.cs
@@ -62,7 +62,7 @@ public static class EndpointServiceCollectionExtensions
         services.TryAddSingleton<HttpClientHandlerFactory>();
         services.TryAddSingleton<ValidateCertificatesHttpClientHandlerConfigurer<CloudFoundryEndpointOptions>>();
 
-        IHttpClientBuilder httpClientBuilder = services.AddHttpClient(PermissionsProvider.HttpClientName).RedactLoggedHeaders(["Authorization"]);
+        IHttpClientBuilder httpClientBuilder = services.AddHttpClient(PermissionsProvider.HttpClientName);
 
         httpClientBuilder.ConfigurePrimaryHttpMessageHandler(serviceProvider =>
         {


### PR DESCRIPTION
## Description

By referencing v9 of `Microsoft.Extensions.Http`, we activate the [breaking change](https://learn.microsoft.com/en-us/dotnet/core/compatibility/networking/9.0/redact-headers) that redacts all HTTP headers by default.

I have verified the behavior can be overruled from outside of Steeltoe using (globally):
```c#
builder.Services.ConfigureHttpClientDefaults(clientBuilder => clientBuilder.RedactLoggedHeaders(_ => false));
```
and locally:
```c#
builder.Services.AddHttpClient("CloudFoundrySecurity").RedactLoggedHeaders(_ => false);
```

Adding any of the lines above causes the test `CloudFoundrySecurityMiddlewareTest.Redacts_HTTP_headers` to fail.

Fixes #1447

## Quality checklist

- [x] Your code complies with our [Coding Style](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-code-style.md).
- [x] You've updated unit and/or integration tests for your change, where applicable.
- [ ] You've updated documentation for your change, where applicable.
      If your change affects other repositories, such as [Documentation](https://github.com/SteeltoeOSS/Documentation), [Samples](https://github.com/SteeltoeOSS/Samples) and/or [MainSite](https://github.com/SteeltoeOSS/MainSite), add linked PRs here.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
- [ ] You've added required license files and/or file headers (explaining where the code came from with proper attribution), where code is copied from StackOverflow, a blog, or OSS.
