### PR TITLE
Fix loss of indication to use ampqs

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,7 +16,7 @@ jobs:
   variables:
     DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
     DOTNET_CLI_TELEMETRY_OPTOUT: 1
-    PackageVersion: $[format('3.2.8-{0}', variables['Build.BuildId'])]
+    PackageVersion: $[format('3.2.9-{0}', variables['Build.BuildId'])]
     BUILD_PACKAGES: true
   steps:
   - pwsh: |

--- a/build/templates/component-build.yaml
+++ b/build/templates/component-build.yaml
@@ -38,7 +38,7 @@ jobs:
       projects: $(SolutionFile)
       arguments: --no-restore -c Release -v n /p:TreatWarningsAsErrors=True
   # RabbitMQ is pinned to 3.13.2 due to failure in Steeltoe.Messaging.RabbitMQ.Core.RabbitAdminIntegrationTest.TestDeclareDelayedExchange
-  # Currently failing versions include 3.13.3 and 3.13.4
+  # This test fails on EVERY higher version, and is the only reason we can't upgrade to "4-management"
   - script: docker run -d --name rabbitmq -p 5672:5672 -p 15672:15672 rabbitmq:3.13.2-management; sleep 10s
     condition: eq(${{parameters.runRabbitMQ}}, 'true')
     displayName: Start RabbitMQ

--- a/src/Messaging/src/RabbitMQ/Connection/AbstractConnectionFactory.cs
+++ b/src/Messaging/src/RabbitMQ/Connection/AbstractConnectionFactory.cs
@@ -231,19 +231,6 @@ public abstract class AbstractConnectionFactory : IConnectionFactory
 
                 return;
             }
-
-            /*
-            var endpoints = RC.AmqpTcpEndpoint.ParseMultiple(addresses);
-            if (endpoints.Length > 0)
-            {
-                Addresses = endpoints.ToList();
-                if (PublisherConnectionFactory != null)
-                {
-                    AbstractPublisherConnectionFactory.SetAddresses(addresses);
-                }
-
-                return;
-            }*/
         }
 
         _logger?.LogInformation("SetAddresses() called with an empty value, will be using the host+port properties for connections");

--- a/src/Messaging/src/RabbitMQ/Extensions/RabbitServicesExtensions.cs
+++ b/src/Messaging/src/RabbitMQ/Extensions/RabbitServicesExtensions.cs
@@ -250,7 +250,12 @@ public static class RabbitServicesExtensions
 
                     if (connectionFactory is not null)
                     {
-                        options.Addresses = $"{connectionFactory.UserName}:{connectionFactory.Password}@{connectionFactory.HostName}:{connectionFactory.Port}";
+                        var scheme = connectionFactory.Ssl.Enabled
+                            ? "amqps://"
+                            : "ampq://";
+                        //var scheme = "";
+
+                        options.Addresses = $"{scheme}{connectionFactory.UserName}:{connectionFactory.Password}@{connectionFactory.HostName}:{connectionFactory.Port}";
                         options.VirtualHost = connectionFactory.VirtualHost;
                         options.Host = connectionFactory.HostName;
                         options.Username = connectionFactory.UserName;

--- a/src/Messaging/src/RabbitMQ/Extensions/RabbitServicesExtensions.cs
+++ b/src/Messaging/src/RabbitMQ/Extensions/RabbitServicesExtensions.cs
@@ -251,9 +251,8 @@ public static class RabbitServicesExtensions
                     if (connectionFactory is not null)
                     {
                         var scheme = connectionFactory.Ssl.Enabled
-                            ? "amqps://"
+                            ? "ampqs://"
                             : "ampq://";
-                        //var scheme = "";
 
                         options.Addresses = $"{scheme}{connectionFactory.UserName}:{connectionFactory.Password}@{connectionFactory.HostName}:{connectionFactory.Port}";
                         options.VirtualHost = connectionFactory.VirtualHost;

--- a/src/Messaging/src/RabbitMQ/Steeltoe.Messaging.RabbitMQ.csproj
+++ b/src/Messaging/src/RabbitMQ/Steeltoe.Messaging.RabbitMQ.csproj
@@ -2,7 +2,7 @@
   
   <PropertyGroup>
     <Description>Steeltoe Messaging RabbitMQ</Description>
-    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net6.0;netcoreapp3.1</TargetFrameworks>
     <RootNamespace>Steeltoe.Messaging.RabbitMQ</RootNamespace>
     <AssemblyName>Steeltoe.Messaging.RabbitMQ</AssemblyName>
     <PackageId>Steeltoe.Messaging.RabbitMQ</PackageId>

--- a/src/Messaging/src/RabbitMQ/Steeltoe.Messaging.RabbitMQ.csproj
+++ b/src/Messaging/src/RabbitMQ/Steeltoe.Messaging.RabbitMQ.csproj
@@ -2,7 +2,7 @@
   
   <PropertyGroup>
     <Description>Steeltoe Messaging RabbitMQ</Description>
-    <TargetFrameworks>net6.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <RootNamespace>Steeltoe.Messaging.RabbitMQ</RootNamespace>
     <AssemblyName>Steeltoe.Messaging.RabbitMQ</AssemblyName>
     <PackageId>Steeltoe.Messaging.RabbitMQ</PackageId>

--- a/src/Messaging/test/RabbitMQ.Test/Core/RabbitAdminIntegrationTest.cs
+++ b/src/Messaging/test/RabbitMQ.Test/Core/RabbitAdminIntegrationTest.cs
@@ -368,6 +368,8 @@ public class RabbitAdminIntegrationTest : IDisposable
         rabbitAdmin.DeleteQueue(queue2.QueueName);
     }
 
+    // TODO: Fix test compatibility with RabbitMQ newer than 3.13.2
+    // docker run --name rabbitmq -p 5672:5672 -p 15672:15672 rabbitmq:3.13.2-management
     [Fact]
     public async Task TestDeclareDelayedExchange()
     {

--- a/src/Messaging/test/RabbitMQ.Test/Extensions/RabbitServiceExtensionsTest.cs
+++ b/src/Messaging/test/RabbitMQ.Test/Extensions/RabbitServiceExtensionsTest.cs
@@ -540,7 +540,7 @@ public class RabbitServiceExtensionsTest
         Assert.Equal("Dd6O1BPXUHdrmzbP", rabbitOptions.Username);
         Assert.Equal("7E1LxXnlH2hhlPVt", rabbitOptions.Password);
         Assert.Equal("cf_b4f8d2fa_a3ea_4e3a_a0e8_2cd040790355", rabbitOptions.VirtualHost);
-        Assert.Equal($"Dd6O1BPXUHdrmzbP:7E1LxXnlH2hhlPVt@192.168.0.90:3306", rabbitOptions.Addresses);
+        Assert.Equal("ampq://Dd6O1BPXUHdrmzbP:7E1LxXnlH2hhlPVt@192.168.0.90:3306", rabbitOptions.Addresses);
     }
 
     [Fact]

--- a/src/Messaging/test/RabbitMQ.Test/Host/RabbitMQHostTest.cs
+++ b/src/Messaging/test/RabbitMQ.Test/Host/RabbitMQHostTest.cs
@@ -98,13 +98,13 @@ public class RabbitMQHostTest
     [Fact]
     public void ShouldWorkWithRabbitMQConnection()
     {
-        using (var host = RabbitMQHost.CreateDefaultBuilder()
-                   .ConfigureServices(svc => svc.AddRabbitMQConnection(new ConfigurationBuilder().Build()))
-                   .Start())
-        {
-            var connectionFactory = host.Services.GetRequiredService<RC.IConnectionFactory>();
+        using var host = RabbitMQHost.CreateDefaultBuilder()
+            .ConfigureServices(svc => svc.AddRabbitMQConnection(new ConfigurationBuilder().Build()))
+            .Start();
+        using var scope = host.Services.CreateScope();
 
-            Assert.NotNull(connectionFactory);
-        }
+        var connectionFactory = scope.ServiceProvider.GetRequiredService<RC.IConnectionFactory>();
+
+        Assert.NotNull(connectionFactory);
     }
 }

