### PR TITLE
Suppress IDE-only diagnostics that result in false positives

### DIFF
--- a/shared-package.props
+++ b/shared-package.props
@@ -1,13 +1,16 @@
 <Project>
   <PropertyGroup>
     <!--
-      Disabled IDE analyzers for "Use collection expression" because they are dangerous in a subtle way.
+      Disabled IDE analyzers for "Use collection expression" (IDE0028, IDE0300-IDE0306) because they are dangerous in a subtle way.
       For example, a suggestion for the following code is raised:
         public IList<string> KeysToSanitize { get; } = new List<string>();
       Taking the suggestion TODAY produces List<string>(), but the spec doesn't require that, so the compiler may change it over time.
       As a result, callers that cast back to List<string> will face a breaking change.
+
+      Disabled IDE analyzers for "Remove unused member" (IDE0051, IDE0052) because they currently don't "see" code added
+      by source generators, resulting in false positives. See https://github.com/dotnet/roslyn/issues/75483.
      -->
-    <NoWarn>$(NoWarn);CS1591;IDE0028;IDE0300;IDE0301;IDE0302;IDE0303;IDE0304;IDE0305;IDE0306</NoWarn>
+    <NoWarn>$(NoWarn);CS1591;IDE0028;IDE0051;IDE0052;IDE0300;IDE0301;IDE0302;IDE0303;IDE0304;IDE0305;IDE0306</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 


### PR DESCRIPTION
## Description

Suppress [IDE0051](https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0051) and [IDE0052](https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0052) to keep the error list in Visual Studio clean.

![image](https://github.com/user-attachments/assets/e48fd513-1a7e-459f-a552-f9bf620e91a2)

Resharper also catches these (but without the bugs), although it doesn't fail the ci-build.

## Quality checklist

- [x] Your code complies with our [Coding Style](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-code-style.md).
- [ ] You've updated unit and/or integration tests for your change, where applicable.
- [ ] You've updated documentation for your change, where applicable.
      If your change affects other repositories, such as [Documentation](https://github.com/SteeltoeOSS/Documentation), [Samples](https://github.com/SteeltoeOSS/Samples) and/or [MainSite](https://github.com/SteeltoeOSS/MainSite), add linked PRs here.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
- [ ] You've added required license files and/or file headers (explaining where the code came from with proper attribution), where code is copied from StackOverflow, a blog, or OSS.