--- a/src/Stream/test/StreamBase.Test/StreamsHost/StreamsHostTest.cs
+++ b/src/Stream/test/StreamBase.Test/StreamsHost/StreamsHostTest.cs
@@ -62,7 +62,7 @@ public class StreamsHostTest
             Assert.Equal("Dd6O1BPXUHdrmzbP", rabbitOptions.Username);
             Assert.Equal("7E1LxXnlH2hhlPVt", rabbitOptions.Password);
             Assert.Equal("cf_b4f8d2fa_a3ea_4e3a_a0e8_2cd040790355", rabbitOptions.VirtualHost);
-            Assert.Equal($"Dd6O1BPXUHdrmzbP:7E1LxXnlH2hhlPVt@192.168.0.90:3306", rabbitOptions.Addresses);
+            Assert.Equal("ampq://Dd6O1BPXUHdrmzbP:7E1LxXnlH2hhlPVt@192.168.0.90:3306", rabbitOptions.Addresses);
         }
     }
 

--- a/versions.props
+++ b/versions.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup Condition="'$(TF_BUILD)' != 'true'">
-    <VersionPrefix>3.2.8</VersionPrefix>
+    <VersionPrefix>3.2.9</VersionPrefix>
   </PropertyGroup>
   <PropertyGroup>
     <CoreFxVersion>4.4.0</CoreFxVersion>


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->

<!-- If this is your first PR in this repo, please read our [Contributing Guidelines (https://github.com/SteeltoeOSS/.github/blob/master/CONTRIBUTING.md) and remember to sign the [Contributor License Agreement](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-license.md). Our bot will notify you shortly after the PR has been created. -->

## Description

Avoids call to `AmqpTcpEndpoint.ParseMultiple` in favor of splitting hosts ourselves and reapplying `SslOptions` already set on the ConnectionFactory

Fixes #1488

## Quality checklist

<!-- Please run through the checklist below to ensure a smooth review and merge process for your PR. -->

- [ ] Your code complies with our [Coding Style](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-code-style.md).
- [ ] You've updated unit and/or integration tests for your change, where applicable.
- [ ] You've updated documentation for your change, where applicable.
      If your change affects other repositories, such as [Documentation](https://github.com/SteeltoeOSS/Documentation), [Samples](https://github.com/SteeltoeOSS/Samples) and/or [MainSite](https://github.com/SteeltoeOSS/MainSite), add linked PRs here.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
- [ ] You've added required license files and/or file headers (explaining where the code came from with proper attribution), where code is copied from StackOverflow, a blog, or OSS.
