### PR TITLE
Prepare for updating tests to xUnit v3

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,9 +1,3 @@
-pr:
-  branches:
-    include:
-    - main
-    - release/*
-
 trigger:
   branches:
     include:

--- a/build/sonar-analyze.yml
+++ b/build/sonar-analyze.yml
@@ -14,6 +14,11 @@ jobs:
   pool:
     vmImage: ubuntu-latest
   steps:
+  - script: |
+      docker run -d --name eurekaserver -p 8761:8761 steeltoe.azurecr.io/eureka-server
+      sleep 10s
+      docker run -d --name configserver -p 8888:8888 --add-host=host.docker.internal:host-gateway steeltoe.azurecr.io/config-server --eureka.client.enabled=true --eureka.instance.hostname=localhost --eureka.instance.instanceId="localhost:configserver:8888"
+    displayName: Start Docker services
   - checkout: self
     fetchDepth: 0
   - task: UseDotNet@2
@@ -38,7 +43,7 @@ jobs:
       targetType: 'inline'
       script: |
         nbgv cloud
-  - task: SonarCloudPrepare@1
+  - task: SonarCloudPrepare@3
     displayName: Prepare analysis on SonarCloud
     inputs:
       SonarCloud: SonarCloud
@@ -54,10 +59,6 @@ jobs:
       command: build
       projects: src/Steeltoe.All.sln
       arguments: --no-restore -c $(buildConfiguration) -v minimal
-  - script: |
-      docker run -d --name configserver -p 8888:8888 steeltoe.azurecr.io/config-server --spring.cloud.config.server.git.default-label=main
-      docker run -d --name rabbitmq -p 5672:5672 -p 15672:15672 rabbitmq:3-management
-    displayName: Start Docker services
   - task: DotNetCoreCLI@2
     displayName: dotnet test
     inputs:
@@ -77,8 +78,9 @@ jobs:
   - script: |
       docker kill configserver
       docker rm configserver
-      docker kill rabbitmq
-      docker rm rabbitmq
+      docker kill eurekaserver
+      docker rm eurekaserver
+    condition: and(succeededOrFailed(), eq(variables['integrationTests'], 'true'))
     displayName: Stop Docker services
   - task: PublishTestResults@2
     condition: succeededOrFailed()
@@ -87,9 +89,9 @@ jobs:
       testResultsFormat: VSTest
       testResultsFiles: '*.trx'
       mergeTestResults: true
-  - task: SonarCloudAnalyze@1
+  - task: SonarCloudAnalyze@3
     condition: succeededOrFailed()
     displayName: Run code analysis
-  - task: SonarCloudPublish@1
+  - task: SonarCloudPublish@3
     condition: succeededOrFailed()
     displayName: Publish quality gate result

--- a/src/Common/test/Certificates.Test/ConfigureCertificateOptionsTest.cs
+++ b/src/Common/test/Certificates.Test/ConfigureCertificateOptionsTest.cs
@@ -4,6 +4,7 @@
 
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
+using FluentAssertions.Extensions;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
@@ -109,11 +110,11 @@ public sealed class ConfigureCertificateOptionsTest
     public async Task CertificateOptionsUpdateOnFileContentChange()
     {
         using var sandbox = new Sandbox();
-        string firstCertificateContent = await File.ReadAllTextAsync("instance.crt");
-        string firstPrivateKeyContent = await File.ReadAllTextAsync("instance.key");
+        string firstCertificateContent = await File.ReadAllTextAsync("instance.crt", TestContext.Current.CancellationToken);
+        string firstPrivateKeyContent = await File.ReadAllTextAsync("instance.key", TestContext.Current.CancellationToken);
         var firstX509 = X509Certificate2.CreateFromPemFile("instance.crt", "instance.key");
-        string secondCertificateContent = await File.ReadAllTextAsync("instance2.crt");
-        string secondPrivateKeyContent = await File.ReadAllTextAsync("instance2.key");
+        string secondCertificateContent = await File.ReadAllTextAsync("instance2.crt", TestContext.Current.CancellationToken);
+        string secondPrivateKeyContent = await File.ReadAllTextAsync("instance2.key", TestContext.Current.CancellationToken);
         var secondX509 = X509Certificate2.CreateFromPemFile("instance.crt", "instance.key");
         string certificateFilePath = sandbox.CreateFile("cert", firstCertificateContent);
         string privateKeyFilePath = sandbox.CreateFile("key", firstPrivateKeyContent);
@@ -133,9 +134,9 @@ public sealed class ConfigureCertificateOptionsTest
 
         optionsMonitor.Get(CertificateName).Certificate.Should().BeEquivalentTo(firstX509);
 
-        await File.WriteAllTextAsync(certificateFilePath, secondCertificateContent);
-        await File.WriteAllTextAsync(privateKeyFilePath, secondPrivateKeyContent);
-        await Task.Delay(2000);
+        await File.WriteAllTextAsync(certificateFilePath, secondCertificateContent, TestContext.Current.CancellationToken);
+        await File.WriteAllTextAsync(privateKeyFilePath, secondPrivateKeyContent, TestContext.Current.CancellationToken);
+        await Task.Delay(2.Seconds(), TestContext.Current.CancellationToken);
 
         optionsMonitor.Get(CertificateName).Certificate.Should().BeEquivalentTo(secondX509);
     }
@@ -144,11 +145,11 @@ public sealed class ConfigureCertificateOptionsTest
     public async Task CertificateOptionsUpdateOnFileLocationChange()
     {
         using var sandbox = new Sandbox();
-        string instance1Certificate = await File.ReadAllTextAsync("instance.crt");
-        string instance1PrivateKey = await File.ReadAllTextAsync("instance.key");
+        string instance1Certificate = await File.ReadAllTextAsync("instance.crt", TestContext.Current.CancellationToken);
+        string instance1PrivateKey = await File.ReadAllTextAsync("instance.key", TestContext.Current.CancellationToken);
         var firstX509 = X509Certificate2.CreateFromPemFile("instance.crt", "instance.key");
-        string instance2Certificate = await File.ReadAllTextAsync("instance2.crt");
-        string instance2PrivateKey = await File.ReadAllTextAsync("instance2.key");
+        string instance2Certificate = await File.ReadAllTextAsync("instance2.crt", TestContext.Current.CancellationToken);
+        string instance2PrivateKey = await File.ReadAllTextAsync("instance2.key", TestContext.Current.CancellationToken);
         var secondX509 = X509Certificate2.CreateFromPemFile("instance.crt", "instance.key");
         string certificate1FilePath = sandbox.CreateFile("cert", instance1Certificate);
         string privateKey1FilePath = sandbox.CreateFile("key", instance1PrivateKey);
@@ -182,9 +183,9 @@ public sealed class ConfigureCertificateOptionsTest
         changeCalled.Should().BeTrue("file path information changed");
 
         _ = changeToken.RegisterChangeCallback(_ => changeCalled = true, "state");
-        await File.WriteAllTextAsync(certificate2FilePath, instance1Certificate);
-        await File.WriteAllTextAsync(privateKey2FilePath, instance1PrivateKey);
-        await Task.Delay(2000);
+        await File.WriteAllTextAsync(certificate2FilePath, instance1Certificate, TestContext.Current.CancellationToken);
+        await File.WriteAllTextAsync(privateKey2FilePath, instance1PrivateKey, TestContext.Current.CancellationToken);
+        await Task.Delay(2.Seconds(), TestContext.Current.CancellationToken);
         optionsMonitor.Get(CertificateName).Certificate.Should().BeEquivalentTo(firstX509);
         changeCalled.Should().BeTrue("file contents changed");
     }

--- a/src/Common/test/Http.Test/HttpClientExtensionsTest.cs
+++ b/src/Common/test/Http.Test/HttpClientExtensionsTest.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
+using FluentAssertions.Extensions;
 using RichardSzalay.MockHttp;
 using Steeltoe.Common.TestResources;
 
@@ -14,12 +15,12 @@ public sealed class HttpClientExtensionsTest
     {
         var httpClient = new HttpClient();
 
-        httpClient.ConfigureForSteeltoe(TimeSpan.FromSeconds(5));
+        httpClient.ConfigureForSteeltoe(5.Seconds());
 
         httpClient.DefaultRequestHeaders.UserAgent.Should().ContainSingle();
         httpClient.DefaultRequestHeaders.UserAgent.ElementAt(0).ToString().Should().Be(HttpClientExtensions.SteeltoeUserAgent);
 
-        httpClient.Timeout.Should().Be(TimeSpan.FromSeconds(5));
+        httpClient.Timeout.Should().Be(5.Seconds());
     }
 
     [Fact]
@@ -33,7 +34,7 @@ public sealed class HttpClientExtensionsTest
         var httpClient = new HttpClient(handler);
 
         string accessToken =
-            await httpClient.GetAccessTokenAsync(new Uri("https://auth-server.com/oauth/token"), "test-user", "test-password", CancellationToken.None);
+            await httpClient.GetAccessTokenAsync(new Uri("https://auth-server.com/oauth/token"), "test-user", "test-password", TestContext.Current.CancellationToken);
 
         handler.Mock.VerifyNoOutstandingExpectation();
 
@@ -54,7 +55,7 @@ public sealed class HttpClientExtensionsTest
         var httpClient = new HttpClient(handler);
 
         string accessToken =
-            await httpClient.GetAccessTokenAsync(new Uri("https://auth-server.com/oauth/token"), null, "test-password", CancellationToken.None);
+            await httpClient.GetAccessTokenAsync(new Uri("https://auth-server.com/oauth/token"), null, "test-password", TestContext.Current.CancellationToken);
 
         handler.Mock.VerifyNoOutstandingExpectation();
 

--- a/src/Common/test/Http.Test/HttpClientExtensionsTest.cs
+++ b/src/Common/test/Http.Test/HttpClientExtensionsTest.cs
@@ -33,8 +33,8 @@ public sealed class HttpClientExtensionsTest
 
         var httpClient = new HttpClient(handler);
 
-        string accessToken =
-            await httpClient.GetAccessTokenAsync(new Uri("https://auth-server.com/oauth/token"), "test-user", "test-password", TestContext.Current.CancellationToken);
+        string accessToken = await httpClient.GetAccessTokenAsync(new Uri("https://auth-server.com/oauth/token"), "test-user", "test-password",
+            TestContext.Current.CancellationToken);
 
         handler.Mock.VerifyNoOutstandingExpectation();
 
@@ -54,8 +54,8 @@ public sealed class HttpClientExtensionsTest
 
         var httpClient = new HttpClient(handler);
 
-        string accessToken =
-            await httpClient.GetAccessTokenAsync(new Uri("https://auth-server.com/oauth/token"), null, "test-password", TestContext.Current.CancellationToken);
+        string accessToken = await httpClient.GetAccessTokenAsync(new Uri("https://auth-server.com/oauth/token"), null, "test-password",
+            TestContext.Current.CancellationToken);
 
         handler.Mock.VerifyNoOutstandingExpectation();
 

--- a/src/Common/test/Logging.Test/BootstrapperLoggerFactoryTest.cs
+++ b/src/Common/test/Logging.Test/BootstrapperLoggerFactoryTest.cs
@@ -33,7 +33,7 @@ public sealed class BootstrapperLoggerFactoryTest
         builder.Services.UpgradeBootstrapLoggerFactory(bootstrapLoggerFactory);
 
         await using WebApplication app = builder.Build();
-        await app.StartAsync();
+        await app.StartAsync(TestContext.Current.CancellationToken);
 
         var loggerFactory = app.Services.GetRequiredService<ILoggerFactory>();
         ILogger afterStartLogger = loggerFactory.CreateLogger("Test_AfterStart");

--- a/src/Common/test/TestResources/ConsoleOutput.cs
+++ b/src/Common/test/TestResources/ConsoleOutput.cs
@@ -45,16 +45,16 @@ public sealed class ConsoleOutput : IDisposable
         _outputBuilder.Clear();
     }
 
-    public async Task WaitForFlushAsync()
+    public async Task WaitForFlushAsync(CancellationToken cancellationToken)
     {
         // Microsoft.Extensions.Logging.Console.ConsoleLogger writes messages to a queue,
         // it takes a bit of time for the background thread to write them to Console.Out.
-        await Task.Delay(1);
+        await Task.Delay(1, cancellationToken);
 
         if (_outputBuilder.Length == 0)
         {
             // Wait a bit longer in case of high contention while running tests on build server.
-            await Task.Delay(100);
+            await Task.Delay(100, cancellationToken);
         }
     }
 

--- a/src/Common/test/TestResources/HostWrapper.cs
+++ b/src/Common/test/TestResources/HostWrapper.cs
@@ -52,14 +52,14 @@ public sealed class HostWrapper : IAsyncDisposable
         return _host?.GetTestClient() ?? _webHost?.GetTestClient() ?? _webApplication?.GetTestClient() ?? throw new NotSupportedException();
     }
 
-    public Task StartAsync()
+    public Task StartAsync(CancellationToken cancellationToken)
     {
-        return _host?.StartAsync() ?? _webHost?.StartAsync() ?? _webApplication?.StartAsync() ?? throw new NotSupportedException();
+        return _host?.StartAsync(cancellationToken) ?? _webHost?.StartAsync(cancellationToken) ?? _webApplication?.StartAsync(cancellationToken) ?? throw new NotSupportedException();
     }
 
-    public Task StopAsync()
+    public Task StopAsync(CancellationToken cancellationToken)
     {
-        return _host?.StopAsync() ?? _webHost?.StopAsync() ?? _webApplication?.StopAsync() ?? throw new NotSupportedException();
+        return _host?.StopAsync(cancellationToken) ?? _webHost?.StopAsync(cancellationToken) ?? _webApplication?.StopAsync(cancellationToken) ?? throw new NotSupportedException();
     }
 
     public async ValueTask DisposeAsync()

--- a/src/Common/test/TestResources/HostWrapper.cs
+++ b/src/Common/test/TestResources/HostWrapper.cs
@@ -54,12 +54,14 @@ public sealed class HostWrapper : IAsyncDisposable
 
     public Task StartAsync(CancellationToken cancellationToken)
     {
-        return _host?.StartAsync(cancellationToken) ?? _webHost?.StartAsync(cancellationToken) ?? _webApplication?.StartAsync(cancellationToken) ?? throw new NotSupportedException();
+        return _host?.StartAsync(cancellationToken) ?? _webHost?.StartAsync(cancellationToken) ??
+            _webApplication?.StartAsync(cancellationToken) ?? throw new NotSupportedException();
     }
 
     public Task StopAsync(CancellationToken cancellationToken)
     {
-        return _host?.StopAsync(cancellationToken) ?? _webHost?.StopAsync(cancellationToken) ?? _webApplication?.StopAsync(cancellationToken) ?? throw new NotSupportedException();
+        return _host?.StopAsync(cancellationToken) ??
+            _webHost?.StopAsync(cancellationToken) ?? _webApplication?.StopAsync(cancellationToken) ?? throw new NotSupportedException();
     }
 
     public async ValueTask DisposeAsync()

--- a/src/Common/test/TestResources/TestContext.cs
+++ b/src/Common/test/TestResources/TestContext.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+#pragma warning disable IDE0130 // Namespace does not match folder structure
+
+// ReSharper disable once CheckNamespace
+namespace Xunit;
+
+/// <summary>
+/// This temporary stub exists to ease the migration to xUnit v3.
+/// </summary>
+public sealed class TestContext
+{
+    public static TestContext Current { get; } = new();
+
+    public CancellationToken CancellationToken { get; } = CancellationToken.None;
+
+    private TestContext()
+    {
+    }
+}

--- a/src/Configuration/test/ConfigServer.Discovery.Test/ConfigServerDiscoveryServiceTest.cs
+++ b/src/Configuration/test/ConfigServer.Discovery.Test/ConfigServerDiscoveryServiceTest.cs
@@ -42,7 +42,7 @@ public sealed class ConfigServerDiscoveryServiceTest
         var options = new ConfigServerClientOptions();
 
         var service = new ConfigServerDiscoveryService(configurationRoot, options, NullLoggerFactory.Instance);
-        IEnumerable<IServiceInstance> result = await service.GetConfigServerInstancesAsync(CancellationToken.None);
+        IEnumerable<IServiceInstance> result = await service.GetConfigServerInstancesAsync(TestContext.Current.CancellationToken);
         Assert.Empty(result);
     }
 
@@ -67,7 +67,7 @@ public sealed class ConfigServerDiscoveryServiceTest
         };
 
         var service = new ConfigServerDiscoveryService(configurationRoot, options, NullLoggerFactory.Instance);
-        IEnumerable<IServiceInstance> result = await service.GetConfigServerInstancesAsync(CancellationToken.None);
+        IEnumerable<IServiceInstance> result = await service.GetConfigServerInstancesAsync(TestContext.Current.CancellationToken);
         Assert.Empty(result);
     }
 
@@ -93,7 +93,7 @@ public sealed class ConfigServerDiscoveryServiceTest
         };
 
         var service = new ConfigServerDiscoveryService(configurationRoot, options, NullLoggerFactory.Instance);
-        IEnumerable<IServiceInstance> result = await service.GetConfigServerInstancesAsync(CancellationToken.None);
+        IEnumerable<IServiceInstance> result = await service.GetConfigServerInstancesAsync(TestContext.Current.CancellationToken);
         Assert.Empty(result);
     }
 
@@ -105,7 +105,7 @@ public sealed class ConfigServerDiscoveryServiceTest
         var testDiscoveryClient = new TestDiscoveryClient();
         var service = new ConfigServerDiscoveryService(configurationRoot, new ConfigServerClientOptions(), NullLoggerFactory.Instance);
 
-        await service.ProvideRuntimeReplacementsAsync([testDiscoveryClient], CancellationToken.None);
+        await service.ProvideRuntimeReplacementsAsync([testDiscoveryClient], TestContext.Current.CancellationToken);
 
         service.DiscoveryClients.Should().ContainSingle();
         service.DiscoveryClients.First().Should().Be(testDiscoveryClient);

--- a/src/Configuration/test/ConfigServer.Integration.Test/ConfigServerConfigurationExtensionsIntegrationTest.cs
+++ b/src/Configuration/test/ConfigServer.Integration.Test/ConfigServerConfigurationExtensionsIntegrationTest.cs
@@ -103,10 +103,10 @@ public sealed class ConfigServerConfigurationExtensionsIntegrationTest
         builder.AddConfigServer();
 
         using IWebHost host = builder.Build();
-        await host.StartAsync();
+        await host.StartAsync(TestContext.Current.CancellationToken);
 
         using HttpClient client = host.GetTestClient();
-        string result = await client.GetStringAsync(new Uri("http://localhost/Home/VerifyAsInjectedOptions"));
+        string result = await client.GetStringAsync(new Uri("http://localhost/Home/VerifyAsInjectedOptions"), TestContext.Current.CancellationToken);
 
         Assert.Equal("spamfrom foo developmentSpring Cloud Sampleshttps://github.com/spring-cloud-samples", result);
     }
@@ -194,10 +194,10 @@ public sealed class ConfigServerConfigurationExtensionsIntegrationTest
         builder.AddConfigServer();
 
         using IWebHost host = builder.Build();
-        await host.StartAsync();
+        await host.StartAsync(TestContext.Current.CancellationToken);
 
         using HttpClient client = host.GetTestClient();
-        string result = await client.GetStringAsync(new Uri("http://localhost/Home/VerifyAsInjectedOptions"));
+        string result = await client.GetStringAsync(new Uri("http://localhost/Home/VerifyAsInjectedOptions"), TestContext.Current.CancellationToken);
 
         Assert.Equal("spamfrom foo developmentSpring Cloud Sampleshttps://github.com/spring-cloud-samples", result);
     }
@@ -291,10 +291,10 @@ public sealed class ConfigServerConfigurationExtensionsIntegrationTest
         builder.AddConfigServer();
 
         using IWebHost host = builder.Build();
-        await host.StartAsync();
+        await host.StartAsync(TestContext.Current.CancellationToken);
 
         using HttpClient client = host.GetTestClient();
-        string result = await client.GetStringAsync(new Uri("http://localhost/Home/Health"));
+        string result = await client.GetStringAsync(new Uri("http://localhost/Home/Health"), TestContext.Current.CancellationToken);
 
         // after switching to newer config server image, the health response has changed to
         // https://github.com/spring-cloud-samples/config-repo/Config resource 'file [/tmp/config-repo-4389533880216684481/application.yml' via location '' (document #0)"

--- a/src/Configuration/test/ConfigServer.Test/ConfigServerConfigurationProviderTest.Loading.cs
+++ b/src/Configuration/test/ConfigServer.Test/ConfigServerConfigurationProviderTest.Loading.cs
@@ -20,7 +20,7 @@ public sealed partial class ConfigServerConfigurationProviderTest
         var options = new ConfigServerClientOptions();
         using var provider = new ConfigServerConfigurationProvider(options, null, null, NullLoggerFactory.Instance);
 
-        await Assert.ThrowsAsync<UriFormatException>(async () => await provider.RemoteLoadAsync([@"foobar\foobar\"], null, CancellationToken.None));
+        await Assert.ThrowsAsync<UriFormatException>(async () => await provider.RemoteLoadAsync([@"foobar\foobar\"], null, TestContext.Current.CancellationToken));
     }
 
     [Fact]
@@ -34,7 +34,7 @@ public sealed partial class ConfigServerConfigurationProviderTest
         var httpClientHandler = new SlowHttpClientHandler(1.Seconds(), new HttpResponseMessage());
         using var provider = new ConfigServerConfigurationProvider(options, null, httpClientHandler, NullLoggerFactory.Instance);
 
-        Func<Task> action = async () => await provider.RemoteLoadAsync(["http://localhost:9999/app/profile"], null, CancellationToken.None);
+        Func<Task> action = async () => await provider.RemoteLoadAsync(["http://localhost:9999/app/profile"], null, TestContext.Current.CancellationToken);
 
         (await action.Should().ThrowExactlyAsync<TaskCanceledException>()).WithInnerExceptionExactly<TimeoutException>();
     }
@@ -50,7 +50,7 @@ public sealed partial class ConfigServerConfigurationProviderTest
         builder.UseStartup<TestConfigServerStartup>();
 
         using IWebHost app = builder.Build();
-        await app.StartAsync();
+        await app.StartAsync(TestContext.Current.CancellationToken);
 
         using TestServer server = app.GetTestServer();
         server.BaseAddress = new Uri("http://localhost:8888");
@@ -59,7 +59,7 @@ public sealed partial class ConfigServerConfigurationProviderTest
         using var httpClientHandler = new ForwardingHttpClientHandler(server.CreateHandler());
         using var provider = new ConfigServerConfigurationProvider(options, null, httpClientHandler, NullLoggerFactory.Instance);
 
-        await Assert.ThrowsAsync<HttpRequestException>(async () => await provider.RemoteLoadAsync(options.GetUris(), null, CancellationToken.None));
+        await Assert.ThrowsAsync<HttpRequestException>(async () => await provider.RemoteLoadAsync(options.GetUris(), null, TestContext.Current.CancellationToken));
 
         Assert.NotNull(TestConfigServerStartup.LastRequest);
         Assert.Equal($"/{options.Name}/{options.Environment}", TestConfigServerStartup.LastRequest.Path.Value);
@@ -76,7 +76,7 @@ public sealed partial class ConfigServerConfigurationProviderTest
         builder.UseStartup<TestConfigServerStartup>();
 
         using IWebHost app = builder.Build();
-        await app.StartAsync();
+        await app.StartAsync(TestContext.Current.CancellationToken);
 
         using TestServer server = app.GetTestServer();
         server.BaseAddress = new Uri("http://localhost:8888");
@@ -85,7 +85,7 @@ public sealed partial class ConfigServerConfigurationProviderTest
         using var httpClientHandler = new ForwardingHttpClientHandler(server.CreateHandler());
         using var provider = new ConfigServerConfigurationProvider(options, null, httpClientHandler, NullLoggerFactory.Instance);
 
-        ConfigEnvironment? result = await provider.RemoteLoadAsync(options.GetUris(), null, CancellationToken.None);
+        ConfigEnvironment? result = await provider.RemoteLoadAsync(options.GetUris(), null, TestContext.Current.CancellationToken);
 
         Assert.NotNull(TestConfigServerStartup.LastRequest);
         Assert.Equal($"/{options.Name}/{options.Environment}", TestConfigServerStartup.LastRequest.Path.Value);
@@ -115,7 +115,7 @@ public sealed partial class ConfigServerConfigurationProviderTest
         builder.UseStartup<TestConfigServerStartup>();
 
         using IWebHost app = builder.Build();
-        await app.StartAsync();
+        await app.StartAsync(TestContext.Current.CancellationToken);
 
         using TestServer server = app.GetTestServer();
         server.BaseAddress = new Uri("http://localhost:8888");
@@ -129,9 +129,9 @@ public sealed partial class ConfigServerConfigurationProviderTest
 
         using var httpClientHandler = new ForwardingHttpClientHandler(server.CreateHandler());
         using var provider = new ConfigServerConfigurationProvider(options, null, httpClientHandler, NullLoggerFactory.Instance);
-        Assert.True(TestConfigServerStartup.InitialRequestLatch.Wait(TimeSpan.FromSeconds(60)));
+        Assert.True(TestConfigServerStartup.InitialRequestLatch.Wait(1.Minutes(), TestContext.Current.CancellationToken));
         Assert.True(TestConfigServerStartup.RequestCount >= 1);
-        await Task.Delay(1000);
+        await Task.Delay(1.Seconds(), TestContext.Current.CancellationToken);
 
         Assert.NotNull(TestConfigServerStartup.LastRequest);
         Assert.True(TestConfigServerStartup.RequestCount >= 2);
@@ -163,7 +163,7 @@ public sealed partial class ConfigServerConfigurationProviderTest
         builder.UseStartup<TestConfigServerStartup>();
 
         using IWebHost app = builder.Build();
-        await app.StartAsync();
+        await app.StartAsync(TestContext.Current.CancellationToken);
 
         using TestServer server = app.GetTestServer();
         server.BaseAddress = new Uri("http://localhost:8888");
@@ -180,9 +180,9 @@ public sealed partial class ConfigServerConfigurationProviderTest
 
         using var provider = new ConfigServerConfigurationProvider(options, null, httpClientHandler, NullLoggerFactory.Instance);
 
-        Assert.True(TestConfigServerStartup.InitialRequestLatch.Wait(TimeSpan.FromSeconds(60)));
+        Assert.True(TestConfigServerStartup.InitialRequestLatch.Wait(1.Minutes(), TestContext.Current.CancellationToken));
         Assert.True(TestConfigServerStartup.RequestCount >= 1);
-        await Task.Delay(1000);
+        await Task.Delay(1.Seconds(), TestContext.Current.CancellationToken);
         Assert.NotNull(TestConfigServerStartup.LastRequest);
         Assert.True(TestConfigServerStartup.RequestCount >= 2);
         Assert.False(provider.GetReloadToken().HasChanged);
@@ -211,7 +211,7 @@ public sealed partial class ConfigServerConfigurationProviderTest
         builder.UseStartup<TestConfigServerStartup>();
 
         using IWebHost app = builder.Build();
-        await app.StartAsync();
+        await app.StartAsync(TestContext.Current.CancellationToken);
 
         using TestServer server = app.GetTestServer();
         server.BaseAddress = new Uri("http://localhost:8888");
@@ -228,7 +228,7 @@ public sealed partial class ConfigServerConfigurationProviderTest
 
         using var provider = new ConfigServerConfigurationProvider(options, null, httpClientHandler, NullLoggerFactory.Instance);
 
-        Assert.False(TestConfigServerStartup.InitialRequestLatch.Wait(TimeSpan.FromSeconds(2)));
+        Assert.False(TestConfigServerStartup.InitialRequestLatch.Wait(2.Seconds(), TestContext.Current.CancellationToken));
     }
 
     [Fact]
@@ -268,7 +268,7 @@ public sealed partial class ConfigServerConfigurationProviderTest
         builder.UseStartup<TestConfigServerStartup>();
 
         using IWebHost app = builder.Build();
-        await app.StartAsync();
+        await app.StartAsync(TestContext.Current.CancellationToken);
 
         using TestServer server = app.GetTestServer();
         server.BaseAddress = new Uri("http://localhost:8888");
@@ -278,7 +278,7 @@ public sealed partial class ConfigServerConfigurationProviderTest
         using var httpClientHandler = new ForwardingHttpClientHandler(server.CreateHandler());
         using var provider = new ConfigServerConfigurationProvider(options, null, httpClientHandler, NullLoggerFactory.Instance);
 
-        await provider.DoLoadAsync(true, CancellationToken.None);
+        await provider.DoLoadAsync(true, TestContext.Current.CancellationToken);
 
         Assert.NotNull(TestConfigServerStartup.LastRequest);
         Assert.Equal(2, TestConfigServerStartup.RequestCount);
@@ -314,7 +314,7 @@ public sealed partial class ConfigServerConfigurationProviderTest
         builder.UseStartup<TestConfigServerStartup>();
 
         using IWebHost app = builder.Build();
-        await app.StartAsync();
+        await app.StartAsync(TestContext.Current.CancellationToken);
 
         using TestServer server = app.GetTestServer();
         server.BaseAddress = new Uri("http://localhost:8888");
@@ -323,7 +323,7 @@ public sealed partial class ConfigServerConfigurationProviderTest
         using var httpClientHandler = new ForwardingHttpClientHandler(server.CreateHandler());
         using var provider = new ConfigServerConfigurationProvider(options, null, httpClientHandler, NullLoggerFactory.Instance);
 
-        ConfigEnvironment? env = await provider.RemoteLoadAsync(options.GetUris(), null, CancellationToken.None);
+        ConfigEnvironment? env = await provider.RemoteLoadAsync(options.GetUris(), null, TestContext.Current.CancellationToken);
         Assert.NotNull(TestConfigServerStartup.LastRequest);
         Assert.Equal($"/{options.Name}/{options.Environment}", TestConfigServerStartup.LastRequest.Path.Value);
         Assert.NotNull(env);
@@ -356,7 +356,7 @@ public sealed partial class ConfigServerConfigurationProviderTest
         builder.UseStartup<TestConfigServerStartup>();
 
         using IWebHost app = builder.Build();
-        await app.StartAsync();
+        await app.StartAsync(TestContext.Current.CancellationToken);
 
         using TestServer server = app.GetTestServer();
         server.BaseAddress = new Uri("http://localhost:8888");
@@ -366,7 +366,7 @@ public sealed partial class ConfigServerConfigurationProviderTest
         using var httpClientHandler = new ForwardingHttpClientHandler(server.CreateHandler());
         using var provider = new ConfigServerConfigurationProvider(options, null, httpClientHandler, NullLoggerFactory.Instance);
 
-        await provider.LoadInternalAsync(true, CancellationToken.None);
+        await provider.LoadInternalAsync(true, TestContext.Current.CancellationToken);
         Assert.NotNull(TestConfigServerStartup.LastRequest);
         Assert.Equal($"/{options.Name}/{options.Environment}", TestConfigServerStartup.LastRequest.Path.Value);
         Assert.Equal(1, TestConfigServerStartup.RequestCount);
@@ -387,7 +387,7 @@ public sealed partial class ConfigServerConfigurationProviderTest
         builder.UseStartup<TestConfigServerStartup>();
 
         using IWebHost app = builder.Build();
-        await app.StartAsync();
+        await app.StartAsync(TestContext.Current.CancellationToken);
 
         using TestServer server = app.GetTestServer();
         server.BaseAddress = new Uri("http://localhost:8888");
@@ -397,7 +397,7 @@ public sealed partial class ConfigServerConfigurationProviderTest
         using var httpClientHandler = new ForwardingHttpClientHandler(server.CreateHandler());
         using var provider = new ConfigServerConfigurationProvider(options, null, httpClientHandler, NullLoggerFactory.Instance);
 
-        await provider.LoadInternalAsync(true, CancellationToken.None);
+        await provider.LoadInternalAsync(true, TestContext.Current.CancellationToken);
         Assert.NotNull(TestConfigServerStartup.LastRequest);
         Assert.Equal($"/{options.Name}/{options.Environment}", TestConfigServerStartup.LastRequest.Path.Value);
         Assert.Equal(1, TestConfigServerStartup.RequestCount);
@@ -414,7 +414,7 @@ public sealed partial class ConfigServerConfigurationProviderTest
         builder.UseStartup<TestConfigServerStartup>();
 
         using IWebHost app = builder.Build();
-        await app.StartAsync();
+        await app.StartAsync(TestContext.Current.CancellationToken);
 
         using TestServer server = app.GetTestServer();
         server.BaseAddress = new Uri("http://localhost:8888");
@@ -423,7 +423,7 @@ public sealed partial class ConfigServerConfigurationProviderTest
         using var httpClientHandler = new ForwardingHttpClientHandler(server.CreateHandler());
         using var provider = new ConfigServerConfigurationProvider(options, null, httpClientHandler, NullLoggerFactory.Instance);
 
-        await provider.LoadInternalAsync(true, CancellationToken.None);
+        await provider.LoadInternalAsync(true, TestContext.Current.CancellationToken);
         Assert.NotNull(TestConfigServerStartup.LastRequest);
         Assert.Equal($"/{options.Name}/{options.Environment}", TestConfigServerStartup.LastRequest.Path.Value);
         Assert.Equal(27, provider.Properties.Count);
@@ -440,7 +440,7 @@ public sealed partial class ConfigServerConfigurationProviderTest
         builder.UseStartup<TestConfigServerStartup>();
 
         using IWebHost app = builder.Build();
-        await app.StartAsync();
+        await app.StartAsync(TestContext.Current.CancellationToken);
 
         using TestServer server = app.GetTestServer();
         server.BaseAddress = new Uri("http://localhost:8888");
@@ -450,7 +450,7 @@ public sealed partial class ConfigServerConfigurationProviderTest
         using var httpClientHandler = new ForwardingHttpClientHandler(server.CreateHandler());
         using var provider = new ConfigServerConfigurationProvider(options, null, httpClientHandler, NullLoggerFactory.Instance);
 
-        await Assert.ThrowsAsync<ConfigServerException>(async () => await provider.LoadInternalAsync(true, CancellationToken.None));
+        await Assert.ThrowsAsync<ConfigServerException>(async () => await provider.LoadInternalAsync(true, TestContext.Current.CancellationToken));
     }
 
     [Fact]
@@ -463,7 +463,7 @@ public sealed partial class ConfigServerConfigurationProviderTest
         builder.UseStartup<TestConfigServerStartup>();
 
         using IWebHost app = builder.Build();
-        await app.StartAsync();
+        await app.StartAsync(TestContext.Current.CancellationToken);
 
         using TestServer server = app.GetTestServer();
         server.BaseAddress = new Uri("http://localhost:8888");
@@ -478,7 +478,7 @@ public sealed partial class ConfigServerConfigurationProviderTest
             200
         ];
 
-        await Assert.ThrowsAsync<ConfigServerException>(async () => await provider.LoadInternalAsync(true, CancellationToken.None));
+        await Assert.ThrowsAsync<ConfigServerException>(async () => await provider.LoadInternalAsync(true, TestContext.Current.CancellationToken));
         Assert.Equal(1, TestConfigServerStartup.RequestCount);
     }
 
@@ -493,7 +493,7 @@ public sealed partial class ConfigServerConfigurationProviderTest
         builder.UseStartup<TestConfigServerStartup>();
 
         using IWebHost app = builder.Build();
-        await app.StartAsync();
+        await app.StartAsync(TestContext.Current.CancellationToken);
 
         using TestServer server = app.GetTestServer();
         server.BaseAddress = new Uri("http://localhost:8888");
@@ -503,7 +503,7 @@ public sealed partial class ConfigServerConfigurationProviderTest
         using var httpClientHandler = new ForwardingHttpClientHandler(server.CreateHandler());
         using var provider = new ConfigServerConfigurationProvider(options, null, httpClientHandler, NullLoggerFactory.Instance);
 
-        await Assert.ThrowsAsync<ConfigServerException>(async () => await provider.LoadInternalAsync(true, CancellationToken.None));
+        await Assert.ThrowsAsync<ConfigServerException>(async () => await provider.LoadInternalAsync(true, TestContext.Current.CancellationToken));
     }
 
     [Fact]
@@ -522,7 +522,7 @@ public sealed partial class ConfigServerConfigurationProviderTest
         builder.UseStartup<TestConfigServerStartup>();
 
         using IWebHost app = builder.Build();
-        await app.StartAsync();
+        await app.StartAsync(TestContext.Current.CancellationToken);
 
         using TestServer server = app.GetTestServer();
         server.BaseAddress = new Uri("http://localhost:8888");
@@ -533,7 +533,7 @@ public sealed partial class ConfigServerConfigurationProviderTest
         using var httpClientHandler = new ForwardingHttpClientHandler(server.CreateHandler());
         using var provider = new ConfigServerConfigurationProvider(options, null, httpClientHandler, NullLoggerFactory.Instance);
 
-        await Assert.ThrowsAsync<ConfigServerException>(async () => await provider.LoadInternalAsync(true, CancellationToken.None));
+        await Assert.ThrowsAsync<ConfigServerException>(async () => await provider.LoadInternalAsync(true, TestContext.Current.CancellationToken));
         Assert.Equal(1, TestConfigServerStartup.RequestCount);
     }
 
@@ -556,7 +556,7 @@ public sealed partial class ConfigServerConfigurationProviderTest
         builder.UseStartup<TestConfigServerStartup>();
 
         using IWebHost app = builder.Build();
-        await app.StartAsync();
+        await app.StartAsync(TestContext.Current.CancellationToken);
 
         using TestServer server = app.GetTestServer();
         server.BaseAddress = new Uri("http://localhost:8888");
@@ -576,7 +576,7 @@ public sealed partial class ConfigServerConfigurationProviderTest
         using var httpClientHandler = new ForwardingHttpClientHandler(server.CreateHandler());
         using var provider = new ConfigServerConfigurationProvider(options, null, httpClientHandler, NullLoggerFactory.Instance);
 
-        await Assert.ThrowsAsync<ConfigServerException>(async () => await provider.LoadInternalAsync(true, CancellationToken.None));
+        await Assert.ThrowsAsync<ConfigServerException>(async () => await provider.LoadInternalAsync(true, TestContext.Current.CancellationToken));
         Assert.Equal(6, TestConfigServerStartup.RequestCount);
     }
 
@@ -609,7 +609,7 @@ public sealed partial class ConfigServerConfigurationProviderTest
         builder.UseStartup<TestConfigServerStartup>();
 
         using IWebHost app = builder.Build();
-        await app.StartAsync();
+        await app.StartAsync(TestContext.Current.CancellationToken);
 
         using TestServer server = app.GetTestServer();
         server.BaseAddress = new Uri("http://localhost:8888");
@@ -618,7 +618,7 @@ public sealed partial class ConfigServerConfigurationProviderTest
         using var httpClientHandler = new ForwardingHttpClientHandler(server.CreateHandler());
         using var provider = new ConfigServerConfigurationProvider(options, null, httpClientHandler, NullLoggerFactory.Instance);
 
-        await provider.LoadInternalAsync(true, CancellationToken.None);
+        await provider.LoadInternalAsync(true, TestContext.Current.CancellationToken);
         Assert.NotNull(TestConfigServerStartup.LastRequest);
         Assert.Equal($"/{options.Name}/{options.Environment}", TestConfigServerStartup.LastRequest.Path.Value);
 
@@ -659,7 +659,7 @@ public sealed partial class ConfigServerConfigurationProviderTest
         builder.UseStartup<TestConfigServerStartup>();
 
         using IWebHost app = builder.Build();
-        await app.StartAsync();
+        await app.StartAsync(TestContext.Current.CancellationToken);
 
         using TestServer server = app.GetTestServer();
         server.BaseAddress = new Uri("http://localhost:8888");
@@ -828,7 +828,7 @@ public sealed partial class ConfigServerConfigurationProviderTest
         ConfigServerClientOptions clientOptions = GetCommonOptions();
 
         using IWebHost app = builder.Build();
-        await app.StartAsync();
+        await app.StartAsync(TestContext.Current.CancellationToken);
 
         using TestServer server = app.GetTestServer();
         server.BaseAddress = new Uri(clientOptions.Uri!);

--- a/src/Configuration/test/ConfigServer.Test/ConfigServerConfigurationProviderTest.Loading.cs
+++ b/src/Configuration/test/ConfigServer.Test/ConfigServerConfigurationProviderTest.Loading.cs
@@ -20,7 +20,8 @@ public sealed partial class ConfigServerConfigurationProviderTest
         var options = new ConfigServerClientOptions();
         using var provider = new ConfigServerConfigurationProvider(options, null, null, NullLoggerFactory.Instance);
 
-        await Assert.ThrowsAsync<UriFormatException>(async () => await provider.RemoteLoadAsync([@"foobar\foobar\"], null, TestContext.Current.CancellationToken));
+        await Assert.ThrowsAsync<UriFormatException>(async () =>
+            await provider.RemoteLoadAsync([@"foobar\foobar\"], null, TestContext.Current.CancellationToken));
     }
 
     [Fact]
@@ -59,7 +60,8 @@ public sealed partial class ConfigServerConfigurationProviderTest
         using var httpClientHandler = new ForwardingHttpClientHandler(server.CreateHandler());
         using var provider = new ConfigServerConfigurationProvider(options, null, httpClientHandler, NullLoggerFactory.Instance);
 
-        await Assert.ThrowsAsync<HttpRequestException>(async () => await provider.RemoteLoadAsync(options.GetUris(), null, TestContext.Current.CancellationToken));
+        await Assert.ThrowsAsync<HttpRequestException>(async () =>
+            await provider.RemoteLoadAsync(options.GetUris(), null, TestContext.Current.CancellationToken));
 
         Assert.NotNull(TestConfigServerStartup.LastRequest);
         Assert.Equal($"/{options.Name}/{options.Environment}", TestConfigServerStartup.LastRequest.Path.Value);

--- a/src/Configuration/test/ConfigServer.Test/ConfigServerConfigurationProviderTest.cs
+++ b/src/Configuration/test/ConfigServer.Test/ConfigServerConfigurationProviderTest.cs
@@ -17,7 +17,7 @@ namespace Steeltoe.Configuration.ConfigServer.Test;
 public sealed partial class ConfigServerConfigurationProviderTest
 {
     [Fact]
-    public async Task Deserialize_GoodJsonAsync()
+    public async Task Deserialize_GoodJson()
     {
         var environment = new ConfigEnvironment
         {
@@ -45,7 +45,7 @@ public sealed partial class ConfigServerConfigurationProviderTest
 
         var content = JsonContent.Create(environment);
 
-        var env = await content.ReadFromJsonAsync<ConfigEnvironment>(ConfigServerConfigurationProvider.SerializerOptions);
+        var env = await content.ReadFromJsonAsync<ConfigEnvironment>(ConfigServerConfigurationProvider.SerializerOptions, TestContext.Current.CancellationToken);
         Assert.NotNull(env);
         Assert.Equal("test-name", env.Name);
         Assert.NotNull(env.Profiles);
@@ -155,7 +155,7 @@ public sealed partial class ConfigServerConfigurationProviderTest
         using var provider = new ConfigServerConfigurationProvider(options, null, null, NullLoggerFactory.Instance);
 
         Uri requestUri = provider.BuildConfigServerUri(options.Uri, null);
-        HttpRequestMessage request = await provider.GetRequestMessageAsync(requestUri, CancellationToken.None);
+        HttpRequestMessage request = await provider.GetRequestMessageAsync(requestUri, TestContext.Current.CancellationToken);
 
         Assert.Equal(HttpMethod.Get, request.Method);
         Assert.Equal(requestUri, request.RequestUri);
@@ -179,7 +179,7 @@ public sealed partial class ConfigServerConfigurationProviderTest
         using var provider = new ConfigServerConfigurationProvider(options, null, null, NullLoggerFactory.Instance);
 
         Uri requestUri = provider.BuildConfigServerUri(options.Uri, null);
-        HttpRequestMessage request = await provider.GetRequestMessageAsync(requestUri, CancellationToken.None);
+        HttpRequestMessage request = await provider.GetRequestMessageAsync(requestUri, TestContext.Current.CancellationToken);
 
         Assert.Equal(HttpMethod.Get, request.Method);
         Assert.Equal(requestUri, request.RequestUri);
@@ -203,7 +203,7 @@ public sealed partial class ConfigServerConfigurationProviderTest
         using var provider = new ConfigServerConfigurationProvider(options, null, null, NullLoggerFactory.Instance);
 
         Uri requestUri = provider.BuildConfigServerUri(options.Uri, null);
-        HttpRequestMessage request = await provider.GetRequestMessageAsync(requestUri, CancellationToken.None);
+        HttpRequestMessage request = await provider.GetRequestMessageAsync(requestUri, TestContext.Current.CancellationToken);
 
         Assert.Equal(HttpMethod.Get, request.Method);
         Assert.Equal(requestUri, request.RequestUri);
@@ -225,7 +225,7 @@ public sealed partial class ConfigServerConfigurationProviderTest
         using var provider = new ConfigServerConfigurationProvider(options, null, null, NullLoggerFactory.Instance);
 
         Uri requestUri = provider.BuildConfigServerUri(options.Uri!, null);
-        HttpRequestMessage request = await provider.GetRequestMessageAsync(requestUri, CancellationToken.None);
+        HttpRequestMessage request = await provider.GetRequestMessageAsync(requestUri, TestContext.Current.CancellationToken);
 
         Assert.Equal(HttpMethod.Get, request.Method);
         Assert.Equal(requestUri, request.RequestUri);
@@ -250,7 +250,7 @@ public sealed partial class ConfigServerConfigurationProviderTest
             .WithContent("{\"increment\":300}").Respond(HttpStatusCode.NoContent);
 
         using var provider = new ConfigServerConfigurationProvider(options, null, handler, NullLoggerFactory.Instance);
-        await provider.RefreshVaultTokenAsync(CancellationToken.None);
+        await provider.RefreshVaultTokenAsync(TestContext.Current.CancellationToken);
 
         handler.Mock.VerifyNoOutstandingExpectation();
     }
@@ -277,7 +277,7 @@ public sealed partial class ConfigServerConfigurationProviderTest
             .WithHeaders("Authorization", "Bearer secret").WithContent("{\"increment\":300}").Respond(HttpStatusCode.NoContent);
 
         using var provider = new ConfigServerConfigurationProvider(options, null, handler, NullLoggerFactory.Instance);
-        await provider.RefreshVaultTokenAsync(CancellationToken.None);
+        await provider.RefreshVaultTokenAsync(TestContext.Current.CancellationToken);
 
         handler.Mock.VerifyNoOutstandingExpectation();
     }
@@ -414,7 +414,7 @@ public sealed partial class ConfigServerConfigurationProviderTest
         var source = new ConfigServerConfigurationSource(options, configuration, NullLoggerFactory.Instance);
         using var provider = new ConfigServerConfigurationProvider(source, NullLoggerFactory.Instance);
 
-        var exception = await Assert.ThrowsAsync<ConfigServerException>(async () => await provider.LoadInternalAsync(true, CancellationToken.None));
+        var exception = await Assert.ThrowsAsync<ConfigServerException>(async () => await provider.LoadInternalAsync(true, TestContext.Current.CancellationToken));
         Assert.StartsWith("Could not locate Config Server via discovery", exception.Message, StringComparison.Ordinal);
     }
 

--- a/src/Configuration/test/ConfigServer.Test/ConfigServerConfigurationProviderTest.cs
+++ b/src/Configuration/test/ConfigServer.Test/ConfigServerConfigurationProviderTest.cs
@@ -45,7 +45,9 @@ public sealed partial class ConfigServerConfigurationProviderTest
 
         var content = JsonContent.Create(environment);
 
-        var env = await content.ReadFromJsonAsync<ConfigEnvironment>(ConfigServerConfigurationProvider.SerializerOptions, TestContext.Current.CancellationToken);
+        var env = await content.ReadFromJsonAsync<ConfigEnvironment>(ConfigServerConfigurationProvider.SerializerOptions,
+            TestContext.Current.CancellationToken);
+
         Assert.NotNull(env);
         Assert.Equal("test-name", env.Name);
         Assert.NotNull(env.Profiles);
@@ -414,7 +416,9 @@ public sealed partial class ConfigServerConfigurationProviderTest
         var source = new ConfigServerConfigurationSource(options, configuration, NullLoggerFactory.Instance);
         using var provider = new ConfigServerConfigurationProvider(source, NullLoggerFactory.Instance);
 
-        var exception = await Assert.ThrowsAsync<ConfigServerException>(async () => await provider.LoadInternalAsync(true, TestContext.Current.CancellationToken));
+        var exception = await Assert.ThrowsAsync<ConfigServerException>(async () =>
+            await provider.LoadInternalAsync(true, TestContext.Current.CancellationToken));
+
         Assert.StartsWith("Could not locate Config Server via discovery", exception.Message, StringComparison.Ordinal);
     }
 

--- a/src/Configuration/test/ConfigServer.Test/ConfigServerHealthContributorTest.cs
+++ b/src/Configuration/test/ConfigServer.Test/ConfigServerHealthContributorTest.cs
@@ -152,7 +152,7 @@ public sealed class ConfigServerHealthContributorTest
         };
 
         long lastAccess = contributor.LastAccess = DateTimeOffset.Now.ToUnixTimeMilliseconds() - 100;
-        IList<PropertySource>? sources = await contributor.GetPropertySourcesAsync(contributor.Provider!, CancellationToken.None);
+        IList<PropertySource>? sources = await contributor.GetPropertySourcesAsync(contributor.Provider!, TestContext.Current.CancellationToken);
 
         Assert.NotEqual(lastAccess, contributor.LastAccess);
         Assert.Null(sources);
@@ -178,7 +178,7 @@ public sealed class ConfigServerHealthContributorTest
 
         var contributor = new ConfigServerHealthContributor(configurationRoot, TimeProvider.System, NullLogger<ConfigServerHealthContributor>.Instance);
         Assert.Null(contributor.Provider);
-        HealthCheckResult? health = await contributor.CheckHealthAsync(CancellationToken.None);
+        HealthCheckResult? health = await contributor.CheckHealthAsync(TestContext.Current.CancellationToken);
         Assert.NotNull(health);
         Assert.Equal(HealthStatus.Unknown, health.Status);
         Assert.True(health.Details.ContainsKey("error"));
@@ -204,7 +204,7 @@ public sealed class ConfigServerHealthContributorTest
 
         var contributor = new ConfigServerHealthContributor(configurationRoot, TimeProvider.System, NullLogger<ConfigServerHealthContributor>.Instance);
         Assert.NotNull(contributor.Provider);
-        HealthCheckResult? health = await contributor.CheckHealthAsync(CancellationToken.None);
+        HealthCheckResult? health = await contributor.CheckHealthAsync(TestContext.Current.CancellationToken);
         Assert.Null(health);
     }
 
@@ -229,7 +229,7 @@ public sealed class ConfigServerHealthContributorTest
 
         var contributor = new ConfigServerHealthContributor(configurationRoot, TimeProvider.System, NullLogger<ConfigServerHealthContributor>.Instance);
         Assert.NotNull(contributor.Provider);
-        HealthCheckResult? health = await contributor.CheckHealthAsync(CancellationToken.None);
+        HealthCheckResult? health = await contributor.CheckHealthAsync(TestContext.Current.CancellationToken);
         Assert.NotNull(health);
         Assert.Equal(HealthStatus.Unknown, health.Status);
         Assert.True(health.Details.ContainsKey("error"));

--- a/src/Configuration/test/ConfigServer.Test/ConfigServerHostBuilderExtensionsTest.cs
+++ b/src/Configuration/test/ConfigServer.Test/ConfigServerHostBuilderExtensionsTest.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Reflection;
+using FluentAssertions.Extensions;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
@@ -87,7 +88,7 @@ public sealed class ConfigServerHostBuilderExtensionsTest
     {
         var appSettings = new Dictionary<string, string?>
         {
-            ["spring:cloud:config:pollingInterval"] = TimeSpan.FromSeconds(1).ToString()
+            ["spring:cloud:config:pollingInterval"] = 1.Seconds().ToString()
         };
 
         HostBuilder hostBuilder = TestHostBuilderFactory.Create();
@@ -111,7 +112,7 @@ public sealed class ConfigServerHostBuilderExtensionsTest
     {
         var appSettings = new Dictionary<string, string?>
         {
-            ["spring:cloud:config:pollingInterval"] = TimeSpan.FromSeconds(1).ToString()
+            ["spring:cloud:config:pollingInterval"] = 1.Seconds().ToString()
         };
 
         WebHostBuilder builder = TestWebHostBuilderFactory.Create();
@@ -135,7 +136,7 @@ public sealed class ConfigServerHostBuilderExtensionsTest
     {
         var appSettings = new Dictionary<string, string?>
         {
-            ["spring:cloud:config:pollingInterval"] = TimeSpan.FromSeconds(1).ToString()
+            ["spring:cloud:config:pollingInterval"] = 1.Seconds().ToString()
         };
 
         WebApplicationBuilder hostBuilder = TestWebApplicationBuilderFactory.Create();
@@ -159,7 +160,7 @@ public sealed class ConfigServerHostBuilderExtensionsTest
     {
         var appSettings = new Dictionary<string, string?>
         {
-            ["spring:cloud:config:pollingInterval"] = TimeSpan.FromSeconds(1).ToString()
+            ["spring:cloud:config:pollingInterval"] = 1.Seconds().ToString()
         };
 
         HostApplicationBuilder hostBuilder = TestHostApplicationBuilderFactory.Create();

--- a/src/Configuration/test/ConfigServer.Test/ConfigServerHostedServiceTest.cs
+++ b/src/Configuration/test/ConfigServer.Test/ConfigServerHostedServiceTest.cs
@@ -25,8 +25,8 @@ public sealed class ConfigServerHostedServiceTest
 
         Func<Task> startStopAction = async () =>
         {
-            await service.StartAsync(CancellationToken.None);
-            await service.StopAsync(CancellationToken.None);
+            await service.StartAsync(TestContext.Current.CancellationToken);
+            await service.StopAsync(TestContext.Current.CancellationToken);
         };
 
         await startStopAction.Should().NotThrowAsync("ConfigServerHostedService should start");
@@ -42,8 +42,8 @@ public sealed class ConfigServerHostedServiceTest
 
         Func<Task> startStopAction = async () =>
         {
-            await service.StartAsync(CancellationToken.None);
-            await service.StopAsync(CancellationToken.None);
+            await service.StartAsync(TestContext.Current.CancellationToken);
+            await service.StopAsync(TestContext.Current.CancellationToken);
         };
 
         await startStopAction.Should().NotThrowAsync("ConfigServerHostedService should start");

--- a/src/Configuration/test/ConfigServer.Test/HttpRequestInfo.cs
+++ b/src/Configuration/test/ConfigServer.Test/HttpRequestInfo.cs
@@ -22,11 +22,11 @@ public sealed class HttpRequestInfo
         QueryString = request.QueryString;
     }
 
-    public static async Task<HttpRequestInfo> CopyFromAsync(HttpRequest request)
+    public static async Task<HttpRequestInfo> CopyFromAsync(HttpContext httpContext)
     {
-        var info = new HttpRequestInfo(request);
+        var info = new HttpRequestInfo(httpContext.Request);
 
-        await request.Body.CopyToAsync(info.Body);
+        await httpContext.Request.Body.CopyToAsync(info.Body, httpContext.RequestAborted);
         info.Body.Seek(0, SeekOrigin.Begin);
 
         return info;

--- a/src/Configuration/test/ConfigServer.Test/TestConfigServerStartup.cs
+++ b/src/Configuration/test/ConfigServer.Test/TestConfigServerStartup.cs
@@ -41,7 +41,7 @@ public sealed class TestConfigServerStartup
     {
         app.Run(async context =>
         {
-            LastRequest = await HttpRequestInfo.CopyFromAsync(context.Request);
+            LastRequest = await HttpRequestInfo.CopyFromAsync(context);
             context.Response.StatusCode = GetStatusCode(context.Request.Path);
             RequestCount++;
 
@@ -51,7 +51,7 @@ public sealed class TestConfigServerStartup
 
                 if (Response != null)
                 {
-                    await context.Response.WriteAsync(Response);
+                    await context.Response.WriteAsync(Response, context.RequestAborted);
                 }
             }
 

--- a/src/Configuration/test/Placeholder.Test/PlaceholderWebApplicationTest.cs
+++ b/src/Configuration/test/Placeholder.Test/PlaceholderWebApplicationTest.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
+using FluentAssertions.Extensions;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -62,9 +63,9 @@ public sealed class PlaceholderWebApplicationTest : IDisposable
             "AppName": "AppTwo"
           }
         }
-        """);
+        """, TestContext.Current.CancellationToken);
 
-        await Task.Delay(TimeSpan.FromSeconds(2));
+        await Task.Delay(2.Seconds(), TestContext.Current.CancellationToken);
 
         optionsMonitor.CurrentValue.Value.Should().Be("AppTwo");
 
@@ -74,9 +75,9 @@ public sealed class PlaceholderWebApplicationTest : IDisposable
             "AppName": "AppThree"
           }
         }
-        """);
+        """, TestContext.Current.CancellationToken);
 
-        await Task.Delay(TimeSpan.FromSeconds(2));
+        await Task.Delay(2.Seconds(), TestContext.Current.CancellationToken);
 
         optionsMonitor.CurrentValue.Value.Should().Be("AppThree");
     }

--- a/src/Connectors/test/Connectors.Test/CosmosDb/CosmosDbHealthContributorTest.cs
+++ b/src/Connectors/test/Connectors.Test/CosmosDb/CosmosDbHealthContributorTest.cs
@@ -37,7 +37,7 @@ public sealed class CosmosDbHealthContributorTest
         using var healthContributor = new CosmosDbHealthContributor(serviceName, serviceProvider, CosmosDbPackageResolver.Default,
             NullLogger<CosmosDbHealthContributor>.Instance);
 
-        HealthCheckResult? result = await healthContributor.CheckHealthAsync(CancellationToken.None);
+        HealthCheckResult? result = await healthContributor.CheckHealthAsync(TestContext.Current.CancellationToken);
 
         result.Should().NotBeNull();
         result.Status.Should().Be(HealthStatus.Down);
@@ -62,7 +62,7 @@ public sealed class CosmosDbHealthContributorTest
 
         healthContributor.Timeout = 1.Milliseconds();
 
-        HealthCheckResult? result = await healthContributor.CheckHealthAsync(CancellationToken.None);
+        HealthCheckResult? result = await healthContributor.CheckHealthAsync(TestContext.Current.CancellationToken);
 
         result.Should().NotBeNull();
         result.Status.Should().Be(HealthStatus.Down);
@@ -85,7 +85,7 @@ public sealed class CosmosDbHealthContributorTest
         using var healthContributor = new CosmosDbHealthContributor(serviceName, serviceProvider, CosmosDbPackageResolver.Default,
             NullLogger<CosmosDbHealthContributor>.Instance);
 
-        HealthCheckResult? result = await healthContributor.CheckHealthAsync(CancellationToken.None);
+        HealthCheckResult? result = await healthContributor.CheckHealthAsync(TestContext.Current.CancellationToken);
 
         result.Should().NotBeNull();
         result.Status.Should().Be(HealthStatus.Up);
@@ -104,7 +104,7 @@ public sealed class CosmosDbHealthContributorTest
 
         cosmosClientMock.Setup(client => client.ReadAccountAsync()).Returns(async () =>
         {
-            await Task.Delay(3.Seconds());
+            await Task.Delay(3.Seconds(), TestContext.Current.CancellationToken);
             return null!;
         });
 
@@ -136,7 +136,7 @@ public sealed class CosmosDbHealthContributorTest
         using var healthContributor = new CosmosDbHealthContributor(serviceName, serviceProvider, CosmosDbPackageResolver.Default,
             NullLogger<CosmosDbHealthContributor>.Instance);
 
-        HealthCheckResult? result = await healthContributor.CheckHealthAsync(CancellationToken.None);
+        HealthCheckResult? result = await healthContributor.CheckHealthAsync(TestContext.Current.CancellationToken);
 
         result.Should().NotBeNull();
         result.Status.Should().Be(HealthStatus.Up);

--- a/src/Connectors/test/Connectors.Test/MongoDb/MongoDbHealthContributorTest.cs
+++ b/src/Connectors/test/Connectors.Test/MongoDb/MongoDbHealthContributorTest.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
+using FluentAssertions.Extensions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using MongoDB.Driver;
@@ -31,7 +32,7 @@ public sealed class MongoDbHealthContributorTest
         var healthContributor = new MongoDbHealthContributor(serviceName, serviceProvider, MongoDbPackageResolver.Default,
             NullLogger<MongoDbHealthContributor>.Instance);
 
-        HealthCheckResult? result = await healthContributor.CheckHealthAsync(CancellationToken.None);
+        HealthCheckResult? result = await healthContributor.CheckHealthAsync(TestContext.Current.CancellationToken);
 
         result.Should().NotBeNull();
         result.Status.Should().Be(HealthStatus.Down);
@@ -54,7 +55,7 @@ public sealed class MongoDbHealthContributorTest
         var healthContributor = new MongoDbHealthContributor(serviceName, serviceProvider, MongoDbPackageResolver.Default,
             NullLogger<MongoDbHealthContributor>.Instance);
 
-        HealthCheckResult? result = await healthContributor.CheckHealthAsync(CancellationToken.None);
+        HealthCheckResult? result = await healthContributor.CheckHealthAsync(TestContext.Current.CancellationToken);
 
         result.Should().NotBeNull();
         result.Status.Should().Be(HealthStatus.Up);
@@ -99,7 +100,7 @@ public sealed class MongoDbHealthContributorTest
         var mongoClient = new MongoClient(new MongoClientSettings
         {
             Server = new MongoServerAddress("localhost"),
-            ServerSelectionTimeout = TimeSpan.FromSeconds(5)
+            ServerSelectionTimeout = 5.Seconds()
         });
 
         await using ServiceProvider serviceProvider = CreateServiceProvider(serviceName, connectionString, mongoClient);
@@ -107,7 +108,7 @@ public sealed class MongoDbHealthContributorTest
         var healthContributor = new MongoDbHealthContributor(serviceName, serviceProvider, MongoDbPackageResolver.Default,
             NullLogger<MongoDbHealthContributor>.Instance);
 
-        HealthCheckResult? result = await healthContributor.CheckHealthAsync(CancellationToken.None);
+        HealthCheckResult? result = await healthContributor.CheckHealthAsync(TestContext.Current.CancellationToken);
 
         result.Should().NotBeNull();
         result.Status.Should().Be(HealthStatus.Up);

--- a/src/Connectors/test/Connectors.Test/RabbitMQ/RabbitMQHealthContributorTest.cs
+++ b/src/Connectors/test/Connectors.Test/RabbitMQ/RabbitMQHealthContributorTest.cs
@@ -27,7 +27,7 @@ public sealed class RabbitMQHealthContributorTest
             ServiceName = "Example"
         };
 
-        HealthCheckResult? result = await healthContributor.CheckHealthAsync(CancellationToken.None);
+        HealthCheckResult? result = await healthContributor.CheckHealthAsync(TestContext.Current.CancellationToken);
 
         result.Should().NotBeNull();
         result.Status.Should().Be(HealthStatus.Down);
@@ -56,7 +56,7 @@ public sealed class RabbitMQHealthContributorTest
             ServiceName = "Example"
         };
 
-        HealthCheckResult? result = await healthContributor.CheckHealthAsync(CancellationToken.None);
+        HealthCheckResult? result = await healthContributor.CheckHealthAsync(TestContext.Current.CancellationToken);
 
         result.Should().NotBeNull();
         result.Status.Should().Be(HealthStatus.Up);
@@ -86,11 +86,11 @@ public sealed class RabbitMQHealthContributorTest
         };
 
         // Ensure initial connection is obtained.
-        _ = await healthContributor.CheckHealthAsync(CancellationToken.None);
+        _ = await healthContributor.CheckHealthAsync(TestContext.Current.CancellationToken);
 
         connectionMock.Setup(connection => connection.IsOpen).Returns(false);
 
-        HealthCheckResult? result = await healthContributor.CheckHealthAsync(CancellationToken.None);
+        HealthCheckResult? result = await healthContributor.CheckHealthAsync(TestContext.Current.CancellationToken);
 
         result.Should().NotBeNull();
         result.Status.Should().Be(HealthStatus.Down);
@@ -127,7 +127,7 @@ public sealed class RabbitMQHealthContributorTest
             ServiceName = "Example"
         };
 
-        HealthCheckResult? result = await healthContributor.CheckHealthAsync(CancellationToken.None);
+        HealthCheckResult? result = await healthContributor.CheckHealthAsync(TestContext.Current.CancellationToken);
 
         result.Should().NotBeNull();
         result.Status.Should().Be(HealthStatus.Up);

--- a/src/Connectors/test/Connectors.Test/Redis/RedisConnectorTest.cs
+++ b/src/Connectors/test/Connectors.Test/Redis/RedisConnectorTest.cs
@@ -247,11 +247,11 @@ public sealed class RedisConnectorTest
         connectorFactory.ServiceBindingNames.Should().Contain("myRedisServiceTwo");
 
         var connectionOne = (RedisCache)connectorFactory.Get("myRedisServiceOne").GetConnection();
-        IConnectionMultiplexer connectionMultiplexerOne = await ExtractUnderlyingMultiplexerFromRedisCacheAsync(connectionOne);
+        IConnectionMultiplexer connectionMultiplexerOne = await ExtractUnderlyingMultiplexerFromRedisCacheAsync(connectionOne, TestContext.Current.CancellationToken);
         connectionMultiplexerOne.Configuration.Should().Be("server1:6380,keepAlive=30");
 
         var connectionTwo = (RedisCache)connectorFactory.Get("myRedisServiceTwo").GetConnection();
-        IConnectionMultiplexer connectionMultiplexerTwo = await ExtractUnderlyingMultiplexerFromRedisCacheAsync(connectionTwo);
+        IConnectionMultiplexer connectionMultiplexerTwo = await ExtractUnderlyingMultiplexerFromRedisCacheAsync(connectionTwo, TestContext.Current.CancellationToken);
         connectionMultiplexerTwo.Configuration.Should().Be("server2:6380,allowAdmin=true");
 
         IDistributedCache connectionOneAgain = connectorFactory.Get("myRedisServiceOne").GetConnection();
@@ -378,9 +378,9 @@ public sealed class RedisConnectorTest
         return connectionMultiplexerMock.Object;
     }
 
-    private static async Task<IConnectionMultiplexer> ExtractUnderlyingMultiplexerFromRedisCacheAsync(RedisCache redisCache)
+    private static async Task<IConnectionMultiplexer> ExtractUnderlyingMultiplexerFromRedisCacheAsync(RedisCache redisCache, CancellationToken cancellationToken)
     {
-        _ = await redisCache.GetAsync("ignored");
+        _ = await redisCache.GetAsync("ignored", cancellationToken);
 
         FieldInfo cacheField = typeof(RedisCache).GetField("_cache", BindingFlags.NonPublic | BindingFlags.Instance)!;
         var database = (IDatabase)cacheField.GetValue(redisCache)!;

--- a/src/Connectors/test/Connectors.Test/Redis/RedisConnectorTest.cs
+++ b/src/Connectors/test/Connectors.Test/Redis/RedisConnectorTest.cs
@@ -247,11 +247,17 @@ public sealed class RedisConnectorTest
         connectorFactory.ServiceBindingNames.Should().Contain("myRedisServiceTwo");
 
         var connectionOne = (RedisCache)connectorFactory.Get("myRedisServiceOne").GetConnection();
-        IConnectionMultiplexer connectionMultiplexerOne = await ExtractUnderlyingMultiplexerFromRedisCacheAsync(connectionOne, TestContext.Current.CancellationToken);
+
+        IConnectionMultiplexer connectionMultiplexerOne =
+            await ExtractUnderlyingMultiplexerFromRedisCacheAsync(connectionOne, TestContext.Current.CancellationToken);
+
         connectionMultiplexerOne.Configuration.Should().Be("server1:6380,keepAlive=30");
 
         var connectionTwo = (RedisCache)connectorFactory.Get("myRedisServiceTwo").GetConnection();
-        IConnectionMultiplexer connectionMultiplexerTwo = await ExtractUnderlyingMultiplexerFromRedisCacheAsync(connectionTwo, TestContext.Current.CancellationToken);
+
+        IConnectionMultiplexer connectionMultiplexerTwo =
+            await ExtractUnderlyingMultiplexerFromRedisCacheAsync(connectionTwo, TestContext.Current.CancellationToken);
+
         connectionMultiplexerTwo.Configuration.Should().Be("server2:6380,allowAdmin=true");
 
         IDistributedCache connectionOneAgain = connectorFactory.Get("myRedisServiceOne").GetConnection();
@@ -378,7 +384,8 @@ public sealed class RedisConnectorTest
         return connectionMultiplexerMock.Object;
     }
 
-    private static async Task<IConnectionMultiplexer> ExtractUnderlyingMultiplexerFromRedisCacheAsync(RedisCache redisCache, CancellationToken cancellationToken)
+    private static async Task<IConnectionMultiplexer> ExtractUnderlyingMultiplexerFromRedisCacheAsync(RedisCache redisCache,
+        CancellationToken cancellationToken)
     {
         _ = await redisCache.GetAsync("ignored", cancellationToken);
 

--- a/src/Connectors/test/Connectors.Test/Redis/RedisHealthContributorTest.cs
+++ b/src/Connectors/test/Connectors.Test/Redis/RedisHealthContributorTest.cs
@@ -28,7 +28,7 @@ public sealed class RedisHealthContributorTest
 
         healthContributor.SetConnectionMultiplexer(connectionMultiplexerMock.Object);
 
-        HealthCheckResult? result = await healthContributor.CheckHealthAsync(CancellationToken.None);
+        HealthCheckResult? result = await healthContributor.CheckHealthAsync(TestContext.Current.CancellationToken);
 
         result.Should().NotBeNull();
         result.Status.Should().Be(HealthStatus.Down);
@@ -56,7 +56,7 @@ public sealed class RedisHealthContributorTest
 
         healthContributor.SetConnectionMultiplexer(connectionMultiplexerMock.Object);
 
-        HealthCheckResult? result = await healthContributor.CheckHealthAsync(CancellationToken.None);
+        HealthCheckResult? result = await healthContributor.CheckHealthAsync(TestContext.Current.CancellationToken);
 
         result.Should().NotBeNull();
         result.Status.Should().Be(HealthStatus.Up);
@@ -89,7 +89,7 @@ public sealed class RedisHealthContributorTest
             ServiceName = "Example"
         };
 
-        HealthCheckResult? result = await healthContributor.CheckHealthAsync(CancellationToken.None);
+        HealthCheckResult? result = await healthContributor.CheckHealthAsync(TestContext.Current.CancellationToken);
 
         result.Should().NotBeNull();
         result.Status.Should().Be(HealthStatus.Up);

--- a/src/Connectors/test/Connectors.Test/RelationalDatabaseHealthContributorTest.cs
+++ b/src/Connectors/test/Connectors.Test/RelationalDatabaseHealthContributorTest.cs
@@ -137,7 +137,7 @@ public sealed class RelationalDatabaseHealthContributorTest
     public async Task Is_Connected_Returns_Up_Status()
     {
         var commandMock = new Mock<DbCommand>();
-        commandMock.Setup(command => command.ExecuteScalar()).Returns(1);
+        commandMock.Setup(command => command.ExecuteScalarAsync(It.IsAny<CancellationToken>())).Returns(Task.FromResult<object?>(1));
 
         var connectionMock = new Mock<DbConnection>();
         connectionMock.Setup(connection => connection.Open());

--- a/src/Connectors/test/Connectors.Test/RelationalDatabaseHealthContributorTest.cs
+++ b/src/Connectors/test/Connectors.Test/RelationalDatabaseHealthContributorTest.cs
@@ -25,7 +25,7 @@ public sealed class RelationalDatabaseHealthContributorTest
             ServiceName = "Example"
         };
 
-        HealthCheckResult? result = await healthContributor.CheckHealthAsync(CancellationToken.None);
+        HealthCheckResult? result = await healthContributor.CheckHealthAsync(TestContext.Current.CancellationToken);
 
         result.Should().NotBeNull();
         result.Status.Should().Be(HealthStatus.Down);
@@ -45,7 +45,7 @@ public sealed class RelationalDatabaseHealthContributorTest
             ServiceName = "Example"
         };
 
-        HealthCheckResult? result = await healthContributor.CheckHealthAsync(CancellationToken.None);
+        HealthCheckResult? result = await healthContributor.CheckHealthAsync(TestContext.Current.CancellationToken);
 
         result.Should().NotBeNull();
         result.Status.Should().Be(HealthStatus.Up);
@@ -64,7 +64,7 @@ public sealed class RelationalDatabaseHealthContributorTest
             ServiceName = "Example"
         };
 
-        HealthCheckResult? result = await healthContributor.CheckHealthAsync(CancellationToken.None);
+        HealthCheckResult? result = await healthContributor.CheckHealthAsync(TestContext.Current.CancellationToken);
 
         result.Should().NotBeNull();
         result.Status.Should().Be(HealthStatus.Down);
@@ -84,7 +84,7 @@ public sealed class RelationalDatabaseHealthContributorTest
             ServiceName = "Example"
         };
 
-        HealthCheckResult? result = await healthContributor.CheckHealthAsync(CancellationToken.None);
+        HealthCheckResult? result = await healthContributor.CheckHealthAsync(TestContext.Current.CancellationToken);
 
         result.Should().NotBeNull();
         result.Status.Should().Be(HealthStatus.Up);
@@ -104,7 +104,7 @@ public sealed class RelationalDatabaseHealthContributorTest
             ServiceName = "Example"
         };
 
-        HealthCheckResult? result = await healthContributor.CheckHealthAsync(CancellationToken.None);
+        HealthCheckResult? result = await healthContributor.CheckHealthAsync(TestContext.Current.CancellationToken);
 
         result.Should().NotBeNull();
         result.Status.Should().Be(HealthStatus.Down);
@@ -124,7 +124,7 @@ public sealed class RelationalDatabaseHealthContributorTest
             ServiceName = "Example"
         };
 
-        HealthCheckResult? result = await healthContributor.CheckHealthAsync(CancellationToken.None);
+        HealthCheckResult? result = await healthContributor.CheckHealthAsync(TestContext.Current.CancellationToken);
 
         result.Should().NotBeNull();
         result.Status.Should().Be(HealthStatus.Up);
@@ -149,7 +149,7 @@ public sealed class RelationalDatabaseHealthContributorTest
                 ServiceName = "Example"
             };
 
-        HealthCheckResult? result = await healthContributor.CheckHealthAsync(CancellationToken.None);
+        HealthCheckResult? result = await healthContributor.CheckHealthAsync(TestContext.Current.CancellationToken);
 
         result.Should().NotBeNull();
         result.Status.Should().Be(HealthStatus.Up);

--- a/src/Connectors/test/EntityFrameworkCore.Test/MigrateDbContextTaskTest.cs
+++ b/src/Connectors/test/EntityFrameworkCore.Test/MigrateDbContextTaskTest.cs
@@ -26,7 +26,7 @@ public sealed class MigrateDbContextTaskTest
 
         await using WebApplication app = builder.Build();
 
-        await app.RunWithTasksAsync(CancellationToken.None);
+        await app.RunWithTasksAsync(TestContext.Current.CancellationToken);
 
         TestMigrator.HasMigrated.Should().BeTrue();
     }

--- a/src/Discovery/test/Configuration.Test/ConfigurationDiscoveryClientTest.cs
+++ b/src/Discovery/test/Configuration.Test/ConfigurationDiscoveryClientTest.cs
@@ -64,13 +64,13 @@ public sealed class ConfigurationDiscoveryClientTest
         TestOptionsMonitor<ConfigurationDiscoveryOptions> optionsMonitor = TestOptionsMonitor.Create(options);
         var client = new ConfigurationDiscoveryClient(optionsMonitor);
 
-        IList<IServiceInstance> fruitInstances = await client.GetInstancesAsync("fruitService", CancellationToken.None);
+        IList<IServiceInstance> fruitInstances = await client.GetInstancesAsync("fruitService", TestContext.Current.CancellationToken);
         Assert.Equal(3, fruitInstances.Count);
 
-        IList<IServiceInstance> vegetableInstances = await client.GetInstancesAsync("vegetableService", CancellationToken.None);
+        IList<IServiceInstance> vegetableInstances = await client.GetInstancesAsync("vegetableService", TestContext.Current.CancellationToken);
         Assert.Equal(3, vegetableInstances.Count);
 
-        ISet<string> servicesIds = await client.GetServiceIdsAsync(CancellationToken.None);
+        ISet<string> servicesIds = await client.GetServiceIdsAsync(TestContext.Current.CancellationToken);
         Assert.Equal(2, servicesIds.Count);
     }
 
@@ -94,7 +94,7 @@ public sealed class ConfigurationDiscoveryClientTest
         TestOptionsMonitor<ConfigurationDiscoveryOptions> optionsMonitor = TestOptionsMonitor.Create(options);
         var client = new ConfigurationDiscoveryClient(optionsMonitor);
 
-        IList<IServiceInstance> fruitInstances = await client.GetInstancesAsync("fruitService", CancellationToken.None);
+        IList<IServiceInstance> fruitInstances = await client.GetInstancesAsync("fruitService", TestContext.Current.CancellationToken);
 
         Assert.Single(fruitInstances);
         Assert.Equal("fruit-ball", fruitInstances[0].Host);
@@ -141,13 +141,13 @@ public sealed class ConfigurationDiscoveryClientTest
         Assert.Single(discoveryClients);
         Assert.IsType<ConfigurationDiscoveryClient>(discoveryClients[0]);
 
-        ISet<string> servicesIds = await discoveryClients[0].GetServiceIdsAsync(CancellationToken.None);
+        ISet<string> servicesIds = await discoveryClients[0].GetServiceIdsAsync(TestContext.Current.CancellationToken);
         Assert.Equal(2, servicesIds.Count);
 
-        IList<IServiceInstance> fruitInstances = await discoveryClients[0].GetInstancesAsync("fruitService", CancellationToken.None);
+        IList<IServiceInstance> fruitInstances = await discoveryClients[0].GetInstancesAsync("fruitService", TestContext.Current.CancellationToken);
         Assert.Equal(2, fruitInstances.Count);
 
-        IList<IServiceInstance> vegetableInstances = await discoveryClients[0].GetInstancesAsync("vegetableService", CancellationToken.None);
+        IList<IServiceInstance> vegetableInstances = await discoveryClients[0].GetInstancesAsync("vegetableService", TestContext.Current.CancellationToken);
         Assert.Equal(2, vegetableInstances.Count);
     }
 

--- a/src/Discovery/test/Consul.Test/Discovery/ConsulDiscoveryClientTest.cs
+++ b/src/Discovery/test/Consul.Test/Discovery/ConsulDiscoveryClientTest.cs
@@ -60,7 +60,8 @@ public sealed class ConsulDiscoveryClientTest
 
         var healthMoq = new Mock<IHealthEndpoint>();
 
-        healthMoq.Setup(endpoint => endpoint.Service("ServiceId", options.DefaultQueryTag, options.QueryPassing, QueryOptions.Default, It.IsAny<CancellationToken>()))
+        healthMoq.Setup(endpoint =>
+                endpoint.Service("ServiceId", options.DefaultQueryTag, options.QueryPassing, QueryOptions.Default, It.IsAny<CancellationToken>()))
             .Returns(Task.FromResult(queryResult));
 
         var clientMoq = new Mock<IConsulClient>();
@@ -70,7 +71,10 @@ public sealed class ConsulDiscoveryClientTest
         var discoveryClient = new ConsulDiscoveryClient(clientMoq.Object, optionsMonitor, NullLoggerFactory.Instance);
 
         List<IServiceInstance> serviceInstances = [];
-        await discoveryClient.AddInstancesToListAsync(serviceInstances, "ServiceId", QueryOptions.Default, optionsMonitor.CurrentValue, TestContext.Current.CancellationToken);
+
+        await discoveryClient.AddInstancesToListAsync(serviceInstances, "ServiceId", QueryOptions.Default, optionsMonitor.CurrentValue,
+            TestContext.Current.CancellationToken);
+
         Assert.Equal(2, serviceInstances.Count);
 
         Assert.Equal("foo.bar.com", serviceInstances[0].Host);

--- a/src/Discovery/test/Consul.Test/Discovery/ConsulDiscoveryClientTest.cs
+++ b/src/Discovery/test/Consul.Test/Discovery/ConsulDiscoveryClientTest.cs
@@ -60,7 +60,7 @@ public sealed class ConsulDiscoveryClientTest
 
         var healthMoq = new Mock<IHealthEndpoint>();
 
-        healthMoq.Setup(endpoint => endpoint.Service("ServiceId", options.DefaultQueryTag, options.QueryPassing, QueryOptions.Default, CancellationToken.None))
+        healthMoq.Setup(endpoint => endpoint.Service("ServiceId", options.DefaultQueryTag, options.QueryPassing, QueryOptions.Default, It.IsAny<CancellationToken>()))
             .Returns(Task.FromResult(queryResult));
 
         var clientMoq = new Mock<IConsulClient>();
@@ -124,7 +124,7 @@ public sealed class ConsulDiscoveryClientTest
         };
 
         var catalogMoq = new Mock<ICatalogEndpoint>();
-        catalogMoq.Setup(endpoint => endpoint.Services(QueryOptions.Default, CancellationToken.None)).Returns(Task.FromResult(queryResult));
+        catalogMoq.Setup(endpoint => endpoint.Services(QueryOptions.Default, It.IsAny<CancellationToken>())).Returns(Task.FromResult(queryResult));
 
         var clientMoq = new Mock<IConsulClient>();
         clientMoq.Setup(client => client.Catalog).Returns(catalogMoq.Object);
@@ -196,7 +196,7 @@ public sealed class ConsulDiscoveryClientTest
         };
 
         var catalogMoq = new Mock<ICatalogEndpoint>();
-        catalogMoq.Setup(endpoint => endpoint.Services(QueryOptions.Default, CancellationToken.None)).Returns(Task.FromResult(queryResult1));
+        catalogMoq.Setup(endpoint => endpoint.Services(QueryOptions.Default, It.IsAny<CancellationToken>())).Returns(Task.FromResult(queryResult1));
 
         var clientMoq = new Mock<IConsulClient>();
         clientMoq.Setup(client => client.Catalog).Returns(catalogMoq.Object);
@@ -204,7 +204,7 @@ public sealed class ConsulDiscoveryClientTest
         var healthMoq = new Mock<IHealthEndpoint>();
         clientMoq.Setup(client => client.Health).Returns(healthMoq.Object);
 
-        healthMoq.Setup(h => h.Service("ServiceId", options.DefaultQueryTag, options.QueryPassing, QueryOptions.Default, CancellationToken.None))
+        healthMoq.Setup(h => h.Service("ServiceId", options.DefaultQueryTag, options.QueryPassing, QueryOptions.Default, It.IsAny<CancellationToken>()))
             .Returns(Task.FromResult(queryResult2));
 
         TestOptionsMonitor<ConsulDiscoveryOptions> optionsMonitor = TestOptionsMonitor.Create(options);

--- a/src/Discovery/test/Consul.Test/Discovery/ConsulDiscoveryClientTest.cs
+++ b/src/Discovery/test/Consul.Test/Discovery/ConsulDiscoveryClientTest.cs
@@ -70,7 +70,7 @@ public sealed class ConsulDiscoveryClientTest
         var discoveryClient = new ConsulDiscoveryClient(clientMoq.Object, optionsMonitor, NullLoggerFactory.Instance);
 
         List<IServiceInstance> serviceInstances = [];
-        await discoveryClient.AddInstancesToListAsync(serviceInstances, "ServiceId", QueryOptions.Default, optionsMonitor.CurrentValue, CancellationToken.None);
+        await discoveryClient.AddInstancesToListAsync(serviceInstances, "ServiceId", QueryOptions.Default, optionsMonitor.CurrentValue, TestContext.Current.CancellationToken);
         Assert.Equal(2, serviceInstances.Count);
 
         Assert.Equal("foo.bar.com", serviceInstances[0].Host);
@@ -131,7 +131,7 @@ public sealed class ConsulDiscoveryClientTest
 
         TestOptionsMonitor<ConsulDiscoveryOptions> optionsMonitor = TestOptionsMonitor.Create(options);
         var discoveryClient = new ConsulDiscoveryClient(clientMoq.Object, optionsMonitor, NullLoggerFactory.Instance);
-        ISet<string> serviceIds = await discoveryClient.GetServiceIdsAsync(QueryOptions.Default, CancellationToken.None);
+        ISet<string> serviceIds = await discoveryClient.GetServiceIdsAsync(QueryOptions.Default, TestContext.Current.CancellationToken);
 
         Assert.Equal(2, serviceIds.Count);
         Assert.Contains("foo", serviceIds);
@@ -209,7 +209,7 @@ public sealed class ConsulDiscoveryClientTest
 
         TestOptionsMonitor<ConsulDiscoveryOptions> optionsMonitor = TestOptionsMonitor.Create(options);
         var discoveryClient = new ConsulDiscoveryClient(clientMoq.Object, optionsMonitor, NullLoggerFactory.Instance);
-        IList<IServiceInstance> serviceInstances = await discoveryClient.GetAllInstancesAsync(QueryOptions.Default, CancellationToken.None);
+        IList<IServiceInstance> serviceInstances = await discoveryClient.GetAllInstancesAsync(QueryOptions.Default, TestContext.Current.CancellationToken);
 
         Assert.Equal(2, serviceInstances.Count);
 

--- a/src/Discovery/test/Consul.Test/Discovery/ConsulHealthContributorTest.cs
+++ b/src/Discovery/test/Consul.Test/Discovery/ConsulHealthContributorTest.cs
@@ -24,7 +24,7 @@ public sealed class ConsulHealthContributorTest
 
         var optionsMonitor = new TestOptionsMonitor<ConsulDiscoveryOptions>();
         var healthContributor = new ConsulHealthContributor(clientMoq.Object, optionsMonitor);
-        string result = await healthContributor.GetLeaderStatusAsync(CancellationToken.None);
+        string result = await healthContributor.GetLeaderStatusAsync(TestContext.Current.CancellationToken);
 
         Assert.Equal("the-status", result);
     }
@@ -57,7 +57,7 @@ public sealed class ConsulHealthContributorTest
 
         var optionsMonitor = new TestOptionsMonitor<ConsulDiscoveryOptions>();
         var healthContributor = new ConsulHealthContributor(clientMoq.Object, optionsMonitor);
-        Dictionary<string, string[]> result = await healthContributor.GetCatalogServicesAsync(CancellationToken.None);
+        Dictionary<string, string[]> result = await healthContributor.GetCatalogServicesAsync(TestContext.Current.CancellationToken);
 
         Assert.Equal(2, result.Count);
         Assert.Contains("foo", result.Keys);
@@ -97,7 +97,7 @@ public sealed class ConsulHealthContributorTest
 
         var optionsMonitor = new TestOptionsMonitor<ConsulDiscoveryOptions>();
         var healthContributor = new ConsulHealthContributor(clientMoq.Object, optionsMonitor);
-        HealthCheckResult? result = await healthContributor.CheckHealthAsync(CancellationToken.None);
+        HealthCheckResult? result = await healthContributor.CheckHealthAsync(TestContext.Current.CancellationToken);
 
         Assert.NotNull(result);
         Assert.Equal(HealthStatus.Up, result.Status);
@@ -119,7 +119,7 @@ public sealed class ConsulHealthContributorTest
 
         TestOptionsMonitor<ConsulDiscoveryOptions> optionsMonitor = TestOptionsMonitor.Create(options);
         var healthContributor = new ConsulHealthContributor(clientMoq.Object, optionsMonitor);
-        HealthCheckResult? result = await healthContributor.CheckHealthAsync(CancellationToken.None);
+        HealthCheckResult? result = await healthContributor.CheckHealthAsync(TestContext.Current.CancellationToken);
 
         Assert.Null(result);
     }

--- a/src/Discovery/test/Consul.Test/Discovery/ConsulHealthContributorTest.cs
+++ b/src/Discovery/test/Consul.Test/Discovery/ConsulHealthContributorTest.cs
@@ -17,7 +17,7 @@ public sealed class ConsulHealthContributorTest
     public async Task GetLeaderStatusAsync_ReturnsExpected()
     {
         var statusMoq = new Mock<IStatusEndpoint>();
-        statusMoq.Setup(endpoint => endpoint.Leader(CancellationToken.None)).Returns(Task.FromResult("the-status"));
+        statusMoq.Setup(endpoint => endpoint.Leader(It.IsAny<CancellationToken>())).Returns(Task.FromResult("the-status"));
 
         var clientMoq = new Mock<IConsulClient>();
         clientMoq.Setup(client => client.Status).Returns(statusMoq.Object);
@@ -50,7 +50,7 @@ public sealed class ConsulHealthContributorTest
         };
 
         var catalogMoq = new Mock<ICatalogEndpoint>();
-        catalogMoq.Setup(endpoint => endpoint.Services(QueryOptions.Default, CancellationToken.None)).Returns(Task.FromResult(queryResult));
+        catalogMoq.Setup(endpoint => endpoint.Services(QueryOptions.Default, It.IsAny<CancellationToken>())).Returns(Task.FromResult(queryResult));
 
         var clientMoq = new Mock<IConsulClient>();
         clientMoq.Setup(client => client.Catalog).Returns(catalogMoq.Object);
@@ -86,10 +86,10 @@ public sealed class ConsulHealthContributorTest
         };
 
         var statusMoq = new Mock<IStatusEndpoint>();
-        statusMoq.Setup(endpoint => endpoint.Leader(CancellationToken.None)).Returns(Task.FromResult("the-status"));
+        statusMoq.Setup(endpoint => endpoint.Leader(It.IsAny<CancellationToken>())).Returns(Task.FromResult("the-status"));
 
         var catalogMoq = new Mock<ICatalogEndpoint>();
-        catalogMoq.Setup(endpoint => endpoint.Services(QueryOptions.Default, CancellationToken.None)).Returns(Task.FromResult(queryResult));
+        catalogMoq.Setup(endpoint => endpoint.Services(QueryOptions.Default, It.IsAny<CancellationToken>())).Returns(Task.FromResult(queryResult));
 
         var clientMoq = new Mock<IConsulClient>();
         clientMoq.Setup(client => client.Status).Returns(statusMoq.Object);

--- a/src/Discovery/test/Consul.Test/Discovery/TtlSchedulerTest.cs
+++ b/src/Discovery/test/Consul.Test/Discovery/TtlSchedulerTest.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Consul;
+using FluentAssertions.Extensions;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Steeltoe.Common.TestResources;
@@ -135,7 +136,7 @@ public sealed class TtlSchedulerTest
         var scheduler = new TtlScheduler(optionsMonitor, clientMoq.Object, NullLoggerFactory.Instance);
         scheduler.Add("foobar");
 
-        await Task.Delay(2500);
+        await Task.Delay(2500.Milliseconds(), TestContext.Current.CancellationToken);
 
         agentMoq.Verify(a => a.PassTTL("service:foobar", "ttl", It.IsAny<CancellationToken>()), Times.AtLeastOnce);
         await scheduler.RemoveAsync("foobar");

--- a/src/Discovery/test/Consul.Test/Registry/ConsulServiceRegistrarTest.cs
+++ b/src/Discovery/test/Consul.Test/Registry/ConsulServiceRegistrarTest.cs
@@ -8,6 +8,7 @@ using Moq;
 using Steeltoe.Common.TestResources;
 using Steeltoe.Discovery.Consul.Configuration;
 using Steeltoe.Discovery.Consul.Registry;
+using Xunit.Sdk;
 
 namespace Steeltoe.Discovery.Consul.Test.Registry;
 
@@ -25,7 +26,7 @@ public sealed class ConsulServiceRegistrarTest
         await using var registry = new ConsulServiceRegistry(clientMock.Object, optionsMonitor, null, NullLogger<ConsulServiceRegistry>.Instance);
         await using var registrar = new ConsulServiceRegistrar(registry, optionsMonitor, registration, NullLogger<ConsulServiceRegistrar>.Instance);
 
-        await registrar.StartAsync(CancellationToken.None);
+        await registrar.StartAsync(TestContext.Current.CancellationToken);
 
         registrar.IsRunning.Should().BeTrue();
         agentMock.Verify(agent => agent.ServiceRegister(registration.InnerRegistration, It.IsAny<CancellationToken>()), Times.Once);
@@ -45,7 +46,7 @@ public sealed class ConsulServiceRegistrarTest
         await using var registry = new ConsulServiceRegistry(clientMock.Object, optionsMonitor, null, NullLogger<ConsulServiceRegistry>.Instance);
         await using var registrar = new ConsulServiceRegistrar(registry, optionsMonitor, registration, NullLogger<ConsulServiceRegistrar>.Instance);
 
-        await registrar.StartAsync(CancellationToken.None);
+        await registrar.StartAsync(TestContext.Current.CancellationToken);
 
         registrar.IsRunning.Should().BeTrue();
         agentMock.Verify(agent => agent.ServiceRegister(registration.InnerRegistration, It.IsAny<CancellationToken>()), Times.Never);
@@ -65,7 +66,7 @@ public sealed class ConsulServiceRegistrarTest
         await using var registry = new ConsulServiceRegistry(clientMock.Object, optionsMonitor, null, NullLogger<ConsulServiceRegistry>.Instance);
         await using var registrar = new ConsulServiceRegistrar(registry, optionsMonitor, registration, NullLogger<ConsulServiceRegistrar>.Instance);
 
-        await registrar.StartAsync(CancellationToken.None);
+        await registrar.StartAsync(TestContext.Current.CancellationToken);
 
         registrar.IsRunning.Should().BeFalse();
         agentMock.Verify(agent => agent.ServiceRegister(registration.InnerRegistration, It.IsAny<CancellationToken>()), Times.Never);
@@ -83,7 +84,7 @@ public sealed class ConsulServiceRegistrarTest
 
         await using (registrar)
         {
-            await registrar.StartAsync(CancellationToken.None);
+            await registrar.StartAsync(TestContext.Current.CancellationToken);
         }
 
         registrar.IsRunning.Should().BeFalse();
@@ -106,7 +107,7 @@ public sealed class ConsulServiceRegistrarTest
 
         await using (registrar)
         {
-            await registrar.StartAsync(CancellationToken.None);
+            await registrar.StartAsync(TestContext.Current.CancellationToken);
         }
 
         agentMock.Verify(agent => agent.ServiceDeregister(registration.InstanceId, It.IsAny<CancellationToken>()), Times.Never);

--- a/src/Discovery/test/Consul.Test/Registry/ConsulServiceRegistrarTest.cs
+++ b/src/Discovery/test/Consul.Test/Registry/ConsulServiceRegistrarTest.cs
@@ -28,7 +28,7 @@ public sealed class ConsulServiceRegistrarTest
         await registrar.StartAsync(CancellationToken.None);
 
         registrar.IsRunning.Should().BeTrue();
-        agentMock.Verify(agent => agent.ServiceRegister(registration.InnerRegistration, CancellationToken.None), Times.Once);
+        agentMock.Verify(agent => agent.ServiceRegister(registration.InnerRegistration, It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
@@ -48,7 +48,7 @@ public sealed class ConsulServiceRegistrarTest
         await registrar.StartAsync(CancellationToken.None);
 
         registrar.IsRunning.Should().BeTrue();
-        agentMock.Verify(agent => agent.ServiceRegister(registration.InnerRegistration, CancellationToken.None), Times.Never);
+        agentMock.Verify(agent => agent.ServiceRegister(registration.InnerRegistration, It.IsAny<CancellationToken>()), Times.Never);
     }
 
     [Fact]
@@ -68,7 +68,7 @@ public sealed class ConsulServiceRegistrarTest
         await registrar.StartAsync(CancellationToken.None);
 
         registrar.IsRunning.Should().BeFalse();
-        agentMock.Verify(agent => agent.ServiceRegister(registration.InnerRegistration, CancellationToken.None), Times.Never);
+        agentMock.Verify(agent => agent.ServiceRegister(registration.InnerRegistration, It.IsAny<CancellationToken>()), Times.Never);
     }
 
     [Fact]
@@ -87,7 +87,7 @@ public sealed class ConsulServiceRegistrarTest
         }
 
         registrar.IsRunning.Should().BeFalse();
-        agentMock.Verify(agent => agent.ServiceDeregister(registration.InstanceId, CancellationToken.None), Times.Once);
+        agentMock.Verify(agent => agent.ServiceDeregister(registration.InstanceId, It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
@@ -109,14 +109,14 @@ public sealed class ConsulServiceRegistrarTest
             await registrar.StartAsync(CancellationToken.None);
         }
 
-        agentMock.Verify(agent => agent.ServiceDeregister(registration.InstanceId, CancellationToken.None), Times.Never);
+        agentMock.Verify(agent => agent.ServiceDeregister(registration.InstanceId, It.IsAny<CancellationToken>()), Times.Never);
     }
 
     private static (Mock<IConsulClient> ClientMock, Mock<IAgentEndpoint> AgentMock) CreateConsulClientAgentMock(ConsulRegistration registration)
     {
         var agentMock = new Mock<IAgentEndpoint>();
-        agentMock.Setup(agent => agent.ServiceRegister(registration.InnerRegistration, CancellationToken.None)).Returns(Task.FromResult(DefaultWriteResult));
-        agentMock.Setup(agent => agent.ServiceDeregister(registration.InstanceId, CancellationToken.None)).Returns(Task.FromResult(DefaultWriteResult));
+        agentMock.Setup(agent => agent.ServiceRegister(registration.InnerRegistration, It.IsAny<CancellationToken>())).Returns(Task.FromResult(DefaultWriteResult));
+        agentMock.Setup(agent => agent.ServiceDeregister(registration.InstanceId, It.IsAny<CancellationToken>())).Returns(Task.FromResult(DefaultWriteResult));
 
         var clientMock = new Mock<IConsulClient>();
         clientMock.Setup(client => client.Agent).Returns(agentMock.Object);

--- a/src/Discovery/test/Consul.Test/Registry/ConsulServiceRegistrarTest.cs
+++ b/src/Discovery/test/Consul.Test/Registry/ConsulServiceRegistrarTest.cs
@@ -8,7 +8,6 @@ using Moq;
 using Steeltoe.Common.TestResources;
 using Steeltoe.Discovery.Consul.Configuration;
 using Steeltoe.Discovery.Consul.Registry;
-using Xunit.Sdk;
 
 namespace Steeltoe.Discovery.Consul.Test.Registry;
 
@@ -116,7 +115,10 @@ public sealed class ConsulServiceRegistrarTest
     private static (Mock<IConsulClient> ClientMock, Mock<IAgentEndpoint> AgentMock) CreateConsulClientAgentMock(ConsulRegistration registration)
     {
         var agentMock = new Mock<IAgentEndpoint>();
-        agentMock.Setup(agent => agent.ServiceRegister(registration.InnerRegistration, It.IsAny<CancellationToken>())).Returns(Task.FromResult(DefaultWriteResult));
+
+        agentMock.Setup(agent => agent.ServiceRegister(registration.InnerRegistration, It.IsAny<CancellationToken>()))
+            .Returns(Task.FromResult(DefaultWriteResult));
+
         agentMock.Setup(agent => agent.ServiceDeregister(registration.InstanceId, It.IsAny<CancellationToken>())).Returns(Task.FromResult(DefaultWriteResult));
 
         var clientMock = new Mock<IConsulClient>();

--- a/src/Discovery/test/Consul.Test/Registry/ConsulServiceRegistryTest.cs
+++ b/src/Discovery/test/Consul.Test/Registry/ConsulServiceRegistryTest.cs
@@ -87,7 +87,9 @@ public sealed class ConsulServiceRegistryTest
         ConsulRegistration registration = TestRegistrationFactory.Create(appSettings);
 
         await using var registry = new ConsulServiceRegistry(clientMoq.Object, optionsMonitor, scheduler, NullLogger<ConsulServiceRegistry>.Instance);
-        await Assert.ThrowsAsync<ArgumentException>(async () => await registry.SetStatusAsync(registration, string.Empty, TestContext.Current.CancellationToken));
+
+        await Assert.ThrowsAsync<ArgumentException>(async () =>
+            await registry.SetStatusAsync(registration, string.Empty, TestContext.Current.CancellationToken));
     }
 
     [Fact]

--- a/src/Discovery/test/Consul.Test/Registry/ConsulServiceRegistryTest.cs
+++ b/src/Discovery/test/Consul.Test/Registry/ConsulServiceRegistryTest.cs
@@ -30,7 +30,7 @@ public sealed class ConsulServiceRegistryTest
         };
 
         ConsulRegistration registration = TestRegistrationFactory.Create(appSettings);
-        await registry.RegisterAsync(registration, CancellationToken.None);
+        await registry.RegisterAsync(registration, TestContext.Current.CancellationToken);
 
         agentMoq.Verify(endpoint => endpoint.ServiceRegister(registration.InnerRegistration, It.IsAny<CancellationToken>()), Times.Once);
 
@@ -56,14 +56,14 @@ public sealed class ConsulServiceRegistryTest
         };
 
         ConsulRegistration registration = TestRegistrationFactory.Create(appSettings);
-        await registry.RegisterAsync(registration, CancellationToken.None);
+        await registry.RegisterAsync(registration, TestContext.Current.CancellationToken);
 
         agentMoq.Verify(endpoint => endpoint.ServiceRegister(registration.InnerRegistration, It.IsAny<CancellationToken>()), Times.Once);
 
         Assert.Single(scheduler.ServiceHeartbeats);
         Assert.Contains(registration.InstanceId, scheduler.ServiceHeartbeats.Keys);
 
-        await registry.DeregisterAsync(registration, CancellationToken.None);
+        await registry.DeregisterAsync(registration, TestContext.Current.CancellationToken);
 
         agentMoq.Verify(endpoint => endpoint.ServiceDeregister(registration.InnerRegistration.ID, It.IsAny<CancellationToken>()), Times.Once);
         Assert.Empty(scheduler.ServiceHeartbeats);
@@ -87,7 +87,7 @@ public sealed class ConsulServiceRegistryTest
         ConsulRegistration registration = TestRegistrationFactory.Create(appSettings);
 
         await using var registry = new ConsulServiceRegistry(clientMoq.Object, optionsMonitor, scheduler, NullLogger<ConsulServiceRegistry>.Instance);
-        await Assert.ThrowsAsync<ArgumentException>(async () => await registry.SetStatusAsync(registration, string.Empty, CancellationToken.None));
+        await Assert.ThrowsAsync<ArgumentException>(async () => await registry.SetStatusAsync(registration, string.Empty, TestContext.Current.CancellationToken));
     }
 
     [Fact]
@@ -108,10 +108,10 @@ public sealed class ConsulServiceRegistryTest
         ConsulRegistration registration = TestRegistrationFactory.Create(appSettings);
 
         await using var registry = new ConsulServiceRegistry(clientMoq.Object, optionsMonitor, scheduler, NullLogger<ConsulServiceRegistry>.Instance);
-        await registry.SetStatusAsync(registration, "Up", CancellationToken.None);
+        await registry.SetStatusAsync(registration, "Up", TestContext.Current.CancellationToken);
         agentMoq.Verify(endpoint => endpoint.DisableServiceMaintenance(registration.InstanceId, It.IsAny<CancellationToken>()), Times.Once);
 
-        await registry.SetStatusAsync(registration, "Out_of_Service", CancellationToken.None);
+        await registry.SetStatusAsync(registration, "Out_of_Service", TestContext.Current.CancellationToken);
         agentMoq.Verify(endpoint => endpoint.EnableServiceMaintenance(registration.InstanceId, "OUT_OF_SERVICE", It.IsAny<CancellationToken>()), Times.Once);
     }
 
@@ -155,7 +155,7 @@ public sealed class ConsulServiceRegistryTest
         await using var scheduler = new TtlScheduler(optionsMonitor, clientMoq.Object, NullLoggerFactory.Instance);
         await using var registry = new ConsulServiceRegistry(clientMoq.Object, optionsMonitor, scheduler, NullLogger<ConsulServiceRegistry>.Instance);
 
-        string status = await registry.GetStatusAsync(registration, CancellationToken.None);
+        string status = await registry.GetStatusAsync(registration, TestContext.Current.CancellationToken);
         Assert.Equal("OUT_OF_SERVICE", status);
     }
 }

--- a/src/Discovery/test/Consul.Test/Registry/ConsulServiceRegistryTest.cs
+++ b/src/Discovery/test/Consul.Test/Registry/ConsulServiceRegistryTest.cs
@@ -32,7 +32,7 @@ public sealed class ConsulServiceRegistryTest
         ConsulRegistration registration = TestRegistrationFactory.Create(appSettings);
         await registry.RegisterAsync(registration, CancellationToken.None);
 
-        agentMoq.Verify(endpoint => endpoint.ServiceRegister(registration.InnerRegistration, CancellationToken.None), Times.Once);
+        agentMoq.Verify(endpoint => endpoint.ServiceRegister(registration.InnerRegistration, It.IsAny<CancellationToken>()), Times.Once);
 
         Assert.Single(scheduler.ServiceHeartbeats);
         Assert.Contains(registration.InstanceId, scheduler.ServiceHeartbeats.Keys);
@@ -58,14 +58,14 @@ public sealed class ConsulServiceRegistryTest
         ConsulRegistration registration = TestRegistrationFactory.Create(appSettings);
         await registry.RegisterAsync(registration, CancellationToken.None);
 
-        agentMoq.Verify(endpoint => endpoint.ServiceRegister(registration.InnerRegistration, CancellationToken.None), Times.Once);
+        agentMoq.Verify(endpoint => endpoint.ServiceRegister(registration.InnerRegistration, It.IsAny<CancellationToken>()), Times.Once);
 
         Assert.Single(scheduler.ServiceHeartbeats);
         Assert.Contains(registration.InstanceId, scheduler.ServiceHeartbeats.Keys);
 
         await registry.DeregisterAsync(registration, CancellationToken.None);
 
-        agentMoq.Verify(endpoint => endpoint.ServiceDeregister(registration.InnerRegistration.ID, CancellationToken.None), Times.Once);
+        agentMoq.Verify(endpoint => endpoint.ServiceDeregister(registration.InnerRegistration.ID, It.IsAny<CancellationToken>()), Times.Once);
         Assert.Empty(scheduler.ServiceHeartbeats);
     }
 
@@ -109,10 +109,10 @@ public sealed class ConsulServiceRegistryTest
 
         await using var registry = new ConsulServiceRegistry(clientMoq.Object, optionsMonitor, scheduler, NullLogger<ConsulServiceRegistry>.Instance);
         await registry.SetStatusAsync(registration, "Up", CancellationToken.None);
-        agentMoq.Verify(endpoint => endpoint.DisableServiceMaintenance(registration.InstanceId, CancellationToken.None), Times.Once);
+        agentMoq.Verify(endpoint => endpoint.DisableServiceMaintenance(registration.InstanceId, It.IsAny<CancellationToken>()), Times.Once);
 
         await registry.SetStatusAsync(registration, "Out_of_Service", CancellationToken.None);
-        agentMoq.Verify(endpoint => endpoint.EnableServiceMaintenance(registration.InstanceId, "OUT_OF_SERVICE", CancellationToken.None), Times.Once);
+        agentMoq.Verify(endpoint => endpoint.EnableServiceMaintenance(registration.InstanceId, "OUT_OF_SERVICE", It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
@@ -150,7 +150,7 @@ public sealed class ConsulServiceRegistryTest
         var healthMoq = new Mock<IHealthEndpoint>();
 
         clientMoq.Setup(client => client.Health).Returns(healthMoq.Object);
-        healthMoq.Setup(endpoint => endpoint.Checks(registration.ServiceId, QueryOptions.Default, CancellationToken.None)).Returns(result);
+        healthMoq.Setup(endpoint => endpoint.Checks(registration.ServiceId, QueryOptions.Default, It.IsAny<CancellationToken>())).Returns(result);
 
         await using var scheduler = new TtlScheduler(optionsMonitor, clientMoq.Object, NullLoggerFactory.Instance);
         await using var registry = new ConsulServiceRegistry(clientMoq.Object, optionsMonitor, scheduler, NullLogger<ConsulServiceRegistry>.Instance);

--- a/src/Discovery/test/Consul.Test/Util/DateTimeConversionsTest.cs
+++ b/src/Discovery/test/Consul.Test/Util/DateTimeConversionsTest.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
+using FluentAssertions.Extensions;
 using Steeltoe.Discovery.Consul.Util;
 
 namespace Steeltoe.Discovery.Consul.Test.Util;
@@ -15,13 +16,13 @@ public sealed class DateTimeConversionsTest
         Assert.Throws<ArgumentException>(() => DateTimeConversions.ToTimeSpan(string.Empty));
         Assert.Throws<ArgumentException>(() => DateTimeConversions.ToTimeSpan(" "));
         Assert.Throws<FormatException>(() => DateTimeConversions.ToTimeSpan("foobar"));
-        Assert.Equal(TimeSpan.FromMilliseconds(1000), DateTimeConversions.ToTimeSpan("1000ms"));
-        Assert.Equal(TimeSpan.FromSeconds(1000), DateTimeConversions.ToTimeSpan("1000s"));
-        Assert.Equal(TimeSpan.FromHours(1), DateTimeConversions.ToTimeSpan("1h"));
-        Assert.Equal(TimeSpan.FromMinutes(1), DateTimeConversions.ToTimeSpan("1m"));
-        Assert.Equal(TimeSpan.FromMilliseconds(1000), DateTimeConversions.ToTimeSpan("1000Ms"));
-        Assert.Equal(TimeSpan.FromSeconds(1000), DateTimeConversions.ToTimeSpan("1000S"));
-        Assert.Equal(TimeSpan.FromHours(1), DateTimeConversions.ToTimeSpan("1H"));
-        Assert.Equal(TimeSpan.FromMinutes(1), DateTimeConversions.ToTimeSpan("1M"));
+        Assert.Equal(1.Seconds(), DateTimeConversions.ToTimeSpan("1000ms"));
+        Assert.Equal(1000.Seconds(), DateTimeConversions.ToTimeSpan("1000s"));
+        Assert.Equal(1.Hours(), DateTimeConversions.ToTimeSpan("1h"));
+        Assert.Equal(1.Minutes(), DateTimeConversions.ToTimeSpan("1m"));
+        Assert.Equal(1.Seconds(), DateTimeConversions.ToTimeSpan("1000Ms"));
+        Assert.Equal(1000.Seconds(), DateTimeConversions.ToTimeSpan("1000S"));
+        Assert.Equal(1.Hours(), DateTimeConversions.ToTimeSpan("1H"));
+        Assert.Equal(1.Minutes(), DateTimeConversions.ToTimeSpan("1M"));
     }
 }

--- a/src/Discovery/test/Eureka.Test/DynamicPortAssignmentTest.cs
+++ b/src/Discovery/test/Eureka.Test/DynamicPortAssignmentTest.cs
@@ -27,7 +27,7 @@ public sealed class DynamicPortAssignmentTest
         builder.Services.AddEurekaDiscoveryClient();
 
         await using WebApplication app = builder.Build();
-        await app.StartAsync();
+        await app.StartAsync(TestContext.Current.CancellationToken);
 
         var infoManager = app.Services.GetRequiredService<EurekaApplicationInfoManager>();
 

--- a/src/Discovery/test/Eureka.Test/EurekaApplicationsHealthContributorTest.cs
+++ b/src/Discovery/test/Eureka.Test/EurekaApplicationsHealthContributorTest.cs
@@ -24,7 +24,7 @@ public sealed class EurekaApplicationsHealthContributorTest
 
         (EurekaApplicationsHealthContributor contributor, _) = CreateHealthContributor(appSettings);
 
-        HealthCheckResult? result = await contributor.CheckHealthAsync(CancellationToken.None);
+        HealthCheckResult? result = await contributor.CheckHealthAsync(TestContext.Current.CancellationToken);
 
         result.Should().BeNull();
     }

--- a/src/Discovery/test/Eureka.Test/EurekaDiscoveryClientTest.cs
+++ b/src/Discovery/test/Eureka.Test/EurekaDiscoveryClientTest.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Net;
+using FluentAssertions.Extensions;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -152,7 +153,7 @@ public sealed class EurekaDiscoveryClientTest
 
         Assert.NotNull(discoveryClient.Description);
 
-        ISet<string> serviceIds = await discoveryClient.GetServiceIdsAsync(CancellationToken.None);
+        ISet<string> serviceIds = await discoveryClient.GetServiceIdsAsync(TestContext.Current.CancellationToken);
         Assert.Empty(serviceIds);
 
         IServiceInstance thisService = discoveryClient.GetLocalServiceInstance();
@@ -217,7 +218,7 @@ public sealed class EurekaDiscoveryClientTest
         webApplication.Services.GetRequiredService<HttpClientHandlerFactory>().Using(handler);
 
         var discoveryClient = webApplication.Services.GetRequiredService<EurekaDiscoveryClient>();
-        ApplicationInfoCollection apps = await discoveryClient.FetchFullRegistryAsync(CancellationToken.None);
+        ApplicationInfoCollection apps = await discoveryClient.FetchFullRegistryAsync(TestContext.Current.CancellationToken);
 
         handler.Mock.VerifyNoOutstandingExpectation();
 
@@ -259,7 +260,7 @@ public sealed class EurekaDiscoveryClientTest
 
         discoveryClient.Applications = apps;
 
-        ApplicationInfoCollection result = await discoveryClient.FetchRegistryDeltaAsync(CancellationToken.None);
+        ApplicationInfoCollection result = await discoveryClient.FetchRegistryDeltaAsync(TestContext.Current.CancellationToken);
 
         handler.Mock.VerifyNoOutstandingExpectation();
 
@@ -293,7 +294,7 @@ public sealed class EurekaDiscoveryClientTest
 
         var discoveryClient = webApplication.Services.GetRequiredService<EurekaDiscoveryClient>();
 
-        Func<Task> action = async () => await discoveryClient.RegisterAsync(false, CancellationToken.None);
+        Func<Task> action = async () => await discoveryClient.RegisterAsync(false, TestContext.Current.CancellationToken);
 
         await action.Should().ThrowExactlyAsync<EurekaTransportException>();
 
@@ -322,7 +323,7 @@ public sealed class EurekaDiscoveryClientTest
 
         var discoveryClient = webApplication.Services.GetRequiredService<EurekaDiscoveryClient>();
 
-        await discoveryClient.RegisterAsync(false, CancellationToken.None);
+        await discoveryClient.RegisterAsync(false, TestContext.Current.CancellationToken);
 
         handler.Mock.VerifyNoOutstandingExpectation();
     }
@@ -355,7 +356,7 @@ public sealed class EurekaDiscoveryClientTest
         var appManager = webApplication.Services.GetRequiredService<EurekaApplicationInfoManager>();
         appManager.Instance.IsDirty = true;
 
-        await discoveryClient.RenewAsync(CancellationToken.None);
+        await discoveryClient.RenewAsync(TestContext.Current.CancellationToken);
 
         handler.Mock.VerifyNoOutstandingExpectation();
     }
@@ -387,7 +388,7 @@ public sealed class EurekaDiscoveryClientTest
         var appManager = webApplication.Services.GetRequiredService<EurekaApplicationInfoManager>();
         appManager.Instance.IsDirty = true;
 
-        await discoveryClient.RenewAsync(CancellationToken.None);
+        await discoveryClient.RenewAsync(TestContext.Current.CancellationToken);
 
         handler.Mock.VerifyNoOutstandingExpectation();
     }
@@ -415,7 +416,7 @@ public sealed class EurekaDiscoveryClientTest
 
         var discoveryClient = webApplication.Services.GetRequiredService<EurekaDiscoveryClient>();
 
-        await discoveryClient.DeregisterAsync(CancellationToken.None);
+        await discoveryClient.DeregisterAsync(TestContext.Current.CancellationToken);
 
         handler.Mock.VerifyNoOutstandingExpectation();
     }
@@ -566,7 +567,7 @@ public sealed class EurekaDiscoveryClientTest
         var discoveryClient = webApplication.Services.GetRequiredService<EurekaDiscoveryClient>();
         var appInfoManager = webApplication.Services.GetRequiredService<EurekaApplicationInfoManager>();
 
-        await discoveryClient.RunHealthChecksAsync(CancellationToken.None);
+        await discoveryClient.RunHealthChecksAsync(TestContext.Current.CancellationToken);
 
         Assert.True(myHandler.Awaited);
         Assert.Equal(InstanceStatus.Down, appInfoManager.Instance.Status);
@@ -595,7 +596,7 @@ public sealed class EurekaDiscoveryClientTest
         var discoveryClient = webApplication.Services.GetRequiredService<EurekaDiscoveryClient>();
         var appInfoManager = webApplication.Services.GetRequiredService<EurekaApplicationInfoManager>();
 
-        await discoveryClient.RunHealthChecksAsync(CancellationToken.None);
+        await discoveryClient.RunHealthChecksAsync(TestContext.Current.CancellationToken);
 
         Assert.False(myHandler.Awaited);
         Assert.Equal(InstanceStatus.Starting, appInfoManager.Instance.Status);
@@ -635,7 +636,7 @@ public sealed class EurekaDiscoveryClientTest
 
         var discoveryClient = webApplication.Services.GetRequiredService<EurekaDiscoveryClient>();
 
-        await discoveryClient.RegisterAsync(false, CancellationToken.None);
+        await discoveryClient.RegisterAsync(false, TestContext.Current.CancellationToken);
 
         handler.Mock.VerifyNoOutstandingExpectation();
     }
@@ -665,12 +666,12 @@ public sealed class EurekaDiscoveryClientTest
 
         discoveryClient.ApplicationsFetched += (_, _) => eventCount++;
 
-        await discoveryClient.FetchRegistryAsync(true, CancellationToken.None);
-        await Task.Delay(500);
+        await discoveryClient.FetchRegistryAsync(true, TestContext.Current.CancellationToken);
+        await Task.Delay(500.Milliseconds(), TestContext.Current.CancellationToken);
         Assert.Equal(1, eventCount);
 
-        await discoveryClient.FetchRegistryAsync(false, CancellationToken.None);
-        await Task.Delay(500);
+        await discoveryClient.FetchRegistryAsync(false, TestContext.Current.CancellationToken);
+        await Task.Delay(500.Milliseconds(), TestContext.Current.CancellationToken);
         Assert.Equal(2, eventCount);
 
         handler.Mock.VerifyNoOutstandingExpectation();

--- a/src/Discovery/test/Eureka.Test/EurekaHealthCheckHandlerTest.cs
+++ b/src/Discovery/test/Eureka.Test/EurekaHealthCheckHandlerTest.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Net;
+using FluentAssertions.Extensions;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -37,7 +38,7 @@ public sealed class EurekaHealthCheckHandlerTest
 
         var optionsMonitor = new TestOptionsMonitor<HealthCheckServiceOptions>();
         var handler = new EurekaHealthCheckHandler(new HealthAggregator(), optionsMonitor, serviceProvider);
-        InstanceStatus result = await handler.GetStatusAsync(false, CancellationToken.None);
+        InstanceStatus result = await handler.GetStatusAsync(false, TestContext.Current.CancellationToken);
 
         result.Should().Be(expectedStatus);
     }
@@ -50,7 +51,7 @@ public sealed class EurekaHealthCheckHandlerTest
 
         var optionsMonitor = new TestOptionsMonitor<HealthCheckServiceOptions>();
         var handler = new EurekaHealthCheckHandler(new HealthAggregator(), optionsMonitor, serviceProvider);
-        InstanceStatus result = await handler.GetStatusAsync(false, CancellationToken.None);
+        InstanceStatus result = await handler.GetStatusAsync(false, TestContext.Current.CancellationToken);
 
         result.Should().Be(InstanceStatus.Up);
     }
@@ -66,7 +67,7 @@ public sealed class EurekaHealthCheckHandlerTest
 
         var optionsMonitor = new TestOptionsMonitor<HealthCheckServiceOptions>();
         var handler = new EurekaHealthCheckHandler(new HealthAggregator(), optionsMonitor, serviceProvider);
-        InstanceStatus result = await handler.GetStatusAsync(false, CancellationToken.None);
+        InstanceStatus result = await handler.GetStatusAsync(false, TestContext.Current.CancellationToken);
 
         result.Should().Be(InstanceStatus.Unknown);
     }
@@ -113,7 +114,7 @@ public sealed class EurekaHealthCheckHandlerTest
 
         var optionsMonitor = new TestOptionsMonitor<HealthCheckServiceOptions>();
         var handler = new EurekaHealthCheckHandler(new HealthAggregator(), optionsMonitor, serviceProvider);
-        InstanceStatus result = await handler.GetStatusAsync(false, CancellationToken.None);
+        InstanceStatus result = await handler.GetStatusAsync(false, TestContext.Current.CancellationToken);
 
         result.Should().Be(expectedStatus);
     }
@@ -150,7 +151,7 @@ public sealed class EurekaHealthCheckHandlerTest
         IDiscoveryClient[] discoveryClients = [.. app.Services.GetServices<IDiscoveryClient>()];
         Assert.Single(discoveryClients);
 
-        await Task.Delay(TimeSpan.FromSeconds(2));
+        await Task.Delay(2.Seconds(), TestContext.Current.CancellationToken);
 
         contributor.IsAwaited.Should().BeTrue();
 

--- a/src/Discovery/test/Eureka.Test/EurekaServerHealthContributorTest.cs
+++ b/src/Discovery/test/Eureka.Test/EurekaServerHealthContributorTest.cs
@@ -24,7 +24,7 @@ public sealed class EurekaServerHealthContributorTest
 
         (EurekaServerHealthContributor contributor, _) = CreateHealthContributor(appSettings);
 
-        HealthCheckResult? result = await contributor.CheckHealthAsync(CancellationToken.None);
+        HealthCheckResult? result = await contributor.CheckHealthAsync(TestContext.Current.CancellationToken);
 
         result.Should().BeNull();
     }
@@ -39,7 +39,7 @@ public sealed class EurekaServerHealthContributorTest
 
         (EurekaServerHealthContributor contributor, _) = CreateHealthContributor(appSettings);
 
-        HealthCheckResult? result = await contributor.CheckHealthAsync(CancellationToken.None);
+        HealthCheckResult? result = await contributor.CheckHealthAsync(TestContext.Current.CancellationToken);
 
         result.Should().BeNull();
     }

--- a/src/Discovery/test/Eureka.Test/GatedActionTest.cs
+++ b/src/Discovery/test/Eureka.Test/GatedActionTest.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
+using FluentAssertions.Extensions;
+
 namespace Steeltoe.Discovery.Eureka.Test;
 
 public sealed class GatedActionTest
@@ -14,7 +16,7 @@ public sealed class GatedActionTest
         Interlocked.Exchange(ref _timerFuncCount, 0);
         var timedTask = new GatedAction(TimerFunc);
         await using var timer = new Timer(_ => timedTask.Run(), null, 10, 100);
-        await Task.Delay(1000);
+        await Task.Delay(1.Seconds(), TestContext.Current.CancellationToken);
         Assert.Equal(1, _timerFuncCount);
     }
 

--- a/src/Discovery/test/Eureka.Test/Transport/EurekaClientTest.cs
+++ b/src/Discovery/test/Eureka.Test/Transport/EurekaClientTest.cs
@@ -154,7 +154,7 @@ public sealed class EurekaClientTest
             LastDirtyTimeUtc = new DateTime(638_440_245_328_236_418, DateTimeKind.Utc)
         };
 
-        Func<Task> asyncAction = async () => await client.RegisterAsync(instance, CancellationToken.None);
+        Func<Task> asyncAction = async () => await client.RegisterAsync(instance, TestContext.Current.CancellationToken);
 
         await asyncAction.Should().ThrowAsync<EurekaTransportException>().WithMessage("Failed to execute request on all known Eureka servers.");
 
@@ -198,7 +198,7 @@ public sealed class EurekaClientTest
             LastDirtyTimeUtc = new DateTime(638_440_245_328_236_418, DateTimeKind.Utc)
         };
 
-        Func<Task> asyncAction = async () => await client.RegisterAsync(instance, CancellationToken.None);
+        Func<Task> asyncAction = async () => await client.RegisterAsync(instance, TestContext.Current.CancellationToken);
 
         await asyncAction.Should().ThrowAsync<EurekaTransportException>().WithMessage("Failed to execute request on all known Eureka servers.");
 
@@ -244,7 +244,7 @@ public sealed class EurekaClientTest
             LastDirtyTimeUtc = new DateTime(638_440_245_328_236_418, DateTimeKind.Utc)
         };
 
-        Func<Task> asyncAction = async () => await client.RegisterAsync(instance, CancellationToken.None);
+        Func<Task> asyncAction = async () => await client.RegisterAsync(instance, TestContext.Current.CancellationToken);
 
         await asyncAction.Should().ThrowAsync<EurekaTransportException>().WithMessage("Retry limit reached; giving up on completing the HTTP request.");
 
@@ -284,7 +284,7 @@ public sealed class EurekaClientTest
 
         var instance = new InstanceInfo("some", "FOOBAR", "localhost", "127.0.0.1", new DataCenterInfo(), TimeProvider.System);
 
-        Func<Task> asyncAction = async () => await client.RegisterAsync(instance, CancellationToken.None);
+        Func<Task> asyncAction = async () => await client.RegisterAsync(instance, TestContext.Current.CancellationToken);
 
         await asyncAction.Should().ThrowAsync<EurekaTransportException>().WithMessage("Failed to execute request on all known Eureka servers.");
 
@@ -356,7 +356,7 @@ public sealed class EurekaClientTest
             LastDirtyTimeUtc = new DateTime(638_440_245_328_236_418, DateTimeKind.Utc)
         };
 
-        await client.RegisterAsync(instance, CancellationToken.None);
+        await client.RegisterAsync(instance, TestContext.Current.CancellationToken);
 
         httpClientHandler.Mock.VerifyNoOutstandingExpectation();
 
@@ -400,7 +400,7 @@ public sealed class EurekaClientTest
             LastDirtyTimeUtc = new DateTime(638_440_245_328_236_418, DateTimeKind.Utc)
         };
 
-        await client.RegisterAsync(instance, CancellationToken.None);
+        await client.RegisterAsync(instance, TestContext.Current.CancellationToken);
 
         httpClientHandler.Mock.VerifyNoOutstandingExpectation();
 
@@ -440,7 +440,7 @@ public sealed class EurekaClientTest
 
         var instance = new InstanceInfo("some", "FOOBAR", "localhost", "127.0.0.1", new DataCenterInfo(), TimeProvider.System);
 
-        await client.RegisterAsync(instance, CancellationToken.None);
+        await client.RegisterAsync(instance, TestContext.Current.CancellationToken);
 
         httpClientHandler.Mock.VerifyNoOutstandingExpectation();
     }
@@ -467,7 +467,7 @@ public sealed class EurekaClientTest
 
         var instance = new InstanceInfo("some", "FOOBAR", "localhost", "127.0.0.1", new DataCenterInfo(), TimeProvider.System);
 
-        await client.RegisterAsync(instance, CancellationToken.None);
+        await client.RegisterAsync(instance, TestContext.Current.CancellationToken);
 
         httpClientHandler.Mock.VerifyNoOutstandingExpectation();
     }
@@ -512,7 +512,7 @@ public sealed class EurekaClientTest
 
         var instance = new InstanceInfo("some", "FOOBAR", "localhost", "127.0.0.1", new DataCenterInfo(), TimeProvider.System);
 
-        await client.RegisterAsync(instance, CancellationToken.None);
+        await client.RegisterAsync(instance, TestContext.Current.CancellationToken);
 
         eurekaHttpClientHandler.Mock.VerifyNoOutstandingExpectation();
     }
@@ -534,7 +534,7 @@ public sealed class EurekaClientTest
         await using ServiceProvider serviceProvider = services.BuildServiceProvider(true);
         var client = serviceProvider.GetRequiredService<EurekaClient>();
 
-        await client.DeregisterAsync("foo", "localhost:bar:1234", CancellationToken.None);
+        await client.DeregisterAsync("foo", "localhost:bar:1234", TestContext.Current.CancellationToken);
 
         httpClientHandler.Mock.VerifyNoOutstandingExpectation();
     }
@@ -559,7 +559,7 @@ public sealed class EurekaClientTest
         await using ServiceProvider serviceProvider = services.BuildServiceProvider(true);
         var client = serviceProvider.GetRequiredService<EurekaClient>();
 
-        await client.HeartbeatAsync("FOO", "localhost:bar:1234", new DateTime(638_439_667_057_566_585, DateTimeKind.Utc), CancellationToken.None);
+        await client.HeartbeatAsync("FOO", "localhost:bar:1234", new DateTime(638_439_667_057_566_585, DateTimeKind.Utc), TestContext.Current.CancellationToken);
 
         httpClientHandler.Mock.VerifyNoOutstandingExpectation();
     }
@@ -581,7 +581,7 @@ public sealed class EurekaClientTest
         await using ServiceProvider serviceProvider = services.BuildServiceProvider(true);
         var client = serviceProvider.GetRequiredService<EurekaClient>();
 
-        ApplicationInfoCollection apps = await client.GetApplicationsAsync(CancellationToken.None);
+        ApplicationInfoCollection apps = await client.GetApplicationsAsync(TestContext.Current.CancellationToken);
 
         httpClientHandler.Mock.VerifyNoOutstandingExpectation();
 
@@ -622,7 +622,7 @@ public sealed class EurekaClientTest
         await using ServiceProvider serviceProvider = services.BuildServiceProvider(true);
         var client = serviceProvider.GetRequiredService<EurekaClient>();
 
-        Func<Task> asyncAction = async () => _ = await client.GetApplicationsAsync(CancellationToken.None);
+        Func<Task> asyncAction = async () => _ = await client.GetApplicationsAsync(TestContext.Current.CancellationToken);
 
         await asyncAction.Should().ThrowAsync<EurekaTransportException>().WithMessage("Failed to execute request on all known Eureka servers.");
 
@@ -655,7 +655,7 @@ public sealed class EurekaClientTest
         await using ServiceProvider serviceProvider = services.BuildServiceProvider(true);
         var client = serviceProvider.GetRequiredService<EurekaClient>();
 
-        ApplicationInfoCollection apps = await client.GetDeltaAsync(CancellationToken.None);
+        ApplicationInfoCollection apps = await client.GetDeltaAsync(TestContext.Current.CancellationToken);
 
         httpClientHandler.Mock.VerifyNoOutstandingExpectation();
 
@@ -692,7 +692,7 @@ public sealed class EurekaClientTest
         await using ServiceProvider serviceProvider = services.BuildServiceProvider(true);
         var client = serviceProvider.GetRequiredService<EurekaClient>();
 
-        ApplicationInfoCollection apps = await client.GetByVipAsync("foo", CancellationToken.None);
+        ApplicationInfoCollection apps = await client.GetByVipAsync("foo", TestContext.Current.CancellationToken);
 
         httpClientHandler.Mock.VerifyNoOutstandingExpectation();
 
@@ -731,7 +731,7 @@ public sealed class EurekaClientTest
         await using ServiceProvider serviceProvider = services.BuildServiceProvider(true);
         var client = serviceProvider.GetRequiredService<EurekaClient>();
 
-        _ = await client.GetApplicationsAsync(CancellationToken.None);
+        _ = await client.GetApplicationsAsync(TestContext.Current.CancellationToken);
 
         httpClientHandler.Mock.VerifyNoOutstandingExpectation();
 

--- a/src/Discovery/test/Eureka.Test/Transport/EurekaClientTest.cs
+++ b/src/Discovery/test/Eureka.Test/Transport/EurekaClientTest.cs
@@ -559,7 +559,8 @@ public sealed class EurekaClientTest
         await using ServiceProvider serviceProvider = services.BuildServiceProvider(true);
         var client = serviceProvider.GetRequiredService<EurekaClient>();
 
-        await client.HeartbeatAsync("FOO", "localhost:bar:1234", new DateTime(638_439_667_057_566_585, DateTimeKind.Utc), TestContext.Current.CancellationToken);
+        await client.HeartbeatAsync("FOO", "localhost:bar:1234", new DateTime(638_439_667_057_566_585, DateTimeKind.Utc),
+            TestContext.Current.CancellationToken);
 
         httpClientHandler.Mock.VerifyNoOutstandingExpectation();
     }

--- a/src/Discovery/test/HttpClients.Test/DiscoveryHostApplicationBuilderExtensionsTest.cs
+++ b/src/Discovery/test/HttpClients.Test/DiscoveryHostApplicationBuilderExtensionsTest.cs
@@ -55,7 +55,7 @@ public sealed class DiscoveryHostApplicationBuilderExtensionsTest
 
         using IHost host = hostBuilder.Build();
 
-        Func<Task> action = async () => await host.StartAsync();
+        Func<Task> action = async () => await host.StartAsync(TestContext.Current.CancellationToken);
         await action.Should().NotThrowAsync();
     }
 

--- a/src/Discovery/test/HttpClients.Test/DiscoveryHostBuilderExtensionsTest.cs
+++ b/src/Discovery/test/HttpClients.Test/DiscoveryHostBuilderExtensionsTest.cs
@@ -55,7 +55,7 @@ public sealed class DiscoveryHostBuilderExtensionsTest
 
         hostBuilder.ConfigureServices(services => services.AddEurekaDiscoveryClient());
 
-        Func<Task> action = async () => await hostBuilder.StartAsync();
+        Func<Task> action = async () => await hostBuilder.StartAsync(TestContext.Current.CancellationToken);
         await action.Should().NotThrowAsync();
     }
 

--- a/src/Discovery/test/HttpClients.Test/DiscoveryWebApplicationBuilderExtensionsTest.cs
+++ b/src/Discovery/test/HttpClients.Test/DiscoveryWebApplicationBuilderExtensionsTest.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
+using FluentAssertions.Extensions;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -74,7 +75,7 @@ public sealed class DiscoveryWebApplicationBuilderExtensionsTest
         await using WebApplication host = builder.Build();
 
         Task<EurekaDiscoveryClient> resolveTask = Task.Run(() => _ = host.Services.GetServices<IDiscoveryClient>().OfType<EurekaDiscoveryClient>().Single());
-        Func<Task> action = async () => await resolveTask.WaitAsync(TimeSpan.FromSeconds(5));
+        Func<Task> action = async () => await resolveTask.WaitAsync(5.Seconds(), TestContext.Current.CancellationToken);
 
         await action.Should().NotThrowAsync();
     }

--- a/src/Discovery/test/HttpClients.Test/LoadBalancers/DiscoveryHttpClientHandlerTest.cs
+++ b/src/Discovery/test/HttpClients.Test/LoadBalancers/DiscoveryHttpClientHandlerTest.cs
@@ -17,7 +17,7 @@ public sealed class DiscoveryHttpClientHandlerTest
         var handler = new DiscoveryHttpClientHandler(loadBalancer, TimeProvider.System);
         using var invoker = new HttpMessageInvoker(handler);
 
-        Func<Task<HttpResponseMessage>> action = async () => _ = await invoker.SendAsync(httpRequestMessage, CancellationToken.None);
+        Func<Task<HttpResponseMessage>> action = async () => _ = await invoker.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
 
         await action.Should().ThrowExactlyAsync<DataException>();
         loadBalancer.Statistics.Should().BeEmpty();
@@ -32,7 +32,7 @@ public sealed class DiscoveryHttpClientHandlerTest
         var handler = new DiscoveryHttpClientHandler(loadBalancer, TimeProvider.System);
         using var invoker = new HttpMessageInvoker(handler);
 
-        Func<Task<HttpResponseMessage>> action = async () => _ = await invoker.SendAsync(httpRequestMessage, CancellationToken.None);
+        Func<Task<HttpResponseMessage>> action = async () => _ = await invoker.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
 
         await action.Should().ThrowExactlyAsync<HttpRequestException>();
         loadBalancer.Statistics.Should().ContainSingle();

--- a/src/Discovery/test/HttpClients.Test/LoadBalancers/DiscoveryHttpDelegatingHandlerTest.cs
+++ b/src/Discovery/test/HttpClients.Test/LoadBalancers/DiscoveryHttpDelegatingHandlerTest.cs
@@ -28,7 +28,7 @@ public sealed class DiscoveryHttpDelegatingHandlerTest
 
         using var invoker = new HttpMessageInvoker(handler);
 
-        HttpResponseMessage result = await invoker.SendAsync(httpRequestMessage, CancellationToken.None);
+        HttpResponseMessage result = await invoker.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
 
         result.Headers.GetValues("requestUri").First().Should().Be("https://some-resolved-host:1234/api");
         loadBalancer.Statistics.Should().ContainSingle();
@@ -55,7 +55,7 @@ public sealed class DiscoveryHttpDelegatingHandlerTest
 
         using var invoker = new HttpMessageInvoker(handler);
 
-        Func<Task<HttpResponseMessage>> action = async () => await invoker.SendAsync(httpRequestMessage, CancellationToken.None);
+        Func<Task<HttpResponseMessage>> action = async () => await invoker.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
 
         await action.Should().ThrowExactlyAsync<OperationCanceledException>();
         loadBalancer.Statistics.Should().BeEmpty();
@@ -79,7 +79,7 @@ public sealed class DiscoveryHttpDelegatingHandlerTest
 
         using var invoker = new HttpMessageInvoker(handler);
 
-        Func<Task<HttpResponseMessage>> action = async () => await invoker.SendAsync(httpRequestMessage, CancellationToken.None);
+        Func<Task<HttpResponseMessage>> action = async () => await invoker.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
 
         await action.Should().ThrowExactlyAsync<DataException>();
         loadBalancer.Statistics.Should().BeEmpty();
@@ -103,7 +103,7 @@ public sealed class DiscoveryHttpDelegatingHandlerTest
 
         using var invoker = new HttpMessageInvoker(handler);
 
-        HttpResponseMessage result = await invoker.SendAsync(httpRequestMessage, CancellationToken.None);
+        HttpResponseMessage result = await invoker.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
 
         loadBalancer.Statistics.Should().ContainSingle();
         result.StatusCode.Should().Be(HttpStatusCode.InternalServerError);

--- a/src/Discovery/test/HttpClients.Test/LoadBalancers/RoundRobinLoadBalancerTest.cs
+++ b/src/Discovery/test/HttpClients.Test/LoadBalancers/RoundRobinLoadBalancerTest.cs
@@ -23,24 +23,24 @@ public sealed class RoundRobinLoadBalancerTest
         var resolver = new ServiceInstancesResolver([client], NullLogger<ServiceInstancesResolver>.Instance);
         var loadBalancer = new RoundRobinLoadBalancer(resolver, null, null, NullLogger<RoundRobinLoadBalancer>.Instance);
 
-        Uri fruitUri = await loadBalancer.ResolveServiceInstanceAsync(new Uri("https://fruit-service/api"), CancellationToken.None);
-        _ = await loadBalancer.ResolveServiceInstanceAsync(new Uri("https://vegetable-service/api"), CancellationToken.None);
-        Uri vegetableUri = await loadBalancer.ResolveServiceInstanceAsync(new Uri("https://vegetable-service/api"), CancellationToken.None);
+        Uri fruitUri = await loadBalancer.ResolveServiceInstanceAsync(new Uri("https://fruit-service/api"), TestContext.Current.CancellationToken);
+        _ = await loadBalancer.ResolveServiceInstanceAsync(new Uri("https://vegetable-service/api"), TestContext.Current.CancellationToken);
+        Uri vegetableUri = await loadBalancer.ResolveServiceInstanceAsync(new Uri("https://vegetable-service/api"), TestContext.Current.CancellationToken);
 
         fruitUri.Port.Should().Be(8000);
         vegetableUri.Port.Should().Be(8011);
 
         // wrap around
-        _ = await loadBalancer.ResolveServiceInstanceAsync(new Uri("https://vegetable-service/api"), CancellationToken.None);
-        vegetableUri = await loadBalancer.ResolveServiceInstanceAsync(new Uri("https://vegetable-service/api"), CancellationToken.None);
+        _ = await loadBalancer.ResolveServiceInstanceAsync(new Uri("https://vegetable-service/api"), TestContext.Current.CancellationToken);
+        vegetableUri = await loadBalancer.ResolveServiceInstanceAsync(new Uri("https://vegetable-service/api"), TestContext.Current.CancellationToken);
 
         vegetableUri.Port.Should().Be(8010);
 
         // reset when service has disappeared
-        _ = await loadBalancer.ResolveServiceInstanceAsync(new Uri("https://vegetable-service/api"), CancellationToken.None);
+        _ = await loadBalancer.ResolveServiceInstanceAsync(new Uri("https://vegetable-service/api"), TestContext.Current.CancellationToken);
         options.Services.RemoveAt(options.Services.Count - 1);
 
-        vegetableUri = await loadBalancer.ResolveServiceInstanceAsync(new Uri("https://vegetable-service/api"), CancellationToken.None);
+        vegetableUri = await loadBalancer.ResolveServiceInstanceAsync(new Uri("https://vegetable-service/api"), TestContext.Current.CancellationToken);
         vegetableUri.Port.Should().Be(8010);
     }
 
@@ -54,25 +54,25 @@ public sealed class RoundRobinLoadBalancerTest
         IDistributedCache distributedCache = GetCache();
         var loadBalancer = new RoundRobinLoadBalancer(resolver, distributedCache, null, NullLogger<RoundRobinLoadBalancer>.Instance);
 
-        Uri fruitUri = await loadBalancer.ResolveServiceInstanceAsync(new Uri("https://fruit-service/api"), CancellationToken.None);
-        _ = await loadBalancer.ResolveServiceInstanceAsync(new Uri("https://vegetable-service/api"), CancellationToken.None);
-        Uri vegetableUri = await loadBalancer.ResolveServiceInstanceAsync(new Uri("https://vegetable-service/api"), CancellationToken.None);
+        Uri fruitUri = await loadBalancer.ResolveServiceInstanceAsync(new Uri("https://fruit-service/api"), TestContext.Current.CancellationToken);
+        _ = await loadBalancer.ResolveServiceInstanceAsync(new Uri("https://vegetable-service/api"), TestContext.Current.CancellationToken);
+        Uri vegetableUri = await loadBalancer.ResolveServiceInstanceAsync(new Uri("https://vegetable-service/api"), TestContext.Current.CancellationToken);
 
         fruitUri.Port.Should().Be(8000);
         vegetableUri.Port.Should().Be(8011);
 
         // wrap around
-        _ = await loadBalancer.ResolveServiceInstanceAsync(new Uri("https://vegetable-service/api"), CancellationToken.None);
-        vegetableUri = await loadBalancer.ResolveServiceInstanceAsync(new Uri("https://vegetable-service/api"), CancellationToken.None);
+        _ = await loadBalancer.ResolveServiceInstanceAsync(new Uri("https://vegetable-service/api"), TestContext.Current.CancellationToken);
+        vegetableUri = await loadBalancer.ResolveServiceInstanceAsync(new Uri("https://vegetable-service/api"), TestContext.Current.CancellationToken);
 
         vegetableUri.Port.Should().Be(8010);
 
         // reset when service has disappeared
-        _ = await loadBalancer.ResolveServiceInstanceAsync(new Uri("https://vegetable-service/api"), CancellationToken.None);
+        _ = await loadBalancer.ResolveServiceInstanceAsync(new Uri("https://vegetable-service/api"), TestContext.Current.CancellationToken);
         options.Services.RemoveAt(options.Services.Count - 1);
-        await distributedCache.RemoveAsync("Steeltoe-LoadBalancerIndex-vegetable-service");
+        await distributedCache.RemoveAsync("Steeltoe-LoadBalancerIndex-vegetable-service", TestContext.Current.CancellationToken);
 
-        vegetableUri = await loadBalancer.ResolveServiceInstanceAsync(new Uri("https://vegetable-service/api"), CancellationToken.None);
+        vegetableUri = await loadBalancer.ResolveServiceInstanceAsync(new Uri("https://vegetable-service/api"), TestContext.Current.CancellationToken);
         vegetableUri.Port.Should().Be(8010);
     }
 
@@ -84,7 +84,7 @@ public sealed class RoundRobinLoadBalancerTest
         var loadBalancer = new RoundRobinLoadBalancer(resolver, NullLogger<RoundRobinLoadBalancer>.Instance);
         var uri = new Uri("https://foo:8080/test");
 
-        Uri result = await loadBalancer.ResolveServiceInstanceAsync(uri, CancellationToken.None);
+        Uri result = await loadBalancer.ResolveServiceInstanceAsync(uri, TestContext.Current.CancellationToken);
         Assert.Equal(uri, result);
     }
 
@@ -96,7 +96,7 @@ public sealed class RoundRobinLoadBalancerTest
         var handler = new RoundRobinLoadBalancer(resolver, NullLogger<RoundRobinLoadBalancer>.Instance);
         var uri = new Uri("https://foo/test");
 
-        Uri result = await handler.ResolveServiceInstanceAsync(uri, CancellationToken.None);
+        Uri result = await handler.ResolveServiceInstanceAsync(uri, TestContext.Current.CancellationToken);
         Assert.Equal(uri, result);
     }
 
@@ -108,7 +108,7 @@ public sealed class RoundRobinLoadBalancerTest
         var handler = new RoundRobinLoadBalancer(resolver, NullLogger<RoundRobinLoadBalancer>.Instance);
         var uri = new Uri("https://foo/test/bar/foo?test=1&test2=2");
 
-        Uri result = await handler.ResolveServiceInstanceAsync(uri, CancellationToken.None);
+        Uri result = await handler.ResolveServiceInstanceAsync(uri, TestContext.Current.CancellationToken);
         Assert.Equal(new Uri("https://foundit:5555/test/bar/foo?test=1&test2=2"), result);
     }
 
@@ -127,7 +127,7 @@ public sealed class RoundRobinLoadBalancerTest
         var resolver = new ServiceInstancesResolver(clients, NullLogger<ServiceInstancesResolver>.Instance);
         var loadBalancer = new RoundRobinLoadBalancer(resolver, null, null, NullLogger<RoundRobinLoadBalancer>.Instance);
 
-        Uri fruitUri = await loadBalancer.ResolveServiceInstanceAsync(new Uri("https://fruit-service/api"), CancellationToken.None);
+        Uri fruitUri = await loadBalancer.ResolveServiceInstanceAsync(new Uri("https://fruit-service/api"), TestContext.Current.CancellationToken);
         fruitUri.Should().Be("https://fruit-ball:8000/api");
     }
 
@@ -141,7 +141,7 @@ public sealed class RoundRobinLoadBalancerTest
         var resolver = new ServiceInstancesResolver([client], distributedCache, null, NullLogger<ServiceInstancesResolver>.Instance);
         var loadBalancer = new RoundRobinLoadBalancer(resolver, null, null, NullLogger<RoundRobinLoadBalancer>.Instance);
 
-        Uri fruitUri = await loadBalancer.ResolveServiceInstanceAsync(new Uri("https://fruit-service/api"), CancellationToken.None);
+        Uri fruitUri = await loadBalancer.ResolveServiceInstanceAsync(new Uri("https://fruit-service/api"), TestContext.Current.CancellationToken);
         fruitUri.Should().Be("https://fruit-ball:8000/api");
 
         optionsMonitor.Change(new ConfigurationDiscoveryOptions
@@ -158,7 +158,7 @@ public sealed class RoundRobinLoadBalancerTest
             }
         });
 
-        fruitUri = await loadBalancer.ResolveServiceInstanceAsync(new Uri("https://fruit-service/api"), CancellationToken.None);
+        fruitUri = await loadBalancer.ResolveServiceInstanceAsync(new Uri("https://fruit-service/api"), TestContext.Current.CancellationToken);
         fruitUri.Should().Be("https://fruit-ball:8000/api");
     }
 

--- a/src/Discovery/test/HttpClients.Test/RegisterMultipleDiscoveryClientsTest.cs
+++ b/src/Discovery/test/HttpClients.Test/RegisterMultipleDiscoveryClientsTest.cs
@@ -138,7 +138,7 @@ public sealed class RegisterMultipleDiscoveryClientsTest
         webApplication.Services.GetRequiredService<HttpClientHandlerFactory>().Using(handler);
 
         var discoveryClient = webApplication.Services.GetRequiredService<EurekaDiscoveryClient>();
-        _ = await discoveryClient.FetchFullRegistryAsync(CancellationToken.None);
+        _ = await discoveryClient.FetchFullRegistryAsync(TestContext.Current.CancellationToken);
 
         Assert.NotNull(handler.ClientCertificates);
         Assert.NotEmpty(handler.ClientCertificates);
@@ -171,7 +171,7 @@ public sealed class RegisterMultipleDiscoveryClientsTest
         webApplication.Services.GetRequiredService<HttpClientHandlerFactory>().Using(handler);
 
         var discoveryClient = webApplication.Services.GetRequiredService<EurekaDiscoveryClient>();
-        _ = await discoveryClient.FetchFullRegistryAsync(CancellationToken.None);
+        _ = await discoveryClient.FetchFullRegistryAsync(TestContext.Current.CancellationToken);
 
         Assert.NotNull(handler.ClientCertificates);
         Assert.NotEmpty(handler.ClientCertificates);
@@ -569,7 +569,7 @@ public sealed class RegisterMultipleDiscoveryClientsTest
 
         var discoveryClient = webApplication.Services.GetRequiredService<EurekaDiscoveryClient>();
 
-        ApplicationInfoCollection apps = await discoveryClient.FetchFullRegistryAsync(CancellationToken.None);
+        ApplicationInfoCollection apps = await discoveryClient.FetchFullRegistryAsync(TestContext.Current.CancellationToken);
 
         handler.Mock.VerifyNoOutstandingExpectation();
 
@@ -639,7 +639,7 @@ public sealed class RegisterMultipleDiscoveryClientsTest
 
         var discoveryClient = webApplication.Services.GetRequiredService<EurekaDiscoveryClient>();
 
-        ApplicationInfoCollection apps = await discoveryClient.FetchFullRegistryAsync(CancellationToken.None);
+        ApplicationInfoCollection apps = await discoveryClient.FetchFullRegistryAsync(TestContext.Current.CancellationToken);
 
         handler.Mock.VerifyNoOutstandingExpectation();
 
@@ -865,13 +865,13 @@ public sealed class RegisterMultipleDiscoveryClientsTest
         Assert.Single(discoveryClients);
         Assert.IsType<ConfigurationDiscoveryClient>(discoveryClients[0]);
 
-        Assert.Contains("fruitService", await discoveryClients[0].GetServiceIdsAsync(CancellationToken.None));
-        Assert.Contains("vegetableService", await discoveryClients[0].GetServiceIdsAsync(CancellationToken.None));
+        Assert.Contains("fruitService", await discoveryClients[0].GetServiceIdsAsync(TestContext.Current.CancellationToken));
+        Assert.Contains("vegetableService", await discoveryClients[0].GetServiceIdsAsync(TestContext.Current.CancellationToken));
 
-        IList<IServiceInstance> fruitInstances = await discoveryClients[0].GetInstancesAsync("fruitService", CancellationToken.None);
+        IList<IServiceInstance> fruitInstances = await discoveryClients[0].GetInstancesAsync("fruitService", TestContext.Current.CancellationToken);
         Assert.Equal(2, fruitInstances.Count);
 
-        IList<IServiceInstance> vegetableInstances = await discoveryClients[0].GetInstancesAsync("vegetableService", CancellationToken.None);
+        IList<IServiceInstance> vegetableInstances = await discoveryClients[0].GetInstancesAsync("vegetableService", TestContext.Current.CancellationToken);
         Assert.Equal(2, vegetableInstances.Count);
     }
 

--- a/src/Logging/test/DynamicConsole.Test/DynamicConsoleLoggerProviderTest.cs
+++ b/src/Logging/test/DynamicConsole.Test/DynamicConsoleLoggerProviderTest.cs
@@ -480,7 +480,7 @@ public sealed class DynamicConsoleLoggerProviderTest : IDisposable
             }
         }
 
-        await _consoleOutput.WaitForFlushAsync();
+        await _consoleOutput.WaitForFlushAsync(TestContext.Current.CancellationToken);
         string logOutput = _consoleOutput.ToString();
 
         logOutput.Should().Be("""
@@ -521,7 +521,7 @@ public sealed class DynamicConsoleLoggerProviderTest : IDisposable
 
         logger.LogInformation("Three");
 
-        await _consoleOutput.WaitForFlushAsync();
+        await _consoleOutput.WaitForFlushAsync(TestContext.Current.CancellationToken);
         string logOutput = _consoleOutput.ToString();
 
         logOutput.Should().Contain("One");
@@ -683,7 +683,7 @@ public sealed class DynamicConsoleLoggerProviderTest : IDisposable
             _logger.LogTrace($"Test:{CategoryName}:Trace");
 #pragma warning restore CA2254 // Template should be a static expression
 
-            await _consoleOutput.WaitForFlushAsync();
+            await _consoleOutput.WaitForFlushAsync(TestContext.Current.CancellationToken);
 
             return _consoleOutput.ToString();
         }

--- a/src/Logging/test/DynamicConsole.Test/HostBuilderTests.cs
+++ b/src/Logging/test/DynamicConsole.Test/HostBuilderTests.cs
@@ -163,7 +163,7 @@ public sealed class HostBuilderTests
         builder.Services.UpgradeBootstrapLoggerFactory(bootstrapLoggerFactory);
         await using WebApplication host = builder.Build();
 
-        await host.StartAsync();
+        await host.StartAsync(TestContext.Current.CancellationToken);
 
         microsoftLogger.ProbeMinLevel().Should().Be(LogLevel.Warning);
         steeltoeLogger.ProbeMinLevel().Should().Be(LogLevel.Error);

--- a/src/Logging/test/DynamicSerilog.Test/HostBuilderTests.cs
+++ b/src/Logging/test/DynamicSerilog.Test/HostBuilderTests.cs
@@ -87,7 +87,7 @@ public sealed class HostBuilderTests : IDisposable
         logger.LogInformation("TestInfo");
         logger.LogError("TestError");
 
-        await _consoleOutput.WaitForFlushAsync();
+        await _consoleOutput.WaitForFlushAsync(TestContext.Current.CancellationToken);
         string logOutput = _consoleOutput.ToString();
 
         logOutput.Should().Contain("SERILOG [INF] TestInfo");

--- a/src/Management/src/Endpoint/Middleware/EndpointMiddleware.cs
+++ b/src/Management/src/Endpoint/Middleware/EndpointMiddleware.cs
@@ -64,13 +64,13 @@ public abstract class EndpointMiddleware<TRequest, TResponse> : IEndpointMiddlew
                 {
                     _logger.LogDebug("Content-Type header '{RequestContentType}' is not supported for this request.", context.Request.ContentType);
                     context.Response.StatusCode = (int)HttpStatusCode.UnsupportedMediaType;
-                    await context.Response.WriteAsync($"Only the '{ContentType}' content type is supported.");
+                    await context.Response.WriteAsync($"Only the '{ContentType}' content type is supported.", context.RequestAborted);
                 }
                 else if (!IsCompatibleAcceptHeader(context.Request))
                 {
                     _logger.LogDebug("Accept header '{AcceptType}' is not supported for this request.", context.Request.Headers.Accept.ToString());
                     context.Response.StatusCode = (int)HttpStatusCode.NotAcceptable;
-                    await context.Response.WriteAsync($"Only the '{ContentType}' content type is supported.");
+                    await context.Response.WriteAsync($"Only the '{ContentType}' content type is supported.", context.RequestAborted);
                 }
                 else
                 {

--- a/src/Management/test/Endpoint.Test/ActuatorContentNegotiationTests.cs
+++ b/src/Management/test/Endpoint.Test/ActuatorContentNegotiationTests.cs
@@ -49,7 +49,7 @@ public sealed class ActuatorContentNegotiationTests
         builder.Services.AddSingleton<IHeapDumper, FakeHeapDumper>();
 
         await using WebApplication host = builder.Build();
-        await host.StartAsync();
+        await host.StartAsync(TestContext.Current.CancellationToken);
 
         var requestMessage = new HttpRequestMessage
         {
@@ -63,7 +63,7 @@ public sealed class ActuatorContentNegotiationTests
         }
 
         using HttpClient client = host.GetTestClient();
-        HttpResponseMessage response = await client.SendAsync(requestMessage);
+        HttpResponseMessage response = await client.SendAsync(requestMessage, TestContext.Current.CancellationToken);
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         response.Content.Headers.ContentType.Should().NotBeNull();
@@ -79,7 +79,7 @@ public sealed class ActuatorContentNegotiationTests
         builder.Services.AddAllActuators();
 
         await using WebApplication host = builder.Build();
-        await host.StartAsync();
+        await host.StartAsync(TestContext.Current.CancellationToken);
 
         var requestMessage = new HttpRequestMessage
         {
@@ -94,7 +94,7 @@ public sealed class ActuatorContentNegotiationTests
         }
 
         using HttpClient client = host.GetTestClient();
-        HttpResponseMessage response = await client.SendAsync(requestMessage);
+        HttpResponseMessage response = await client.SendAsync(requestMessage, TestContext.Current.CancellationToken);
 
         response.StatusCode.Should().Be(HttpStatusCode.NoContent);
         response.Content.Headers.ContentType.Should().BeNull();

--- a/src/Management/test/Endpoint.Test/ActuatorRouteBuilderExtensionsTest.cs
+++ b/src/Management/test/Endpoint.Test/ActuatorRouteBuilderExtensionsTest.cs
@@ -135,7 +135,7 @@ public sealed class ActuatorRouteBuilderExtensionsTest
 
     private async Task ActAndAssertAsync(IHostBuilder builder, Type endpointOptionsType, bool expectSuccess)
     {
-        using IHost host = await builder.StartAsync();
+        using IHost host = await builder.StartAsync(TestContext.Current.CancellationToken);
 
         Type optionsMonitorType = typeof(IOptionsMonitor<>).MakeGenericType(endpointOptionsType);
         object optionsMonitor = host.Services.GetRequiredService(optionsMonitorType);
@@ -150,11 +150,11 @@ public sealed class ActuatorRouteBuilderExtensionsTest
 
         if (options.AllowedVerbs.Contains("Get"))
         {
-            response = await httpClient.GetAsync(new Uri(path, UriKind.RelativeOrAbsolute));
+            response = await httpClient.GetAsync(new Uri(path, UriKind.RelativeOrAbsolute), TestContext.Current.CancellationToken);
         }
         else
         {
-            response = await httpClient.PostAsync(new Uri(path, UriKind.RelativeOrAbsolute), null);
+            response = await httpClient.PostAsync(new Uri(path, UriKind.RelativeOrAbsolute), null, TestContext.Current.CancellationToken);
         }
 
         response.StatusCode.Should().Be(expectSuccess ? HttpStatusCode.OK : HttpStatusCode.Forbidden);

--- a/src/Management/test/Endpoint.Test/Actuators/CloudFoundry/CloudFoundryEndpointTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/CloudFoundry/CloudFoundryEndpointTest.cs
@@ -17,7 +17,7 @@ public sealed class CloudFoundryEndpointTest(ITestOutputHelper testOutputHelper)
     [Fact]
     public async Task Invoke_ReturnsExpectedLinks()
     {
-        using var testContext = new TestContext(_testOutputHelper);
+        using var testContext = new SteeltoeTestContext(_testOutputHelper);
 
         testContext.AdditionalServices = (services, _) =>
         {
@@ -44,7 +44,7 @@ public sealed class CloudFoundryEndpointTest(ITestOutputHelper testOutputHelper)
     [Fact]
     public async Task Invoke_OnlyCloudFoundryEndpoint_ReturnsExpectedLinks()
     {
-        using var testContext = new TestContext(_testOutputHelper);
+        using var testContext = new SteeltoeTestContext(_testOutputHelper);
 
         testContext.AdditionalServices = (services, _) =>
         {
@@ -61,7 +61,7 @@ public sealed class CloudFoundryEndpointTest(ITestOutputHelper testOutputHelper)
     [Fact]
     public async Task Invoke_HonorsEndpointEnabled_ReturnsExpectedLinks()
     {
-        using var testContext = new TestContext(_testOutputHelper);
+        using var testContext = new SteeltoeTestContext(_testOutputHelper);
 
         testContext.AdditionalServices = (services, _) =>
         {
@@ -89,7 +89,7 @@ public sealed class CloudFoundryEndpointTest(ITestOutputHelper testOutputHelper)
     [Fact]
     public void Invoke_CloudFoundryDisabled_DoesNotInvoke()
     {
-        using var testContext = new TestContext(_testOutputHelper);
+        using var testContext = new SteeltoeTestContext(_testOutputHelper);
 
         testContext.AdditionalServices = (services, _) =>
         {

--- a/src/Management/test/Endpoint.Test/Actuators/CloudFoundry/CloudFoundryEndpointTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/CloudFoundry/CloudFoundryEndpointTest.cs
@@ -35,7 +35,7 @@ public sealed class CloudFoundryEndpointTest(ITestOutputHelper testOutputHelper)
 
         var handler = testContext.GetRequiredService<ICloudFoundryEndpointHandler>();
 
-        Links links = await handler.InvokeAsync("http://localhost:5000/foobar", CancellationToken.None);
+        Links links = await handler.InvokeAsync("http://localhost:5000/foobar", TestContext.Current.CancellationToken);
         links.Entries.Should().Contain(entry => entry.Key == "self" && entry.Value.Href == "http://localhost:5000/foobar");
         links.Entries.Should().Contain(entry => entry.Key == "info" && entry.Value.Href == "http://localhost:5000/foobar/info");
         links.Entries.Should().HaveCount(2);
@@ -53,7 +53,7 @@ public sealed class CloudFoundryEndpointTest(ITestOutputHelper testOutputHelper)
 
         var handler = testContext.GetRequiredService<ICloudFoundryEndpointHandler>();
 
-        Links links = await handler.InvokeAsync("http://localhost:5000/foobar", CancellationToken.None);
+        Links links = await handler.InvokeAsync("http://localhost:5000/foobar", TestContext.Current.CancellationToken);
         links.Entries.Should().Contain(entry => entry.Key == "self" && entry.Value.Href == "http://localhost:5000/foobar");
         links.Entries.Should().ContainSingle();
     }
@@ -80,7 +80,7 @@ public sealed class CloudFoundryEndpointTest(ITestOutputHelper testOutputHelper)
 
         var handler = testContext.GetRequiredService<ICloudFoundryEndpointHandler>();
 
-        Links links = await handler.InvokeAsync("http://localhost:5000/foobar", CancellationToken.None);
+        Links links = await handler.InvokeAsync("http://localhost:5000/foobar", TestContext.Current.CancellationToken);
         links.Entries.Should().Contain(entry => entry.Key == "self" && entry.Value.Href == "http://localhost:5000/foobar");
         links.Entries.Should().Contain(entry => entry.Key == "info" && entry.Value.Href == "http://localhost:5000/foobar/info");
         links.Entries.Should().HaveCount(2);

--- a/src/Management/test/Endpoint.Test/Actuators/CloudFoundry/CloudFoundrySecurityMiddlewareTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/CloudFoundry/CloudFoundrySecurityMiddlewareTest.cs
@@ -38,7 +38,10 @@ public sealed class CloudFoundrySecurityMiddlewareTest : BaseTest
         using HttpClient client = host.GetTestClient();
         HttpResponseMessage response = await client.GetAsync(new Uri("http://localhost/cloudfoundryapplication/info"), TestContext.Current.CancellationToken);
         Assert.Equal(HttpStatusCode.ServiceUnavailable, response.StatusCode);
-        Assert.Equal("""{"security_error":"Application ID is not available"}""", await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken));
+
+        Assert.Equal("""{"security_error":"Application ID is not available"}""",
+            await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken));
+
         Assert.NotNull(response.Content.Headers.ContentType);
         Assert.Equal("application/json", response.Content.Headers.ContentType.MediaType);
     }
@@ -61,7 +64,10 @@ public sealed class CloudFoundrySecurityMiddlewareTest : BaseTest
         using HttpClient client = host.GetTestClient();
         HttpResponseMessage response = await client.GetAsync(new Uri("http://localhost/cloudfoundryapplication/info"), TestContext.Current.CancellationToken);
         Assert.Equal(HttpStatusCode.ServiceUnavailable, response.StatusCode);
-        Assert.Equal("""{"security_error":"Cloud controller URL is not available"}""", await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken));
+
+        Assert.Equal("""{"security_error":"Cloud controller URL is not available"}""",
+            await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken));
+
         Assert.NotNull(response.Content.Headers.ContentType);
         Assert.Equal("application/json", response.Content.Headers.ContentType.MediaType);
     }
@@ -83,7 +89,10 @@ public sealed class CloudFoundrySecurityMiddlewareTest : BaseTest
         await host.StartAsync(TestContext.Current.CancellationToken);
 
         using HttpClient client = host.GetTestClient();
-        HttpResponseMessage response = await client.GetAsync(new Uri("http://localhost/cloudfoundryapplication/does-not-exist"), TestContext.Current.CancellationToken);
+
+        HttpResponseMessage response =
+            await client.GetAsync(new Uri("http://localhost/cloudfoundryapplication/does-not-exist"), TestContext.Current.CancellationToken);
+
         Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
         Assert.Equal(string.Empty, await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken));
         Assert.Null(response.Content.Headers.ContentType);
@@ -108,7 +117,10 @@ public sealed class CloudFoundrySecurityMiddlewareTest : BaseTest
         using HttpClient client = host.GetTestClient();
         HttpResponseMessage response = await client.GetAsync(new Uri("http://localhost/cloudfoundryapplication/info"), TestContext.Current.CancellationToken);
         Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
-        Assert.Equal("""{"security_error":"Authorization header is missing or invalid"}""", await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken));
+
+        Assert.Equal("""{"security_error":"Authorization header is missing or invalid"}""",
+            await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken));
+
         Assert.NotNull(response.Content.Headers.ContentType);
         Assert.Equal("application/json", response.Content.Headers.ContentType.MediaType);
     }
@@ -131,7 +143,10 @@ public sealed class CloudFoundrySecurityMiddlewareTest : BaseTest
         using HttpClient client = host.GetTestClient();
         HttpResponseMessage response = await client.GetAsync(new Uri("http://localhost/cloudfoundryapplication/info"), TestContext.Current.CancellationToken);
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        Assert.Equal("""{"security_error":"Application ID is not available"}""", await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken));
+
+        Assert.Equal("""{"security_error":"Application ID is not available"}""",
+            await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken));
+
         Assert.NotNull(response.Content.Headers.ContentType);
         Assert.Equal("application/json", response.Content.Headers.ContentType.MediaType);
     }
@@ -156,7 +171,10 @@ public sealed class CloudFoundrySecurityMiddlewareTest : BaseTest
         using HttpClient client = host.GetTestClient();
         HttpResponseMessage response = await client.GetAsync(new Uri("http://localhost/cloudfoundryapplication/info"), TestContext.Current.CancellationToken);
         Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
-        Assert.Equal("""{"security_error":"Authorization header is missing or invalid"}""", await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken));
+
+        Assert.Equal("""{"security_error":"Authorization header is missing or invalid"}""",
+            await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken));
+
         Assert.NotNull(response.Content.Headers.ContentType);
         Assert.Equal("application/json", response.Content.Headers.ContentType.MediaType);
     }
@@ -244,13 +262,19 @@ public sealed class CloudFoundrySecurityMiddlewareTest : BaseTest
         using HttpClient client = host.GetTestClient();
         HttpResponseMessage response = await client.GetAsync(new Uri("http://localhost/cloudfoundryapplication"), TestContext.Current.CancellationToken);
         Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode); // We expect the authorization to fail, but the FindTargetEndpoint logic to work.
-        Assert.Equal("""{"security_error":"Authorization header is missing or invalid"}""", await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken));
+
+        Assert.Equal("""{"security_error":"Authorization header is missing or invalid"}""",
+            await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken));
+
         Assert.NotNull(response.Content.Headers.ContentType);
         Assert.Equal("application/json", response.Content.Headers.ContentType.MediaType);
 
         HttpResponseMessage response2 = await client.GetAsync(new Uri("http://localhost/cloudfoundryapplication/info"), TestContext.Current.CancellationToken);
         Assert.Equal(HttpStatusCode.Unauthorized, response2.StatusCode);
-        Assert.Equal("""{"security_error":"Authorization header is missing or invalid"}""", await response2.Content.ReadAsStringAsync(TestContext.Current.CancellationToken));
+
+        Assert.Equal("""{"security_error":"Authorization header is missing or invalid"}""",
+            await response2.Content.ReadAsStringAsync(TestContext.Current.CancellationToken));
+
         Assert.NotNull(response2.Content.Headers.ContentType);
         Assert.Equal("application/json", response2.Content.Headers.ContentType.MediaType);
     }

--- a/src/Management/test/Endpoint.Test/Actuators/CloudFoundry/CloudFoundrySecurityMiddlewareTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/CloudFoundry/CloudFoundrySecurityMiddlewareTest.cs
@@ -33,12 +33,12 @@ public sealed class CloudFoundrySecurityMiddlewareTest : BaseTest
         builder.UseStartup<StartupWithSecurity>();
 
         using IWebHost host = builder.Build();
-        await host.StartAsync();
+        await host.StartAsync(TestContext.Current.CancellationToken);
 
         using HttpClient client = host.GetTestClient();
-        HttpResponseMessage response = await client.GetAsync(new Uri("http://localhost/cloudfoundryapplication/info"));
+        HttpResponseMessage response = await client.GetAsync(new Uri("http://localhost/cloudfoundryapplication/info"), TestContext.Current.CancellationToken);
         Assert.Equal(HttpStatusCode.ServiceUnavailable, response.StatusCode);
-        Assert.Equal("""{"security_error":"Application ID is not available"}""", await response.Content.ReadAsStringAsync());
+        Assert.Equal("""{"security_error":"Application ID is not available"}""", await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken));
         Assert.NotNull(response.Content.Headers.ContentType);
         Assert.Equal("application/json", response.Content.Headers.ContentType.MediaType);
     }
@@ -56,12 +56,12 @@ public sealed class CloudFoundrySecurityMiddlewareTest : BaseTest
         builder.ConfigureAppConfiguration((_, configuration) => configuration.AddInMemoryCollection(appSettings));
 
         using IWebHost host = builder.Build();
-        await host.StartAsync();
+        await host.StartAsync(TestContext.Current.CancellationToken);
 
         using HttpClient client = host.GetTestClient();
-        HttpResponseMessage response = await client.GetAsync(new Uri("http://localhost/cloudfoundryapplication/info"));
+        HttpResponseMessage response = await client.GetAsync(new Uri("http://localhost/cloudfoundryapplication/info"), TestContext.Current.CancellationToken);
         Assert.Equal(HttpStatusCode.ServiceUnavailable, response.StatusCode);
-        Assert.Equal("""{"security_error":"Cloud controller URL is not available"}""", await response.Content.ReadAsStringAsync());
+        Assert.Equal("""{"security_error":"Cloud controller URL is not available"}""", await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken));
         Assert.NotNull(response.Content.Headers.ContentType);
         Assert.Equal("application/json", response.Content.Headers.ContentType.MediaType);
     }
@@ -80,12 +80,12 @@ public sealed class CloudFoundrySecurityMiddlewareTest : BaseTest
         builder.ConfigureAppConfiguration((_, configuration) => configuration.AddInMemoryCollection(appSettings));
 
         using IWebHost host = builder.Build();
-        await host.StartAsync();
+        await host.StartAsync(TestContext.Current.CancellationToken);
 
         using HttpClient client = host.GetTestClient();
-        HttpResponseMessage response = await client.GetAsync(new Uri("http://localhost/cloudfoundryapplication/does-not-exist"));
+        HttpResponseMessage response = await client.GetAsync(new Uri("http://localhost/cloudfoundryapplication/does-not-exist"), TestContext.Current.CancellationToken);
         Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
-        Assert.Equal(string.Empty, await response.Content.ReadAsStringAsync());
+        Assert.Equal(string.Empty, await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken));
         Assert.Null(response.Content.Headers.ContentType);
     }
 
@@ -103,12 +103,12 @@ public sealed class CloudFoundrySecurityMiddlewareTest : BaseTest
         builder.ConfigureAppConfiguration((_, configuration) => configuration.AddInMemoryCollection(appSettings));
 
         using IWebHost host = builder.Build();
-        await host.StartAsync();
+        await host.StartAsync(TestContext.Current.CancellationToken);
 
         using HttpClient client = host.GetTestClient();
-        HttpResponseMessage response = await client.GetAsync(new Uri("http://localhost/cloudfoundryapplication/info"));
+        HttpResponseMessage response = await client.GetAsync(new Uri("http://localhost/cloudfoundryapplication/info"), TestContext.Current.CancellationToken);
         Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
-        Assert.Equal("""{"security_error":"Authorization header is missing or invalid"}""", await response.Content.ReadAsStringAsync());
+        Assert.Equal("""{"security_error":"Authorization header is missing or invalid"}""", await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken));
         Assert.NotNull(response.Content.Headers.ContentType);
         Assert.Equal("application/json", response.Content.Headers.ContentType.MediaType);
     }
@@ -126,12 +126,12 @@ public sealed class CloudFoundrySecurityMiddlewareTest : BaseTest
         builder.ConfigureAppConfiguration((_, configuration) => configuration.AddInMemoryCollection(appSettings));
 
         using IWebHost host = builder.Build();
-        await host.StartAsync();
+        await host.StartAsync(TestContext.Current.CancellationToken);
 
         using HttpClient client = host.GetTestClient();
-        HttpResponseMessage response = await client.GetAsync(new Uri("http://localhost/cloudfoundryapplication/info"));
+        HttpResponseMessage response = await client.GetAsync(new Uri("http://localhost/cloudfoundryapplication/info"), TestContext.Current.CancellationToken);
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        Assert.Equal("""{"security_error":"Application ID is not available"}""", await response.Content.ReadAsStringAsync());
+        Assert.Equal("""{"security_error":"Application ID is not available"}""", await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken));
         Assert.NotNull(response.Content.Headers.ContentType);
         Assert.Equal("application/json", response.Content.Headers.ContentType.MediaType);
     }
@@ -151,12 +151,12 @@ public sealed class CloudFoundrySecurityMiddlewareTest : BaseTest
         builder.ConfigureAppConfiguration((_, configuration) => configuration.AddInMemoryCollection(appSettings));
 
         using IWebHost host = builder.Build();
-        await host.StartAsync();
+        await host.StartAsync(TestContext.Current.CancellationToken);
 
         using HttpClient client = host.GetTestClient();
-        HttpResponseMessage response = await client.GetAsync(new Uri("http://localhost/cloudfoundryapplication/info"));
+        HttpResponseMessage response = await client.GetAsync(new Uri("http://localhost/cloudfoundryapplication/info"), TestContext.Current.CancellationToken);
         Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
-        Assert.Equal("""{"security_error":"Authorization header is missing or invalid"}""", await response.Content.ReadAsStringAsync());
+        Assert.Equal("""{"security_error":"Authorization header is missing or invalid"}""", await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken));
         Assert.NotNull(response.Content.Headers.ContentType);
         Assert.Equal("application/json", response.Content.Headers.ContentType.MediaType);
     }
@@ -174,12 +174,12 @@ public sealed class CloudFoundrySecurityMiddlewareTest : BaseTest
         builder.ConfigureAppConfiguration((_, configuration) => configuration.AddInMemoryCollection(appSettings));
         using IWebHost host = builder.Build();
 
-        await host.StartAsync();
+        await host.StartAsync(TestContext.Current.CancellationToken);
         using HttpClient client = host.GetTestClient();
-        HttpResponseMessage response = await client.GetAsync(new Uri("http://localhost/cloudfoundryapplication/info"));
+        HttpResponseMessage response = await client.GetAsync(new Uri("http://localhost/cloudfoundryapplication/info"), TestContext.Current.CancellationToken);
 
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
-        string responseBody = await response.Content.ReadAsStringAsync();
+        string responseBody = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
         responseBody.Should().BeEmpty();
     }
 
@@ -196,10 +196,10 @@ public sealed class CloudFoundrySecurityMiddlewareTest : BaseTest
         builder.ConfigureAppConfiguration((_, configuration) => configuration.AddInMemoryCollection(appSettings));
 
         using IWebHost host = builder.Build();
-        await host.StartAsync();
+        await host.StartAsync(TestContext.Current.CancellationToken);
 
         using HttpClient client = host.GetTestClient();
-        HttpResponseMessage response = await client.GetAsync(new Uri("http://localhost/cloudfoundryapplication/info"));
+        HttpResponseMessage response = await client.GetAsync(new Uri("http://localhost/cloudfoundryapplication/info"), TestContext.Current.CancellationToken);
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         Assert.NotNull(response.Content.Headers.ContentType);
         Assert.NotEqual("application/json", response.Content.Headers.ContentType.MediaType);
@@ -215,10 +215,10 @@ public sealed class CloudFoundrySecurityMiddlewareTest : BaseTest
         builder.ConfigureAppConfiguration((_, configuration) => configuration.AddEnvironmentVariables());
 
         using IWebHost host = builder.Build();
-        await host.StartAsync();
+        await host.StartAsync(TestContext.Current.CancellationToken);
 
         using HttpClient client = host.GetTestClient();
-        HttpResponseMessage response = await client.GetAsync(new Uri("http://localhost/cloudfoundryapplication/info"));
+        HttpResponseMessage response = await client.GetAsync(new Uri("http://localhost/cloudfoundryapplication/info"), TestContext.Current.CancellationToken);
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         Assert.NotNull(response.Content.Headers.ContentType);
         Assert.NotEqual("application/json", response.Content.Headers.ContentType.MediaType);
@@ -239,18 +239,18 @@ public sealed class CloudFoundrySecurityMiddlewareTest : BaseTest
         builder.ConfigureAppConfiguration((_, configuration) => configuration.AddInMemoryCollection(appSettings));
 
         using IWebHost host = builder.Build();
-        await host.StartAsync();
+        await host.StartAsync(TestContext.Current.CancellationToken);
 
         using HttpClient client = host.GetTestClient();
-        HttpResponseMessage response = await client.GetAsync(new Uri("http://localhost/cloudfoundryapplication"));
+        HttpResponseMessage response = await client.GetAsync(new Uri("http://localhost/cloudfoundryapplication"), TestContext.Current.CancellationToken);
         Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode); // We expect the authorization to fail, but the FindTargetEndpoint logic to work.
-        Assert.Equal("""{"security_error":"Authorization header is missing or invalid"}""", await response.Content.ReadAsStringAsync());
+        Assert.Equal("""{"security_error":"Authorization header is missing or invalid"}""", await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken));
         Assert.NotNull(response.Content.Headers.ContentType);
         Assert.Equal("application/json", response.Content.Headers.ContentType.MediaType);
 
-        HttpResponseMessage response2 = await client.GetAsync(new Uri("http://localhost/cloudfoundryapplication/info"));
+        HttpResponseMessage response2 = await client.GetAsync(new Uri("http://localhost/cloudfoundryapplication/info"), TestContext.Current.CancellationToken);
         Assert.Equal(HttpStatusCode.Unauthorized, response2.StatusCode);
-        Assert.Equal("""{"security_error":"Authorization header is missing or invalid"}""", await response2.Content.ReadAsStringAsync());
+        Assert.Equal("""{"security_error":"Authorization header is missing or invalid"}""", await response2.Content.ReadAsStringAsync(TestContext.Current.CancellationToken));
         Assert.NotNull(response2.Content.Headers.ContentType);
         Assert.Equal("application/json", response2.Content.Headers.ContentType.MediaType);
     }
@@ -329,13 +329,13 @@ public sealed class CloudFoundrySecurityMiddlewareTest : BaseTest
         builder.Services.AddLogging(options => options.SetMinimumLevel(LogLevel.Trace).AddProvider(capturingLoggerProvider));
         builder.Services.AddCloudFoundryActuator();
         await using WebApplication app = builder.Build();
-        await app.StartAsync();
+        await app.StartAsync(TestContext.Current.CancellationToken);
 
         using HttpClient httpClient = app.GetTestClient();
         var requestMessage = new HttpRequestMessage(HttpMethod.Get, new Uri("http://localhost/cloudfoundryapplication"));
         requestMessage.Headers.Authorization = new AuthenticationHeaderValue("Bearer", "some");
 
-        _ = await httpClient.SendAsync(requestMessage);
+        _ = await httpClient.SendAsync(requestMessage, TestContext.Current.CancellationToken);
 
         string logMessages = string.Join(System.Environment.NewLine, capturingLoggerProvider.GetAll());
         logMessages.Should().Contain("Authorization: *");

--- a/src/Management/test/Endpoint.Test/Actuators/CloudFoundry/EndpointMiddlewareTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/CloudFoundry/EndpointMiddlewareTest.cs
@@ -37,10 +37,10 @@ public sealed class EndpointMiddlewareTest : BaseTest
         builder.UseStartup<Startup>();
 
         using IWebHost host = builder.Build();
-        await host.StartAsync();
+        await host.StartAsync(TestContext.Current.CancellationToken);
 
         using HttpClient client = host.GetTestClient();
-        var links = await client.GetFromJsonAsync<Links>("http://localhost/cloudfoundryapplication", SerializerOptions);
+        var links = await client.GetFromJsonAsync<Links>("http://localhost/cloudfoundryapplication", SerializerOptions, TestContext.Current.CancellationToken);
 
         links.Should().NotBeNull();
         links.Entries["beans"].Href.Should().Be("http://localhost/cloudfoundryapplication/beans");
@@ -65,11 +65,11 @@ public sealed class EndpointMiddlewareTest : BaseTest
         builder.UseStartup<Startup>();
 
         using IWebHost host = builder.Build();
-        await host.StartAsync();
+        await host.StartAsync(TestContext.Current.CancellationToken);
 
         using HttpClient client = host.GetTestClient();
-        HttpResponseMessage response = await client.GetAsync(new Uri("http://localhost/cloudfoundryapplication"));
-        string json = await response.Content.ReadAsStringAsync();
+        HttpResponseMessage response = await client.GetAsync(new Uri("http://localhost/cloudfoundryapplication"), TestContext.Current.CancellationToken);
+        string json = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
         json.Should().BeJson("""
             {
@@ -135,10 +135,10 @@ public sealed class EndpointMiddlewareTest : BaseTest
         builder.UseStartup<Startup>();
 
         using IWebHost host = builder.Build();
-        await host.StartAsync();
+        await host.StartAsync(TestContext.Current.CancellationToken);
 
         using HttpClient client = host.GetTestClient();
-        string response = await client.GetStringAsync(new Uri("http://localhost/cloudfoundryapplication/info"));
+        string response = await client.GetStringAsync(new Uri("http://localhost/cloudfoundryapplication/info"), TestContext.Current.CancellationToken);
 
         response.Should().Contain("2017-07-12T18:40:39Z");
         response.Should().Contain("2017-06-08T12:47:02Z");
@@ -157,10 +157,10 @@ public sealed class EndpointMiddlewareTest : BaseTest
         builder.ConfigureAppConfiguration((_, configuration) => configuration.AddInMemoryCollection(settings));
 
         using IWebHost host = builder.Build();
-        await host.StartAsync();
+        await host.StartAsync(TestContext.Current.CancellationToken);
 
         using HttpClient client = host.GetTestClient();
-        string response = await client.GetStringAsync(new Uri("http://localhost/cloudfoundryapplication/info"));
+        string response = await client.GetStringAsync(new Uri("http://localhost/cloudfoundryapplication/info"), TestContext.Current.CancellationToken);
 
         response.Should().Contain("1499884839000");
         response.Should().NotContain("2017-07-12T18:40:39Z");
@@ -177,7 +177,7 @@ public sealed class EndpointMiddlewareTest : BaseTest
         builder.Services.AddInfoActuator();
         await using WebApplication app = builder.Build();
 
-        Func<Task> action = async () => await app.StartAsync();
+        Func<Task> action = async () => await app.StartAsync(TestContext.Current.CancellationToken);
 
         await action.Should().ThrowExactlyAsync<InvalidOperationException>()
             .WithMessage("Running on Cloud Foundry without security middleware. Call services.AddCloudFoundryActuator() to fix this.");

--- a/src/Management/test/Endpoint.Test/Actuators/CloudFoundry/PermissionsProviderTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/CloudFoundry/PermissionsProviderTest.cs
@@ -25,7 +25,7 @@ public sealed class PermissionsProviderTest : BaseTest
     public async Task GetPermissionsAsyncTest()
     {
         PermissionsProvider permissionsProvider = GetPermissionsProvider();
-        SecurityResult result = await permissionsProvider.GetPermissionsAsync("testToken", CancellationToken.None);
+        SecurityResult result = await permissionsProvider.GetPermissionsAsync("testToken", TestContext.Current.CancellationToken);
         Assert.NotNull(result);
     }
 
@@ -41,7 +41,7 @@ public sealed class PermissionsProviderTest : BaseTest
         };
 
         response.Content = JsonContent.Create(permissions);
-        EndpointPermissions result = await permissionsProvider.GetPermissionsAsync(response, CancellationToken.None);
+        EndpointPermissions result = await permissionsProvider.GetPermissionsAsync(response, TestContext.Current.CancellationToken);
         Assert.Equal(EndpointPermissions.Full, result);
     }
 

--- a/src/Management/test/Endpoint.Test/Actuators/DbMigrations/DbMigrationsEndpointTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/DbMigrations/DbMigrationsEndpointTest.cs
@@ -38,7 +38,7 @@ public sealed class DbMigrationsEndpointTest(ITestOutputHelper testOutputHelper)
     [Fact]
     public async Task Invoke_WhenExistingDatabase_ReturnsExpected()
     {
-        using var testContext = new TestContext(_testOutputHelper);
+        using var testContext = new SteeltoeTestContext(_testOutputHelper);
 
         testContext.AdditionalServices = (services, _) =>
         {
@@ -59,7 +59,7 @@ public sealed class DbMigrationsEndpointTest(ITestOutputHelper testOutputHelper)
     [Fact]
     public async Task Invoke_NonExistingDatabase_ReturnsExpected()
     {
-        using var testContext = new TestContext(_testOutputHelper);
+        using var testContext = new SteeltoeTestContext(_testOutputHelper);
 
         var migrationScanner = new TestDatabaseMigrationScanner
         {
@@ -85,7 +85,7 @@ public sealed class DbMigrationsEndpointTest(ITestOutputHelper testOutputHelper)
     [Fact]
     public async Task Invoke_NoDbContextRegistered_ReturnsExpected()
     {
-        using var testContext = new TestContext(_testOutputHelper);
+        using var testContext = new SteeltoeTestContext(_testOutputHelper);
 
         testContext.AdditionalServices = (services, _) =>
         {

--- a/src/Management/test/Endpoint.Test/Actuators/DbMigrations/DbMigrationsEndpointTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/DbMigrations/DbMigrationsEndpointTest.cs
@@ -48,7 +48,7 @@ public sealed class DbMigrationsEndpointTest(ITestOutputHelper testOutputHelper)
         };
 
         var sut = testContext.GetRequiredService<IDbMigrationsEndpointHandler>();
-        Dictionary<string, DbMigrationsDescriptor> result = await sut.InvokeAsync(null, CancellationToken.None);
+        Dictionary<string, DbMigrationsDescriptor> result = await sut.InvokeAsync(null, TestContext.Current.CancellationToken);
 
         const string contextName = nameof(MockDbContext);
         result.Should().ContainKey(contextName);
@@ -74,7 +74,7 @@ public sealed class DbMigrationsEndpointTest(ITestOutputHelper testOutputHelper)
         };
 
         var handler = testContext.GetRequiredService<IDbMigrationsEndpointHandler>();
-        Dictionary<string, DbMigrationsDescriptor> result = await handler.InvokeAsync(null, CancellationToken.None);
+        Dictionary<string, DbMigrationsDescriptor> result = await handler.InvokeAsync(null, TestContext.Current.CancellationToken);
 
         const string contextName = nameof(MockDbContext);
         result.Should().ContainKey(contextName);
@@ -94,7 +94,7 @@ public sealed class DbMigrationsEndpointTest(ITestOutputHelper testOutputHelper)
         };
 
         var handler = testContext.GetRequiredService<IDbMigrationsEndpointHandler>();
-        Dictionary<string, DbMigrationsDescriptor> result = await handler.InvokeAsync(null, CancellationToken.None);
+        Dictionary<string, DbMigrationsDescriptor> result = await handler.InvokeAsync(null, TestContext.Current.CancellationToken);
 
         result.Should().BeEmpty();
     }

--- a/src/Management/test/Endpoint.Test/Actuators/DbMigrations/EndpointMiddlewareTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/DbMigrations/EndpointMiddlewareTest.cs
@@ -43,7 +43,7 @@ public sealed class EndpointMiddlewareTest : BaseTest
 
         context.Response.Body.Seek(0, SeekOrigin.Begin);
         var reader = new StreamReader(context.Response.Body, Encoding.UTF8);
-        string json = await reader.ReadToEndAsync();
+        string json = await reader.ReadToEndAsync(TestContext.Current.CancellationToken);
         var descriptor = new DbMigrationsDescriptor();
         descriptor.AppliedMigrations.Add("applied");
         descriptor.PendingMigrations.Add("pending");
@@ -64,13 +64,13 @@ public sealed class EndpointMiddlewareTest : BaseTest
         builder.ConfigureAppConfiguration((_, configuration) => configuration.AddInMemoryCollection(AppSettings));
 
         using IWebHost app = builder.Build();
-        await app.StartAsync();
+        await app.StartAsync(TestContext.Current.CancellationToken);
 
         using HttpClient client = app.GetTestClient();
-        HttpResponseMessage response = await client.GetAsync(new Uri("http://localhost/actuator/dbmigrations"));
+        HttpResponseMessage response = await client.GetAsync(new Uri("http://localhost/actuator/dbmigrations"), TestContext.Current.CancellationToken);
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
-        string json = await response.Content.ReadAsStringAsync();
+        string json = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
         var descriptor = new DbMigrationsDescriptor();
         descriptor.AppliedMigrations.Add("applied");
         descriptor.PendingMigrations.Add("pending");

--- a/src/Management/test/Endpoint.Test/Actuators/Environment/EndpointMiddlewareTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/Environment/EndpointMiddlewareTest.cs
@@ -53,7 +53,7 @@ public sealed class EndpointMiddlewareTest : BaseTest
         await middleware.InvokeAsync(context, null);
         context.Response.Body.Seek(0, SeekOrigin.Begin);
         var reader = new StreamReader(context.Response.Body, Encoding.UTF8);
-        string? json = await reader.ReadLineAsync();
+        string? json = await reader.ReadLineAsync(TestContext.Current.CancellationToken);
 
         json.Should().BeJson("""
             {
@@ -97,13 +97,13 @@ public sealed class EndpointMiddlewareTest : BaseTest
         builder.ConfigureAppConfiguration((_, configuration) => configuration.AddInMemoryCollection(AppSettings));
 
         using IWebHost app = builder.Build();
-        await app.StartAsync();
+        await app.StartAsync(TestContext.Current.CancellationToken);
 
         using HttpClient client = app.GetTestClient();
-        HttpResponseMessage response = await client.GetAsync(new Uri("http://localhost/actuator/env"));
+        HttpResponseMessage response = await client.GetAsync(new Uri("http://localhost/actuator/env"), TestContext.Current.CancellationToken);
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
-        string json = await response.Content.ReadAsStringAsync();
+        string json = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
         json.Should().BeJson("""
             {
@@ -171,13 +171,13 @@ public sealed class EndpointMiddlewareTest : BaseTest
         });
 
         using IWebHost app = builder.Build();
-        await app.StartAsync();
+        await app.StartAsync(TestContext.Current.CancellationToken);
 
         using HttpClient client = app.GetTestClient();
-        HttpResponseMessage response = await client.GetAsync(new Uri("http://localhost/actuator/env"));
+        HttpResponseMessage response = await client.GetAsync(new Uri("http://localhost/actuator/env"), TestContext.Current.CancellationToken);
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
-        string json = await response.Content.ReadAsStringAsync();
+        string json = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
         json.Should().BeJson("""
             {
@@ -290,13 +290,13 @@ public sealed class EndpointMiddlewareTest : BaseTest
         builder.Services.AddEnvironmentActuator();
 
         await using WebApplication app = builder.Build();
-        await app.StartAsync();
+        await app.StartAsync(TestContext.Current.CancellationToken);
 
         using HttpClient httpClient = app.GetTestClient();
-        HttpResponseMessage response = await httpClient.GetAsync(new Uri("http://localhost/actuator/env"));
+        HttpResponseMessage response = await httpClient.GetAsync(new Uri("http://localhost/actuator/env"), TestContext.Current.CancellationToken);
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        string json = await response.Content.ReadAsStringAsync();
+        string json = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
         json.Should().BeJson("""
             {
@@ -356,10 +356,10 @@ public sealed class EndpointMiddlewareTest : BaseTest
 
         fileProvider.NotifyChanged();
 
-        response = await httpClient.GetAsync(new Uri("http://localhost/actuator/env"));
+        response = await httpClient.GetAsync(new Uri("http://localhost/actuator/env"), TestContext.Current.CancellationToken);
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        json = await response.Content.ReadAsStringAsync();
+        json = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
         json.Should().BeJson("""
             {

--- a/src/Management/test/Endpoint.Test/Actuators/Environment/EnvironmentEndpointTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/Environment/EnvironmentEndpointTest.cs
@@ -224,7 +224,7 @@ public sealed class EnvironmentEndpointTest(ITestOutputHelper testOutputHelper) 
         };
 
         var handler = testContext.GetRequiredService<IEnvironmentEndpointHandler>();
-        EnvironmentResponse result = await handler.InvokeAsync(null, CancellationToken.None);
+        EnvironmentResponse result = await handler.InvokeAsync(null, TestContext.Current.CancellationToken);
         Assert.NotNull(result);
         Assert.Single(result.ActiveProfiles);
         Assert.Equal("Test", result.ActiveProfiles[0]);
@@ -273,7 +273,7 @@ public sealed class EnvironmentEndpointTest(ITestOutputHelper testOutputHelper) 
         };
 
         var handler = testContext.GetRequiredService<IEnvironmentEndpointHandler>();
-        EnvironmentResponse result = await handler.InvokeAsync(null, CancellationToken.None);
+        EnvironmentResponse result = await handler.InvokeAsync(null, TestContext.Current.CancellationToken);
         Assert.NotNull(result);
 
         PropertySourceDescriptor desc = result.PropertySources[0];
@@ -314,7 +314,7 @@ public sealed class EnvironmentEndpointTest(ITestOutputHelper testOutputHelper) 
         };
 
         var handler = testContext.GetRequiredService<IEnvironmentEndpointHandler>();
-        EnvironmentResponse result = await handler.InvokeAsync(null, CancellationToken.None);
+        EnvironmentResponse result = await handler.InvokeAsync(null, TestContext.Current.CancellationToken);
         Assert.NotNull(result);
 
         PropertySourceDescriptor desc = result.PropertySources[0];

--- a/src/Management/test/Endpoint.Test/Actuators/Environment/EnvironmentEndpointTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/Environment/EnvironmentEndpointTest.cs
@@ -17,7 +17,7 @@ public sealed class EnvironmentEndpointTest(ITestOutputHelper testOutputHelper) 
     [Fact]
     public void GetPropertySourceName_ReturnsExpected()
     {
-        using (var testContext = new TestContext(_testOutputHelper))
+        using (var testContext = new SteeltoeTestContext(_testOutputHelper))
         {
             testContext.AdditionalServices = (services, _) =>
             {
@@ -37,7 +37,7 @@ public sealed class EnvironmentEndpointTest(ITestOutputHelper testOutputHelper) 
             Assert.Equal(provider.GetType().Name, name);
         }
 
-        using (var testContext = new TestContext(_testOutputHelper))
+        using (var testContext = new SteeltoeTestContext(_testOutputHelper))
         {
             testContext.AdditionalServices = (services, _) =>
             {
@@ -80,7 +80,7 @@ public sealed class EnvironmentEndpointTest(ITestOutputHelper testOutputHelper) 
             ["charSize"] = "should not duplicate"
         };
 
-        using var testContext = new TestContext(_testOutputHelper);
+        using var testContext = new SteeltoeTestContext(_testOutputHelper);
 
         testContext.AdditionalServices = (services, _) =>
         {
@@ -132,7 +132,7 @@ public sealed class EnvironmentEndpointTest(ITestOutputHelper testOutputHelper) 
             ["management:endpoints:cloudfoundry:enabled"] = "true"
         };
 
-        using var testContext = new TestContext(_testOutputHelper);
+        using var testContext = new SteeltoeTestContext(_testOutputHelper);
 
         testContext.AdditionalServices = (services, _) =>
         {
@@ -172,7 +172,7 @@ public sealed class EnvironmentEndpointTest(ITestOutputHelper testOutputHelper) 
             ["appsManagerBase"] = "${management:endpoints:path}"
         };
 
-        using var testContext = new TestContext(_testOutputHelper);
+        using var testContext = new SteeltoeTestContext(_testOutputHelper);
 
         testContext.AdditionalServices = (services, _) =>
         {
@@ -210,7 +210,7 @@ public sealed class EnvironmentEndpointTest(ITestOutputHelper testOutputHelper) 
             ["management:endpoints:cloudfoundry:enabled"] = "true"
         };
 
-        using var testContext = new TestContext(_testOutputHelper);
+        using var testContext = new SteeltoeTestContext(_testOutputHelper);
 
         testContext.AdditionalServices = (services, _) =>
         {
@@ -259,7 +259,7 @@ public sealed class EnvironmentEndpointTest(ITestOutputHelper testOutputHelper) 
             ["vcap_services"] = "my-secret"
         };
 
-        using var testContext = new TestContext(_testOutputHelper);
+        using var testContext = new SteeltoeTestContext(_testOutputHelper);
 
         testContext.AdditionalServices = (services, _) =>
         {
@@ -300,7 +300,7 @@ public sealed class EnvironmentEndpointTest(ITestOutputHelper testOutputHelper) 
             ["password"] = "my-secret"
         };
 
-        using var testContext = new TestContext(_testOutputHelper);
+        using var testContext = new SteeltoeTestContext(_testOutputHelper);
 
         testContext.AdditionalServices = (services, _) =>
         {

--- a/src/Management/test/Endpoint.Test/Actuators/Health/Availability/LivenessStateHealthContributorTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/Health/Availability/LivenessStateHealthContributorTest.cs
@@ -23,7 +23,7 @@ public sealed class LivenessStateHealthContributorTest
     {
         var contributor = new LivenessStateHealthContributor(_availability, _optionsMonitor, NullLoggerFactory.Instance);
 
-        HealthCheckResult? result = await contributor.CheckHealthAsync(CancellationToken.None);
+        HealthCheckResult? result = await contributor.CheckHealthAsync(TestContext.Current.CancellationToken);
 
         Assert.NotNull(result);
         Assert.Equal(HealthStatus.Unknown, result.Status);
@@ -35,7 +35,7 @@ public sealed class LivenessStateHealthContributorTest
         _availability.SetAvailabilityState(ApplicationAvailability.LivenessKey, LivenessState.Correct, "tests");
         var contributor = new LivenessStateHealthContributor(_availability, _optionsMonitor, NullLoggerFactory.Instance);
 
-        HealthCheckResult? result = await contributor.CheckHealthAsync(CancellationToken.None);
+        HealthCheckResult? result = await contributor.CheckHealthAsync(TestContext.Current.CancellationToken);
 
         Assert.NotNull(result);
         Assert.Equal(HealthStatus.Up, result.Status);
@@ -47,7 +47,7 @@ public sealed class LivenessStateHealthContributorTest
         _availability.SetAvailabilityState(ApplicationAvailability.LivenessKey, LivenessState.Broken, "tests");
         var contributor = new LivenessStateHealthContributor(_availability, _optionsMonitor, NullLoggerFactory.Instance);
 
-        HealthCheckResult? result = await contributor.CheckHealthAsync(CancellationToken.None);
+        HealthCheckResult? result = await contributor.CheckHealthAsync(TestContext.Current.CancellationToken);
 
         Assert.NotNull(result);
         Assert.Equal(HealthStatus.Down, result.Status);

--- a/src/Management/test/Endpoint.Test/Actuators/Health/Availability/ReadinessStateHealthContributorTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/Health/Availability/ReadinessStateHealthContributorTest.cs
@@ -23,7 +23,7 @@ public sealed class ReadinessStateHealthContributorTest
     {
         var contributor = new ReadinessStateHealthContributor(_availability, _optionsMonitor, NullLoggerFactory.Instance);
 
-        HealthCheckResult? result = await contributor.CheckHealthAsync(CancellationToken.None);
+        HealthCheckResult? result = await contributor.CheckHealthAsync(TestContext.Current.CancellationToken);
 
         Assert.NotNull(result);
         Assert.Equal(HealthStatus.Unknown, result.Status);
@@ -35,7 +35,7 @@ public sealed class ReadinessStateHealthContributorTest
         _availability.SetAvailabilityState(ApplicationAvailability.ReadinessKey, ReadinessState.AcceptingTraffic, "tests");
         var contributor = new ReadinessStateHealthContributor(_availability, _optionsMonitor, NullLoggerFactory.Instance);
 
-        HealthCheckResult? result = await contributor.CheckHealthAsync(CancellationToken.None);
+        HealthCheckResult? result = await contributor.CheckHealthAsync(TestContext.Current.CancellationToken);
 
         Assert.NotNull(result);
         Assert.Equal(HealthStatus.Up, result.Status);
@@ -47,7 +47,7 @@ public sealed class ReadinessStateHealthContributorTest
         _availability.SetAvailabilityState(ApplicationAvailability.ReadinessKey, ReadinessState.RefusingTraffic, "tests");
         var contributor = new ReadinessStateHealthContributor(_availability, _optionsMonitor, NullLoggerFactory.Instance);
 
-        HealthCheckResult? result = await contributor.CheckHealthAsync(CancellationToken.None);
+        HealthCheckResult? result = await contributor.CheckHealthAsync(TestContext.Current.CancellationToken);
 
         Assert.NotNull(result);
         Assert.Equal(HealthStatus.OutOfService, result.Status);

--- a/src/Management/test/Endpoint.Test/Actuators/Health/Contributors/DiskSpaceHealthContributorTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/Health/Contributors/DiskSpaceHealthContributorTest.cs
@@ -25,7 +25,7 @@ public sealed class DiskSpaceHealthContributorTest : BaseTest
         IOptionsMonitor<DiskSpaceContributorOptions> optionsMonitor = GetOptionsMonitorFromSettings<DiskSpaceContributorOptions>();
         var contributor = new DiskSpaceHealthContributor(optionsMonitor);
         Assert.Equal("diskSpace", contributor.Id);
-        HealthCheckResult? result = await contributor.CheckHealthAsync(CancellationToken.None);
+        HealthCheckResult? result = await contributor.CheckHealthAsync(TestContext.Current.CancellationToken);
         Assert.NotNull(result);
         Assert.Equal(HealthStatus.Up, result.Status);
         Assert.NotNull(result.Details);
@@ -46,7 +46,7 @@ public sealed class DiskSpaceHealthContributorTest : BaseTest
 
         var contributor = new DiskSpaceHealthContributor(optionsMonitor);
 
-        HealthCheckResult? result = await contributor.CheckHealthAsync(CancellationToken.None);
+        HealthCheckResult? result = await contributor.CheckHealthAsync(TestContext.Current.CancellationToken);
 
         result.Should().NotBeNull();
         result.Status.Should().Be(HealthStatus.Unknown);

--- a/src/Management/test/Endpoint.Test/Actuators/Health/EndpointMiddlewareTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/Health/EndpointMiddlewareTest.cs
@@ -366,7 +366,10 @@ public sealed class EndpointMiddlewareTest : BaseTest
         await app.StartAsync(TestContext.Current.CancellationToken);
 
         using HttpClient client = app.GetTestClient();
-        HttpResponseMessage responseMessage = await client.GetAsync(new Uri("http://localhost/cloudfoundryapplication/health"), TestContext.Current.CancellationToken);
+
+        HttpResponseMessage responseMessage =
+            await client.GetAsync(new Uri("http://localhost/cloudfoundryapplication/health"), TestContext.Current.CancellationToken);
+
         responseMessage.StatusCode.Should().Be(HttpStatusCode.OK);
 
         string json = await responseMessage.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);

--- a/src/Management/test/Endpoint.Test/Actuators/Health/EndpointMiddlewareTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/Health/EndpointMiddlewareTest.cs
@@ -29,13 +29,13 @@ public sealed class EndpointMiddlewareTest : BaseTest
         builder.ConfigureAppConfiguration((_, configuration) => configuration.AddInMemoryCollection(_appSettings));
 
         using IWebHost app = builder.Build();
-        await app.StartAsync();
+        await app.StartAsync(TestContext.Current.CancellationToken);
 
         using HttpClient client = app.GetTestClient();
-        HttpResponseMessage response = await client.GetAsync(new Uri("http://localhost/cloudfoundryapplication/health"));
+        HttpResponseMessage response = await client.GetAsync(new Uri("http://localhost/cloudfoundryapplication/health"), TestContext.Current.CancellationToken);
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        string json = await response.Content.ReadAsStringAsync();
+        string json = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
         json.Should().NotBeNull();
 
         var health = JsonSerializer.Deserialize<Dictionary<string, object>>(json);
@@ -57,13 +57,13 @@ public sealed class EndpointMiddlewareTest : BaseTest
         builder.ConfigureAppConfiguration((_, configuration) => configuration.AddInMemoryCollection(settings));
 
         using IWebHost app = builder.Build();
-        await app.StartAsync();
+        await app.StartAsync(TestContext.Current.CancellationToken);
 
         using HttpClient client = app.GetTestClient();
-        HttpResponseMessage response = await client.GetAsync(new Uri("http://localhost/cloudfoundryapplication/health"));
+        HttpResponseMessage response = await client.GetAsync(new Uri("http://localhost/cloudfoundryapplication/health"), TestContext.Current.CancellationToken);
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        string json = await response.Content.ReadAsStringAsync();
+        string json = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
         json.Should().NotBeNull();
 
         var health = JsonSerializer.Deserialize<Dictionary<string, object>>(json);
@@ -85,13 +85,13 @@ public sealed class EndpointMiddlewareTest : BaseTest
         builder.ConfigureAppConfiguration((_, configuration) => configuration.AddInMemoryCollection(settings));
 
         using IWebHost app = builder.Build();
-        await app.StartAsync();
+        await app.StartAsync(TestContext.Current.CancellationToken);
 
         using HttpClient client = app.GetTestClient();
-        HttpResponseMessage response = await client.GetAsync(new Uri("http://localhost/cloudfoundryapplication/health"));
+        HttpResponseMessage response = await client.GetAsync(new Uri("http://localhost/cloudfoundryapplication/health"), TestContext.Current.CancellationToken);
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        string json = await response.Content.ReadAsStringAsync();
+        string json = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
         json.Should().NotBeNull();
 
         var health = JsonSerializer.Deserialize<Dictionary<string, object>>(json);
@@ -115,13 +115,13 @@ public sealed class EndpointMiddlewareTest : BaseTest
         builder.ConfigureAppConfiguration((_, configuration) => configuration.AddInMemoryCollection(settings));
 
         using IWebHost app = builder.Build();
-        await app.StartAsync();
+        await app.StartAsync(TestContext.Current.CancellationToken);
 
         using HttpClient client = app.GetTestClient();
-        HttpResponseMessage response = await client.GetAsync(new Uri("http://localhost/cloudfoundryapplication/health"));
+        HttpResponseMessage response = await client.GetAsync(new Uri("http://localhost/cloudfoundryapplication/health"), TestContext.Current.CancellationToken);
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        string json = await response.Content.ReadAsStringAsync();
+        string json = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
         json.Should().NotBeNull();
 
         var health = JsonSerializer.Deserialize<Dictionary<string, object>>(json);
@@ -147,13 +147,13 @@ public sealed class EndpointMiddlewareTest : BaseTest
         builder.ConfigureAppConfiguration((_, configuration) => configuration.AddInMemoryCollection(settings));
 
         using IWebHost app = builder.Build();
-        await app.StartAsync();
+        await app.StartAsync(TestContext.Current.CancellationToken);
 
         using HttpClient client = app.GetTestClient();
-        HttpResponseMessage response = await client.GetAsync(new Uri("http://localhost/cloudfoundryapplication/health"));
+        HttpResponseMessage response = await client.GetAsync(new Uri("http://localhost/cloudfoundryapplication/health"), TestContext.Current.CancellationToken);
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        string json = await response.Content.ReadAsStringAsync();
+        string json = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
         json.Should().NotBeNull();
 
         var health = JsonSerializer.Deserialize<Dictionary<string, object>>(json);
@@ -181,13 +181,13 @@ public sealed class EndpointMiddlewareTest : BaseTest
         builder.ConfigureAppConfiguration((_, configuration) => configuration.AddInMemoryCollection(settings));
 
         using IWebHost app = builder.Build();
-        await app.StartAsync();
+        await app.StartAsync(TestContext.Current.CancellationToken);
 
         using HttpClient client = app.GetTestClient();
-        HttpResponseMessage response = await client.GetAsync(new Uri("http://localhost/cloudfoundryapplication/health"));
+        HttpResponseMessage response = await client.GetAsync(new Uri("http://localhost/cloudfoundryapplication/health"), TestContext.Current.CancellationToken);
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        string json = await response.Content.ReadAsStringAsync();
+        string json = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
         json.Should().NotBeNull();
 
         var health = JsonSerializer.Deserialize<Dictionary<string, object>>(json);
@@ -214,13 +214,13 @@ public sealed class EndpointMiddlewareTest : BaseTest
         builder.ConfigureAppConfiguration((_, configuration) => configuration.AddInMemoryCollection(settings));
 
         using IWebHost app = builder.Build();
-        await app.StartAsync();
+        await app.StartAsync(TestContext.Current.CancellationToken);
 
         using HttpClient client = app.GetTestClient();
-        HttpResponseMessage response = await client.GetAsync(new Uri("http://localhost/cloudfoundryapplication/health"));
+        HttpResponseMessage response = await client.GetAsync(new Uri("http://localhost/cloudfoundryapplication/health"), TestContext.Current.CancellationToken);
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        string json = await response.Content.ReadAsStringAsync();
+        string json = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
         json.Should().NotBeNull();
 
         var health = JsonSerializer.Deserialize<Dictionary<string, object>>(json);
@@ -247,13 +247,13 @@ public sealed class EndpointMiddlewareTest : BaseTest
         });
 
         using IWebHost app = builder.Build();
-        await app.StartAsync();
+        await app.StartAsync(TestContext.Current.CancellationToken);
 
         using HttpClient client = app.GetTestClient();
-        HttpResponseMessage response = await client.GetAsync(new Uri("http://localhost/cloudfoundryapplication/health"));
+        HttpResponseMessage response = await client.GetAsync(new Uri("http://localhost/cloudfoundryapplication/health"), TestContext.Current.CancellationToken);
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        string json = await response.Content.ReadAsStringAsync();
+        string json = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
         json.Should().NotBeNull();
     }
 
@@ -282,13 +282,13 @@ public sealed class EndpointMiddlewareTest : BaseTest
         });
 
         using IWebHost app = builder.Build();
-        await app.StartAsync();
+        await app.StartAsync(TestContext.Current.CancellationToken);
 
         using HttpClient client = app.GetTestClient();
-        HttpResponseMessage response = await client.GetAsync(new Uri("http://localhost/cloudfoundryapplication/health"));
+        HttpResponseMessage response = await client.GetAsync(new Uri("http://localhost/cloudfoundryapplication/health"), TestContext.Current.CancellationToken);
         response.StatusCode.Should().Be(expectedStatusCode);
 
-        string json = await response.Content.ReadAsStringAsync();
+        string json = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
         json.Should().Contain(expectedJson);
     }
 
@@ -310,13 +310,13 @@ public sealed class EndpointMiddlewareTest : BaseTest
         });
 
         using IWebHost app = builder.Build();
-        await app.StartAsync();
+        await app.StartAsync(TestContext.Current.CancellationToken);
 
         using HttpClient client = app.GetTestClient();
-        HttpResponseMessage response = await client.GetAsync(new Uri("http://localhost/cloudfoundryapplication/health"));
+        HttpResponseMessage response = await client.GetAsync(new Uri("http://localhost/cloudfoundryapplication/health"), TestContext.Current.CancellationToken);
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        string json = await response.Content.ReadAsStringAsync();
+        string json = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
         json.Should().Be("""{"status":"DOWN"}""");
     }
 
@@ -338,16 +338,16 @@ public sealed class EndpointMiddlewareTest : BaseTest
         });
 
         using IWebHost app = builder.Build();
-        await app.StartAsync();
+        await app.StartAsync(TestContext.Current.CancellationToken);
 
         using var requestMessage = new HttpRequestMessage(HttpMethod.Get, new Uri("http://localhost/cloudfoundryapplication/health"));
         requestMessage.Headers.Add("X-Use-Status-Code-From-Response", "true");
 
         using HttpClient client = app.GetTestClient();
-        HttpResponseMessage response = await client.SendAsync(requestMessage);
+        HttpResponseMessage response = await client.SendAsync(requestMessage, TestContext.Current.CancellationToken);
         response.StatusCode.Should().Be(HttpStatusCode.ServiceUnavailable);
 
-        string json = await response.Content.ReadAsStringAsync();
+        string json = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
         json.Should().Be("""{"status":"DOWN"}""");
     }
 
@@ -363,13 +363,13 @@ public sealed class EndpointMiddlewareTest : BaseTest
         }));
 
         using IWebHost app = builder.Build();
-        await app.StartAsync();
+        await app.StartAsync(TestContext.Current.CancellationToken);
 
         using HttpClient client = app.GetTestClient();
-        HttpResponseMessage responseMessage = await client.GetAsync(new Uri("http://localhost/cloudfoundryapplication/health"));
+        HttpResponseMessage responseMessage = await client.GetAsync(new Uri("http://localhost/cloudfoundryapplication/health"), TestContext.Current.CancellationToken);
         responseMessage.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        string json = await responseMessage.Content.ReadAsStringAsync();
+        string json = await responseMessage.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
         json.Should().Be("""{"status":"UP"}""");
     }
 
@@ -380,13 +380,13 @@ public sealed class EndpointMiddlewareTest : BaseTest
         builder.UseStartup<Startup>();
 
         using IWebHost app = builder.Build();
-        await app.StartAsync();
+        await app.StartAsync(TestContext.Current.CancellationToken);
 
         using HttpClient client = app.GetTestClient();
-        HttpResponseMessage responseMessage = await client.GetAsync(new Uri("http://localhost/actuator/health/foo"));
+        HttpResponseMessage responseMessage = await client.GetAsync(new Uri("http://localhost/actuator/health/foo"), TestContext.Current.CancellationToken);
         responseMessage.StatusCode.Should().Be(HttpStatusCode.NotFound);
 
-        string body = await responseMessage.Content.ReadAsStringAsync();
+        string body = await responseMessage.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
         body.Should().BeEmpty();
     }
 

--- a/src/Management/test/Endpoint.Test/Actuators/Health/HealthAggregatorTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/Health/HealthAggregatorTest.cs
@@ -36,8 +36,8 @@ public sealed class HealthAggregatorTest : BaseTest
         List<IHealthContributor> contributors = [new DisabledContributor()];
         var aggregator = new HealthAggregator();
 
-        SteeltoeHealthCheckResult result =
-            await aggregator.AggregateAsync(contributors, EmptyHealthCheckRegistrations, EmptyServiceProvider, TestContext.Current.CancellationToken);
+        SteeltoeHealthCheckResult result = await aggregator.AggregateAsync(contributors, EmptyHealthCheckRegistrations, EmptyServiceProvider,
+            TestContext.Current.CancellationToken);
 
         Assert.NotNull(result);
         Assert.Equal(SteeltoeHealthStatus.Unknown, result.Status);
@@ -50,8 +50,8 @@ public sealed class HealthAggregatorTest : BaseTest
         List<IHealthContributor> contributors = [new UpContributor()];
         var aggregator = new HealthAggregator();
 
-        SteeltoeHealthCheckResult result =
-            await aggregator.AggregateAsync(contributors, EmptyHealthCheckRegistrations, EmptyServiceProvider, TestContext.Current.CancellationToken);
+        SteeltoeHealthCheckResult result = await aggregator.AggregateAsync(contributors, EmptyHealthCheckRegistrations, EmptyServiceProvider,
+            TestContext.Current.CancellationToken);
 
         Assert.NotNull(result);
         Assert.Equal(SteeltoeHealthStatus.Up, result.Status);
@@ -86,8 +86,8 @@ public sealed class HealthAggregatorTest : BaseTest
 
         var aggregator = new HealthAggregator();
 
-        SteeltoeHealthCheckResult result =
-            await aggregator.AggregateAsync(contributors, EmptyHealthCheckRegistrations, EmptyServiceProvider, TestContext.Current.CancellationToken);
+        SteeltoeHealthCheckResult result = await aggregator.AggregateAsync(contributors, EmptyHealthCheckRegistrations, EmptyServiceProvider,
+            TestContext.Current.CancellationToken);
 
         Assert.NotNull(result);
         Assert.Equal(SteeltoeHealthStatus.Down, result.Status);
@@ -106,8 +106,8 @@ public sealed class HealthAggregatorTest : BaseTest
 
         var aggregator = new HealthAggregator();
 
-        SteeltoeHealthCheckResult result =
-            await aggregator.AggregateAsync(contributors, EmptyHealthCheckRegistrations, EmptyServiceProvider, TestContext.Current.CancellationToken);
+        SteeltoeHealthCheckResult result = await aggregator.AggregateAsync(contributors, EmptyHealthCheckRegistrations, EmptyServiceProvider,
+            TestContext.Current.CancellationToken);
 
         Assert.NotNull(result);
         Assert.Equal(SteeltoeHealthStatus.Up, result.Status);
@@ -127,8 +127,8 @@ public sealed class HealthAggregatorTest : BaseTest
 
         var aggregator = new HealthAggregator();
 
-        SteeltoeHealthCheckResult result =
-            await aggregator.AggregateAsync(contributors, EmptyHealthCheckRegistrations, EmptyServiceProvider, TestContext.Current.CancellationToken);
+        SteeltoeHealthCheckResult result = await aggregator.AggregateAsync(contributors, EmptyHealthCheckRegistrations, EmptyServiceProvider,
+            TestContext.Current.CancellationToken);
 
         Assert.NotNull(result);
         Assert.Equal(SteeltoeHealthStatus.OutOfService, result.Status);
@@ -150,8 +150,8 @@ public sealed class HealthAggregatorTest : BaseTest
         var aggregator = new HealthAggregator();
         stopwatch.Start();
 
-        SteeltoeHealthCheckResult result =
-            await aggregator.AggregateAsync(contributors, EmptyHealthCheckRegistrations, EmptyServiceProvider, TestContext.Current.CancellationToken);
+        SteeltoeHealthCheckResult result = await aggregator.AggregateAsync(contributors, EmptyHealthCheckRegistrations, EmptyServiceProvider,
+            TestContext.Current.CancellationToken);
 
         stopwatch.Stop();
         Assert.NotNull(result);

--- a/src/Management/test/Endpoint.Test/Actuators/Health/HealthAggregatorTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/Health/HealthAggregatorTest.cs
@@ -23,7 +23,7 @@ public sealed class HealthAggregatorTest : BaseTest
         var aggregator = new HealthAggregator();
 
         SteeltoeHealthCheckResult result = await aggregator.AggregateAsync(Array.Empty<IHealthContributor>(), EmptyHealthCheckRegistrations,
-            EmptyServiceProvider, CancellationToken.None);
+            EmptyServiceProvider, TestContext.Current.CancellationToken);
 
         Assert.NotNull(result);
         Assert.Equal(SteeltoeHealthStatus.Unknown, result.Status);
@@ -37,7 +37,7 @@ public sealed class HealthAggregatorTest : BaseTest
         var aggregator = new HealthAggregator();
 
         SteeltoeHealthCheckResult result =
-            await aggregator.AggregateAsync(contributors, EmptyHealthCheckRegistrations, EmptyServiceProvider, CancellationToken.None);
+            await aggregator.AggregateAsync(contributors, EmptyHealthCheckRegistrations, EmptyServiceProvider, TestContext.Current.CancellationToken);
 
         Assert.NotNull(result);
         Assert.Equal(SteeltoeHealthStatus.Unknown, result.Status);
@@ -51,7 +51,7 @@ public sealed class HealthAggregatorTest : BaseTest
         var aggregator = new HealthAggregator();
 
         SteeltoeHealthCheckResult result =
-            await aggregator.AggregateAsync(contributors, EmptyHealthCheckRegistrations, EmptyServiceProvider, CancellationToken.None);
+            await aggregator.AggregateAsync(contributors, EmptyHealthCheckRegistrations, EmptyServiceProvider, TestContext.Current.CancellationToken);
 
         Assert.NotNull(result);
         Assert.Equal(SteeltoeHealthStatus.Up, result.Status);
@@ -87,7 +87,7 @@ public sealed class HealthAggregatorTest : BaseTest
         var aggregator = new HealthAggregator();
 
         SteeltoeHealthCheckResult result =
-            await aggregator.AggregateAsync(contributors, EmptyHealthCheckRegistrations, EmptyServiceProvider, CancellationToken.None);
+            await aggregator.AggregateAsync(contributors, EmptyHealthCheckRegistrations, EmptyServiceProvider, TestContext.Current.CancellationToken);
 
         Assert.NotNull(result);
         Assert.Equal(SteeltoeHealthStatus.Down, result.Status);
@@ -107,7 +107,7 @@ public sealed class HealthAggregatorTest : BaseTest
         var aggregator = new HealthAggregator();
 
         SteeltoeHealthCheckResult result =
-            await aggregator.AggregateAsync(contributors, EmptyHealthCheckRegistrations, EmptyServiceProvider, CancellationToken.None);
+            await aggregator.AggregateAsync(contributors, EmptyHealthCheckRegistrations, EmptyServiceProvider, TestContext.Current.CancellationToken);
 
         Assert.NotNull(result);
         Assert.Equal(SteeltoeHealthStatus.Up, result.Status);
@@ -128,7 +128,7 @@ public sealed class HealthAggregatorTest : BaseTest
         var aggregator = new HealthAggregator();
 
         SteeltoeHealthCheckResult result =
-            await aggregator.AggregateAsync(contributors, EmptyHealthCheckRegistrations, EmptyServiceProvider, CancellationToken.None);
+            await aggregator.AggregateAsync(contributors, EmptyHealthCheckRegistrations, EmptyServiceProvider, TestContext.Current.CancellationToken);
 
         Assert.NotNull(result);
         Assert.Equal(SteeltoeHealthStatus.OutOfService, result.Status);
@@ -151,7 +151,7 @@ public sealed class HealthAggregatorTest : BaseTest
         stopwatch.Start();
 
         SteeltoeHealthCheckResult result =
-            await aggregator.AggregateAsync(contributors, EmptyHealthCheckRegistrations, EmptyServiceProvider, CancellationToken.None);
+            await aggregator.AggregateAsync(contributors, EmptyHealthCheckRegistrations, EmptyServiceProvider, TestContext.Current.CancellationToken);
 
         stopwatch.Stop();
         Assert.NotNull(result);

--- a/src/Management/test/Endpoint.Test/Actuators/Health/HealthAggregatorTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/Health/HealthAggregatorTest.cs
@@ -142,9 +142,9 @@ public sealed class HealthAggregatorTest : BaseTest
 
         List<IHealthContributor> contributors =
         [
-            new UpContributor(500),
-            new UpContributor(500),
-            new UpContributor(500)
+            new UpContributor(1000),
+            new UpContributor(1500),
+            new UpContributor(2500)
         ];
 
         var aggregator = new HealthAggregator();
@@ -156,6 +156,6 @@ public sealed class HealthAggregatorTest : BaseTest
         stopwatch.Stop();
         Assert.NotNull(result);
         Assert.Equal(SteeltoeHealthStatus.Up, result.Status);
-        Assert.InRange(stopwatch.ElapsedMilliseconds, 450, 1200);
+        Assert.InRange(stopwatch.ElapsedMilliseconds, 900, 4500);
     }
 }

--- a/src/Management/test/Endpoint.Test/Actuators/Health/HealthEndpointTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/Health/HealthEndpointTest.cs
@@ -25,7 +25,7 @@ public sealed class HealthEndpointTest(ITestOutputHelper testOutputHelper) : Bas
     [Fact]
     public async Task Invoke_NoContributors_ReturnsExpectedHealth()
     {
-        using var testContext = new TestContext(_testOutputHelper);
+        using var testContext = new SteeltoeTestContext(_testOutputHelper);
 
         testContext.AdditionalServices = (services, _) =>
         {
@@ -47,7 +47,7 @@ public sealed class HealthEndpointTest(ITestOutputHelper testOutputHelper) : Bas
     [Fact]
     public async Task Invoke_CallsAllContributors()
     {
-        using var testContext = new TestContext(_testOutputHelper);
+        using var testContext = new SteeltoeTestContext(_testOutputHelper);
 
         List<IHealthContributor> contributors =
         [
@@ -75,7 +75,7 @@ public sealed class HealthEndpointTest(ITestOutputHelper testOutputHelper) : Bas
     [Fact]
     public async Task Invoke_HandlesCancellation_Throws()
     {
-        using var testContext = new TestContext(_testOutputHelper);
+        using var testContext = new SteeltoeTestContext(_testOutputHelper);
 
         List<IHealthContributor> contributors = [new UpContributor(5000)];
 
@@ -99,7 +99,7 @@ public sealed class HealthEndpointTest(ITestOutputHelper testOutputHelper) : Bas
     [Fact]
     public async Task Invoke_HandlesExceptions_ReturnsExpectedHealth()
     {
-        using var testContext = new TestContext(_testOutputHelper);
+        using var testContext = new SteeltoeTestContext(_testOutputHelper);
 
         List<IHealthContributor> contributors =
         [
@@ -137,7 +137,7 @@ public sealed class HealthEndpointTest(ITestOutputHelper testOutputHelper) : Bas
     [Fact]
     public void GetStatusCode_ReturnsExpected()
     {
-        using var testContext = new TestContext(_testOutputHelper);
+        using var testContext = new SteeltoeTestContext(_testOutputHelper);
 
         List<IHealthContributor> contributors = [new DiskSpaceHealthContributor(GetOptionsMonitorFromSettings<DiskSpaceContributorOptions>())];
 
@@ -173,7 +173,7 @@ public sealed class HealthEndpointTest(ITestOutputHelper testOutputHelper) : Bas
     [Fact]
     public async Task InvokeWithLivenessGroupReturnsGroupResults()
     {
-        using var testContext = new TestContext(_testOutputHelper);
+        using var testContext = new SteeltoeTestContext(_testOutputHelper);
 
         var appSettings = new Dictionary<string, string?>
         {
@@ -214,7 +214,7 @@ public sealed class HealthEndpointTest(ITestOutputHelper testOutputHelper) : Bas
     [Fact]
     public async Task InvokeWithReadinessGroupReturnsGroupResults()
     {
-        using var testContext = new TestContext(_testOutputHelper);
+        using var testContext = new SteeltoeTestContext(_testOutputHelper);
 
         var appSettings = new Dictionary<string, string?>
         {
@@ -349,7 +349,7 @@ public sealed class HealthEndpointTest(ITestOutputHelper testOutputHelper) : Bas
     public async Task InvokeWithGroupUsesShowComponentShowDetailOptions(string? endpointShowComponents, string? endpointShowDetails,
         string? groupShowComponents, string? groupShowDetails, bool hasClaim, bool returnComponents, bool returnDetails)
     {
-        using var testContext = new TestContext(_testOutputHelper);
+        using var testContext = new SteeltoeTestContext(_testOutputHelper);
 
         testContext.AdditionalConfiguration = configuration => configuration.AddInMemoryCollection(new Dictionary<string, string?>
         {

--- a/src/Management/test/Endpoint.Test/Actuators/Health/HealthEndpointTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/Health/HealthEndpointTest.cs
@@ -39,7 +39,7 @@ public sealed class HealthEndpointTest(ITestOutputHelper testOutputHelper) : Bas
 
         HealthEndpointRequest healthRequest = GetHealthRequest();
 
-        HealthEndpointResponse result = await handler.InvokeAsync(healthRequest, CancellationToken.None);
+        HealthEndpointResponse result = await handler.InvokeAsync(healthRequest, TestContext.Current.CancellationToken);
         Assert.NotNull(result);
         Assert.Equal(HealthStatus.Unknown, result.Status);
     }
@@ -64,7 +64,7 @@ public sealed class HealthEndpointTest(ITestOutputHelper testOutputHelper) : Bas
 
         var handler = testContext.GetRequiredService<IHealthEndpointHandler>();
         HealthEndpointRequest healthRequest = GetHealthRequest();
-        await handler.InvokeAsync(healthRequest, CancellationToken.None);
+        await handler.InvokeAsync(healthRequest, TestContext.Current.CancellationToken);
 
         foreach (TestHealthContributor testContributor in contributors.Cast<TestHealthContributor>())
         {
@@ -117,7 +117,7 @@ public sealed class HealthEndpointTest(ITestOutputHelper testOutputHelper) : Bas
         var handler = testContext.GetRequiredService<IHealthEndpointHandler>();
 
         HealthEndpointRequest healthRequest = GetHealthRequest();
-        HealthEndpointResponse info = await handler.InvokeAsync(healthRequest, CancellationToken.None);
+        HealthEndpointResponse info = await handler.InvokeAsync(healthRequest, TestContext.Current.CancellationToken);
 
         foreach (TestHealthContributor testContributor in contributors.Cast<TestHealthContributor>())
         {
@@ -204,7 +204,7 @@ public sealed class HealthEndpointTest(ITestOutputHelper testOutputHelper) : Bas
 
         var healthRequest = new HealthEndpointRequest("liVeness", true);
 
-        HealthEndpointResponse result = await handler.InvokeAsync(healthRequest, CancellationToken.None);
+        HealthEndpointResponse result = await handler.InvokeAsync(healthRequest, TestContext.Current.CancellationToken);
 
         result.Status.Should().Be(HealthStatus.Up);
         result.Components.Keys.Should().ContainSingle();
@@ -250,7 +250,7 @@ public sealed class HealthEndpointTest(ITestOutputHelper testOutputHelper) : Bas
 
         var healthRequest = new HealthEndpointRequest("readiness", true);
 
-        HealthEndpointResponse result = await handler.InvokeAsync(healthRequest, CancellationToken.None);
+        HealthEndpointResponse result = await handler.InvokeAsync(healthRequest, TestContext.Current.CancellationToken);
 
         result.Status.Should().Be(HealthStatus.Up);
         result.Components.Keys.Should().ContainSingle();
@@ -283,7 +283,7 @@ public sealed class HealthEndpointTest(ITestOutputHelper testOutputHelper) : Bas
 
         var healthRequest = new HealthEndpointRequest("msft", true);
 
-        HealthEndpointResponse result = await handler.InvokeAsync(healthRequest, CancellationToken.None);
+        HealthEndpointResponse result = await handler.InvokeAsync(healthRequest, TestContext.Current.CancellationToken);
 
         result.Components.Keys.Should().HaveCount(2);
         result.Components.Should().ContainKey("alwaysUp");
@@ -369,7 +369,7 @@ public sealed class HealthEndpointTest(ITestOutputHelper testOutputHelper) : Bas
 
         var healthRequest = new HealthEndpointRequest("test", hasClaim);
 
-        HealthEndpointResponse result = await handler.InvokeAsync(healthRequest, CancellationToken.None);
+        HealthEndpointResponse result = await handler.InvokeAsync(healthRequest, TestContext.Current.CancellationToken);
 
         result.Status.Should().Be(HealthStatus.Up);
 

--- a/src/Management/test/Endpoint.Test/Actuators/HeapDump/HeapDumpEndpointTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/HeapDump/HeapDumpEndpointTest.cs
@@ -15,7 +15,7 @@ public sealed class HeapDumpEndpointTest(ITestOutputHelper testOutputHelper) : B
     [Fact]
     public async Task Invoke_CreatesDump()
     {
-        using var testContext = new TestContext(_testOutputHelper);
+        using var testContext = new SteeltoeTestContext(_testOutputHelper);
 
         testContext.AdditionalServices = (services, _) =>
         {

--- a/src/Management/test/Endpoint.Test/Actuators/HeapDump/HeapDumpEndpointTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/HeapDump/HeapDumpEndpointTest.cs
@@ -25,7 +25,7 @@ public sealed class HeapDumpEndpointTest(ITestOutputHelper testOutputHelper) : B
 
         var handler = testContext.GetRequiredService<IHeapDumpEndpointHandler>();
 
-        string? path = await handler.InvokeAsync(null, CancellationToken.None);
+        string? path = await handler.InvokeAsync(null, TestContext.Current.CancellationToken);
 
         path.Should().NotBeNull();
         File.Exists(path).Should().BeTrue();

--- a/src/Management/test/Endpoint.Test/Actuators/HttpExchanges/EndpointMiddlewareTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/HttpExchanges/EndpointMiddlewareTest.cs
@@ -33,13 +33,13 @@ public sealed class EndpointMiddlewareTest : BaseTest
         builder.Services.AddHttpExchangesActuator();
         await using WebApplication host = builder.Build();
         host.MapGet("/hello", () => "Hello World!");
-        await host.StartAsync();
+        await host.StartAsync(TestContext.Current.CancellationToken);
         using var httpClient = new HttpClient();
-        HttpResponseMessage helloResponse = await httpClient.GetAsync(new Uri("http://localhost:5000/hello?someQuery=value"));
+        HttpResponseMessage helloResponse = await httpClient.GetAsync(new Uri("http://localhost:5000/hello?someQuery=value"), TestContext.Current.CancellationToken);
         helloResponse.StatusCode.Should().Be(HttpStatusCode.OK);
-        HttpResponseMessage actuatorResponse = await httpClient.GetAsync(new Uri("http://localhost:5000/actuator/httpexchanges"));
+        HttpResponseMessage actuatorResponse = await httpClient.GetAsync(new Uri("http://localhost:5000/actuator/httpexchanges"), TestContext.Current.CancellationToken);
         actuatorResponse.StatusCode.Should().Be(HttpStatusCode.OK);
-        var actuatorRootElement = await actuatorResponse.Content.ReadFromJsonAsync<JsonElement>();
+        var actuatorRootElement = await actuatorResponse.Content.ReadFromJsonAsync<JsonElement>(TestContext.Current.CancellationToken);
         JsonElement[] exchangesArray = [.. actuatorRootElement.GetProperty("exchanges").EnumerateArray()];
         exchangesArray.Should().ContainSingle();
         JsonElement testExchange = exchangesArray[0];
@@ -48,7 +48,7 @@ public sealed class EndpointMiddlewareTest : BaseTest
         requestTimestamp.Should().EndWith("Z");
         string requestTimeTaken = testExchange.GetProperty("timeTaken").ToString();
         var timeTaken = XmlConvert.ToTimeSpan(requestTimeTaken);
-        timeTaken.Should().BeGreaterThan(TimeSpan.Zero).And.BeLessThan(TimeSpan.FromSeconds(1));
+        timeTaken.Should().BeGreaterThan(TimeSpan.Zero).And.BeLessThan(1.Seconds());
         testExchange.Invoking(jsonElement => jsonElement.GetProperty("principal")).Should().Throw<KeyNotFoundException>();
         testExchange.Invoking(jsonElement => jsonElement.GetProperty("session")).Should().Throw<KeyNotFoundException>();
 
@@ -96,17 +96,17 @@ public sealed class EndpointMiddlewareTest : BaseTest
         builder.Services.AddHttpExchangesActuator();
         await using WebApplication host = builder.Build();
 
-        await host.StartAsync();
+        await host.StartAsync(TestContext.Current.CancellationToken);
 
         var observer = (HttpExchangesDiagnosticObserver)host.Services.GetRequiredService<IHttpExchangesRepository>();
         HttpExchange exchange = CreateTestHttpExchange();
         observer.Queue.Enqueue(exchange);
 
         using HttpClient httpClient = host.GetTestClient();
-        HttpResponseMessage response = await httpClient.GetAsync(new Uri("http://localhost/actuator/httpexchanges"));
+        HttpResponseMessage response = await httpClient.GetAsync(new Uri("http://localhost/actuator/httpexchanges"), TestContext.Current.CancellationToken);
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        string json = await response.Content.ReadAsStringAsync();
+        string json = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
         json.Should().BeJson("""
             {
@@ -171,17 +171,17 @@ public sealed class EndpointMiddlewareTest : BaseTest
         builder.Services.AddHttpExchangesActuator();
         await using WebApplication host = builder.Build();
 
-        await host.StartAsync();
+        await host.StartAsync(TestContext.Current.CancellationToken);
 
         var observer = (HttpExchangesDiagnosticObserver)host.Services.GetRequiredService<IHttpExchangesRepository>();
         HttpExchange exchange = CreateTestHttpExchange();
         observer.Queue.Enqueue(exchange);
 
         using HttpClient httpClient = host.GetTestClient();
-        HttpResponseMessage response = await httpClient.GetAsync(new Uri("http://localhost/actuator/httpexchanges"));
+        HttpResponseMessage response = await httpClient.GetAsync(new Uri("http://localhost/actuator/httpexchanges"), TestContext.Current.CancellationToken);
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        string json = await response.Content.ReadAsStringAsync();
+        string json = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
         json.Should().BeJson("""
             {

--- a/src/Management/test/Endpoint.Test/Actuators/HttpExchanges/EndpointMiddlewareTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/HttpExchanges/EndpointMiddlewareTest.cs
@@ -35,9 +35,15 @@ public sealed class EndpointMiddlewareTest : BaseTest
         host.MapGet("/hello", () => "Hello World!");
         await host.StartAsync(TestContext.Current.CancellationToken);
         using var httpClient = new HttpClient();
-        HttpResponseMessage helloResponse = await httpClient.GetAsync(new Uri("http://localhost:5000/hello?someQuery=value"), TestContext.Current.CancellationToken);
+
+        HttpResponseMessage helloResponse =
+            await httpClient.GetAsync(new Uri("http://localhost:5000/hello?someQuery=value"), TestContext.Current.CancellationToken);
+
         helloResponse.StatusCode.Should().Be(HttpStatusCode.OK);
-        HttpResponseMessage actuatorResponse = await httpClient.GetAsync(new Uri("http://localhost:5000/actuator/httpexchanges"), TestContext.Current.CancellationToken);
+
+        HttpResponseMessage actuatorResponse =
+            await httpClient.GetAsync(new Uri("http://localhost:5000/actuator/httpexchanges"), TestContext.Current.CancellationToken);
+
         actuatorResponse.StatusCode.Should().Be(HttpStatusCode.OK);
         var actuatorRootElement = await actuatorResponse.Content.ReadFromJsonAsync<JsonElement>(TestContext.Current.CancellationToken);
         JsonElement[] exchangesArray = [.. actuatorRootElement.GetProperty("exchanges").EnumerateArray()];

--- a/src/Management/test/Endpoint.Test/Actuators/HttpExchanges/HttpExchangesDiagnosticObserverTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/HttpExchanges/HttpExchangesDiagnosticObserverTest.cs
@@ -5,6 +5,7 @@
 using System.Diagnostics;
 using System.Net;
 using System.Security.Claims;
+using FluentAssertions.Extensions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -64,7 +65,7 @@ public sealed class HttpExchangesDiagnosticObserverTest : BaseTest
             HttpContext = context
         });
 
-        await Task.Delay(1000);
+        await Task.Delay(1.Seconds(), TestContext.Current.CancellationToken);
 
         listener.StopActivity(current, context);
 

--- a/src/Management/test/Endpoint.Test/Actuators/HttpExchanges/HttpExchangesEndpointTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/HttpExchanges/HttpExchangesEndpointTest.cs
@@ -25,7 +25,7 @@ public sealed class HttpExchangesEndpointTest(ITestOutputHelper testOutputHelper
         };
 
         var handler = testContext.GetRequiredService<IHttpExchangesEndpointHandler>();
-        HttpExchangesResult result = await handler.InvokeAsync(null, CancellationToken.None);
+        HttpExchangesResult result = await handler.InvokeAsync(null, TestContext.Current.CancellationToken);
         result.Should().NotBeNull();
         repository.GetHttpExchangesCalled.Should().BeTrue();
     }

--- a/src/Management/test/Endpoint.Test/Actuators/HttpExchanges/HttpExchangesEndpointTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/HttpExchanges/HttpExchangesEndpointTest.cs
@@ -15,7 +15,7 @@ public sealed class HttpExchangesEndpointTest(ITestOutputHelper testOutputHelper
     [Fact]
     public async Task HttpExchangeEndpointHandler_CallsHttpExchangeRepository()
     {
-        using var testContext = new TestContext(_testOutputHelper);
+        using var testContext = new SteeltoeTestContext(_testOutputHelper);
         var repository = new TestHttpExchangesRepository();
 
         testContext.AdditionalServices = (services, _) =>

--- a/src/Management/test/Endpoint.Test/Actuators/Hypermedia/EndpointMiddlewareTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/Hypermedia/EndpointMiddlewareTest.cs
@@ -25,11 +25,11 @@ public sealed class EndpointMiddlewareTest : BaseTest
         builder.UseStartup<Startup>();
 
         using IWebHost host = builder.Build();
-        await host.StartAsync();
+        await host.StartAsync(TestContext.Current.CancellationToken);
 
         using HttpClient client = host.GetTestClient();
         client.DefaultRequestHeaders.Add("X-Forwarded-Proto", xForwarded);
-        var links = await client.GetFromJsonAsync<Links>($"{requestUriString}/actuator", SerializerOptions);
+        var links = await client.GetFromJsonAsync<Links>($"{requestUriString}/actuator", SerializerOptions, TestContext.Current.CancellationToken);
 
         links.Should().NotBeNull();
         links.Entries.Should().ContainKey("self").WhoseValue.Href.Should().Be($"{calculatedHost}/actuator");
@@ -43,11 +43,11 @@ public sealed class EndpointMiddlewareTest : BaseTest
         builder.UseStartup<Startup>();
 
         using IWebHost host = builder.Build();
-        await host.StartAsync();
+        await host.StartAsync(TestContext.Current.CancellationToken);
 
         using HttpClient client = host.GetTestClient();
-        HttpResponseMessage response = await client.GetAsync(new Uri("http://localhost/actuator"));
-        string json = await response.Content.ReadAsStringAsync();
+        HttpResponseMessage response = await client.GetAsync(new Uri("http://localhost/actuator"), TestContext.Current.CancellationToken);
+        string json = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
         json.Should().BeJson("""
             {
@@ -79,11 +79,11 @@ public sealed class EndpointMiddlewareTest : BaseTest
         builder.ConfigureAppConfiguration((_, configuration) => configuration.AddInMemoryCollection(appSettings));
 
         using IWebHost host = builder.Build();
-        await host.StartAsync();
+        await host.StartAsync(TestContext.Current.CancellationToken);
 
         using HttpClient client = host.GetTestClient();
-        HttpResponseMessage response = await client.GetAsync(new Uri("http://localhost/"));
-        string json = await response.Content.ReadAsStringAsync();
+        HttpResponseMessage response = await client.GetAsync(new Uri("http://localhost/"), TestContext.Current.CancellationToken);
+        string json = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
         json.Should().BeJson("""
             {

--- a/src/Management/test/Endpoint.Test/Actuators/Hypermedia/HypermediaEndpointTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/Hypermedia/HypermediaEndpointTest.cs
@@ -34,7 +34,7 @@ public sealed class HypermediaEndpointTest(ITestOutputHelper testOutputHelper) :
 
         var handler = testContext.GetRequiredService<IHypermediaEndpointHandler>();
 
-        Links links = await handler.InvokeAsync("http://localhost:5000/foobar", CancellationToken.None);
+        Links links = await handler.InvokeAsync("http://localhost:5000/foobar", TestContext.Current.CancellationToken);
         links.Entries.Should().Contain(entry => entry.Key == "self" && entry.Value.Href == "http://localhost:5000/foobar");
         links.Entries.Should().Contain(entry => entry.Key == "info" && entry.Value.Href == "http://localhost:5000/foobar/info");
         links.Entries.Should().HaveCount(2);
@@ -52,7 +52,7 @@ public sealed class HypermediaEndpointTest(ITestOutputHelper testOutputHelper) :
 
         var handler = testContext.GetRequiredService<IHypermediaEndpointHandler>();
 
-        Links links = await handler.InvokeAsync("http://localhost:5000/foobar", CancellationToken.None);
+        Links links = await handler.InvokeAsync("http://localhost:5000/foobar", TestContext.Current.CancellationToken);
         links.Entries.Should().Contain(entry => entry.Key == "self" && entry.Value.Href == "http://localhost:5000/foobar");
         links.Entries.Should().ContainSingle();
     }
@@ -78,7 +78,7 @@ public sealed class HypermediaEndpointTest(ITestOutputHelper testOutputHelper) :
 
         var handler = testContext.GetRequiredService<IHypermediaEndpointHandler>();
 
-        Links links = await handler.InvokeAsync("http://localhost:5000/foobar", CancellationToken.None);
+        Links links = await handler.InvokeAsync("http://localhost:5000/foobar", TestContext.Current.CancellationToken);
         links.Entries.Should().Contain(entry => entry.Key == "self" && entry.Value.Href == "http://localhost:5000/foobar");
         links.Entries.Should().ContainSingle();
     }
@@ -105,7 +105,7 @@ public sealed class HypermediaEndpointTest(ITestOutputHelper testOutputHelper) :
 
         var handler = testContext.GetRequiredService<IHypermediaEndpointHandler>();
 
-        Links links = await handler.InvokeAsync("http://localhost:5000/foobar", CancellationToken.None);
+        Links links = await handler.InvokeAsync("http://localhost:5000/foobar", TestContext.Current.CancellationToken);
         links.Entries.Should().BeEmpty();
     }
 }

--- a/src/Management/test/Endpoint.Test/Actuators/Hypermedia/HypermediaEndpointTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/Hypermedia/HypermediaEndpointTest.cs
@@ -16,7 +16,7 @@ public sealed class HypermediaEndpointTest(ITestOutputHelper testOutputHelper) :
     [Fact]
     public async Task Invoke_ReturnsExpectedLinks()
     {
-        using var testContext = new TestContext(_testOutputHelper);
+        using var testContext = new SteeltoeTestContext(_testOutputHelper);
 
         testContext.AdditionalServices = (services, _) =>
         {
@@ -43,7 +43,7 @@ public sealed class HypermediaEndpointTest(ITestOutputHelper testOutputHelper) :
     [Fact]
     public async Task Invoke_OnlyActuatorHypermediaEndpoint_ReturnsExpectedLinks()
     {
-        using var testContext = new TestContext(_testOutputHelper);
+        using var testContext = new SteeltoeTestContext(_testOutputHelper);
 
         testContext.AdditionalServices = (services, _) =>
         {
@@ -60,7 +60,7 @@ public sealed class HypermediaEndpointTest(ITestOutputHelper testOutputHelper) :
     [Fact]
     public async Task Invoke_HonorsEndpointEnabled_ReturnsExpectedLinks()
     {
-        using var testContext = new TestContext(_testOutputHelper);
+        using var testContext = new SteeltoeTestContext(_testOutputHelper);
 
         testContext.AdditionalServices = (services, _) =>
         {
@@ -86,7 +86,7 @@ public sealed class HypermediaEndpointTest(ITestOutputHelper testOutputHelper) :
     [Fact]
     public async Task Invoke_CloudFoundryDisable_ReturnsExpectedLinks()
     {
-        using var testContext = new TestContext(_testOutputHelper);
+        using var testContext = new SteeltoeTestContext(_testOutputHelper);
 
         testContext.AdditionalServices = (services, _) =>
         {

--- a/src/Management/test/Endpoint.Test/Actuators/Info/AppSettingsInfoContributorTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/Info/AppSettingsInfoContributorTest.cs
@@ -25,7 +25,7 @@ public sealed class AppSettingsInfoContributorTest : BaseTest
     {
         var contributor = new AppSettingsInfoContributor(null);
         var builder = new InfoBuilder();
-        contributor.ContributeAsync(builder, CancellationToken.None);
+        contributor.ContributeAsync(builder, TestContext.Current.CancellationToken);
         IDictionary<string, object> result = builder.Build();
         Assert.NotNull(result);
         Assert.Empty(result);
@@ -39,7 +39,7 @@ public sealed class AppSettingsInfoContributorTest : BaseTest
         IConfigurationRoot configurationRoot = configurationBuilder.Build();
         var settings = new AppSettingsInfoContributor(configurationRoot);
 
-        await Assert.ThrowsAsync<ArgumentNullException>(async () => await settings.ContributeAsync(null!, CancellationToken.None));
+        await Assert.ThrowsAsync<ArgumentNullException>(async () => await settings.ContributeAsync(null!, TestContext.Current.CancellationToken));
     }
 
     [Fact]
@@ -53,7 +53,7 @@ public sealed class AppSettingsInfoContributorTest : BaseTest
         var settings = new AppSettingsInfoContributor(configurationRoot);
 
         var builder = new InfoBuilder();
-        settings.ContributeAsync(builder, CancellationToken.None);
+        settings.ContributeAsync(builder, TestContext.Current.CancellationToken);
 
         IDictionary<string, object> info = builder.Build();
         Assert.NotNull(info);

--- a/src/Management/test/Endpoint.Test/Actuators/Info/Contributors/AppSettingsInfoContributorTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/Info/Contributors/AppSettingsInfoContributorTest.cs
@@ -15,7 +15,7 @@ public sealed class AppSettingsInfoContributorTest : BaseTest
     {
         var contributor = new AppSettingsInfoContributor(null);
         var builder = new InfoBuilder();
-        contributor.ContributeAsync(builder, CancellationToken.None);
+        contributor.ContributeAsync(builder, TestContext.Current.CancellationToken);
         IDictionary<string, object> result = builder.Build();
         Assert.NotNull(result);
         Assert.Empty(result);
@@ -39,7 +39,7 @@ public sealed class AppSettingsInfoContributorTest : BaseTest
         IConfigurationRoot configurationRoot = configurationBuilder.Build();
         var settings = new AppSettingsInfoContributor(configurationRoot);
 
-        await Assert.ThrowsAsync<ArgumentNullException>(async () => await settings.ContributeAsync(null!, CancellationToken.None));
+        await Assert.ThrowsAsync<ArgumentNullException>(async () => await settings.ContributeAsync(null!, TestContext.Current.CancellationToken));
     }
 
     [Fact]
@@ -63,7 +63,7 @@ public sealed class AppSettingsInfoContributorTest : BaseTest
         var settings = new AppSettingsInfoContributor(configurationRoot);
 
         var builder = new InfoBuilder();
-        settings.ContributeAsync(builder, CancellationToken.None);
+        settings.ContributeAsync(builder, TestContext.Current.CancellationToken);
 
         IDictionary<string, object> info = builder.Build();
         Assert.NotNull(info);

--- a/src/Management/test/Endpoint.Test/Actuators/Info/Contributors/BuildInfoContributorTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/Info/Contributors/BuildInfoContributorTest.cs
@@ -15,7 +15,7 @@ public sealed class BuildInfoContributorTest
         var contributor = new BuildInfoContributor();
         var builder = new InfoBuilder();
 
-        contributor.ContributeAsync(builder, CancellationToken.None);
+        contributor.ContributeAsync(builder, TestContext.Current.CancellationToken);
         IDictionary<string, object> results = builder.Build();
 
         Assert.True(results.ContainsKey("applicationVersionInfo"));

--- a/src/Management/test/Endpoint.Test/Actuators/Info/Contributors/GitInfoContributorTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/Info/Contributors/GitInfoContributorTest.cs
@@ -17,7 +17,7 @@ public sealed class GitInfoContributorTest : BaseTest
     {
         var contributor = new GitInfoContributor("foobar", NullLogger<GitInfoContributor>.Instance);
 
-        IConfiguration? configuration = await contributor.ReadGitPropertiesAsync(CancellationToken.None);
+        IConfiguration? configuration = await contributor.ReadGitPropertiesAsync(TestContext.Current.CancellationToken);
 
         Assert.Null(configuration);
     }
@@ -28,7 +28,7 @@ public sealed class GitInfoContributorTest : BaseTest
         string path = $"{Directory.GetCurrentDirectory()}{Path.DirectorySeparatorChar}empty.git.properties";
         var contributor = new GitInfoContributor(path, NullLogger<GitInfoContributor>.Instance);
 
-        IConfiguration? configuration = await contributor.ReadGitPropertiesAsync(CancellationToken.None);
+        IConfiguration? configuration = await contributor.ReadGitPropertiesAsync(TestContext.Current.CancellationToken);
 
         Assert.Null(configuration);
     }
@@ -39,7 +39,7 @@ public sealed class GitInfoContributorTest : BaseTest
         string path = $"{Directory.GetCurrentDirectory()}{Path.DirectorySeparatorChar}garbage.git.properties";
         var contributor = new GitInfoContributor(path, NullLogger<GitInfoContributor>.Instance);
 
-        IConfiguration? configuration = await contributor.ReadGitPropertiesAsync(CancellationToken.None);
+        IConfiguration? configuration = await contributor.ReadGitPropertiesAsync(TestContext.Current.CancellationToken);
 
         Assert.NotNull(configuration);
         Assert.Null(configuration["git"]);
@@ -51,7 +51,7 @@ public sealed class GitInfoContributorTest : BaseTest
         string path = $"{Directory.GetCurrentDirectory()}{Path.DirectorySeparatorChar}git.properties";
         var contributor = new GitInfoContributor(path, NullLogger<GitInfoContributor>.Instance);
 
-        IConfiguration? configuration = await contributor.ReadGitPropertiesAsync(CancellationToken.None);
+        IConfiguration? configuration = await contributor.ReadGitPropertiesAsync(TestContext.Current.CancellationToken);
 
         Assert.NotNull(configuration);
         Assert.Equal("true", configuration["git:dirty"]);
@@ -67,7 +67,7 @@ public sealed class GitInfoContributorTest : BaseTest
     {
         // Uses git.properties file in test project
         var contributor = new GitInfoContributor(NullLogger<GitInfoContributor>.Instance);
-        await Assert.ThrowsAsync<ArgumentNullException>(async () => await contributor.ContributeAsync(null!, CancellationToken.None));
+        await Assert.ThrowsAsync<ArgumentNullException>(async () => await contributor.ContributeAsync(null!, TestContext.Current.CancellationToken));
     }
 
     [Fact]
@@ -76,7 +76,7 @@ public sealed class GitInfoContributorTest : BaseTest
         // Uses git.properties file in test project
         var contributor = new GitInfoContributor(NullLogger<GitInfoContributor>.Instance);
         var builder = new InfoBuilder();
-        await contributor.ContributeAsync(builder, CancellationToken.None);
+        await contributor.ContributeAsync(builder, TestContext.Current.CancellationToken);
 
         IDictionary<string, object> result = builder.Build();
         Assert.NotNull(result);

--- a/src/Management/test/Endpoint.Test/Actuators/Info/EndpointMiddlewareTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/Info/EndpointMiddlewareTest.cs
@@ -41,12 +41,12 @@ public sealed class EndpointMiddlewareTest : BaseTest
         builder.ConfigureAppConfiguration((_, configuration) => configuration.AddInMemoryCollection(_appSettings));
 
         using IWebHost app = builder.Build();
-        await app.StartAsync();
+        await app.StartAsync(TestContext.Current.CancellationToken);
 
         using HttpClient client = app.GetTestClient();
 
         var dictionary = await client.GetFromJsonAsync<Dictionary<string, Dictionary<string, JsonElement>>>("http://localhost/management/info-management",
-            SerializerOptions);
+            SerializerOptions, TestContext.Current.CancellationToken);
 
         Assert.NotNull(dictionary);
 
@@ -93,10 +93,10 @@ public sealed class EndpointMiddlewareTest : BaseTest
         builder.ConfigureAppConfiguration((_, configuration) => configuration.AddInMemoryCollection(settings));
 
         using IWebHost app = builder.Build();
-        await app.StartAsync();
+        await app.StartAsync(TestContext.Current.CancellationToken);
 
         using HttpClient client = app.GetTestClient();
-        string response = await client.GetStringAsync(new Uri("http://localhost/actuator/info"));
+        string response = await client.GetStringAsync(new Uri("http://localhost/actuator/info"), TestContext.Current.CancellationToken);
 
         Assert.Contains("1499884839000", response, StringComparison.Ordinal);
         Assert.DoesNotContain("2017-07-12T18:40:39Z", response, StringComparison.Ordinal);

--- a/src/Management/test/Endpoint.Test/Actuators/Info/InfoEndpointTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/Info/InfoEndpointTest.cs
@@ -16,7 +16,7 @@ public sealed class InfoEndpointTest(ITestOutputHelper testOutputHelper) : BaseT
     [Fact]
     public async Task Invoke_NoContributors_ReturnsExpectedInfo()
     {
-        using var testContext = new TestContext(_testOutputHelper);
+        using var testContext = new SteeltoeTestContext(_testOutputHelper);
 
         testContext.AdditionalServices = (services, _) =>
         {
@@ -34,7 +34,7 @@ public sealed class InfoEndpointTest(ITestOutputHelper testOutputHelper) : BaseT
     [Fact]
     public async Task Invoke_CallsAllContributors()
     {
-        using var testContext = new TestContext(_testOutputHelper);
+        using var testContext = new SteeltoeTestContext(_testOutputHelper);
 
         List<IInfoContributor> contributors =
         [
@@ -63,7 +63,7 @@ public sealed class InfoEndpointTest(ITestOutputHelper testOutputHelper) : BaseT
     [Fact]
     public async Task Invoke_HandlesExceptions()
     {
-        using var testContext = new TestContext(_testOutputHelper);
+        using var testContext = new SteeltoeTestContext(_testOutputHelper);
 
         List<IInfoContributor> contributors =
         [

--- a/src/Management/test/Endpoint.Test/Actuators/Info/InfoEndpointTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/Info/InfoEndpointTest.cs
@@ -26,7 +26,7 @@ public sealed class InfoEndpointTest(ITestOutputHelper testOutputHelper) : BaseT
 
         var handler = testContext.GetRequiredService<IInfoEndpointHandler>();
 
-        IDictionary<string, object> info = await handler.InvokeAsync(null, CancellationToken.None);
+        IDictionary<string, object> info = await handler.InvokeAsync(null, TestContext.Current.CancellationToken);
         Assert.NotNull(info);
         Assert.Empty(info);
     }
@@ -51,7 +51,7 @@ public sealed class InfoEndpointTest(ITestOutputHelper testOutputHelper) : BaseT
 
         var handler = testContext.GetRequiredService<IInfoEndpointHandler>();
 
-        await handler.InvokeAsync(null, CancellationToken.None);
+        await handler.InvokeAsync(null, TestContext.Current.CancellationToken);
 
         foreach (IInfoContributor contributor in contributors)
         {
@@ -80,7 +80,7 @@ public sealed class InfoEndpointTest(ITestOutputHelper testOutputHelper) : BaseT
 
         var handler = testContext.GetRequiredService<IInfoEndpointHandler>();
 
-        await handler.InvokeAsync(null, CancellationToken.None);
+        await handler.InvokeAsync(null, TestContext.Current.CancellationToken);
 
         foreach (IInfoContributor contributor in contributors)
         {

--- a/src/Management/test/Endpoint.Test/Actuators/Loggers/EndpointMiddlewareTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/Loggers/EndpointMiddlewareTest.cs
@@ -37,10 +37,10 @@ public sealed class EndpointMiddlewareTest : BaseTest
         builder.Logging.AddConfiguration(builder.Configuration.GetSection("Logging"));
 
         await using WebApplication host = builder.Build();
-        await host.StartAsync();
+        await host.StartAsync(TestContext.Current.CancellationToken);
 
         using HttpClient client = host.GetTestClient();
-        var json = await client.GetFromJsonAsync<JsonElement>("http://localhost/actuator/loggers");
+        var json = await client.GetFromJsonAsync<JsonElement>("http://localhost/actuator/loggers", TestContext.Current.CancellationToken);
 
         json.TryGetProperty("levels", out JsonElement levels).Should().BeTrue();
         levels.ToString().Should().Be("""["OFF","FATAL","ERROR","WARN","INFO","DEBUG","TRACE"]""");
@@ -62,14 +62,14 @@ public sealed class EndpointMiddlewareTest : BaseTest
         builder.Logging.AddConfiguration(builder.Configuration.GetSection("Logging"));
 
         await using WebApplication host = builder.Build();
-        await host.StartAsync();
+        await host.StartAsync(TestContext.Current.CancellationToken);
 
         using HttpClient client = host.GetTestClient();
         HttpContent content = new StringContent("{\"configuredLevel\":\"BadData\"}", ContentType);
-        HttpResponseMessage response = await client.PostAsync(new Uri("http://localhost/actuator/loggers/Default"), content);
+        HttpResponseMessage response = await client.PostAsync(new Uri("http://localhost/actuator/loggers/Default"), content, TestContext.Current.CancellationToken);
 
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
-        string responseText = await response.Content.ReadAsStringAsync();
+        string responseText = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
         responseText.Should().BeEmpty();
     }
 
@@ -82,17 +82,17 @@ public sealed class EndpointMiddlewareTest : BaseTest
         builder.Logging.AddConfiguration(builder.Configuration.GetSection("Logging"));
 
         await using WebApplication host = builder.Build();
-        await host.StartAsync();
+        await host.StartAsync(TestContext.Current.CancellationToken);
 
         using HttpClient client = host.GetTestClient();
         HttpContent content = new StringContent("{\"configuredLevel\":\"ERROR\"}", ContentType);
-        HttpResponseMessage response = await client.PostAsync(new Uri("http://localhost/actuator/loggers/Default"), content);
+        HttpResponseMessage response = await client.PostAsync(new Uri("http://localhost/actuator/loggers/Default"), content, TestContext.Current.CancellationToken);
 
         response.StatusCode.Should().Be(HttpStatusCode.NoContent);
-        string responseText = await response.Content.ReadAsStringAsync();
+        string responseText = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
         responseText.Should().BeEmpty();
 
-        var json = await client.GetFromJsonAsync<JsonElement>("http://localhost/actuator/loggers");
+        var json = await client.GetFromJsonAsync<JsonElement>("http://localhost/actuator/loggers", TestContext.Current.CancellationToken);
 
         json.TryGetProperty("loggers", out JsonElement loggers).Should().BeTrue();
         AssertLoggerCategoryHasJson(loggers, "Default", """{"configuredLevel":"WARN","effectiveLevel":"ERROR"}""");
@@ -112,17 +112,17 @@ public sealed class EndpointMiddlewareTest : BaseTest
         builder.Logging.AddConfiguration(builder.Configuration.GetSection("Logging"));
 
         await using WebApplication host = builder.Build();
-        await host.StartAsync();
+        await host.StartAsync(TestContext.Current.CancellationToken);
 
         using HttpClient client = host.GetTestClient();
         HttpContent content = new StringContent("{\"configuredLevel\":\"ERROR\"}", ContentType);
-        HttpResponseMessage response = await client.PostAsync(new Uri("http://localhost/loggers/Default"), content);
+        HttpResponseMessage response = await client.PostAsync(new Uri("http://localhost/loggers/Default"), content, TestContext.Current.CancellationToken);
 
         response.StatusCode.Should().Be(HttpStatusCode.NoContent);
-        string responseText = await response.Content.ReadAsStringAsync();
+        string responseText = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
         responseText.Should().BeEmpty();
 
-        var json = await client.GetFromJsonAsync<JsonElement>("http://localhost/loggers");
+        var json = await client.GetFromJsonAsync<JsonElement>("http://localhost/loggers", TestContext.Current.CancellationToken);
 
         json.TryGetProperty("loggers", out JsonElement loggers).Should().BeTrue();
         AssertLoggerCategoryHasJson(loggers, "Default", """{"configuredLevel":"WARN","effectiveLevel":"ERROR"}""");
@@ -137,17 +137,17 @@ public sealed class EndpointMiddlewareTest : BaseTest
         builder.Logging.AddConfiguration(builder.Configuration.GetSection("Logging"));
 
         await using WebApplication host = builder.Build();
-        await host.StartAsync();
+        await host.StartAsync(TestContext.Current.CancellationToken);
 
         using HttpClient client = host.GetTestClient();
         HttpContent content = new StringContent("{\"configuredLevel\":\"TRACE\"}", ContentType);
-        HttpResponseMessage response = await client.PostAsync(new Uri("http://localhost/actuator/loggers/Steeltoe"), content);
+        HttpResponseMessage response = await client.PostAsync(new Uri("http://localhost/actuator/loggers/Steeltoe"), content, TestContext.Current.CancellationToken);
 
         response.StatusCode.Should().Be(HttpStatusCode.NoContent);
-        string responseText = await response.Content.ReadAsStringAsync();
+        string responseText = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
         responseText.Should().BeEmpty();
 
-        var json = await client.GetFromJsonAsync<JsonElement>("http://localhost/actuator/loggers");
+        var json = await client.GetFromJsonAsync<JsonElement>("http://localhost/actuator/loggers", TestContext.Current.CancellationToken);
 
         json.TryGetProperty("loggers", out JsonElement loggers).Should().BeTrue();
         AssertLoggerCategoryHasJson(loggers, "Steeltoe", """{"configuredLevel":"INFO","effectiveLevel":"TRACE"}""");
@@ -187,10 +187,10 @@ public sealed class EndpointMiddlewareTest : BaseTest
         builder.Logging.AddDebug();
 
         await using WebApplication host = builder.Build();
-        await host.StartAsync();
+        await host.StartAsync(TestContext.Current.CancellationToken);
 
         using HttpClient client = host.GetTestClient();
-        var json = await client.GetFromJsonAsync<JsonElement>("http://localhost/actuator/loggers");
+        var json = await client.GetFromJsonAsync<JsonElement>("http://localhost/actuator/loggers", TestContext.Current.CancellationToken);
 
         json.TryGetProperty("levels", out JsonElement levels).Should().BeTrue();
         levels.ToString().Should().Be("""["OFF","FATAL","ERROR","WARN","INFO","DEBUG","TRACE"]""");

--- a/src/Management/test/Endpoint.Test/Actuators/Loggers/EndpointMiddlewareTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/Loggers/EndpointMiddlewareTest.cs
@@ -66,7 +66,9 @@ public sealed class EndpointMiddlewareTest : BaseTest
 
         using HttpClient client = host.GetTestClient();
         HttpContent content = new StringContent("{\"configuredLevel\":\"BadData\"}", ContentType);
-        HttpResponseMessage response = await client.PostAsync(new Uri("http://localhost/actuator/loggers/Default"), content, TestContext.Current.CancellationToken);
+
+        HttpResponseMessage response =
+            await client.PostAsync(new Uri("http://localhost/actuator/loggers/Default"), content, TestContext.Current.CancellationToken);
 
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
         string responseText = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
@@ -86,7 +88,9 @@ public sealed class EndpointMiddlewareTest : BaseTest
 
         using HttpClient client = host.GetTestClient();
         HttpContent content = new StringContent("{\"configuredLevel\":\"ERROR\"}", ContentType);
-        HttpResponseMessage response = await client.PostAsync(new Uri("http://localhost/actuator/loggers/Default"), content, TestContext.Current.CancellationToken);
+
+        HttpResponseMessage response =
+            await client.PostAsync(new Uri("http://localhost/actuator/loggers/Default"), content, TestContext.Current.CancellationToken);
 
         response.StatusCode.Should().Be(HttpStatusCode.NoContent);
         string responseText = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
@@ -141,7 +145,9 @@ public sealed class EndpointMiddlewareTest : BaseTest
 
         using HttpClient client = host.GetTestClient();
         HttpContent content = new StringContent("{\"configuredLevel\":\"TRACE\"}", ContentType);
-        HttpResponseMessage response = await client.PostAsync(new Uri("http://localhost/actuator/loggers/Steeltoe"), content, TestContext.Current.CancellationToken);
+
+        HttpResponseMessage response =
+            await client.PostAsync(new Uri("http://localhost/actuator/loggers/Steeltoe"), content, TestContext.Current.CancellationToken);
 
         response.StatusCode.Should().Be(HttpStatusCode.NoContent);
         string responseText = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);

--- a/src/Management/test/Endpoint.Test/Actuators/Loggers/LoggersEndpointTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/Loggers/LoggersEndpointTest.cs
@@ -28,7 +28,7 @@ public sealed class LoggersEndpointTest(ITestOutputHelper testOutputHelper) : Ba
         var handler = testContext.GetRequiredService<ILoggersEndpointHandler>();
         var provider = (TestLoggerProvider)testContext.GetRequiredService<IDynamicLoggerProvider>();
 
-        _ = await handler.InvokeAsync(new LoggersRequest(), CancellationToken.None);
+        _ = await handler.InvokeAsync(new LoggersRequest(), TestContext.Current.CancellationToken);
 
         provider.HasCalledGetLogLevels.Should().BeTrue();
     }
@@ -41,7 +41,7 @@ public sealed class LoggersEndpointTest(ITestOutputHelper testOutputHelper) : Ba
 
         var handler = testContext.GetRequiredService<ILoggersEndpointHandler>();
 
-        LoggersResponse? response = await handler.InvokeAsync(new LoggersRequest(), CancellationToken.None);
+        LoggersResponse? response = await handler.InvokeAsync(new LoggersRequest(), TestContext.Current.CancellationToken);
 
         response.Should().NotBeNull();
         response.HasError.Should().BeFalse();
@@ -75,7 +75,7 @@ public sealed class LoggersEndpointTest(ITestOutputHelper testOutputHelper) : Ba
         var provider = (TestLoggerProvider)testContext.GetRequiredService<IDynamicLoggerProvider>();
 
         var changeRequest = new LoggersRequest("foobar", "WARN");
-        LoggersResponse? response = await handler.InvokeAsync(changeRequest, CancellationToken.None);
+        LoggersResponse? response = await handler.InvokeAsync(changeRequest, TestContext.Current.CancellationToken);
 
         response.Should().BeNull();
 
@@ -92,7 +92,7 @@ public sealed class LoggersEndpointTest(ITestOutputHelper testOutputHelper) : Ba
         var handler = testContext.GetRequiredService<ILoggersEndpointHandler>();
 
         var changeRequest = new LoggersRequest("foobar", "WARN");
-        LoggersResponse? response = await handler.InvokeAsync(changeRequest, CancellationToken.None);
+        LoggersResponse? response = await handler.InvokeAsync(changeRequest, TestContext.Current.CancellationToken);
 
         response.Should().BeNull();
     }

--- a/src/Management/test/Endpoint.Test/Actuators/Loggers/LoggersEndpointTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/Loggers/LoggersEndpointTest.cs
@@ -17,7 +17,7 @@ public sealed class LoggersEndpointTest(ITestOutputHelper testOutputHelper) : Ba
     [Fact]
     public async Task GetLoggerConfiguration_CallsProvider()
     {
-        using var testContext = new TestContext(_testOutputHelper);
+        using var testContext = new SteeltoeTestContext(_testOutputHelper);
 
         testContext.AdditionalServices = (services, _) =>
         {
@@ -36,7 +36,7 @@ public sealed class LoggersEndpointTest(ITestOutputHelper testOutputHelper) : Ba
     [Fact]
     public async Task GetLoggerConfiguration_ReturnsExpected()
     {
-        using var testContext = new TestContext(_testOutputHelper);
+        using var testContext = new SteeltoeTestContext(_testOutputHelper);
         testContext.AdditionalServices = (services, _) => services.AddLoggersActuator();
 
         var handler = testContext.GetRequiredService<ILoggersEndpointHandler>();
@@ -63,7 +63,7 @@ public sealed class LoggersEndpointTest(ITestOutputHelper testOutputHelper) : Ba
     [Fact]
     public async Task SetLogLevel_CallsProvider()
     {
-        using var testContext = new TestContext(_testOutputHelper);
+        using var testContext = new SteeltoeTestContext(_testOutputHelper);
 
         testContext.AdditionalServices = (services, _) =>
         {
@@ -86,7 +86,7 @@ public sealed class LoggersEndpointTest(ITestOutputHelper testOutputHelper) : Ba
     [Fact]
     public async Task SetLogLevel_ReturnsExpected()
     {
-        using var testContext = new TestContext(_testOutputHelper);
+        using var testContext = new SteeltoeTestContext(_testOutputHelper);
         testContext.AdditionalServices = (services, _) => services.AddLoggersActuator();
 
         var handler = testContext.GetRequiredService<ILoggersEndpointHandler>();

--- a/src/Management/test/Endpoint.Test/Actuators/Refresh/EndpointMiddlewareTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/Refresh/EndpointMiddlewareTest.cs
@@ -45,7 +45,7 @@ public sealed class EndpointMiddlewareTest : BaseTest
         await middleware.InvokeAsync(context, null);
         context.Response.Body.Seek(0, SeekOrigin.Begin);
         var reader = new StreamReader(context.Response.Body, Encoding.UTF8);
-        string? json = await reader.ReadLineAsync();
+        string? json = await reader.ReadLineAsync(TestContext.Current.CancellationToken);
 
         json.Should().BeJson("""
             [
@@ -79,13 +79,13 @@ public sealed class EndpointMiddlewareTest : BaseTest
         builder.ConfigureAppConfiguration((_, configuration) => configuration.AddInMemoryCollection(appSettings));
 
         using IWebHost host = builder.Build();
-        await host.StartAsync();
+        await host.StartAsync(TestContext.Current.CancellationToken);
 
         using HttpClient client = host.GetTestClient();
-        HttpResponseMessage response = await client.PostAsync(new Uri("http://localhost/actuator/refresh"), null);
+        HttpResponseMessage response = await client.PostAsync(new Uri("http://localhost/actuator/refresh"), null, TestContext.Current.CancellationToken);
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
-        string json = await response.Content.ReadAsStringAsync();
+        string json = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
         json.Should().BeJson("""
             [

--- a/src/Management/test/Endpoint.Test/Actuators/Refresh/HttpVerbInConventionalRoutingTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/Refresh/HttpVerbInConventionalRoutingTest.cs
@@ -29,15 +29,15 @@ public sealed class HttpVerbInConventionalRoutingTest
 
         await using WebApplication app = builder.Build();
         app.UseMvcWithDefaultRoute();
-        await app.StartAsync();
+        await app.StartAsync(TestContext.Current.CancellationToken);
 
         using HttpClient httpClient = app.GetTestClient();
         var requestUri = new Uri("/actuator/refresh", UriKind.Relative);
 
-        HttpResponseMessage getResponse = await httpClient.GetAsync(requestUri);
+        HttpResponseMessage getResponse = await httpClient.GetAsync(requestUri, TestContext.Current.CancellationToken);
         getResponse.StatusCode.Should().Be(HttpStatusCode.MethodNotAllowed);
 
-        HttpResponseMessage postResponse = await httpClient.PostAsync(requestUri, null);
+        HttpResponseMessage postResponse = await httpClient.PostAsync(requestUri, null, TestContext.Current.CancellationToken);
         postResponse.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
@@ -56,15 +56,15 @@ public sealed class HttpVerbInConventionalRoutingTest
 
         await using WebApplication app = builder.Build();
         app.UseMvcWithDefaultRoute();
-        await app.StartAsync();
+        await app.StartAsync(TestContext.Current.CancellationToken);
 
         using HttpClient httpClient = app.GetTestClient();
         var requestUri = new Uri("/actuator/refresh", UriKind.Relative);
 
-        HttpResponseMessage getResponse = await httpClient.GetAsync(requestUri);
+        HttpResponseMessage getResponse = await httpClient.GetAsync(requestUri, TestContext.Current.CancellationToken);
         getResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
 
-        HttpResponseMessage postResponse = await httpClient.PostAsync(requestUri, null);
+        HttpResponseMessage postResponse = await httpClient.PostAsync(requestUri, null, TestContext.Current.CancellationToken);
         postResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
     }
 
@@ -84,15 +84,15 @@ public sealed class HttpVerbInConventionalRoutingTest
 
         await using WebApplication app = builder.Build();
         app.UseMvcWithDefaultRoute();
-        await app.StartAsync();
+        await app.StartAsync(TestContext.Current.CancellationToken);
 
         using HttpClient httpClient = app.GetTestClient();
         var requestUri = new Uri("/actuator/refresh", UriKind.Relative);
 
-        HttpResponseMessage getResponse = await httpClient.GetAsync(requestUri);
+        HttpResponseMessage getResponse = await httpClient.GetAsync(requestUri, TestContext.Current.CancellationToken);
         getResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
 
-        HttpResponseMessage postResponse = await httpClient.PostAsync(requestUri, null);
+        HttpResponseMessage postResponse = await httpClient.PostAsync(requestUri, null, TestContext.Current.CancellationToken);
         postResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
     }
 
@@ -112,15 +112,15 @@ public sealed class HttpVerbInConventionalRoutingTest
 
         await using WebApplication app = builder.Build();
         app.UseMvcWithDefaultRoute();
-        await app.StartAsync();
+        await app.StartAsync(TestContext.Current.CancellationToken);
 
         using HttpClient httpClient = app.GetTestClient();
         var requestUri = new Uri("/actuator/refresh", UriKind.Relative);
 
-        HttpResponseMessage getResponse = await httpClient.GetAsync(requestUri);
+        HttpResponseMessage getResponse = await httpClient.GetAsync(requestUri, TestContext.Current.CancellationToken);
         getResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
 
-        HttpResponseMessage postResponse = await httpClient.PostAsync(requestUri, null);
+        HttpResponseMessage postResponse = await httpClient.PostAsync(requestUri, null, TestContext.Current.CancellationToken);
         postResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
     }
 
@@ -140,15 +140,15 @@ public sealed class HttpVerbInConventionalRoutingTest
 
         await using WebApplication app = builder.Build();
         app.UseMvcWithDefaultRoute();
-        await app.StartAsync();
+        await app.StartAsync(TestContext.Current.CancellationToken);
 
         using HttpClient httpClient = app.GetTestClient();
         var requestUri = new Uri("/actuator/refresh", UriKind.Relative);
 
-        HttpResponseMessage getResponse = await httpClient.GetAsync(requestUri);
+        HttpResponseMessage getResponse = await httpClient.GetAsync(requestUri, TestContext.Current.CancellationToken);
         getResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        HttpResponseMessage postResponse = await httpClient.PostAsync(requestUri, null);
+        HttpResponseMessage postResponse = await httpClient.PostAsync(requestUri, null, TestContext.Current.CancellationToken);
         postResponse.StatusCode.Should().Be(HttpStatusCode.MethodNotAllowed);
     }
 
@@ -169,15 +169,15 @@ public sealed class HttpVerbInConventionalRoutingTest
 
         await using WebApplication app = builder.Build();
         app.UseMvcWithDefaultRoute();
-        await app.StartAsync();
+        await app.StartAsync(TestContext.Current.CancellationToken);
 
         using HttpClient httpClient = app.GetTestClient();
         var requestUri = new Uri("/actuator/refresh", UriKind.Relative);
 
-        HttpResponseMessage getResponse = await httpClient.GetAsync(requestUri);
+        HttpResponseMessage getResponse = await httpClient.GetAsync(requestUri, TestContext.Current.CancellationToken);
         getResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        HttpResponseMessage postResponse = await httpClient.PostAsync(requestUri, null);
+        HttpResponseMessage postResponse = await httpClient.PostAsync(requestUri, null, TestContext.Current.CancellationToken);
         postResponse.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
@@ -208,15 +208,15 @@ public sealed class HttpVerbInConventionalRoutingTest
 
         await using WebApplication app = builder.Build();
         app.UseMvcWithDefaultRoute();
-        await app.StartAsync();
+        await app.StartAsync(TestContext.Current.CancellationToken);
 
         using HttpClient httpClient = app.GetTestClient();
         var requestUri = new Uri("/actuator/refresh", UriKind.Relative);
 
-        HttpResponseMessage getResponse = await httpClient.GetAsync(requestUri);
+        HttpResponseMessage getResponse = await httpClient.GetAsync(requestUri, TestContext.Current.CancellationToken);
         getResponse.StatusCode.Should().Be(HttpStatusCode.MethodNotAllowed);
 
-        HttpResponseMessage postResponse = await httpClient.PostAsync(requestUri, null);
+        HttpResponseMessage postResponse = await httpClient.PostAsync(requestUri, null, TestContext.Current.CancellationToken);
         postResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
         fileProvider.ReplaceFile(fileName, """
@@ -238,10 +238,10 @@ public sealed class HttpVerbInConventionalRoutingTest
 
         fileProvider.NotifyChanged();
 
-        getResponse = await httpClient.GetAsync(requestUri);
+        getResponse = await httpClient.GetAsync(requestUri, TestContext.Current.CancellationToken);
         getResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        postResponse = await httpClient.PostAsync(requestUri, null);
+        postResponse = await httpClient.PostAsync(requestUri, null, TestContext.Current.CancellationToken);
         postResponse.StatusCode.Should().Be(HttpStatusCode.MethodNotAllowed);
     }
 

--- a/src/Management/test/Endpoint.Test/Actuators/Refresh/HttpVerbInEndpointRoutingTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/Refresh/HttpVerbInEndpointRoutingTest.cs
@@ -29,15 +29,15 @@ public sealed class HttpVerbInEndpointRoutingTest
 
         await using WebApplication app = builder.Build();
         app.MapDefaultControllerRoute();
-        await app.StartAsync();
+        await app.StartAsync(TestContext.Current.CancellationToken);
 
         using HttpClient httpClient = app.GetTestClient();
         var requestUri = new Uri("/actuator/refresh", UriKind.Relative);
 
-        HttpResponseMessage getResponse = await httpClient.GetAsync(requestUri);
+        HttpResponseMessage getResponse = await httpClient.GetAsync(requestUri, TestContext.Current.CancellationToken);
         getResponse.StatusCode.Should().Be(HttpStatusCode.MethodNotAllowed);
 
-        HttpResponseMessage postResponse = await httpClient.PostAsync(requestUri, null);
+        HttpResponseMessage postResponse = await httpClient.PostAsync(requestUri, null, TestContext.Current.CancellationToken);
         postResponse.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
@@ -56,15 +56,15 @@ public sealed class HttpVerbInEndpointRoutingTest
 
         await using WebApplication app = builder.Build();
         app.MapDefaultControllerRoute();
-        await app.StartAsync();
+        await app.StartAsync(TestContext.Current.CancellationToken);
 
         using HttpClient httpClient = app.GetTestClient();
         var requestUri = new Uri("/actuator/refresh", UriKind.Relative);
 
-        HttpResponseMessage getResponse = await httpClient.GetAsync(requestUri);
+        HttpResponseMessage getResponse = await httpClient.GetAsync(requestUri, TestContext.Current.CancellationToken);
         getResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
 
-        HttpResponseMessage postResponse = await httpClient.PostAsync(requestUri, null);
+        HttpResponseMessage postResponse = await httpClient.PostAsync(requestUri, null, TestContext.Current.CancellationToken);
         postResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
     }
 
@@ -84,15 +84,15 @@ public sealed class HttpVerbInEndpointRoutingTest
 
         await using WebApplication app = builder.Build();
         app.MapDefaultControllerRoute();
-        await app.StartAsync();
+        await app.StartAsync(TestContext.Current.CancellationToken);
 
         using HttpClient httpClient = app.GetTestClient();
         var requestUri = new Uri("/actuator/refresh", UriKind.Relative);
 
-        HttpResponseMessage getResponse = await httpClient.GetAsync(requestUri);
+        HttpResponseMessage getResponse = await httpClient.GetAsync(requestUri, TestContext.Current.CancellationToken);
         getResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
 
-        HttpResponseMessage postResponse = await httpClient.PostAsync(requestUri, null);
+        HttpResponseMessage postResponse = await httpClient.PostAsync(requestUri, null, TestContext.Current.CancellationToken);
         postResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
     }
 
@@ -112,15 +112,15 @@ public sealed class HttpVerbInEndpointRoutingTest
 
         await using WebApplication app = builder.Build();
         app.MapDefaultControllerRoute();
-        await app.StartAsync();
+        await app.StartAsync(TestContext.Current.CancellationToken);
 
         using HttpClient httpClient = app.GetTestClient();
         var requestUri = new Uri("/actuator/refresh", UriKind.Relative);
 
-        HttpResponseMessage getResponse = await httpClient.GetAsync(requestUri);
+        HttpResponseMessage getResponse = await httpClient.GetAsync(requestUri, TestContext.Current.CancellationToken);
         getResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
 
-        HttpResponseMessage postResponse = await httpClient.PostAsync(requestUri, null);
+        HttpResponseMessage postResponse = await httpClient.PostAsync(requestUri, null, TestContext.Current.CancellationToken);
         postResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
     }
 
@@ -140,15 +140,15 @@ public sealed class HttpVerbInEndpointRoutingTest
 
         await using WebApplication app = builder.Build();
         app.MapDefaultControllerRoute();
-        await app.StartAsync();
+        await app.StartAsync(TestContext.Current.CancellationToken);
 
         using HttpClient httpClient = app.GetTestClient();
         var requestUri = new Uri("/actuator/refresh", UriKind.Relative);
 
-        HttpResponseMessage getResponse = await httpClient.GetAsync(requestUri);
+        HttpResponseMessage getResponse = await httpClient.GetAsync(requestUri, TestContext.Current.CancellationToken);
         getResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        HttpResponseMessage postResponse = await httpClient.PostAsync(requestUri, null);
+        HttpResponseMessage postResponse = await httpClient.PostAsync(requestUri, null, TestContext.Current.CancellationToken);
         postResponse.StatusCode.Should().Be(HttpStatusCode.MethodNotAllowed);
     }
 
@@ -169,15 +169,15 @@ public sealed class HttpVerbInEndpointRoutingTest
 
         await using WebApplication app = builder.Build();
         app.MapDefaultControllerRoute();
-        await app.StartAsync();
+        await app.StartAsync(TestContext.Current.CancellationToken);
 
         using HttpClient httpClient = app.GetTestClient();
         var requestUri = new Uri("/actuator/refresh", UriKind.Relative);
 
-        HttpResponseMessage getResponse = await httpClient.GetAsync(requestUri);
+        HttpResponseMessage getResponse = await httpClient.GetAsync(requestUri, TestContext.Current.CancellationToken);
         getResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        HttpResponseMessage postResponse = await httpClient.PostAsync(requestUri, null);
+        HttpResponseMessage postResponse = await httpClient.PostAsync(requestUri, null, TestContext.Current.CancellationToken);
         postResponse.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
@@ -208,15 +208,15 @@ public sealed class HttpVerbInEndpointRoutingTest
 
         await using WebApplication app = builder.Build();
         app.MapDefaultControllerRoute();
-        await app.StartAsync();
+        await app.StartAsync(TestContext.Current.CancellationToken);
 
         using HttpClient httpClient = app.GetTestClient();
         var requestUri = new Uri("/actuator/refresh", UriKind.Relative);
 
-        HttpResponseMessage getResponse = await httpClient.GetAsync(requestUri);
+        HttpResponseMessage getResponse = await httpClient.GetAsync(requestUri, TestContext.Current.CancellationToken);
         getResponse.StatusCode.Should().Be(HttpStatusCode.MethodNotAllowed);
 
-        HttpResponseMessage postResponse = await httpClient.PostAsync(requestUri, null);
+        HttpResponseMessage postResponse = await httpClient.PostAsync(requestUri, null, TestContext.Current.CancellationToken);
         postResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
         fileProvider.ReplaceFile(fileName, """
@@ -238,10 +238,10 @@ public sealed class HttpVerbInEndpointRoutingTest
 
         fileProvider.NotifyChanged();
 
-        getResponse = await httpClient.GetAsync(requestUri);
+        getResponse = await httpClient.GetAsync(requestUri, TestContext.Current.CancellationToken);
         getResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        postResponse = await httpClient.PostAsync(requestUri, null);
+        postResponse = await httpClient.PostAsync(requestUri, null, TestContext.Current.CancellationToken);
         postResponse.StatusCode.Should().Be(HttpStatusCode.MethodNotAllowed);
     }
 }

--- a/src/Management/test/Endpoint.Test/Actuators/Refresh/RefreshEndpointTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/Refresh/RefreshEndpointTest.cs
@@ -21,7 +21,7 @@ public sealed class RefreshEndpointTest(ITestOutputHelper testOutputHelper) : Ba
             ["management:endpoints:cloudfoundry:enabled"] = "true"
         };
 
-        using var testContext = new TestContext(_testOutputHelper);
+        using var testContext = new SteeltoeTestContext(_testOutputHelper);
 
         testContext.AdditionalServices = (services, _) =>
         {

--- a/src/Management/test/Endpoint.Test/Actuators/Refresh/RefreshEndpointTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/Refresh/RefreshEndpointTest.cs
@@ -34,7 +34,7 @@ public sealed class RefreshEndpointTest(ITestOutputHelper testOutputHelper) : Ba
         };
 
         var handler = testContext.GetRequiredService<IRefreshEndpointHandler>();
-        IList<string> result = await handler.InvokeAsync(null, CancellationToken.None);
+        IList<string> result = await handler.InvokeAsync(null, TestContext.Current.CancellationToken);
         Assert.NotNull(result);
 
         Assert.Contains("management:endpoints:loggers:enabled", result);

--- a/src/Management/test/Endpoint.Test/Actuators/RouteMappings/ActuatorRouteMappingsTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/RouteMappings/ActuatorRouteMappingsTest.cs
@@ -809,13 +809,13 @@ public sealed class ActuatorRouteMappingsTest
         builder.Configure(applicationBuilder => applicationBuilder.UseMvcWithDefaultRoute());
         using IWebHost host = builder.Build();
 
-        await host.StartAsync();
+        await host.StartAsync(TestContext.Current.CancellationToken);
         using HttpClient httpClient = host.GetTestClient();
 
-        HttpResponseMessage response = await httpClient.GetAsync(new Uri("http://localhost/actuator/mappings"));
+        HttpResponseMessage response = await httpClient.GetAsync(new Uri("http://localhost/actuator/mappings"), TestContext.Current.CancellationToken);
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        string responseText = await response.Content.ReadAsStringAsync();
+        string responseText = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
         responseText.Should().Be("""
             {
@@ -1031,10 +1031,10 @@ public sealed class ActuatorRouteMappingsTest
             });
         });
 
-        await host.StartAsync();
+        await host.StartAsync(TestContext.Current.CancellationToken);
         using HttpClient httpClient = host.GetTestClient();
 
-        var responseNode = await httpClient.GetFromJsonAsync<JsonNode>(new Uri("http://localhost/actuator/mappings"));
+        var responseNode = await httpClient.GetFromJsonAsync<JsonNode>(new Uri("http://localhost/actuator/mappings"), TestContext.Current.CancellationToken);
         responseNode.Should().NotBeNull();
 
         return removeMappingsActuatorInResponse ? RemoveMappingsActuatorInResponse(responseNode) : responseNode;

--- a/src/Management/test/Endpoint.Test/Actuators/RouteMappings/AppTypes/ApiControllerTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/RouteMappings/AppTypes/ApiControllerTest.cs
@@ -34,13 +34,13 @@ public sealed class ApiControllerTest
         await using WebApplication host = builder.Build();
 
         host.MapControllers();
-        await host.StartAsync();
+        await host.StartAsync(TestContext.Current.CancellationToken);
         using HttpClient httpClient = host.GetTestClient();
 
-        HttpResponseMessage response = await httpClient.GetAsync(new Uri("http://localhost/actuator/mappings"));
+        HttpResponseMessage response = await httpClient.GetAsync(new Uri("http://localhost/actuator/mappings"), TestContext.Current.CancellationToken);
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        string responseText = await response.Content.ReadAsStringAsync();
+        string responseText = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
         responseText.Should().Be("""
             {
@@ -104,13 +104,13 @@ public sealed class ApiControllerTest
         await using WebApplication host = builder.Build();
 
         host.MapControllers();
-        await host.StartAsync();
+        await host.StartAsync(TestContext.Current.CancellationToken);
         using HttpClient httpClient = host.GetTestClient();
 
-        HttpResponseMessage response = await httpClient.GetAsync(new Uri("http://localhost/actuator/mappings"));
+        HttpResponseMessage response = await httpClient.GetAsync(new Uri("http://localhost/actuator/mappings"), TestContext.Current.CancellationToken);
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        string responseText = await response.Content.ReadAsStringAsync();
+        string responseText = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
         responseText.Should().Be("""
             {
@@ -221,13 +221,13 @@ public sealed class ApiControllerTest
         await using WebApplication host = builder.Build();
 
         host.MapControllers();
-        await host.StartAsync();
+        await host.StartAsync(TestContext.Current.CancellationToken);
         using HttpClient httpClient = host.GetTestClient();
 
-        HttpResponseMessage response = await httpClient.GetAsync(new Uri("http://localhost/actuator/mappings"));
+        HttpResponseMessage response = await httpClient.GetAsync(new Uri("http://localhost/actuator/mappings"), TestContext.Current.CancellationToken);
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        string responseText = await response.Content.ReadAsStringAsync();
+        string responseText = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
         responseText.Should().Be("""
             {
@@ -411,13 +411,13 @@ public sealed class ApiControllerTest
         await using WebApplication host = builder.Build();
 
         host.MapControllers();
-        await host.StartAsync();
+        await host.StartAsync(TestContext.Current.CancellationToken);
         using HttpClient httpClient = host.GetTestClient();
 
-        HttpResponseMessage response = await httpClient.GetAsync(new Uri("http://localhost/actuator/mappings"));
+        HttpResponseMessage response = await httpClient.GetAsync(new Uri("http://localhost/actuator/mappings"), TestContext.Current.CancellationToken);
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        string responseText = await response.Content.ReadAsStringAsync();
+        string responseText = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
         responseText.Should().Be("""
             {
@@ -479,13 +479,13 @@ public sealed class ApiControllerTest
         builder.Configure(applicationBuilder => applicationBuilder.UseEndpoints(routes => routes.MapControllers()));
         using IWebHost host = builder.Build();
 
-        await host.StartAsync();
+        await host.StartAsync(TestContext.Current.CancellationToken);
         using HttpClient httpClient = host.GetTestClient();
 
-        HttpResponseMessage response = await httpClient.GetAsync(new Uri("http://localhost/actuator/mappings"));
+        HttpResponseMessage response = await httpClient.GetAsync(new Uri("http://localhost/actuator/mappings"), TestContext.Current.CancellationToken);
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        string responseText = await response.Content.ReadAsStringAsync();
+        string responseText = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
         responseText.Should().Be("""
             {
@@ -556,13 +556,13 @@ public sealed class ApiControllerTest
 
         using IHost host = builder.Build();
 
-        await host.StartAsync();
+        await host.StartAsync(TestContext.Current.CancellationToken);
         using HttpClient httpClient = host.GetTestClient();
 
-        HttpResponseMessage response = await httpClient.GetAsync(new Uri("http://localhost/actuator/mappings"));
+        HttpResponseMessage response = await httpClient.GetAsync(new Uri("http://localhost/actuator/mappings"), TestContext.Current.CancellationToken);
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        string responseText = await response.Content.ReadAsStringAsync();
+        string responseText = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
         responseText.Should().Be("""
             {

--- a/src/Management/test/Endpoint.Test/Actuators/RouteMappings/AppTypes/MinimalApiTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/RouteMappings/AppTypes/MinimalApiTest.cs
@@ -34,13 +34,13 @@ public sealed class MinimalApiTest
 
         host.MapGet("/api/ping", HandlePingRequest);
 
-        await host.StartAsync();
+        await host.StartAsync(TestContext.Current.CancellationToken);
         using HttpClient httpClient = host.GetTestClient();
 
-        HttpResponseMessage response = await httpClient.GetAsync(new Uri("http://localhost/actuator/mappings"));
+        HttpResponseMessage response = await httpClient.GetAsync(new Uri("http://localhost/actuator/mappings"), TestContext.Current.CancellationToken);
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        string responseText = await response.Content.ReadAsStringAsync();
+        string responseText = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
         responseText.Should().Be("""
             {
@@ -96,13 +96,13 @@ public sealed class MinimalApiTest
 
         host.MapGet("/api/ping", () => "pong");
 
-        await host.StartAsync();
+        await host.StartAsync(TestContext.Current.CancellationToken);
         using HttpClient httpClient = host.GetTestClient();
 
-        HttpResponseMessage response = await httpClient.GetAsync(new Uri("http://localhost/actuator/mappings"));
+        HttpResponseMessage response = await httpClient.GetAsync(new Uri("http://localhost/actuator/mappings"), TestContext.Current.CancellationToken);
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        string responseText = await response.Content.ReadAsStringAsync();
+        string responseText = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
         responseText.Should().Be("""
             {
@@ -174,13 +174,13 @@ public sealed class MinimalApiTest
             .Produces(404, null, "application/json");
         // @formatter:wrap_chained_method_calls restore
 
-        await host.StartAsync();
+        await host.StartAsync(TestContext.Current.CancellationToken);
         using HttpClient httpClient = host.GetTestClient();
 
-        HttpResponseMessage response = await httpClient.GetAsync(new Uri("http://localhost/actuator/mappings"));
+        HttpResponseMessage response = await httpClient.GetAsync(new Uri("http://localhost/actuator/mappings"), TestContext.Current.CancellationToken);
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        string responseText = await response.Content.ReadAsStringAsync();
+        string responseText = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
         responseText.Should().Be("""
             {
@@ -287,13 +287,13 @@ public sealed class MinimalApiTest
 
         host.MapMethods("/api/ping", httpMethods, HandlePingRequest);
 
-        await host.StartAsync();
+        await host.StartAsync(TestContext.Current.CancellationToken);
         using HttpClient httpClient = host.GetTestClient();
 
-        HttpResponseMessage response = await httpClient.GetAsync(new Uri("http://localhost/actuator/mappings"));
+        HttpResponseMessage response = await httpClient.GetAsync(new Uri("http://localhost/actuator/mappings"), TestContext.Current.CancellationToken);
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        string responseText = await response.Content.ReadAsStringAsync();
+        string responseText = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
         responseText.Should().Be("""
             {
@@ -377,13 +377,13 @@ public sealed class MinimalApiTest
 
         host.MapMethods("/api/ping", [], HandlePingRequest);
 
-        await host.StartAsync();
+        await host.StartAsync(TestContext.Current.CancellationToken);
         using HttpClient httpClient = host.GetTestClient();
 
-        HttpResponseMessage response = await httpClient.GetAsync(new Uri("http://localhost/actuator/mappings"));
+        HttpResponseMessage response = await httpClient.GetAsync(new Uri("http://localhost/actuator/mappings"), TestContext.Current.CancellationToken);
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        string responseText = await response.Content.ReadAsStringAsync();
+        string responseText = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
         responseText.Should().Be("""
             {
@@ -446,13 +446,13 @@ public sealed class MinimalApiTest
         host.MapGet("/api/ping", HandlePingRequest);
         host.MapPost("/api/ping", HandlePingRequest);
 
-        await host.StartAsync();
+        await host.StartAsync(TestContext.Current.CancellationToken);
         using HttpClient httpClient = host.GetTestClient();
 
-        HttpResponseMessage response = await httpClient.GetAsync(new Uri("http://localhost/actuator/mappings"));
+        HttpResponseMessage response = await httpClient.GetAsync(new Uri("http://localhost/actuator/mappings"), TestContext.Current.CancellationToken);
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        string responseText = await response.Content.ReadAsStringAsync();
+        string responseText = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
         responseText.Should().Be("""
             {
@@ -538,13 +538,13 @@ public sealed class MinimalApiTest
 
         host.MapGroup("/api/en-us").MapGet("ping", HandlePingRequest);
 
-        await host.StartAsync();
+        await host.StartAsync(TestContext.Current.CancellationToken);
         using HttpClient httpClient = host.GetTestClient();
 
-        HttpResponseMessage response = await httpClient.GetAsync(new Uri("http://localhost/actuator/mappings"));
+        HttpResponseMessage response = await httpClient.GetAsync(new Uri("http://localhost/actuator/mappings"), TestContext.Current.CancellationToken);
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        string responseText = await response.Content.ReadAsStringAsync();
+        string responseText = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
         responseText.Should().Be("""
             {
@@ -636,13 +636,13 @@ public sealed class MinimalApiTest
             _ = productId;
         });
 
-        await host.StartAsync();
+        await host.StartAsync(TestContext.Current.CancellationToken);
         using HttpClient httpClient = host.GetTestClient();
 
-        HttpResponseMessage response = await httpClient.GetAsync(new Uri("http://localhost/actuator/mappings"));
+        HttpResponseMessage response = await httpClient.GetAsync(new Uri("http://localhost/actuator/mappings"), TestContext.Current.CancellationToken);
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        string responseText = await response.Content.ReadAsStringAsync();
+        string responseText = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
         responseText.Should().Be("""
             {
@@ -732,13 +732,13 @@ public sealed class MinimalApiTest
         builder.Configure(applicationBuilder => applicationBuilder.UseEndpoints(routes => routes.MapGet("/api/ping", () => "pong")));
         using IWebHost host = builder.Build();
 
-        await host.StartAsync();
+        await host.StartAsync(TestContext.Current.CancellationToken);
         using HttpClient httpClient = host.GetTestClient();
 
-        HttpResponseMessage response = await httpClient.GetAsync(new Uri("http://localhost/actuator/mappings"));
+        HttpResponseMessage response = await httpClient.GetAsync(new Uri("http://localhost/actuator/mappings"), TestContext.Current.CancellationToken);
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        string responseText = await response.Content.ReadAsStringAsync();
+        string responseText = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
         responseText.Should().Be("""
             {
@@ -796,13 +796,13 @@ public sealed class MinimalApiTest
 
         using IHost host = builder.Build();
 
-        await host.StartAsync();
+        await host.StartAsync(TestContext.Current.CancellationToken);
         using HttpClient httpClient = host.GetTestClient();
 
-        HttpResponseMessage response = await httpClient.GetAsync(new Uri("http://localhost/actuator/mappings"));
+        HttpResponseMessage response = await httpClient.GetAsync(new Uri("http://localhost/actuator/mappings"), TestContext.Current.CancellationToken);
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        string responseText = await response.Content.ReadAsStringAsync();
+        string responseText = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
         responseText.Should().Be("""
             {

--- a/src/Management/test/Endpoint.Test/Actuators/RouteMappings/AppTypes/MvcControllerTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/RouteMappings/AppTypes/MvcControllerTest.cs
@@ -34,13 +34,13 @@ public sealed class MvcControllerTest
         await using WebApplication host = builder.Build();
 
         host.MapControllerRoute("default", "{controller=SimpleTest}/{action=Index}/{id?}");
-        await host.StartAsync();
+        await host.StartAsync(TestContext.Current.CancellationToken);
         using HttpClient httpClient = host.GetTestClient();
 
-        HttpResponseMessage response = await httpClient.GetAsync(new Uri("http://localhost/actuator/mappings"));
+        HttpResponseMessage response = await httpClient.GetAsync(new Uri("http://localhost/actuator/mappings"), TestContext.Current.CancellationToken);
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        string responseText = await response.Content.ReadAsStringAsync();
+        string responseText = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
         responseText.Should().Be("""
             {
@@ -149,13 +149,13 @@ public sealed class MvcControllerTest
         await using WebApplication host = builder.Build();
 
         host.MapDefaultControllerRoute();
-        await host.StartAsync();
+        await host.StartAsync(TestContext.Current.CancellationToken);
         using HttpClient httpClient = host.GetTestClient();
 
-        HttpResponseMessage response = await httpClient.GetAsync(new Uri("http://localhost/actuator/mappings"));
+        HttpResponseMessage response = await httpClient.GetAsync(new Uri("http://localhost/actuator/mappings"), TestContext.Current.CancellationToken);
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        string responseText = await response.Content.ReadAsStringAsync();
+        string responseText = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
         responseText.Should().Be("""
             {
@@ -313,13 +313,13 @@ public sealed class MvcControllerTest
         await using WebApplication host = builder.Build();
 
         host.MapDefaultControllerRoute();
-        await host.StartAsync();
+        await host.StartAsync(TestContext.Current.CancellationToken);
         using HttpClient httpClient = host.GetTestClient();
 
-        HttpResponseMessage response = await httpClient.GetAsync(new Uri("http://localhost/actuator/mappings"));
+        HttpResponseMessage response = await httpClient.GetAsync(new Uri("http://localhost/actuator/mappings"), TestContext.Current.CancellationToken);
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        string responseText = await response.Content.ReadAsStringAsync();
+        string responseText = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
         responseText.Should().Be("""
             {
@@ -445,13 +445,13 @@ public sealed class MvcControllerTest
         await using WebApplication host = builder.Build();
 
         host.MapDefaultControllerRoute();
-        await host.StartAsync();
+        await host.StartAsync(TestContext.Current.CancellationToken);
         using HttpClient httpClient = host.GetTestClient();
 
-        HttpResponseMessage response = await httpClient.GetAsync(new Uri("http://localhost/actuator/mappings"));
+        HttpResponseMessage response = await httpClient.GetAsync(new Uri("http://localhost/actuator/mappings"), TestContext.Current.CancellationToken);
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        string responseText = await response.Content.ReadAsStringAsync();
+        string responseText = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
         responseText.Should().Be("""
             {
@@ -530,13 +530,13 @@ public sealed class MvcControllerTest
 
         using IWebHost host = builder.Build();
 
-        await host.StartAsync();
+        await host.StartAsync(TestContext.Current.CancellationToken);
         using HttpClient httpClient = host.GetTestClient();
 
-        HttpResponseMessage response = await httpClient.GetAsync(new Uri("http://localhost/actuator/mappings"));
+        HttpResponseMessage response = await httpClient.GetAsync(new Uri("http://localhost/actuator/mappings"), TestContext.Current.CancellationToken);
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        string responseText = await response.Content.ReadAsStringAsync();
+        string responseText = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
         responseText.Should().Be("""
             {
@@ -650,13 +650,13 @@ public sealed class MvcControllerTest
 
         using IHost host = builder.Build();
 
-        await host.StartAsync();
+        await host.StartAsync(TestContext.Current.CancellationToken);
         using HttpClient httpClient = host.GetTestClient();
 
-        HttpResponseMessage response = await httpClient.GetAsync(new Uri("http://localhost/actuator/mappings"));
+        HttpResponseMessage response = await httpClient.GetAsync(new Uri("http://localhost/actuator/mappings"), TestContext.Current.CancellationToken);
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        string responseText = await response.Content.ReadAsStringAsync();
+        string responseText = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
         responseText.Should().Be("""
             {

--- a/src/Management/test/Endpoint.Test/Actuators/RouteMappings/AppTypes/RazorPagesExternalAppTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/RouteMappings/AppTypes/RazorPagesExternalAppTest.cs
@@ -16,11 +16,11 @@ public sealed class RazorPagesExternalAppTest(WebApplicationFactory<IndexModel> 
     public async Task Can_get_routes_for_razor_pages()
     {
         using HttpClient client = _factory.CreateClient();
-        using HttpResponseMessage response = await client.GetAsync(new Uri("http://localhost/actuator/mappings"));
+        using HttpResponseMessage response = await client.GetAsync(new Uri("http://localhost/actuator/mappings"), TestContext.Current.CancellationToken);
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        string responseText = await response.Content.ReadAsStringAsync();
+        string responseText = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
         responseText.Should().Be("""
             {

--- a/src/Management/test/Endpoint.Test/Actuators/Services/EndpointMiddlewareTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/Services/EndpointMiddlewareTest.cs
@@ -52,7 +52,7 @@ public sealed class EndpointMiddlewareTest(ITestOutputHelper testOutputHelper) :
 
         httpContext.Response.Body.Seek(0, SeekOrigin.Begin);
         using var reader = new StreamReader(httpContext.Response.Body, Encoding.UTF8);
-        string json = await reader.ReadToEndAsync();
+        string json = await reader.ReadToEndAsync(TestContext.Current.CancellationToken);
 
         json.Should().BeJson($$"""
             {
@@ -97,13 +97,13 @@ public sealed class EndpointMiddlewareTest(ITestOutputHelper testOutputHelper) :
         builder.ConfigureAppConfiguration((_, configuration) => configuration.AddInMemoryCollection(AppSettings));
 
         using IWebHost host = builder.Build();
-        await host.StartAsync();
+        await host.StartAsync(TestContext.Current.CancellationToken);
 
         using HttpClient client = host.GetTestClient();
-        HttpResponseMessage result = await client.GetAsync(new Uri("http://localhost/actuator/beans"));
+        HttpResponseMessage result = await client.GetAsync(new Uri("http://localhost/actuator/beans"), TestContext.Current.CancellationToken);
         result.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        string json = await result.Content.ReadAsStringAsync();
+        string json = await result.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
         using JsonDocument sourceJson = JsonDocument.Parse(json);
 
         string jsonFragment = sourceJson.RootElement.GetProperty("contexts").GetProperty("application").GetProperty("beans")
@@ -152,7 +152,7 @@ public sealed class EndpointMiddlewareTest(ITestOutputHelper testOutputHelper) :
         httpContext.Response.Body.Seek(0, SeekOrigin.Begin);
         using var reader = new StreamReader(httpContext.Response.Body, Encoding.UTF8);
 
-        string response = await reader.ReadToEndAsync();
+        string response = await reader.ReadToEndAsync(TestContext.Current.CancellationToken);
         response.Should().StartWith("""{"contexts":{"application":{"beans":{""");
     }
 

--- a/src/Management/test/Endpoint.Test/Actuators/Services/EndpointMiddlewareTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/Services/EndpointMiddlewareTest.cs
@@ -138,7 +138,7 @@ public sealed class EndpointMiddlewareTest(ITestOutputHelper testOutputHelper) :
     [Fact]
     public async Task DoInvoke_ReturnsExpected()
     {
-        using var testContext = new TestContext(_testOutputHelper);
+        using var testContext = new SteeltoeTestContext(_testOutputHelper);
         testContext.AdditionalServices = (services, _) => services.AddServicesActuator();
         testContext.AdditionalConfiguration = configuration => configuration.AddInMemoryCollection(AppSettings);
 

--- a/src/Management/test/Endpoint.Test/Actuators/Services/ServicesEndpointTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/Services/ServicesEndpointTest.cs
@@ -183,7 +183,7 @@ public sealed class ServicesEndpointTest(ITestOutputHelper testOutputHelper) : B
 
     private async Task<ServiceRegistration> GetRegistrationForAsync(string? registrationName, Action<IServiceCollection>? registerService = null)
     {
-        using var testContext = new TestContext(_testOutputHelper);
+        using var testContext = new SteeltoeTestContext(_testOutputHelper);
 
         testContext.AdditionalServices = (services, _) =>
         {

--- a/src/Management/test/Endpoint.Test/Actuators/Services/ServicesEndpointTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/Services/ServicesEndpointTest.cs
@@ -192,7 +192,7 @@ public sealed class ServicesEndpointTest(ITestOutputHelper testOutputHelper) : B
         };
 
         var handler = testContext.GetRequiredService<IServicesEndpointHandler>();
-        IList<ServiceRegistration> registrations = await handler.InvokeAsync(null, CancellationToken.None);
+        IList<ServiceRegistration> registrations = await handler.InvokeAsync(null, TestContext.Current.CancellationToken);
 
         ServiceRegistration? registration = registrations.SingleOrDefault(registration => registration.Name == registrationName);
         registration.Should().NotBeNull();

--- a/src/Management/test/Endpoint.Test/Actuators/ThreadDump/EndpointMiddlewareTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/ThreadDump/EndpointMiddlewareTest.cs
@@ -35,7 +35,7 @@ public sealed class EndpointMiddlewareTest : BaseTest
         await middleware.InvokeAsync(context, null);
         context.Response.Body.Seek(0, SeekOrigin.Begin);
         var reader = new StreamReader(context.Response.Body);
-        string json = await reader.ReadToEndAsync();
+        string json = await reader.ReadToEndAsync(TestContext.Current.CancellationToken);
         Assert.NotNull(json);
         Assert.NotEqual("[]", json);
         Assert.StartsWith("[", json, StringComparison.Ordinal);
@@ -50,13 +50,13 @@ public sealed class EndpointMiddlewareTest : BaseTest
         builder.ConfigureAppConfiguration((_, configuration) => configuration.AddInMemoryCollection(AppSettings));
 
         using IWebHost host = builder.Build();
-        await host.StartAsync();
+        await host.StartAsync(TestContext.Current.CancellationToken);
 
         using HttpClient client = host.GetTestClient();
-        HttpResponseMessage response = await client.GetAsync(new Uri("http://localhost/actuator/threaddump"));
+        HttpResponseMessage response = await client.GetAsync(new Uri("http://localhost/actuator/threaddump"), TestContext.Current.CancellationToken);
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
-        string json = await response.Content.ReadAsStringAsync();
+        string json = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
         Assert.NotNull(json);
         Assert.NotEqual("{}", json);
         Assert.StartsWith("{", json, StringComparison.Ordinal);

--- a/src/Management/test/Endpoint.Test/Actuators/ThreadDump/ThreadDumpEndpointTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/ThreadDump/ThreadDumpEndpointTest.cs
@@ -24,7 +24,7 @@ public sealed class ThreadDumpEndpointTest(ITestOutputHelper testOutputHelper) :
         };
 
         var handler = testContext.GetRequiredService<IThreadDumpEndpointHandler>();
-        IList<ThreadInfo> result = await handler.InvokeAsync(null, CancellationToken.None);
+        IList<ThreadInfo> result = await handler.InvokeAsync(null, TestContext.Current.CancellationToken);
 
         result.Should().NotBeEmpty();
     }

--- a/src/Management/test/Endpoint.Test/Actuators/ThreadDump/ThreadDumpEndpointTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/ThreadDump/ThreadDumpEndpointTest.cs
@@ -15,7 +15,7 @@ public sealed class ThreadDumpEndpointTest(ITestOutputHelper testOutputHelper) :
     [Fact]
     public async Task Invoke_CallsDumpThreads()
     {
-        using var testContext = new TestContext(_testOutputHelper);
+        using var testContext = new SteeltoeTestContext(_testOutputHelper);
 
         testContext.AdditionalServices = (services, _) =>
         {

--- a/src/Management/test/Endpoint.Test/ActuatorsHostBuilderTest.cs
+++ b/src/Management/test/Endpoint.Test/ActuatorsHostBuilderTest.cs
@@ -4,6 +4,7 @@
 
 using System.Net;
 using System.Net.Http.Headers;
+using FluentAssertions.Extensions;
 using Microsoft.AspNetCore.Cors.Infrastructure;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
@@ -82,16 +83,16 @@ public sealed class ActuatorsHostBuilderTest
 
         host.Services.GetRequiredService<HttpClientHandlerFactory>().Using(handler);
 
-        await host.StartAsync();
+        await host.StartAsync(TestContext.Current.CancellationToken);
         using HttpClient httpClient = host.GetTestClient();
 
         var request = new HttpRequestMessage(HttpMethod.Get, new Uri("http://localhost/cloudfoundryapplication"));
         request.Headers.Authorization = AuthenticationHeaderValue.Parse($"bearer {token}");
 
-        HttpResponseMessage response = await httpClient.SendAsync(request);
+        HttpResponseMessage response = await httpClient.SendAsync(request, TestContext.Current.CancellationToken);
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        string responseText = await response.Content.ReadAsStringAsync();
+        string responseText = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
         responseText.Should().Contain("\"http://localhost/cloudfoundryapplication\"");
 
         handler.Mock.VerifyNoOutstandingExpectation();
@@ -109,10 +110,10 @@ public sealed class ActuatorsHostBuilderTest
             builder.ConfigureServices(services => services.AddDbMigrationsActuator());
         });
 
-        await host.StartAsync();
+        await host.StartAsync(TestContext.Current.CancellationToken);
         using HttpClient httpClient = host.GetTestClient();
 
-        HttpResponseMessage response = await httpClient.GetAsync(new Uri("http://localhost/actuator/dbmigrations"));
+        HttpResponseMessage response = await httpClient.GetAsync(new Uri("http://localhost/actuator/dbmigrations"), TestContext.Current.CancellationToken);
         response.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
@@ -128,10 +129,10 @@ public sealed class ActuatorsHostBuilderTest
             builder.ConfigureServices(services => services.AddEnvironmentActuator());
         });
 
-        await host.StartAsync();
+        await host.StartAsync(TestContext.Current.CancellationToken);
         using HttpClient httpClient = host.GetTestClient();
 
-        HttpResponseMessage response = await httpClient.GetAsync(new Uri("http://localhost/actuator/env"));
+        HttpResponseMessage response = await httpClient.GetAsync(new Uri("http://localhost/actuator/env"), TestContext.Current.CancellationToken);
         response.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
@@ -147,13 +148,13 @@ public sealed class ActuatorsHostBuilderTest
             builder.ConfigureServices(services => services.AddHealthActuator());
         });
 
-        await host.StartAsync();
+        await host.StartAsync(TestContext.Current.CancellationToken);
         using HttpClient httpClient = host.GetTestClient();
 
-        HttpResponseMessage response = await httpClient.GetAsync(new Uri("http://localhost/actuator/health"));
+        HttpResponseMessage response = await httpClient.GetAsync(new Uri("http://localhost/actuator/health"), TestContext.Current.CancellationToken);
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        string responseText = await response.Content.ReadAsStringAsync();
+        string responseText = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
         responseText.Should().Be("""{"status":"UP"}""");
     }
 
@@ -175,13 +176,13 @@ public sealed class ActuatorsHostBuilderTest
             builder.ConfigureServices(services => services.AddHealthActuator());
         });
 
-        await host.StartAsync();
+        await host.StartAsync(TestContext.Current.CancellationToken);
         using HttpClient httpClient = host.GetTestClient();
 
-        HttpResponseMessage response = await httpClient.GetAsync(new Uri("http://localhost/actuator/health"));
+        HttpResponseMessage response = await httpClient.GetAsync(new Uri("http://localhost/actuator/health"), TestContext.Current.CancellationToken);
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        string responseText = await response.Content.ReadAsStringAsync();
+        string responseText = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
         responseText.Should().Be("""
             {"status":"UP","groups":["liveness","readiness"]}
@@ -207,13 +208,13 @@ public sealed class ActuatorsHostBuilderTest
             builder.ConfigureServices(services => services.AddHealthActuator());
         });
 
-        await host.StartAsync();
+        await host.StartAsync(TestContext.Current.CancellationToken);
         using HttpClient httpClient = host.GetTestClient();
 
-        HttpResponseMessage response = await httpClient.GetAsync(new Uri("http://localhost/actuator/health"));
+        HttpResponseMessage response = await httpClient.GetAsync(new Uri("http://localhost/actuator/health"), TestContext.Current.CancellationToken);
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        string responseText = await response.Content.ReadAsStringAsync();
+        string responseText = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
         responseText.Should().Be("""
             {"status":"UP","components":{"ping":{"status":"UP"},"diskSpace":{"status":"UP"},"readinessState":{"status":"UP"},"livenessState":{"status":"UP"}},"groups":["liveness","readiness"]}
@@ -238,13 +239,13 @@ public sealed class ActuatorsHostBuilderTest
             builder.ConfigureServices(services => services.AddHealthActuator());
         });
 
-        await host.StartAsync();
+        await host.StartAsync(TestContext.Current.CancellationToken);
         using HttpClient httpClient = host.GetTestClient();
 
-        HttpResponseMessage response = await httpClient.GetAsync(new Uri("http://localhost/actuator/health"));
+        HttpResponseMessage response = await httpClient.GetAsync(new Uri("http://localhost/actuator/health"), TestContext.Current.CancellationToken);
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        string responseText = await response.Content.ReadAsStringAsync();
+        string responseText = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
         responseText.Should().Be("""{"status":"UNKNOWN"}""");
     }
@@ -271,13 +272,13 @@ public sealed class ActuatorsHostBuilderTest
             });
         });
 
-        await host.StartAsync();
+        await host.StartAsync(TestContext.Current.CancellationToken);
         using HttpClient httpClient = host.GetTestClient();
 
-        HttpResponseMessage response = await httpClient.GetAsync(new Uri("http://localhost/actuator/health"));
+        HttpResponseMessage response = await httpClient.GetAsync(new Uri("http://localhost/actuator/health"), TestContext.Current.CancellationToken);
         response.StatusCode.Should().Be(HttpStatusCode.ServiceUnavailable);
 
-        string responseText = await response.Content.ReadAsStringAsync();
+        string responseText = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
         responseText.Should().Be("""
             {"status":"DOWN","components":{"alwaysDown":{"status":"DOWN"},"ping":{"status":"UP"},"diskSpace":{"status":"UP"}}}
@@ -303,23 +304,23 @@ public sealed class ActuatorsHostBuilderTest
             builder.ConfigureServices(services => services.AddHealthActuator());
         });
 
-        await host.StartAsync();
+        await host.StartAsync(TestContext.Current.CancellationToken);
         using HttpClient httpClient = host.GetTestClient();
 
-        HttpResponseMessage livenessResponse = await httpClient.GetAsync(new Uri("http://localhost/actuator/health/liveness"));
+        HttpResponseMessage livenessResponse = await httpClient.GetAsync(new Uri("http://localhost/actuator/health/liveness"), TestContext.Current.CancellationToken);
         livenessResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        string livenessResponseText = await livenessResponse.Content.ReadAsStringAsync();
+        string livenessResponseText = await livenessResponse.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
         livenessResponseText.Should().Be("""{"status":"UP","components":{"livenessState":{"status":"UP"}}}""");
 
-        HttpResponseMessage readinessResponse = await httpClient.GetAsync(new Uri("http://localhost/actuator/health/readiness"));
+        HttpResponseMessage readinessResponse = await httpClient.GetAsync(new Uri("http://localhost/actuator/health/readiness"), TestContext.Current.CancellationToken);
         readinessResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        string readinessResponseText = await readinessResponse.Content.ReadAsStringAsync();
+        string readinessResponseText = await readinessResponse.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
         readinessResponseText.Should().Be("""{"status":"UP","components":{"readinessState":{"status":"UP"}}}""");
 
         var availability = host.Services.GetRequiredService<ApplicationAvailability>();
-        await host.StopAsync();
+        await host.StopAsync(TestContext.Current.CancellationToken);
 
         availability.GetLivenessState().Should().Be(LivenessState.Correct);
         availability.GetReadinessState().Should().Be(ReadinessState.RefusingTraffic);
@@ -342,10 +343,10 @@ public sealed class ActuatorsHostBuilderTest
             });
         });
 
-        await host.StartAsync();
+        await host.StartAsync(TestContext.Current.CancellationToken);
         using HttpClient httpClient = host.GetTestClient();
 
-        HttpResponseMessage response = await httpClient.GetAsync(new Uri("http://localhost/actuator/heapdump"));
+        HttpResponseMessage response = await httpClient.GetAsync(new Uri("http://localhost/actuator/heapdump"), TestContext.Current.CancellationToken);
         response.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
@@ -361,17 +362,17 @@ public sealed class ActuatorsHostBuilderTest
             builder.ConfigureServices(services => services.AddHttpExchangesActuator());
         });
 
-        await host.StartAsync();
+        await host.StartAsync(TestContext.Current.CancellationToken);
         using HttpClient httpClient = host.GetTestClient();
 
-        _ = await httpClient.GetAsync(new Uri("http://localhost/does-not-exist"));
+        _ = await httpClient.GetAsync(new Uri("http://localhost/does-not-exist"), TestContext.Current.CancellationToken);
 
-        await Task.Delay(250);
+        await Task.Delay(250.Milliseconds(), TestContext.Current.CancellationToken);
 
-        HttpResponseMessage response = await httpClient.GetAsync(new Uri("http://localhost/actuator/httpexchanges"));
+        HttpResponseMessage response = await httpClient.GetAsync(new Uri("http://localhost/actuator/httpexchanges"), TestContext.Current.CancellationToken);
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        string responseText = await response.Content.ReadAsStringAsync();
+        string responseText = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
         responseText.Should().Contain("/does-not-exist");
     }
 
@@ -387,10 +388,10 @@ public sealed class ActuatorsHostBuilderTest
             builder.ConfigureServices(services => services.AddHypermediaActuator());
         });
 
-        await host.StartAsync();
+        await host.StartAsync(TestContext.Current.CancellationToken);
         using HttpClient httpClient = host.GetTestClient();
 
-        HttpResponseMessage response = await httpClient.GetAsync(new Uri("http://localhost/actuator"));
+        HttpResponseMessage response = await httpClient.GetAsync(new Uri("http://localhost/actuator"), TestContext.Current.CancellationToken);
         response.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
@@ -406,13 +407,13 @@ public sealed class ActuatorsHostBuilderTest
             builder.ConfigureServices(services => services.AddInfoActuator());
         });
 
-        await host.StartAsync();
+        await host.StartAsync(TestContext.Current.CancellationToken);
         using HttpClient httpClient = host.GetTestClient();
 
-        HttpResponseMessage response = await httpClient.GetAsync(new Uri("http://localhost/actuator/info"));
+        HttpResponseMessage response = await httpClient.GetAsync(new Uri("http://localhost/actuator/info"), TestContext.Current.CancellationToken);
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        string responseText = await response.Content.ReadAsStringAsync();
+        string responseText = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
         responseText.Should().Contain("\"buildmaster@springframework.org\"");
         responseText.Should().Contain("\"Steeltoe.Management.Endpoint\"");
     }
@@ -434,13 +435,13 @@ public sealed class ActuatorsHostBuilderTest
             });
         });
 
-        await host.StartAsync();
+        await host.StartAsync(TestContext.Current.CancellationToken);
         using HttpClient httpClient = host.GetTestClient();
 
-        HttpResponseMessage response = await httpClient.GetAsync(new Uri("http://localhost/actuator/info"));
+        HttpResponseMessage response = await httpClient.GetAsync(new Uri("http://localhost/actuator/info"), TestContext.Current.CancellationToken);
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        string responseText = await response.Content.ReadAsStringAsync();
+        string responseText = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
         responseText.Should().Contain("\"buildmaster@springframework.org\"");
         responseText.Should().Contain("\"Steeltoe.Management.Endpoint\"");
         responseText.Should().Contain("\"IsTest\"");
@@ -458,13 +459,13 @@ public sealed class ActuatorsHostBuilderTest
             builder.ConfigureServices(services => services.AddLoggersActuator());
         });
 
-        await host.StartAsync();
+        await host.StartAsync(TestContext.Current.CancellationToken);
         using HttpClient httpClient = host.GetTestClient();
 
-        HttpResponseMessage response = await httpClient.GetAsync(new Uri("http://localhost/actuator/loggers"));
+        HttpResponseMessage response = await httpClient.GetAsync(new Uri("http://localhost/actuator/loggers"), TestContext.Current.CancellationToken);
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        string responseText = await response.Content.ReadAsStringAsync();
+        string responseText = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
         responseText.Should().Contain("\"Microsoft.AspNetCore.");
     }
 
@@ -480,7 +481,7 @@ public sealed class ActuatorsHostBuilderTest
             builder.ConfigureServices(services => services.AddLoggersActuator());
         });
 
-        await host.StartAsync();
+        await host.StartAsync(TestContext.Current.CancellationToken);
         using HttpClient httpClient = host.GetTestClient();
 
         const string requestBody = """
@@ -490,13 +491,13 @@ public sealed class ActuatorsHostBuilderTest
             """;
 
         var requestContent = new StringContent(requestBody, MediaTypeHeaderValue.Parse("application/vnd.spring-boot.actuator.v3+json"));
-        HttpResponseMessage postResponse = await httpClient.PostAsync(new Uri("http://localhost/actuator/loggers/Microsoft"), requestContent);
+        HttpResponseMessage postResponse = await httpClient.PostAsync(new Uri("http://localhost/actuator/loggers/Microsoft"), requestContent, TestContext.Current.CancellationToken);
         postResponse.StatusCode.Should().Be(HttpStatusCode.NoContent);
 
-        HttpResponseMessage getResponse = await httpClient.GetAsync(new Uri("http://localhost/actuator/loggers"));
+        HttpResponseMessage getResponse = await httpClient.GetAsync(new Uri("http://localhost/actuator/loggers"), TestContext.Current.CancellationToken);
         getResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        string responseText = await getResponse.Content.ReadAsStringAsync();
+        string responseText = await getResponse.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
         responseText.Should().Contain("\"Microsoft.AspNetCore\":{\"effectiveLevel\":\"FATAL\"}");
     }
 
@@ -513,13 +514,13 @@ public sealed class ActuatorsHostBuilderTest
             builder.ConfigureServices(services => services.AddLoggersActuator());
         });
 
-        await host.StartAsync();
+        await host.StartAsync(TestContext.Current.CancellationToken);
         using HttpClient httpClient = host.GetTestClient();
 
-        HttpResponseMessage response = await httpClient.GetAsync(new Uri("http://localhost/actuator/loggers"));
+        HttpResponseMessage response = await httpClient.GetAsync(new Uri("http://localhost/actuator/loggers"), TestContext.Current.CancellationToken);
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        string responseText = await response.Content.ReadAsStringAsync();
+        string responseText = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
         responseText.Should().Contain("\"Microsoft.AspNetCore.");
     }
 
@@ -535,10 +536,10 @@ public sealed class ActuatorsHostBuilderTest
             builder.ConfigureServices(services => services.AddRefreshActuator());
         });
 
-        await host.StartAsync();
+        await host.StartAsync(TestContext.Current.CancellationToken);
         using HttpClient httpClient = host.GetTestClient();
 
-        HttpResponseMessage response = await httpClient.GetAsync(new Uri("http://localhost/actuator/refresh"));
+        HttpResponseMessage response = await httpClient.GetAsync(new Uri("http://localhost/actuator/refresh"), TestContext.Current.CancellationToken);
         response.StatusCode.Should().Be(HttpStatusCode.MethodNotAllowed);
     }
 
@@ -554,13 +555,13 @@ public sealed class ActuatorsHostBuilderTest
             builder.ConfigureServices(services => services.AddRefreshActuator());
         });
 
-        await host.StartAsync();
+        await host.StartAsync(TestContext.Current.CancellationToken);
         using HttpClient httpClient = host.GetTestClient();
 
-        HttpResponseMessage response = await httpClient.PostAsync(new Uri("http://localhost/actuator/refresh"), null);
+        HttpResponseMessage response = await httpClient.PostAsync(new Uri("http://localhost/actuator/refresh"), null, TestContext.Current.CancellationToken);
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        string responseText = await response.Content.ReadAsStringAsync();
+        string responseText = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
         responseText.Should().Contain("\"Management:Endpoints:Actuator:Exposure:Include\"");
     }
 
@@ -576,13 +577,13 @@ public sealed class ActuatorsHostBuilderTest
             builder.ConfigureServices(services => services.AddRouteMappingsActuator());
         });
 
-        await host.StartAsync();
+        await host.StartAsync(TestContext.Current.CancellationToken);
         using HttpClient httpClient = host.GetTestClient();
 
-        HttpResponseMessage response = await httpClient.GetAsync(new Uri("http://localhost/actuator/mappings"));
+        HttpResponseMessage response = await httpClient.GetAsync(new Uri("http://localhost/actuator/mappings"), TestContext.Current.CancellationToken);
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        string responseText = await response.Content.ReadAsStringAsync();
+        string responseText = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
         responseText.Should().Contain("\"dispatcherServlet\"");
     }
 
@@ -598,13 +599,13 @@ public sealed class ActuatorsHostBuilderTest
             builder.ConfigureServices(services => services.AddServicesActuator());
         });
 
-        await host.StartAsync();
+        await host.StartAsync(TestContext.Current.CancellationToken);
         using HttpClient httpClient = host.GetTestClient();
 
-        HttpResponseMessage response = await httpClient.GetAsync(new Uri("http://localhost/actuator/beans"));
+        HttpResponseMessage response = await httpClient.GetAsync(new Uri("http://localhost/actuator/beans"), TestContext.Current.CancellationToken);
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        string responseText = await response.Content.ReadAsStringAsync();
+        string responseText = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
         responseText.Should().Contain("\"Microsoft.Extensions.Configuration.IConfiguration\"");
     }
 
@@ -620,13 +621,13 @@ public sealed class ActuatorsHostBuilderTest
             builder.ConfigureServices(services => services.AddThreadDumpActuator());
         });
 
-        await host.StartAsync();
+        await host.StartAsync(TestContext.Current.CancellationToken);
         using HttpClient httpClient = host.GetTestClient();
 
-        HttpResponseMessage response = await httpClient.GetAsync(new Uri("http://localhost/actuator/threaddump"));
+        HttpResponseMessage response = await httpClient.GetAsync(new Uri("http://localhost/actuator/threaddump"), TestContext.Current.CancellationToken);
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        string responseText = await response.Content.ReadAsStringAsync();
+        string responseText = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
         responseText.Should().Contain("\"stackTrace\"");
     }
 

--- a/src/Management/test/Endpoint.Test/ActuatorsHostBuilderTest.cs
+++ b/src/Management/test/Endpoint.Test/ActuatorsHostBuilderTest.cs
@@ -307,13 +307,17 @@ public sealed class ActuatorsHostBuilderTest
         await host.StartAsync(TestContext.Current.CancellationToken);
         using HttpClient httpClient = host.GetTestClient();
 
-        HttpResponseMessage livenessResponse = await httpClient.GetAsync(new Uri("http://localhost/actuator/health/liveness"), TestContext.Current.CancellationToken);
+        HttpResponseMessage livenessResponse =
+            await httpClient.GetAsync(new Uri("http://localhost/actuator/health/liveness"), TestContext.Current.CancellationToken);
+
         livenessResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
         string livenessResponseText = await livenessResponse.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
         livenessResponseText.Should().Be("""{"status":"UP","components":{"livenessState":{"status":"UP"}}}""");
 
-        HttpResponseMessage readinessResponse = await httpClient.GetAsync(new Uri("http://localhost/actuator/health/readiness"), TestContext.Current.CancellationToken);
+        HttpResponseMessage readinessResponse =
+            await httpClient.GetAsync(new Uri("http://localhost/actuator/health/readiness"), TestContext.Current.CancellationToken);
+
         readinessResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
         string readinessResponseText = await readinessResponse.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
@@ -491,7 +495,10 @@ public sealed class ActuatorsHostBuilderTest
             """;
 
         var requestContent = new StringContent(requestBody, MediaTypeHeaderValue.Parse("application/vnd.spring-boot.actuator.v3+json"));
-        HttpResponseMessage postResponse = await httpClient.PostAsync(new Uri("http://localhost/actuator/loggers/Microsoft"), requestContent, TestContext.Current.CancellationToken);
+
+        HttpResponseMessage postResponse = await httpClient.PostAsync(new Uri("http://localhost/actuator/loggers/Microsoft"), requestContent,
+            TestContext.Current.CancellationToken);
+
         postResponse.StatusCode.Should().Be(HttpStatusCode.NoContent);
 
         HttpResponseMessage getResponse = await httpClient.GetAsync(new Uri("http://localhost/actuator/loggers"), TestContext.Current.CancellationToken);

--- a/src/Management/test/Endpoint.Test/ConfigureOptionsTest.cs
+++ b/src/Management/test/Endpoint.Test/ConfigureOptionsTest.cs
@@ -99,10 +99,10 @@ public sealed class ConfigureOptionsTest
         builder.Services.AddAllActuators();
 
         await using WebApplication app = builder.Build();
-        await app.StartAsync();
+        await app.StartAsync(TestContext.Current.CancellationToken);
 
         using HttpClient httpClient = app.GetTestClient();
-        HttpResponseMessage response1 = await httpClient.GetAsync(new Uri("/actuator/env", UriKind.Relative));
+        HttpResponseMessage response1 = await httpClient.GetAsync(new Uri("/actuator/env", UriKind.Relative), TestContext.Current.CancellationToken);
         response1.StatusCode.Should().Be(HttpStatusCode.OK);
 
         fileProvider.ReplaceFile(fileName, """
@@ -114,7 +114,7 @@ public sealed class ConfigureOptionsTest
 
         fileProvider.NotifyChanged();
 
-        HttpResponseMessage response2 = await httpClient.GetAsync(new Uri("/actuator/env", UriKind.Relative));
+        HttpResponseMessage response2 = await httpClient.GetAsync(new Uri("/actuator/env", UriKind.Relative), TestContext.Current.CancellationToken);
         response2.StatusCode.Should().Be(HttpStatusCode.NotFound);
     }
 
@@ -136,10 +136,10 @@ public sealed class ConfigureOptionsTest
         builder.Services.AddAllActuators();
 
         await using WebApplication app = builder.Build();
-        await app.StartAsync();
+        await app.StartAsync(TestContext.Current.CancellationToken);
 
         using HttpClient httpClient = app.GetTestClient();
-        HttpResponseMessage response1 = await httpClient.GetAsync(new Uri("/actuator/env", UriKind.Relative));
+        HttpResponseMessage response1 = await httpClient.GetAsync(new Uri("/actuator/env", UriKind.Relative), TestContext.Current.CancellationToken);
         response1.StatusCode.Should().Be(HttpStatusCode.NotFound);
 
         fileProvider.ReplaceFile(fileName, """
@@ -150,7 +150,7 @@ public sealed class ConfigureOptionsTest
 
         fileProvider.NotifyChanged();
 
-        HttpResponseMessage response2 = await httpClient.GetAsync(new Uri("/actuator/env", UriKind.Relative));
+        HttpResponseMessage response2 = await httpClient.GetAsync(new Uri("/actuator/env", UriKind.Relative), TestContext.Current.CancellationToken);
         response2.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
@@ -172,10 +172,10 @@ public sealed class ConfigureOptionsTest
         builder.Services.AddAllActuators();
 
         await using WebApplication app = builder.Build();
-        await app.StartAsync();
+        await app.StartAsync(TestContext.Current.CancellationToken);
 
         using HttpClient httpClient = app.GetTestClient();
-        HttpResponseMessage response1 = await httpClient.GetAsync(new Uri("/actuator/env", UriKind.Relative));
+        HttpResponseMessage response1 = await httpClient.GetAsync(new Uri("/actuator/env", UriKind.Relative), TestContext.Current.CancellationToken);
         response1.StatusCode.Should().Be(HttpStatusCode.OK);
 
         fileProvider.ReplaceFile(fileName, """
@@ -187,7 +187,7 @@ public sealed class ConfigureOptionsTest
 
         fileProvider.NotifyChanged();
 
-        HttpResponseMessage response2 = await httpClient.GetAsync(new Uri("/actuator/env", UriKind.Relative));
+        HttpResponseMessage response2 = await httpClient.GetAsync(new Uri("/actuator/env", UriKind.Relative), TestContext.Current.CancellationToken);
         response2.StatusCode.Should().Be(HttpStatusCode.NotFound);
     }
 
@@ -209,10 +209,10 @@ public sealed class ConfigureOptionsTest
         builder.Services.AddAllActuators();
 
         await using WebApplication app = builder.Build();
-        await app.StartAsync();
+        await app.StartAsync(TestContext.Current.CancellationToken);
 
         using HttpClient httpClient = app.GetTestClient();
-        HttpResponseMessage response1 = await httpClient.GetAsync(new Uri("/actuator/env", UriKind.Relative));
+        HttpResponseMessage response1 = await httpClient.GetAsync(new Uri("/actuator/env", UriKind.Relative), TestContext.Current.CancellationToken);
         response1.StatusCode.Should().Be(HttpStatusCode.NotFound);
 
         fileProvider.ReplaceFile(fileName, """
@@ -224,7 +224,7 @@ public sealed class ConfigureOptionsTest
 
         fileProvider.NotifyChanged();
 
-        HttpResponseMessage response2 = await httpClient.GetAsync(new Uri("/actuator/env", UriKind.Relative));
+        HttpResponseMessage response2 = await httpClient.GetAsync(new Uri("/actuator/env", UriKind.Relative), TestContext.Current.CancellationToken);
         response2.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 

--- a/src/Management/test/Endpoint.Test/ContentNegotiationTests.cs
+++ b/src/Management/test/Endpoint.Test/ContentNegotiationTests.cs
@@ -35,7 +35,9 @@ public sealed class ContentNegotiationTests
         using HttpClient client = host.GetTestClient();
         MediaTypeHeaderValue contentType = MediaTypeHeaderValue.Parse("APPLICATION/vnd.Spring-Boot.Actuator.v3+JSON");
         HttpContent requestContent = new StringContent("{}", contentType);
-        HttpResponseMessage response = await client.PostAsync(new Uri("http://localhost/actuator/loggers/Default"), requestContent, TestContext.Current.CancellationToken);
+
+        HttpResponseMessage response =
+            await client.PostAsync(new Uri("http://localhost/actuator/loggers/Default"), requestContent, TestContext.Current.CancellationToken);
 
         response.StatusCode.Should().Be(HttpStatusCode.NoContent);
     }
@@ -53,7 +55,9 @@ public sealed class ContentNegotiationTests
         using HttpClient client = host.GetTestClient();
         MediaTypeHeaderValue contentType = MediaTypeHeaderValue.Parse("application/vnd.spring-boot.actuator.v3+json; charset=utf-8");
         HttpContent requestContent = new StringContent("{}", contentType);
-        HttpResponseMessage response = await client.PostAsync(new Uri("http://localhost/actuator/loggers/Default"), requestContent, TestContext.Current.CancellationToken);
+
+        HttpResponseMessage response =
+            await client.PostAsync(new Uri("http://localhost/actuator/loggers/Default"), requestContent, TestContext.Current.CancellationToken);
 
         response.StatusCode.Should().Be(HttpStatusCode.NoContent);
     }
@@ -71,7 +75,9 @@ public sealed class ContentNegotiationTests
         using HttpClient client = host.GetTestClient();
         MediaTypeHeaderValue contentType = MediaTypeHeaderValue.Parse("application/xhtml+xml");
         HttpContent requestContent = new StringContent("{}", contentType);
-        HttpResponseMessage response = await client.PostAsync(new Uri("http://localhost/actuator/loggers/Default"), requestContent, TestContext.Current.CancellationToken);
+
+        HttpResponseMessage response =
+            await client.PostAsync(new Uri("http://localhost/actuator/loggers/Default"), requestContent, TestContext.Current.CancellationToken);
 
         response.StatusCode.Should().Be(HttpStatusCode.UnsupportedMediaType);
         string responseText = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);

--- a/src/Management/test/Endpoint.Test/ContentNegotiationTests.cs
+++ b/src/Management/test/Endpoint.Test/ContentNegotiationTests.cs
@@ -30,12 +30,12 @@ public sealed class ContentNegotiationTests
         builder.Services.AddLoggersActuator();
 
         await using WebApplication host = builder.Build();
-        await host.StartAsync();
+        await host.StartAsync(TestContext.Current.CancellationToken);
 
         using HttpClient client = host.GetTestClient();
         MediaTypeHeaderValue contentType = MediaTypeHeaderValue.Parse("APPLICATION/vnd.Spring-Boot.Actuator.v3+JSON");
         HttpContent requestContent = new StringContent("{}", contentType);
-        HttpResponseMessage response = await client.PostAsync(new Uri("http://localhost/actuator/loggers/Default"), requestContent);
+        HttpResponseMessage response = await client.PostAsync(new Uri("http://localhost/actuator/loggers/Default"), requestContent, TestContext.Current.CancellationToken);
 
         response.StatusCode.Should().Be(HttpStatusCode.NoContent);
     }
@@ -48,12 +48,12 @@ public sealed class ContentNegotiationTests
         builder.Services.AddLoggersActuator();
 
         await using WebApplication host = builder.Build();
-        await host.StartAsync();
+        await host.StartAsync(TestContext.Current.CancellationToken);
 
         using HttpClient client = host.GetTestClient();
         MediaTypeHeaderValue contentType = MediaTypeHeaderValue.Parse("application/vnd.spring-boot.actuator.v3+json; charset=utf-8");
         HttpContent requestContent = new StringContent("{}", contentType);
-        HttpResponseMessage response = await client.PostAsync(new Uri("http://localhost/actuator/loggers/Default"), requestContent);
+        HttpResponseMessage response = await client.PostAsync(new Uri("http://localhost/actuator/loggers/Default"), requestContent, TestContext.Current.CancellationToken);
 
         response.StatusCode.Should().Be(HttpStatusCode.NoContent);
     }
@@ -66,15 +66,15 @@ public sealed class ContentNegotiationTests
         builder.Services.AddLoggersActuator();
 
         await using WebApplication host = builder.Build();
-        await host.StartAsync();
+        await host.StartAsync(TestContext.Current.CancellationToken);
 
         using HttpClient client = host.GetTestClient();
         MediaTypeHeaderValue contentType = MediaTypeHeaderValue.Parse("application/xhtml+xml");
         HttpContent requestContent = new StringContent("{}", contentType);
-        HttpResponseMessage response = await client.PostAsync(new Uri("http://localhost/actuator/loggers/Default"), requestContent);
+        HttpResponseMessage response = await client.PostAsync(new Uri("http://localhost/actuator/loggers/Default"), requestContent, TestContext.Current.CancellationToken);
 
         response.StatusCode.Should().Be(HttpStatusCode.UnsupportedMediaType);
-        string responseText = await response.Content.ReadAsStringAsync();
+        string responseText = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
         responseText.Should().Be("Only the 'application/vnd.spring-boot.actuator.v3+json' content type is supported.");
     }
 
@@ -86,10 +86,10 @@ public sealed class ContentNegotiationTests
         builder.Services.AddLoggersActuator();
 
         await using WebApplication host = builder.Build();
-        await host.StartAsync();
+        await host.StartAsync(TestContext.Current.CancellationToken);
 
         using HttpClient client = host.GetTestClient();
-        HttpResponseMessage response = await client.GetAsync(new Uri("http://localhost/actuator/loggers"));
+        HttpResponseMessage response = await client.GetAsync(new Uri("http://localhost/actuator/loggers"), TestContext.Current.CancellationToken);
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
     }
@@ -102,7 +102,7 @@ public sealed class ContentNegotiationTests
         builder.Services.AddLoggersActuator();
 
         await using WebApplication host = builder.Build();
-        await host.StartAsync();
+        await host.StartAsync(TestContext.Current.CancellationToken);
 
         var requestMessage = new HttpRequestMessage
         {
@@ -119,10 +119,10 @@ public sealed class ContentNegotiationTests
         };
 
         using HttpClient client = host.GetTestClient();
-        HttpResponseMessage response = await client.SendAsync(requestMessage);
+        HttpResponseMessage response = await client.SendAsync(requestMessage, TestContext.Current.CancellationToken);
 
         response.StatusCode.Should().Be(HttpStatusCode.NotAcceptable);
-        string responseText = await response.Content.ReadAsStringAsync();
+        string responseText = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
         responseText.Should().Be("Only the 'application/vnd.spring-boot.actuator.v3+json' content type is supported.");
     }
 
@@ -134,7 +134,7 @@ public sealed class ContentNegotiationTests
         builder.Services.AddLoggersActuator();
 
         await using WebApplication host = builder.Build();
-        await host.StartAsync();
+        await host.StartAsync(TestContext.Current.CancellationToken);
 
         var requestMessage = new HttpRequestMessage
         {
@@ -151,7 +151,7 @@ public sealed class ContentNegotiationTests
         };
 
         using HttpClient client = host.GetTestClient();
-        HttpResponseMessage response = await client.SendAsync(requestMessage);
+        HttpResponseMessage response = await client.SendAsync(requestMessage, TestContext.Current.CancellationToken);
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
     }
@@ -164,7 +164,7 @@ public sealed class ContentNegotiationTests
         builder.Services.AddLoggersActuator();
 
         await using WebApplication host = builder.Build();
-        await host.StartAsync();
+        await host.StartAsync(TestContext.Current.CancellationToken);
 
         var requestMessage = new HttpRequestMessage
         {
@@ -181,7 +181,7 @@ public sealed class ContentNegotiationTests
         };
 
         using HttpClient client = host.GetTestClient();
-        HttpResponseMessage response = await client.SendAsync(requestMessage);
+        HttpResponseMessage response = await client.SendAsync(requestMessage, TestContext.Current.CancellationToken);
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
     }
@@ -199,12 +199,12 @@ public sealed class ContentNegotiationTests
         builder.Services.AddHeapDumpActuator();
 
         await using WebApplication host = builder.Build();
-        await host.StartAsync();
+        await host.StartAsync(TestContext.Current.CancellationToken);
 
         using HttpClient client = host.GetTestClient();
         using var request = new HttpRequestMessage(HttpMethod.Get, new Uri("http://localhost/actuator/heapdump"));
         request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
-        HttpResponseMessage response = await client.SendAsync(request);
+        HttpResponseMessage response = await client.SendAsync(request, TestContext.Current.CancellationToken);
 
         response.StatusCode.Should().Be(HttpStatusCode.NotAcceptable);
     }
@@ -223,12 +223,12 @@ public sealed class ContentNegotiationTests
         builder.Services.AddSingleton<IHeapDumper, FakeHeapDumper>();
 
         await using WebApplication host = builder.Build();
-        await host.StartAsync();
+        await host.StartAsync(TestContext.Current.CancellationToken);
 
         using HttpClient client = host.GetTestClient();
         using var request = new HttpRequestMessage(HttpMethod.Get, new Uri("http://localhost/actuator/heapdump"));
         request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/octet-stream"));
-        HttpResponseMessage response = await client.SendAsync(request);
+        HttpResponseMessage response = await client.SendAsync(request, TestContext.Current.CancellationToken);
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
     }

--- a/src/Management/test/Endpoint.Test/CorsPolicyTest.cs
+++ b/src/Management/test/Endpoint.Test/CorsPolicyTest.cs
@@ -36,12 +36,12 @@ public sealed class CorsPolicyTest
         corsPolicy.Methods.Should().ContainSingle();
         corsPolicy.Methods.Should().Contain("GET");
 
-        await app.StartAsync();
+        await app.StartAsync(TestContext.Current.CancellationToken);
         using HttpClient httpClient = app.GetTestClient();
 
         var request = new HttpRequestMessage(HttpMethod.Get, new Uri("http://localhost/actuator/info"));
         request.Headers.Add("Origin", "http://example.api.com");
-        HttpResponseMessage response = await httpClient.SendAsync(request);
+        HttpResponseMessage response = await httpClient.SendAsync(request, TestContext.Current.CancellationToken);
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         response.Headers.Should().ContainKey("Access-Control-Allow-Origin");
@@ -62,13 +62,13 @@ public sealed class CorsPolicyTest
         corsPolicy.Methods.Should().ContainSingle();
         corsPolicy.Methods.Should().Contain("POST");
 
-        await app.StartAsync();
+        await app.StartAsync(TestContext.Current.CancellationToken);
         using HttpClient httpClient = app.GetTestClient();
 
         var request = new HttpRequestMessage(HttpMethod.Options, new Uri("http://localhost/actuator/refresh"));
         request.Headers.Add("Origin", "http://example.api.com");
         request.Headers.Add("Access-Control-Request-Method", "POST");
-        HttpResponseMessage response = await httpClient.SendAsync(request);
+        HttpResponseMessage response = await httpClient.SendAsync(request, TestContext.Current.CancellationToken);
 
         response.StatusCode.Should().Be(HttpStatusCode.NoContent);
         response.Headers.Should().ContainKey("Access-Control-Allow-Origin");
@@ -94,12 +94,12 @@ public sealed class CorsPolicyTest
         corsPolicy.Methods.Should().ContainSingle();
         corsPolicy.Methods.Should().Contain("GET");
 
-        await app.StartAsync();
+        await app.StartAsync(TestContext.Current.CancellationToken);
         using HttpClient httpClient = app.GetTestClient();
 
         var request = new HttpRequestMessage(HttpMethod.Get, new Uri("http://localhost/actuator/info"));
         request.Headers.Add("Origin", "http://example.api.com");
-        HttpResponseMessage response = await httpClient.SendAsync(request);
+        HttpResponseMessage response = await httpClient.SendAsync(request, TestContext.Current.CancellationToken);
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         response.Headers.Should().ContainKey("Access-Control-Allow-Origin");
@@ -107,7 +107,7 @@ public sealed class CorsPolicyTest
 
         request = new HttpRequestMessage(HttpMethod.Get, new Uri("http://localhost/actuator/info"));
         request.Headers.Add("Origin", "http://google.com");
-        response = await httpClient.SendAsync(request);
+        response = await httpClient.SendAsync(request, TestContext.Current.CancellationToken);
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         response.Headers.Should().NotContainKey("Access-Control-Allow-Origin");
@@ -131,13 +131,13 @@ public sealed class CorsPolicyTest
         corsPolicy.Methods.Should().ContainSingle();
         corsPolicy.Methods.Should().Contain("POST");
 
-        await app.StartAsync();
+        await app.StartAsync(TestContext.Current.CancellationToken);
         using HttpClient httpClient = app.GetTestClient();
 
         var request = new HttpRequestMessage(HttpMethod.Options, new Uri("http://localhost/actuator/refresh"));
         request.Headers.Add("Origin", "http://example.api.com");
         request.Headers.Add("Access-Control-Request-Method", "POST");
-        HttpResponseMessage response = await httpClient.SendAsync(request);
+        HttpResponseMessage response = await httpClient.SendAsync(request, TestContext.Current.CancellationToken);
 
         response.StatusCode.Should().Be(HttpStatusCode.NoContent);
         response.Headers.Should().ContainKey("Access-Control-Allow-Origin");
@@ -205,13 +205,13 @@ public sealed class CorsPolicyTest
         corsPolicy.Methods.Should().Contain("GET");
         corsPolicy.Headers.Should().BeEquivalentTo("Authorization", "X-Cf-App-Instance", "Content-Type", "Content-Disposition");
 
-        await app.StartAsync();
+        await app.StartAsync(TestContext.Current.CancellationToken);
         using HttpClient httpClient = app.GetTestClient();
 
         var request = new HttpRequestMessage(HttpMethod.Get, new Uri("http://localhost/cloudfoundryapplication/info"));
         request.Headers.Authorization = AuthenticationHeaderValue.Parse($"bearer {token}");
         request.Headers.Add("Origin", "http://example.api.com");
-        HttpResponseMessage response = await httpClient.SendAsync(request);
+        HttpResponseMessage response = await httpClient.SendAsync(request, TestContext.Current.CancellationToken);
 
         handler.Mock.VerifyNoOutstandingExpectation();
 
@@ -229,14 +229,14 @@ public sealed class CorsPolicyTest
         builder.Services.AddCloudFoundryActuator();
         await using WebApplication app = builder.Build();
 
-        await app.StartAsync();
+        await app.StartAsync(TestContext.Current.CancellationToken);
 
         using HttpClient httpClient = app.GetTestClient();
         var corsRequest = new HttpRequestMessage(HttpMethod.Options, new Uri("http://localhost/cloudfoundryapplication"));
         corsRequest.Headers.Add("access-control-request-method", "GET");
         corsRequest.Headers.Add("access-control-request-headers", "authorization");
         corsRequest.Headers.Add("origin", "http://example.api.com");
-        HttpResponseMessage corsResponse = await httpClient.SendAsync(corsRequest);
+        HttpResponseMessage corsResponse = await httpClient.SendAsync(corsRequest, TestContext.Current.CancellationToken);
 
         corsResponse.StatusCode.Should().Be(HttpStatusCode.NoContent);
         corsResponse.Headers.Should().ContainKey("Access-Control-Allow-Origin");
@@ -251,7 +251,7 @@ public sealed class CorsPolicyTest
 
         var actuatorRequest = new HttpRequestMessage(HttpMethod.Get, new Uri("http://localhost/cloudfoundryapplication"));
         actuatorRequest.Headers.Add("Origin", "http://example.api.com");
-        HttpResponseMessage response = await httpClient.SendAsync(actuatorRequest);
+        HttpResponseMessage response = await httpClient.SendAsync(actuatorRequest, TestContext.Current.CancellationToken);
 
         // Returns ServiceUnavailable because UseCloudFoundrySecurity is invoked, but not fully mocked
         response.StatusCode.Should().Be(HttpStatusCode.ServiceUnavailable);

--- a/src/Management/test/Endpoint.Test/ManagementPort/ManagementEndpointServedOnDifferentPortTest.cs
+++ b/src/Management/test/Endpoint.Test/ManagementPort/ManagementEndpointServedOnDifferentPortTest.cs
@@ -32,10 +32,10 @@ public sealed class ManagementEndpointServedOnDifferentPortTest
 
         using HttpClient httpClient = CreateHttpClient();
 
-        HttpResponseMessage appResponse = await httpClient.GetAsync(new Uri($"http://localhost:{AspNetDefaultPort}"));
+        HttpResponseMessage appResponse = await httpClient.GetAsync(new Uri($"http://localhost:{AspNetDefaultPort}"), TestContext.Current.CancellationToken);
         appResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        HttpResponseMessage actuatorResponse = await httpClient.GetAsync(new Uri($"http://localhost:{AspNetDefaultPort}/actuator"));
+        HttpResponseMessage actuatorResponse = await httpClient.GetAsync(new Uri($"http://localhost:{AspNetDefaultPort}/actuator"), TestContext.Current.CancellationToken);
         actuatorResponse.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
@@ -57,10 +57,10 @@ public sealed class ManagementEndpointServedOnDifferentPortTest
 
         using HttpClient httpClient = CreateHttpClient();
 
-        HttpResponseMessage appResponse = await httpClient.GetAsync(new Uri($"http://localhost:{AspNetDefaultPort}"));
+        HttpResponseMessage appResponse = await httpClient.GetAsync(new Uri($"http://localhost:{AspNetDefaultPort}"), TestContext.Current.CancellationToken);
         appResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
 
-        HttpResponseMessage actuatorResponse = await httpClient.GetAsync(new Uri($"http://localhost:{AspNetDefaultPort}/actuator"));
+        HttpResponseMessage actuatorResponse = await httpClient.GetAsync(new Uri($"http://localhost:{AspNetDefaultPort}/actuator"), TestContext.Current.CancellationToken);
         actuatorResponse.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
@@ -85,16 +85,16 @@ public sealed class ManagementEndpointServedOnDifferentPortTest
 
         using HttpClient httpClient = CreateHttpClient();
 
-        HttpResponseMessage appResponse = await httpClient.GetAsync(new Uri($"http://localhost:{AspNetDefaultPort}"));
+        HttpResponseMessage appResponse = await httpClient.GetAsync(new Uri($"http://localhost:{AspNetDefaultPort}"), TestContext.Current.CancellationToken);
         appResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        appResponse = await httpClient.GetAsync(new Uri($"http://localhost:{managementPort}"));
+        appResponse = await httpClient.GetAsync(new Uri($"http://localhost:{managementPort}"), TestContext.Current.CancellationToken);
         appResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
 
-        HttpResponseMessage actuatorResponse = await httpClient.GetAsync(new Uri($"http://localhost:{AspNetDefaultPort}/actuator"));
+        HttpResponseMessage actuatorResponse = await httpClient.GetAsync(new Uri($"http://localhost:{AspNetDefaultPort}/actuator"), TestContext.Current.CancellationToken);
         actuatorResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
 
-        actuatorResponse = await httpClient.GetAsync(new Uri($"http://localhost:{managementPort}/actuator"));
+        actuatorResponse = await httpClient.GetAsync(new Uri($"http://localhost:{managementPort}/actuator"), TestContext.Current.CancellationToken);
         actuatorResponse.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
@@ -126,13 +126,13 @@ public sealed class ManagementEndpointServedOnDifferentPortTest
 
         using HttpClient httpClient = CreateHttpClient();
 
-        HttpResponseMessage actuatorResponse = await httpClient.GetAsync(new Uri($"http://localhost:{managementPort}/actuator"));
+        HttpResponseMessage actuatorResponse = await httpClient.GetAsync(new Uri($"http://localhost:{managementPort}/actuator"), TestContext.Current.CancellationToken);
         actuatorResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        actuatorResponse = await httpClient.GetAsync(new Uri($"http://localhost:{internalTlsProxyPort}/actuator"));
+        actuatorResponse = await httpClient.GetAsync(new Uri($"http://localhost:{internalTlsProxyPort}/actuator"), TestContext.Current.CancellationToken);
         actuatorResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        actuatorResponse = await httpClient.GetAsync(new Uri($"http://localhost:{externalTlsProxyPort}/actuator"));
+        actuatorResponse = await httpClient.GetAsync(new Uri($"http://localhost:{externalTlsProxyPort}/actuator"), TestContext.Current.CancellationToken);
         actuatorResponse.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
@@ -159,16 +159,16 @@ public sealed class ManagementEndpointServedOnDifferentPortTest
 
         using HttpClient httpClient = CreateHttpClient();
 
-        HttpResponseMessage appResponse = await httpClient.GetAsync(new Uri($"http://localhost:{AspNetDefaultPort}"));
+        HttpResponseMessage appResponse = await httpClient.GetAsync(new Uri($"http://localhost:{AspNetDefaultPort}"), TestContext.Current.CancellationToken);
         appResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        appResponse = await httpClient.GetAsync(new Uri($"https://localhost:{managementPort}"));
+        appResponse = await httpClient.GetAsync(new Uri($"https://localhost:{managementPort}"), TestContext.Current.CancellationToken);
         appResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
 
-        HttpResponseMessage actuatorResponse = await httpClient.GetAsync(new Uri($"http://localhost:{AspNetDefaultPort}/actuator"));
+        HttpResponseMessage actuatorResponse = await httpClient.GetAsync(new Uri($"http://localhost:{AspNetDefaultPort}/actuator"), TestContext.Current.CancellationToken);
         actuatorResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
 
-        actuatorResponse = await httpClient.GetAsync(new Uri($"https://localhost:{managementPort}/actuator"));
+        actuatorResponse = await httpClient.GetAsync(new Uri($"https://localhost:{managementPort}/actuator"), TestContext.Current.CancellationToken);
         actuatorResponse.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
@@ -195,16 +195,16 @@ public sealed class ManagementEndpointServedOnDifferentPortTest
 
         using HttpClient httpClient = CreateHttpClient();
 
-        HttpResponseMessage appResponse = await httpClient.GetAsync(new Uri($"http://localhost:{appHttpPort}"));
+        HttpResponseMessage appResponse = await httpClient.GetAsync(new Uri($"http://localhost:{appHttpPort}"), TestContext.Current.CancellationToken);
         appResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        appResponse = await httpClient.GetAsync(new Uri($"https://localhost:{appHttpsPort}"));
+        appResponse = await httpClient.GetAsync(new Uri($"https://localhost:{appHttpsPort}"), TestContext.Current.CancellationToken);
         appResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        HttpResponseMessage actuatorResponse = await httpClient.GetAsync(new Uri($"http://localhost:{appHttpPort}/actuator"));
+        HttpResponseMessage actuatorResponse = await httpClient.GetAsync(new Uri($"http://localhost:{appHttpPort}/actuator"), TestContext.Current.CancellationToken);
         actuatorResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        actuatorResponse = await httpClient.GetAsync(new Uri($"https://localhost:{appHttpsPort}/actuator"));
+        actuatorResponse = await httpClient.GetAsync(new Uri($"https://localhost:{appHttpsPort}/actuator"), TestContext.Current.CancellationToken);
         actuatorResponse.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
@@ -232,16 +232,16 @@ public sealed class ManagementEndpointServedOnDifferentPortTest
 
         using HttpClient httpClient = CreateHttpClient();
 
-        HttpResponseMessage appResponse = await httpClient.GetAsync(new Uri($"http://localhost:{appHttpPort}"));
+        HttpResponseMessage appResponse = await httpClient.GetAsync(new Uri($"http://localhost:{appHttpPort}"), TestContext.Current.CancellationToken);
         appResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
 
-        appResponse = await httpClient.GetAsync(new Uri($"https://localhost:{appHttpsPort}"));
+        appResponse = await httpClient.GetAsync(new Uri($"https://localhost:{appHttpsPort}"), TestContext.Current.CancellationToken);
         appResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        HttpResponseMessage actuatorResponse = await httpClient.GetAsync(new Uri($"http://localhost:{appHttpPort}/actuator"));
+        HttpResponseMessage actuatorResponse = await httpClient.GetAsync(new Uri($"http://localhost:{appHttpPort}/actuator"), TestContext.Current.CancellationToken);
         actuatorResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        actuatorResponse = await httpClient.GetAsync(new Uri($"https://localhost:{appHttpsPort}/actuator"));
+        actuatorResponse = await httpClient.GetAsync(new Uri($"https://localhost:{appHttpsPort}/actuator"), TestContext.Current.CancellationToken);
         actuatorResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
     }
 
@@ -271,22 +271,22 @@ public sealed class ManagementEndpointServedOnDifferentPortTest
 
         using HttpClient httpClient = CreateHttpClient();
 
-        HttpResponseMessage appResponse = await httpClient.GetAsync(new Uri($"http://localhost:{appHttpPort}"));
+        HttpResponseMessage appResponse = await httpClient.GetAsync(new Uri($"http://localhost:{appHttpPort}"), TestContext.Current.CancellationToken);
         appResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        appResponse = await httpClient.GetAsync(new Uri($"https://localhost:{appHttpsPort}"));
+        appResponse = await httpClient.GetAsync(new Uri($"https://localhost:{appHttpsPort}"), TestContext.Current.CancellationToken);
         appResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        appResponse = await httpClient.GetAsync(new Uri($"http://localhost:{managementPort}"));
+        appResponse = await httpClient.GetAsync(new Uri($"http://localhost:{managementPort}"), TestContext.Current.CancellationToken);
         appResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
 
-        HttpResponseMessage actuatorResponse = await httpClient.GetAsync(new Uri($"http://localhost:{appHttpPort}/actuator"));
+        HttpResponseMessage actuatorResponse = await httpClient.GetAsync(new Uri($"http://localhost:{appHttpPort}/actuator"), TestContext.Current.CancellationToken);
         actuatorResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
 
-        actuatorResponse = await httpClient.GetAsync(new Uri($"https://localhost:{appHttpsPort}/actuator"));
+        actuatorResponse = await httpClient.GetAsync(new Uri($"https://localhost:{appHttpsPort}/actuator"), TestContext.Current.CancellationToken);
         actuatorResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
 
-        actuatorResponse = await httpClient.GetAsync(new Uri($"http://localhost:{managementPort}/actuator"));
+        actuatorResponse = await httpClient.GetAsync(new Uri($"http://localhost:{managementPort}/actuator"), TestContext.Current.CancellationToken);
         actuatorResponse.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
@@ -317,22 +317,22 @@ public sealed class ManagementEndpointServedOnDifferentPortTest
 
         using HttpClient httpClient = CreateHttpClient();
 
-        HttpResponseMessage appResponse = await httpClient.GetAsync(new Uri($"http://localhost:{appHttpPort}"));
+        HttpResponseMessage appResponse = await httpClient.GetAsync(new Uri($"http://localhost:{appHttpPort}"), TestContext.Current.CancellationToken);
         appResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        appResponse = await httpClient.GetAsync(new Uri($"https://localhost:{appHttpsPort}"));
+        appResponse = await httpClient.GetAsync(new Uri($"https://localhost:{appHttpsPort}"), TestContext.Current.CancellationToken);
         appResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        appResponse = await httpClient.GetAsync(new Uri($"https://localhost:{managementPort}"));
+        appResponse = await httpClient.GetAsync(new Uri($"https://localhost:{managementPort}"), TestContext.Current.CancellationToken);
         appResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
 
-        HttpResponseMessage actuatorResponse = await httpClient.GetAsync(new Uri($"http://localhost:{appHttpPort}/actuator"));
+        HttpResponseMessage actuatorResponse = await httpClient.GetAsync(new Uri($"http://localhost:{appHttpPort}/actuator"), TestContext.Current.CancellationToken);
         actuatorResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
 
-        actuatorResponse = await httpClient.GetAsync(new Uri($"https://localhost:{appHttpsPort}/actuator"));
+        actuatorResponse = await httpClient.GetAsync(new Uri($"https://localhost:{appHttpsPort}/actuator"), TestContext.Current.CancellationToken);
         actuatorResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
 
-        actuatorResponse = await httpClient.GetAsync(new Uri($"https://localhost:{managementPort}/actuator"));
+        actuatorResponse = await httpClient.GetAsync(new Uri($"https://localhost:{managementPort}/actuator"), TestContext.Current.CancellationToken);
         actuatorResponse.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
@@ -357,16 +357,16 @@ public sealed class ManagementEndpointServedOnDifferentPortTest
 
         using HttpClient httpClient = CreateHttpClient();
 
-        HttpResponseMessage appResponse = await httpClient.GetAsync(new Uri($"http://localhost:{appHttpPort}"));
+        HttpResponseMessage appResponse = await httpClient.GetAsync(new Uri($"http://localhost:{appHttpPort}"), TestContext.Current.CancellationToken);
         appResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        appResponse = await httpClient.GetAsync(new Uri($"https://localhost:{appHttpsPort}"));
+        appResponse = await httpClient.GetAsync(new Uri($"https://localhost:{appHttpsPort}"), TestContext.Current.CancellationToken);
         appResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        HttpResponseMessage actuatorResponse = await httpClient.GetAsync(new Uri($"http://localhost:{appHttpPort}/actuator"));
+        HttpResponseMessage actuatorResponse = await httpClient.GetAsync(new Uri($"http://localhost:{appHttpPort}/actuator"), TestContext.Current.CancellationToken);
         actuatorResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        actuatorResponse = await httpClient.GetAsync(new Uri($"https://localhost:{appHttpsPort}/actuator"));
+        actuatorResponse = await httpClient.GetAsync(new Uri($"https://localhost:{appHttpsPort}/actuator"), TestContext.Current.CancellationToken);
         actuatorResponse.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
@@ -396,16 +396,16 @@ public sealed class ManagementEndpointServedOnDifferentPortTest
 
         using HttpClient httpClient = CreateHttpClient();
 
-        HttpResponseMessage appResponse = await httpClient.GetAsync(new Uri($"http://localhost:{appHttpPort}"));
+        HttpResponseMessage appResponse = await httpClient.GetAsync(new Uri($"http://localhost:{appHttpPort}"), TestContext.Current.CancellationToken);
         appResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
 
-        appResponse = await httpClient.GetAsync(new Uri($"https://localhost:{appHttpsPort}"));
+        appResponse = await httpClient.GetAsync(new Uri($"https://localhost:{appHttpsPort}"), TestContext.Current.CancellationToken);
         appResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        HttpResponseMessage actuatorResponse = await httpClient.GetAsync(new Uri($"http://localhost:{appHttpPort}/actuator"));
+        HttpResponseMessage actuatorResponse = await httpClient.GetAsync(new Uri($"http://localhost:{appHttpPort}/actuator"), TestContext.Current.CancellationToken);
         actuatorResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        actuatorResponse = await httpClient.GetAsync(new Uri($"https://localhost:{appHttpsPort}/actuator"));
+        actuatorResponse = await httpClient.GetAsync(new Uri($"https://localhost:{appHttpsPort}/actuator"), TestContext.Current.CancellationToken);
         actuatorResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
     }
 
@@ -437,22 +437,22 @@ public sealed class ManagementEndpointServedOnDifferentPortTest
 
         using HttpClient httpClient = CreateHttpClient();
 
-        HttpResponseMessage appResponse = await httpClient.GetAsync(new Uri($"http://localhost:{appHttpPort}"));
+        HttpResponseMessage appResponse = await httpClient.GetAsync(new Uri($"http://localhost:{appHttpPort}"), TestContext.Current.CancellationToken);
         appResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        appResponse = await httpClient.GetAsync(new Uri($"https://localhost:{appHttpsPort}"));
+        appResponse = await httpClient.GetAsync(new Uri($"https://localhost:{appHttpsPort}"), TestContext.Current.CancellationToken);
         appResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        appResponse = await httpClient.GetAsync(new Uri($"http://localhost:{managementPort}"));
+        appResponse = await httpClient.GetAsync(new Uri($"http://localhost:{managementPort}"), TestContext.Current.CancellationToken);
         appResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
 
-        HttpResponseMessage actuatorResponse = await httpClient.GetAsync(new Uri($"http://localhost:{appHttpPort}/actuator"));
+        HttpResponseMessage actuatorResponse = await httpClient.GetAsync(new Uri($"http://localhost:{appHttpPort}/actuator"), TestContext.Current.CancellationToken);
         actuatorResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
 
-        actuatorResponse = await httpClient.GetAsync(new Uri($"https://localhost:{appHttpsPort}/actuator"));
+        actuatorResponse = await httpClient.GetAsync(new Uri($"https://localhost:{appHttpsPort}/actuator"), TestContext.Current.CancellationToken);
         actuatorResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
 
-        actuatorResponse = await httpClient.GetAsync(new Uri($"http://localhost:{managementPort}/actuator"));
+        actuatorResponse = await httpClient.GetAsync(new Uri($"http://localhost:{managementPort}/actuator"), TestContext.Current.CancellationToken);
         actuatorResponse.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
@@ -485,22 +485,22 @@ public sealed class ManagementEndpointServedOnDifferentPortTest
 
         using HttpClient httpClient = CreateHttpClient();
 
-        HttpResponseMessage appResponse = await httpClient.GetAsync(new Uri($"http://localhost:{appHttpPort}"));
+        HttpResponseMessage appResponse = await httpClient.GetAsync(new Uri($"http://localhost:{appHttpPort}"), TestContext.Current.CancellationToken);
         appResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        appResponse = await httpClient.GetAsync(new Uri($"https://localhost:{appHttpsPort}"));
+        appResponse = await httpClient.GetAsync(new Uri($"https://localhost:{appHttpsPort}"), TestContext.Current.CancellationToken);
         appResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        appResponse = await httpClient.GetAsync(new Uri($"https://localhost:{managementPort}"));
+        appResponse = await httpClient.GetAsync(new Uri($"https://localhost:{managementPort}"), TestContext.Current.CancellationToken);
         appResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
 
-        HttpResponseMessage actuatorResponse = await httpClient.GetAsync(new Uri($"http://localhost:{appHttpPort}/actuator"));
+        HttpResponseMessage actuatorResponse = await httpClient.GetAsync(new Uri($"http://localhost:{appHttpPort}/actuator"), TestContext.Current.CancellationToken);
         actuatorResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
 
-        actuatorResponse = await httpClient.GetAsync(new Uri($"https://localhost:{appHttpsPort}/actuator"));
+        actuatorResponse = await httpClient.GetAsync(new Uri($"https://localhost:{appHttpsPort}/actuator"), TestContext.Current.CancellationToken);
         actuatorResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
 
-        actuatorResponse = await httpClient.GetAsync(new Uri($"https://localhost:{managementPort}/actuator"));
+        actuatorResponse = await httpClient.GetAsync(new Uri($"https://localhost:{managementPort}/actuator"), TestContext.Current.CancellationToken);
         actuatorResponse.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
@@ -526,16 +526,16 @@ public sealed class ManagementEndpointServedOnDifferentPortTest
 
         using HttpClient httpClient = CreateHttpClient();
 
-        HttpResponseMessage appResponse = await httpClient.GetAsync(new Uri($"http://localhost:{appHttpPort}"));
+        HttpResponseMessage appResponse = await httpClient.GetAsync(new Uri($"http://localhost:{appHttpPort}"), TestContext.Current.CancellationToken);
         appResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        appResponse = await httpClient.GetAsync(new Uri($"https://localhost:{appHttpsPort}"));
+        appResponse = await httpClient.GetAsync(new Uri($"https://localhost:{appHttpsPort}"), TestContext.Current.CancellationToken);
         appResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        HttpResponseMessage actuatorResponse = await httpClient.GetAsync(new Uri($"http://localhost:{appHttpPort}/actuator"));
+        HttpResponseMessage actuatorResponse = await httpClient.GetAsync(new Uri($"http://localhost:{appHttpPort}/actuator"), TestContext.Current.CancellationToken);
         actuatorResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        actuatorResponse = await httpClient.GetAsync(new Uri($"https://localhost:{appHttpsPort}/actuator"));
+        actuatorResponse = await httpClient.GetAsync(new Uri($"https://localhost:{appHttpsPort}/actuator"), TestContext.Current.CancellationToken);
         actuatorResponse.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
@@ -566,16 +566,16 @@ public sealed class ManagementEndpointServedOnDifferentPortTest
 
         using HttpClient httpClient = CreateHttpClient();
 
-        HttpResponseMessage appResponse = await httpClient.GetAsync(new Uri($"http://localhost:{appHttpPort}"));
+        HttpResponseMessage appResponse = await httpClient.GetAsync(new Uri($"http://localhost:{appHttpPort}"), TestContext.Current.CancellationToken);
         appResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
 
-        appResponse = await httpClient.GetAsync(new Uri($"https://localhost:{appHttpsPort}"));
+        appResponse = await httpClient.GetAsync(new Uri($"https://localhost:{appHttpsPort}"), TestContext.Current.CancellationToken);
         appResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        HttpResponseMessage actuatorResponse = await httpClient.GetAsync(new Uri($"http://localhost:{appHttpPort}/actuator"));
+        HttpResponseMessage actuatorResponse = await httpClient.GetAsync(new Uri($"http://localhost:{appHttpPort}/actuator"), TestContext.Current.CancellationToken);
         actuatorResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        actuatorResponse = await httpClient.GetAsync(new Uri($"https://localhost:{appHttpsPort}/actuator"));
+        actuatorResponse = await httpClient.GetAsync(new Uri($"https://localhost:{appHttpsPort}/actuator"), TestContext.Current.CancellationToken);
         actuatorResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
     }
 
@@ -608,22 +608,22 @@ public sealed class ManagementEndpointServedOnDifferentPortTest
 
         using HttpClient httpClient = CreateHttpClient();
 
-        HttpResponseMessage appResponse = await httpClient.GetAsync(new Uri($"http://localhost:{appHttpPort}"));
+        HttpResponseMessage appResponse = await httpClient.GetAsync(new Uri($"http://localhost:{appHttpPort}"), TestContext.Current.CancellationToken);
         appResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        appResponse = await httpClient.GetAsync(new Uri($"https://localhost:{appHttpsPort}"));
+        appResponse = await httpClient.GetAsync(new Uri($"https://localhost:{appHttpsPort}"), TestContext.Current.CancellationToken);
         appResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        appResponse = await httpClient.GetAsync(new Uri($"http://localhost:{managementPort}"));
+        appResponse = await httpClient.GetAsync(new Uri($"http://localhost:{managementPort}"), TestContext.Current.CancellationToken);
         appResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
 
-        HttpResponseMessage actuatorResponse = await httpClient.GetAsync(new Uri($"http://localhost:{appHttpPort}/actuator"));
+        HttpResponseMessage actuatorResponse = await httpClient.GetAsync(new Uri($"http://localhost:{appHttpPort}/actuator"), TestContext.Current.CancellationToken);
         actuatorResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
 
-        actuatorResponse = await httpClient.GetAsync(new Uri($"https://localhost:{appHttpsPort}/actuator"));
+        actuatorResponse = await httpClient.GetAsync(new Uri($"https://localhost:{appHttpsPort}/actuator"), TestContext.Current.CancellationToken);
         actuatorResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
 
-        actuatorResponse = await httpClient.GetAsync(new Uri($"http://localhost:{managementPort}/actuator"));
+        actuatorResponse = await httpClient.GetAsync(new Uri($"http://localhost:{managementPort}/actuator"), TestContext.Current.CancellationToken);
         actuatorResponse.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
@@ -657,22 +657,22 @@ public sealed class ManagementEndpointServedOnDifferentPortTest
 
         using HttpClient httpClient = CreateHttpClient();
 
-        HttpResponseMessage appResponse = await httpClient.GetAsync(new Uri($"http://localhost:{appHttpPort}"));
+        HttpResponseMessage appResponse = await httpClient.GetAsync(new Uri($"http://localhost:{appHttpPort}"), TestContext.Current.CancellationToken);
         appResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        appResponse = await httpClient.GetAsync(new Uri($"https://localhost:{appHttpsPort}"));
+        appResponse = await httpClient.GetAsync(new Uri($"https://localhost:{appHttpsPort}"), TestContext.Current.CancellationToken);
         appResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        appResponse = await httpClient.GetAsync(new Uri($"https://localhost:{managementPort}"));
+        appResponse = await httpClient.GetAsync(new Uri($"https://localhost:{managementPort}"), TestContext.Current.CancellationToken);
         appResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
 
-        HttpResponseMessage actuatorResponse = await httpClient.GetAsync(new Uri($"http://localhost:{appHttpPort}/actuator"));
+        HttpResponseMessage actuatorResponse = await httpClient.GetAsync(new Uri($"http://localhost:{appHttpPort}/actuator"), TestContext.Current.CancellationToken);
         actuatorResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
 
-        actuatorResponse = await httpClient.GetAsync(new Uri($"https://localhost:{appHttpsPort}/actuator"));
+        actuatorResponse = await httpClient.GetAsync(new Uri($"https://localhost:{appHttpsPort}/actuator"), TestContext.Current.CancellationToken);
         actuatorResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
 
-        actuatorResponse = await httpClient.GetAsync(new Uri($"https://localhost:{managementPort}/actuator"));
+        actuatorResponse = await httpClient.GetAsync(new Uri($"https://localhost:{managementPort}/actuator"), TestContext.Current.CancellationToken);
         actuatorResponse.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
@@ -700,16 +700,16 @@ public sealed class ManagementEndpointServedOnDifferentPortTest
 
         using HttpClient httpClient = CreateHttpClient();
 
-        HttpResponseMessage appResponse = await httpClient.GetAsync(new Uri($"http://localhost:{appHttpPort}"));
+        HttpResponseMessage appResponse = await httpClient.GetAsync(new Uri($"http://localhost:{appHttpPort}"), TestContext.Current.CancellationToken);
         appResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        appResponse = await httpClient.GetAsync(new Uri($"https://localhost:{appHttpsPort}"));
+        appResponse = await httpClient.GetAsync(new Uri($"https://localhost:{appHttpsPort}"), TestContext.Current.CancellationToken);
         appResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        HttpResponseMessage actuatorResponse = await httpClient.GetAsync(new Uri($"http://localhost:{appHttpPort}/actuator"));
+        HttpResponseMessage actuatorResponse = await httpClient.GetAsync(new Uri($"http://localhost:{appHttpPort}/actuator"), TestContext.Current.CancellationToken);
         actuatorResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        actuatorResponse = await httpClient.GetAsync(new Uri($"https://localhost:{appHttpsPort}/actuator"));
+        actuatorResponse = await httpClient.GetAsync(new Uri($"https://localhost:{appHttpsPort}/actuator"), TestContext.Current.CancellationToken);
         actuatorResponse.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
@@ -741,22 +741,22 @@ public sealed class ManagementEndpointServedOnDifferentPortTest
 
         using HttpClient httpClient = CreateHttpClient();
 
-        HttpResponseMessage appResponse = await httpClient.GetAsync(new Uri($"http://localhost:{appHttpPort}"));
+        HttpResponseMessage appResponse = await httpClient.GetAsync(new Uri($"http://localhost:{appHttpPort}"), TestContext.Current.CancellationToken);
         appResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        appResponse = await httpClient.GetAsync(new Uri($"https://localhost:{appHttpsPort}"));
+        appResponse = await httpClient.GetAsync(new Uri($"https://localhost:{appHttpsPort}"), TestContext.Current.CancellationToken);
         appResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        appResponse = await httpClient.GetAsync(new Uri($"http://localhost:{managementPort}"));
+        appResponse = await httpClient.GetAsync(new Uri($"http://localhost:{managementPort}"), TestContext.Current.CancellationToken);
         appResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
 
-        HttpResponseMessage actuatorResponse = await httpClient.GetAsync(new Uri($"http://localhost:{appHttpPort}/actuator"));
+        HttpResponseMessage actuatorResponse = await httpClient.GetAsync(new Uri($"http://localhost:{appHttpPort}/actuator"), TestContext.Current.CancellationToken);
         actuatorResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
 
-        actuatorResponse = await httpClient.GetAsync(new Uri($"https://localhost:{appHttpsPort}/actuator"));
+        actuatorResponse = await httpClient.GetAsync(new Uri($"https://localhost:{appHttpsPort}/actuator"), TestContext.Current.CancellationToken);
         actuatorResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
 
-        actuatorResponse = await httpClient.GetAsync(new Uri($"http://localhost:{managementPort}/actuator"));
+        actuatorResponse = await httpClient.GetAsync(new Uri($"http://localhost:{managementPort}/actuator"), TestContext.Current.CancellationToken);
         actuatorResponse.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
@@ -789,22 +789,22 @@ public sealed class ManagementEndpointServedOnDifferentPortTest
 
         using HttpClient httpClient = CreateHttpClient();
 
-        HttpResponseMessage appResponse = await httpClient.GetAsync(new Uri($"http://localhost:{appHttpPort}"));
+        HttpResponseMessage appResponse = await httpClient.GetAsync(new Uri($"http://localhost:{appHttpPort}"), TestContext.Current.CancellationToken);
         appResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        appResponse = await httpClient.GetAsync(new Uri($"https://localhost:{appHttpsPort}"));
+        appResponse = await httpClient.GetAsync(new Uri($"https://localhost:{appHttpsPort}"), TestContext.Current.CancellationToken);
         appResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        appResponse = await httpClient.GetAsync(new Uri($"https://localhost:{managementPort}"));
+        appResponse = await httpClient.GetAsync(new Uri($"https://localhost:{managementPort}"), TestContext.Current.CancellationToken);
         appResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
 
-        HttpResponseMessage actuatorResponse = await httpClient.GetAsync(new Uri($"http://localhost:{appHttpPort}/actuator"));
+        HttpResponseMessage actuatorResponse = await httpClient.GetAsync(new Uri($"http://localhost:{appHttpPort}/actuator"), TestContext.Current.CancellationToken);
         actuatorResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
 
-        actuatorResponse = await httpClient.GetAsync(new Uri($"https://localhost:{appHttpsPort}/actuator"));
+        actuatorResponse = await httpClient.GetAsync(new Uri($"https://localhost:{appHttpsPort}/actuator"), TestContext.Current.CancellationToken);
         actuatorResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
 
-        actuatorResponse = await httpClient.GetAsync(new Uri($"https://localhost:{managementPort}/actuator"));
+        actuatorResponse = await httpClient.GetAsync(new Uri($"https://localhost:{managementPort}/actuator"), TestContext.Current.CancellationToken);
         actuatorResponse.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
@@ -818,7 +818,7 @@ public sealed class ManagementEndpointServedOnDifferentPortTest
         configureApp?.Invoke(app);
 
         app.MapGet("/", () => "Hello World!");
-        await app.StartAsync();
+        await app.StartAsync(TestContext.Current.CancellationToken);
 
         return app;
     }

--- a/src/Management/test/Endpoint.Test/ManagementPort/ManagementEndpointServedOnDifferentPortTest.cs
+++ b/src/Management/test/Endpoint.Test/ManagementPort/ManagementEndpointServedOnDifferentPortTest.cs
@@ -35,7 +35,9 @@ public sealed class ManagementEndpointServedOnDifferentPortTest
         HttpResponseMessage appResponse = await httpClient.GetAsync(new Uri($"http://localhost:{AspNetDefaultPort}"), TestContext.Current.CancellationToken);
         appResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        HttpResponseMessage actuatorResponse = await httpClient.GetAsync(new Uri($"http://localhost:{AspNetDefaultPort}/actuator"), TestContext.Current.CancellationToken);
+        HttpResponseMessage actuatorResponse =
+            await httpClient.GetAsync(new Uri($"http://localhost:{AspNetDefaultPort}/actuator"), TestContext.Current.CancellationToken);
+
         actuatorResponse.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
@@ -60,7 +62,9 @@ public sealed class ManagementEndpointServedOnDifferentPortTest
         HttpResponseMessage appResponse = await httpClient.GetAsync(new Uri($"http://localhost:{AspNetDefaultPort}"), TestContext.Current.CancellationToken);
         appResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
 
-        HttpResponseMessage actuatorResponse = await httpClient.GetAsync(new Uri($"http://localhost:{AspNetDefaultPort}/actuator"), TestContext.Current.CancellationToken);
+        HttpResponseMessage actuatorResponse =
+            await httpClient.GetAsync(new Uri($"http://localhost:{AspNetDefaultPort}/actuator"), TestContext.Current.CancellationToken);
+
         actuatorResponse.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
@@ -91,7 +95,9 @@ public sealed class ManagementEndpointServedOnDifferentPortTest
         appResponse = await httpClient.GetAsync(new Uri($"http://localhost:{managementPort}"), TestContext.Current.CancellationToken);
         appResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
 
-        HttpResponseMessage actuatorResponse = await httpClient.GetAsync(new Uri($"http://localhost:{AspNetDefaultPort}/actuator"), TestContext.Current.CancellationToken);
+        HttpResponseMessage actuatorResponse =
+            await httpClient.GetAsync(new Uri($"http://localhost:{AspNetDefaultPort}/actuator"), TestContext.Current.CancellationToken);
+
         actuatorResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
 
         actuatorResponse = await httpClient.GetAsync(new Uri($"http://localhost:{managementPort}/actuator"), TestContext.Current.CancellationToken);
@@ -126,7 +132,9 @@ public sealed class ManagementEndpointServedOnDifferentPortTest
 
         using HttpClient httpClient = CreateHttpClient();
 
-        HttpResponseMessage actuatorResponse = await httpClient.GetAsync(new Uri($"http://localhost:{managementPort}/actuator"), TestContext.Current.CancellationToken);
+        HttpResponseMessage actuatorResponse =
+            await httpClient.GetAsync(new Uri($"http://localhost:{managementPort}/actuator"), TestContext.Current.CancellationToken);
+
         actuatorResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
         actuatorResponse = await httpClient.GetAsync(new Uri($"http://localhost:{internalTlsProxyPort}/actuator"), TestContext.Current.CancellationToken);
@@ -165,7 +173,9 @@ public sealed class ManagementEndpointServedOnDifferentPortTest
         appResponse = await httpClient.GetAsync(new Uri($"https://localhost:{managementPort}"), TestContext.Current.CancellationToken);
         appResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
 
-        HttpResponseMessage actuatorResponse = await httpClient.GetAsync(new Uri($"http://localhost:{AspNetDefaultPort}/actuator"), TestContext.Current.CancellationToken);
+        HttpResponseMessage actuatorResponse =
+            await httpClient.GetAsync(new Uri($"http://localhost:{AspNetDefaultPort}/actuator"), TestContext.Current.CancellationToken);
+
         actuatorResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
 
         actuatorResponse = await httpClient.GetAsync(new Uri($"https://localhost:{managementPort}/actuator"), TestContext.Current.CancellationToken);
@@ -201,7 +211,9 @@ public sealed class ManagementEndpointServedOnDifferentPortTest
         appResponse = await httpClient.GetAsync(new Uri($"https://localhost:{appHttpsPort}"), TestContext.Current.CancellationToken);
         appResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        HttpResponseMessage actuatorResponse = await httpClient.GetAsync(new Uri($"http://localhost:{appHttpPort}/actuator"), TestContext.Current.CancellationToken);
+        HttpResponseMessage actuatorResponse =
+            await httpClient.GetAsync(new Uri($"http://localhost:{appHttpPort}/actuator"), TestContext.Current.CancellationToken);
+
         actuatorResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
         actuatorResponse = await httpClient.GetAsync(new Uri($"https://localhost:{appHttpsPort}/actuator"), TestContext.Current.CancellationToken);
@@ -238,7 +250,9 @@ public sealed class ManagementEndpointServedOnDifferentPortTest
         appResponse = await httpClient.GetAsync(new Uri($"https://localhost:{appHttpsPort}"), TestContext.Current.CancellationToken);
         appResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        HttpResponseMessage actuatorResponse = await httpClient.GetAsync(new Uri($"http://localhost:{appHttpPort}/actuator"), TestContext.Current.CancellationToken);
+        HttpResponseMessage actuatorResponse =
+            await httpClient.GetAsync(new Uri($"http://localhost:{appHttpPort}/actuator"), TestContext.Current.CancellationToken);
+
         actuatorResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
         actuatorResponse = await httpClient.GetAsync(new Uri($"https://localhost:{appHttpsPort}/actuator"), TestContext.Current.CancellationToken);
@@ -280,7 +294,9 @@ public sealed class ManagementEndpointServedOnDifferentPortTest
         appResponse = await httpClient.GetAsync(new Uri($"http://localhost:{managementPort}"), TestContext.Current.CancellationToken);
         appResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
 
-        HttpResponseMessage actuatorResponse = await httpClient.GetAsync(new Uri($"http://localhost:{appHttpPort}/actuator"), TestContext.Current.CancellationToken);
+        HttpResponseMessage actuatorResponse =
+            await httpClient.GetAsync(new Uri($"http://localhost:{appHttpPort}/actuator"), TestContext.Current.CancellationToken);
+
         actuatorResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
 
         actuatorResponse = await httpClient.GetAsync(new Uri($"https://localhost:{appHttpsPort}/actuator"), TestContext.Current.CancellationToken);
@@ -326,7 +342,9 @@ public sealed class ManagementEndpointServedOnDifferentPortTest
         appResponse = await httpClient.GetAsync(new Uri($"https://localhost:{managementPort}"), TestContext.Current.CancellationToken);
         appResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
 
-        HttpResponseMessage actuatorResponse = await httpClient.GetAsync(new Uri($"http://localhost:{appHttpPort}/actuator"), TestContext.Current.CancellationToken);
+        HttpResponseMessage actuatorResponse =
+            await httpClient.GetAsync(new Uri($"http://localhost:{appHttpPort}/actuator"), TestContext.Current.CancellationToken);
+
         actuatorResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
 
         actuatorResponse = await httpClient.GetAsync(new Uri($"https://localhost:{appHttpsPort}/actuator"), TestContext.Current.CancellationToken);
@@ -363,7 +381,9 @@ public sealed class ManagementEndpointServedOnDifferentPortTest
         appResponse = await httpClient.GetAsync(new Uri($"https://localhost:{appHttpsPort}"), TestContext.Current.CancellationToken);
         appResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        HttpResponseMessage actuatorResponse = await httpClient.GetAsync(new Uri($"http://localhost:{appHttpPort}/actuator"), TestContext.Current.CancellationToken);
+        HttpResponseMessage actuatorResponse =
+            await httpClient.GetAsync(new Uri($"http://localhost:{appHttpPort}/actuator"), TestContext.Current.CancellationToken);
+
         actuatorResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
         actuatorResponse = await httpClient.GetAsync(new Uri($"https://localhost:{appHttpsPort}/actuator"), TestContext.Current.CancellationToken);
@@ -402,7 +422,9 @@ public sealed class ManagementEndpointServedOnDifferentPortTest
         appResponse = await httpClient.GetAsync(new Uri($"https://localhost:{appHttpsPort}"), TestContext.Current.CancellationToken);
         appResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        HttpResponseMessage actuatorResponse = await httpClient.GetAsync(new Uri($"http://localhost:{appHttpPort}/actuator"), TestContext.Current.CancellationToken);
+        HttpResponseMessage actuatorResponse =
+            await httpClient.GetAsync(new Uri($"http://localhost:{appHttpPort}/actuator"), TestContext.Current.CancellationToken);
+
         actuatorResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
         actuatorResponse = await httpClient.GetAsync(new Uri($"https://localhost:{appHttpsPort}/actuator"), TestContext.Current.CancellationToken);
@@ -446,7 +468,9 @@ public sealed class ManagementEndpointServedOnDifferentPortTest
         appResponse = await httpClient.GetAsync(new Uri($"http://localhost:{managementPort}"), TestContext.Current.CancellationToken);
         appResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
 
-        HttpResponseMessage actuatorResponse = await httpClient.GetAsync(new Uri($"http://localhost:{appHttpPort}/actuator"), TestContext.Current.CancellationToken);
+        HttpResponseMessage actuatorResponse =
+            await httpClient.GetAsync(new Uri($"http://localhost:{appHttpPort}/actuator"), TestContext.Current.CancellationToken);
+
         actuatorResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
 
         actuatorResponse = await httpClient.GetAsync(new Uri($"https://localhost:{appHttpsPort}/actuator"), TestContext.Current.CancellationToken);
@@ -494,7 +518,9 @@ public sealed class ManagementEndpointServedOnDifferentPortTest
         appResponse = await httpClient.GetAsync(new Uri($"https://localhost:{managementPort}"), TestContext.Current.CancellationToken);
         appResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
 
-        HttpResponseMessage actuatorResponse = await httpClient.GetAsync(new Uri($"http://localhost:{appHttpPort}/actuator"), TestContext.Current.CancellationToken);
+        HttpResponseMessage actuatorResponse =
+            await httpClient.GetAsync(new Uri($"http://localhost:{appHttpPort}/actuator"), TestContext.Current.CancellationToken);
+
         actuatorResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
 
         actuatorResponse = await httpClient.GetAsync(new Uri($"https://localhost:{appHttpsPort}/actuator"), TestContext.Current.CancellationToken);
@@ -532,7 +558,9 @@ public sealed class ManagementEndpointServedOnDifferentPortTest
         appResponse = await httpClient.GetAsync(new Uri($"https://localhost:{appHttpsPort}"), TestContext.Current.CancellationToken);
         appResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        HttpResponseMessage actuatorResponse = await httpClient.GetAsync(new Uri($"http://localhost:{appHttpPort}/actuator"), TestContext.Current.CancellationToken);
+        HttpResponseMessage actuatorResponse =
+            await httpClient.GetAsync(new Uri($"http://localhost:{appHttpPort}/actuator"), TestContext.Current.CancellationToken);
+
         actuatorResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
         actuatorResponse = await httpClient.GetAsync(new Uri($"https://localhost:{appHttpsPort}/actuator"), TestContext.Current.CancellationToken);
@@ -572,7 +600,9 @@ public sealed class ManagementEndpointServedOnDifferentPortTest
         appResponse = await httpClient.GetAsync(new Uri($"https://localhost:{appHttpsPort}"), TestContext.Current.CancellationToken);
         appResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        HttpResponseMessage actuatorResponse = await httpClient.GetAsync(new Uri($"http://localhost:{appHttpPort}/actuator"), TestContext.Current.CancellationToken);
+        HttpResponseMessage actuatorResponse =
+            await httpClient.GetAsync(new Uri($"http://localhost:{appHttpPort}/actuator"), TestContext.Current.CancellationToken);
+
         actuatorResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
         actuatorResponse = await httpClient.GetAsync(new Uri($"https://localhost:{appHttpsPort}/actuator"), TestContext.Current.CancellationToken);
@@ -617,7 +647,9 @@ public sealed class ManagementEndpointServedOnDifferentPortTest
         appResponse = await httpClient.GetAsync(new Uri($"http://localhost:{managementPort}"), TestContext.Current.CancellationToken);
         appResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
 
-        HttpResponseMessage actuatorResponse = await httpClient.GetAsync(new Uri($"http://localhost:{appHttpPort}/actuator"), TestContext.Current.CancellationToken);
+        HttpResponseMessage actuatorResponse =
+            await httpClient.GetAsync(new Uri($"http://localhost:{appHttpPort}/actuator"), TestContext.Current.CancellationToken);
+
         actuatorResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
 
         actuatorResponse = await httpClient.GetAsync(new Uri($"https://localhost:{appHttpsPort}/actuator"), TestContext.Current.CancellationToken);
@@ -666,7 +698,9 @@ public sealed class ManagementEndpointServedOnDifferentPortTest
         appResponse = await httpClient.GetAsync(new Uri($"https://localhost:{managementPort}"), TestContext.Current.CancellationToken);
         appResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
 
-        HttpResponseMessage actuatorResponse = await httpClient.GetAsync(new Uri($"http://localhost:{appHttpPort}/actuator"), TestContext.Current.CancellationToken);
+        HttpResponseMessage actuatorResponse =
+            await httpClient.GetAsync(new Uri($"http://localhost:{appHttpPort}/actuator"), TestContext.Current.CancellationToken);
+
         actuatorResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
 
         actuatorResponse = await httpClient.GetAsync(new Uri($"https://localhost:{appHttpsPort}/actuator"), TestContext.Current.CancellationToken);
@@ -706,7 +740,9 @@ public sealed class ManagementEndpointServedOnDifferentPortTest
         appResponse = await httpClient.GetAsync(new Uri($"https://localhost:{appHttpsPort}"), TestContext.Current.CancellationToken);
         appResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        HttpResponseMessage actuatorResponse = await httpClient.GetAsync(new Uri($"http://localhost:{appHttpPort}/actuator"), TestContext.Current.CancellationToken);
+        HttpResponseMessage actuatorResponse =
+            await httpClient.GetAsync(new Uri($"http://localhost:{appHttpPort}/actuator"), TestContext.Current.CancellationToken);
+
         actuatorResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
         actuatorResponse = await httpClient.GetAsync(new Uri($"https://localhost:{appHttpsPort}/actuator"), TestContext.Current.CancellationToken);
@@ -750,7 +786,9 @@ public sealed class ManagementEndpointServedOnDifferentPortTest
         appResponse = await httpClient.GetAsync(new Uri($"http://localhost:{managementPort}"), TestContext.Current.CancellationToken);
         appResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
 
-        HttpResponseMessage actuatorResponse = await httpClient.GetAsync(new Uri($"http://localhost:{appHttpPort}/actuator"), TestContext.Current.CancellationToken);
+        HttpResponseMessage actuatorResponse =
+            await httpClient.GetAsync(new Uri($"http://localhost:{appHttpPort}/actuator"), TestContext.Current.CancellationToken);
+
         actuatorResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
 
         actuatorResponse = await httpClient.GetAsync(new Uri($"https://localhost:{appHttpsPort}/actuator"), TestContext.Current.CancellationToken);
@@ -798,7 +836,9 @@ public sealed class ManagementEndpointServedOnDifferentPortTest
         appResponse = await httpClient.GetAsync(new Uri($"https://localhost:{managementPort}"), TestContext.Current.CancellationToken);
         appResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
 
-        HttpResponseMessage actuatorResponse = await httpClient.GetAsync(new Uri($"http://localhost:{appHttpPort}/actuator"), TestContext.Current.CancellationToken);
+        HttpResponseMessage actuatorResponse =
+            await httpClient.GetAsync(new Uri($"http://localhost:{appHttpPort}/actuator"), TestContext.Current.CancellationToken);
+
         actuatorResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
 
         actuatorResponse = await httpClient.GetAsync(new Uri($"https://localhost:{appHttpsPort}/actuator"), TestContext.Current.CancellationToken);

--- a/src/Management/test/Endpoint.Test/SpringBootAdminClient/SpringBootAdminClientHostedServiceTest.cs
+++ b/src/Management/test/Endpoint.Test/SpringBootAdminClient/SpringBootAdminClientHostedServiceTest.cs
@@ -42,8 +42,8 @@ public sealed class SpringBootAdminClientHostedServiceTest : BaseTest
         SpringBootAdminClientHostedService hostedService = app.Services.GetServices<IHostedService>().OfType<SpringBootAdminClientHostedService>().Single();
         Assert.Null(hostedService.RegistrationResult);
 
-        await hostedService.StartAsync(CancellationToken.None);
-        await hostedService.StopAsync(CancellationToken.None);
+        await hostedService.StartAsync(TestContext.Current.CancellationToken);
+        await hostedService.StopAsync(TestContext.Current.CancellationToken);
 
         handler.Mock.VerifyNoOutstandingExpectation();
         Assert.Equal("1234567", hostedService.RegistrationResult?.Id);
@@ -76,7 +76,7 @@ public sealed class SpringBootAdminClientHostedServiceTest : BaseTest
         SpringBootAdminClientHostedService hostedService = app.Services.GetServices<IHostedService>().OfType<SpringBootAdminClientHostedService>().Single();
         Assert.Null(hostedService.RegistrationResult);
 
-        await hostedService.StartAsync(CancellationToken.None);
+        await hostedService.StartAsync(TestContext.Current.CancellationToken);
 
         handler.Mock.VerifyNoOutstandingExpectation();
     }

--- a/src/Management/test/Endpoint.Test/SpringBootAdminClient/TestMiddleware.cs
+++ b/src/Management/test/Endpoint.Test/SpringBootAdminClient/TestMiddleware.cs
@@ -28,7 +28,8 @@ public sealed class TestMiddleware : IMiddleware
             bool isValid = dictionary != null && KeyNames.All(dictionary.ContainsKey);
 
             // Registration response
-            await context.Response.WriteAsync(isValid ? """{"Id":"1234567"}""" : """{"SerializationError: invalid keys in Application object."}""", context.RequestAborted);
+            await context.Response.WriteAsync(isValid ? """{"Id":"1234567"}""" : """{"SerializationError: invalid keys in Application object."}""",
+                context.RequestAborted);
         }
         else
         {

--- a/src/Management/test/Endpoint.Test/SpringBootAdminClient/TestMiddleware.cs
+++ b/src/Management/test/Endpoint.Test/SpringBootAdminClient/TestMiddleware.cs
@@ -28,12 +28,12 @@ public sealed class TestMiddleware : IMiddleware
             bool isValid = dictionary != null && KeyNames.All(dictionary.ContainsKey);
 
             // Registration response
-            await context.Response.WriteAsync(isValid ? """{"Id":"1234567"}""" : """{"SerializationError: invalid keys in Application object."}""");
+            await context.Response.WriteAsync(isValid ? """{"Id":"1234567"}""" : """{"SerializationError: invalid keys in Application object."}""", context.RequestAborted);
         }
         else
         {
             // Unregister response
-            await context.Response.WriteAsync("Ok!");
+            await context.Response.WriteAsync("Ok!", context.RequestAborted);
         }
     }
 }

--- a/src/Management/test/Endpoint.Test/SteeltoeTestContext.cs
+++ b/src/Management/test/Endpoint.Test/SteeltoeTestContext.cs
@@ -13,7 +13,7 @@ namespace Steeltoe.Management.Endpoint.Test;
 /// <summary>
 /// Provides encapsulation of data for a single test.
 /// </summary>
-internal sealed class TestContext : IDisposable
+internal sealed class SteeltoeTestContext : IDisposable
 {
     private readonly XunitLoggerProvider _loggerProvider;
     private readonly ServiceCollection _serviceCollection = [];
@@ -69,7 +69,7 @@ internal sealed class TestContext : IDisposable
         }
     }
 
-    public TestContext(ITestOutputHelper testOutputHelper)
+    public SteeltoeTestContext(ITestOutputHelper testOutputHelper)
     {
         ArgumentNullException.ThrowIfNull(testOutputHelper);
 

--- a/src/Management/test/Prometheus.Test/PrometheusExtensionsTest.cs
+++ b/src/Management/test/Prometheus.Test/PrometheusExtensionsTest.cs
@@ -57,13 +57,13 @@ public sealed class PrometheusExtensionsTest
             builder.ConfigureServices(services => services.AddPrometheusActuator());
         });
 
-        await host.StartAsync();
+        await host.StartAsync(TestContext.Current.CancellationToken);
         using HttpClient httpClient = host.GetTestClient();
 
-        HttpResponseMessage response = await httpClient.GetAsync(new Uri("http://localhost/actuator/prometheus"));
+        HttpResponseMessage response = await httpClient.GetAsync(new Uri("http://localhost/actuator/prometheus"), TestContext.Current.CancellationToken);
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        string responseText = await response.Content.ReadAsStringAsync();
+        string responseText = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
         responseText.Should().Contain("# EOF");
     }
 
@@ -76,12 +76,12 @@ public sealed class PrometheusExtensionsTest
         await using WebApplication app = hostBuilder.Build();
         app.UsePrometheusActuator();
 
-        await app.StartAsync();
+        await app.StartAsync(TestContext.Current.CancellationToken);
         using HttpClient httpClient = app.GetTestClient();
-        HttpResponseMessage response = await httpClient.GetAsync(new Uri("http://localhost/actuator/prometheus"));
+        HttpResponseMessage response = await httpClient.GetAsync(new Uri("http://localhost/actuator/prometheus"), TestContext.Current.CancellationToken);
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        string responseText = await response.Content.ReadAsStringAsync();
+        string responseText = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
         responseText.Should().Contain("# EOF");
     }
 
@@ -106,10 +106,10 @@ public sealed class PrometheusExtensionsTest
             });
         });
 
-        await host.StartAsync();
+        await host.StartAsync(TestContext.Current.CancellationToken);
         using HttpClient httpClient = host.GetTestClient();
 
-        HttpResponseMessage response = await httpClient.GetAsync(new Uri("http://localhost/actuator/prometheus"));
+        HttpResponseMessage response = await httpClient.GetAsync(new Uri("http://localhost/actuator/prometheus"), TestContext.Current.CancellationToken);
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
     }
 
@@ -131,12 +131,12 @@ public sealed class PrometheusExtensionsTest
             builder.ConfigureServices(services => services.AddPrometheusActuator());
         });
 
-        await host.StartAsync();
+        await host.StartAsync(TestContext.Current.CancellationToken);
         using HttpClient httpClient = host.GetTestClient();
-        HttpResponseMessage response = await httpClient.GetAsync(new Uri("http://localhost/actuator/prometheus"));
+        HttpResponseMessage response = await httpClient.GetAsync(new Uri("http://localhost/actuator/prometheus"), TestContext.Current.CancellationToken);
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        response = await httpClient.GetAsync(new Uri("http://localhost/cloudfoundryapplication/prometheus"));
+        response = await httpClient.GetAsync(new Uri("http://localhost/cloudfoundryapplication/prometheus"), TestContext.Current.CancellationToken);
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
     }
 
@@ -164,12 +164,12 @@ public sealed class PrometheusExtensionsTest
             });
         });
 
-        await host.StartAsync();
+        await host.StartAsync(TestContext.Current.CancellationToken);
         using HttpClient httpClient = host.GetTestClient();
-        HttpResponseMessage response = await httpClient.GetAsync(new Uri("http://localhost/actuator/prometheus"));
+        HttpResponseMessage response = await httpClient.GetAsync(new Uri("http://localhost/actuator/prometheus"), TestContext.Current.CancellationToken);
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        response = await httpClient.GetAsync(new Uri("http://localhost/cloudfoundryapplication/prometheus"));
+        response = await httpClient.GetAsync(new Uri("http://localhost/cloudfoundryapplication/prometheus"), TestContext.Current.CancellationToken);
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
     }
 }

--- a/src/Management/test/Tasks.Test/TaskHostExtensionsTest.cs
+++ b/src/Management/test/Tasks.Test/TaskHostExtensionsTest.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
+using FluentAssertions.Extensions;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
@@ -21,7 +22,7 @@ public sealed class TaskHostExtensionsTest
         WebApplicationBuilder builder = TestWebApplicationBuilderFactory.Create();
         WebApplication app = builder.Build();
 
-        using var timeoutSource = new CancellationTokenSource(TimeSpan.FromSeconds(1));
+        using var timeoutSource = new CancellationTokenSource(1.Seconds());
 
         app.HasApplicationTask().Should().BeFalse();
         await app.RunWithTasksAsync(timeoutSource.Token);
@@ -44,7 +45,7 @@ public sealed class TaskHostExtensionsTest
         var sharedState = app.Services.GetRequiredService<TaskApplicationState>();
 
         app.HasApplicationTask().Should().BeTrue();
-        await app.RunWithTasksAsync(CancellationToken.None);
+        await app.RunWithTasksAsync(TestContext.Current.CancellationToken);
 
         sharedState.HasExecuted.Should().BeTrue();
     }
@@ -64,7 +65,7 @@ public sealed class TaskHostExtensionsTest
         var sharedState = app.Services.GetRequiredService<TaskApplicationState>();
 
         app.HasApplicationTask().Should().BeTrue();
-        await app.RunWithTasksAsync(CancellationToken.None);
+        await app.RunWithTasksAsync(TestContext.Current.CancellationToken);
 
         sharedState.HasExecuted.Should().BeTrue();
     }
@@ -84,7 +85,7 @@ public sealed class TaskHostExtensionsTest
         var sharedState = app.Services.GetRequiredService<TaskApplicationState>();
 
         app.HasApplicationTask().Should().BeTrue();
-        await app.RunWithTasksAsync(CancellationToken.None);
+        await app.RunWithTasksAsync(TestContext.Current.CancellationToken);
 
         sharedState.HasExecuted.Should().BeTrue();
     }
@@ -105,7 +106,7 @@ public sealed class TaskHostExtensionsTest
         WebApplication app = builder.Build();
 
         app.HasApplicationTask().Should().BeTrue();
-        await app.RunWithTasksAsync(CancellationToken.None);
+        await app.RunWithTasksAsync(TestContext.Current.CancellationToken);
 
         sharedState.HasExecuted.Should().BeTrue();
     }
@@ -134,7 +135,7 @@ public sealed class TaskHostExtensionsTest
         WebApplication app = builder.Build();
 
         app.HasApplicationTask().Should().BeTrue();
-        await app.RunWithTasksAsync(CancellationToken.None);
+        await app.RunWithTasksAsync(TestContext.Current.CancellationToken);
 
         hasExecuted.Should().BeTrue();
     }
@@ -164,7 +165,7 @@ public sealed class TaskHostExtensionsTest
         var sharedState = app.Services.GetRequiredService<TaskApplicationState>();
 
         app.HasApplicationTask().Should().BeTrue();
-        await app.RunWithTasksAsync(CancellationToken.None);
+        await app.RunWithTasksAsync(TestContext.Current.CancellationToken);
 
         sharedState.HasExecuted.Should().BeTrue();
     }
@@ -185,7 +186,7 @@ public sealed class TaskHostExtensionsTest
         var sharedState = app.Services.GetRequiredService<TaskApplicationState>();
 
         app.HasApplicationTask().Should().BeTrue();
-        await app.RunWithTasksAsync(CancellationToken.None);
+        await app.RunWithTasksAsync(TestContext.Current.CancellationToken);
 
         sharedState.HasExecuted.Should().BeTrue();
     }
@@ -203,7 +204,7 @@ public sealed class TaskHostExtensionsTest
         WebApplication app = builder.Build();
 
         app.HasApplicationTask().Should().BeTrue();
-        await app.RunWithTasksAsync(CancellationToken.None);
+        await app.RunWithTasksAsync(TestContext.Current.CancellationToken);
 
         IList<string> logMessages = capturingLoggerProvider.GetAll();
 
@@ -225,7 +226,7 @@ public sealed class TaskHostExtensionsTest
         WebApplication app = builder.Build();
 
         app.HasApplicationTask().Should().BeTrue();
-        Func<Task> action = async () => await app.RunWithTasksAsync(CancellationToken.None);
+        Func<Task> action = async () => await app.RunWithTasksAsync(TestContext.Current.CancellationToken);
 
         await action.Should().ThrowExactlyAsync<InvalidOperationException>();
     }
@@ -246,7 +247,7 @@ public sealed class TaskHostExtensionsTest
         WebApplication app = builder.Build();
 
         app.HasApplicationTask().Should().BeTrue();
-        await app.RunWithTasksAsync(CancellationToken.None);
+        await app.RunWithTasksAsync(TestContext.Current.CancellationToken);
 
         Action action = () => _ = app.Services.GetRequiredService<ILoggerFactory>();
 
@@ -267,7 +268,7 @@ public sealed class TaskHostExtensionsTest
         var sharedState = app.Services.GetRequiredService<TaskApplicationState>();
 
         app.HasApplicationTask().Should().BeTrue();
-        await app.RunWithTasksAsync(CancellationToken.None);
+        await app.RunWithTasksAsync(TestContext.Current.CancellationToken);
 
         sharedState.HasExecuted.Should().BeTrue();
     }
@@ -292,7 +293,7 @@ public sealed class TaskHostExtensionsTest
         var sharedState = app.Services.GetRequiredService<TaskApplicationState>();
 
         app.HasApplicationTask().Should().BeTrue();
-        await app.RunWithTasksAsync(CancellationToken.None);
+        await app.RunWithTasksAsync(TestContext.Current.CancellationToken);
 
         sharedState.HasExecuted.Should().BeTrue();
     }
@@ -316,7 +317,7 @@ public sealed class TaskHostExtensionsTest
         var sharedState = app.Services.GetRequiredService<TaskApplicationState>();
 
         app.HasApplicationTask().Should().BeTrue();
-        await app.RunWithTasksAsync(CancellationToken.None);
+        await app.RunWithTasksAsync(TestContext.Current.CancellationToken);
 
         sharedState.HasExecuted.Should().BeTrue();
     }

--- a/src/Security/test/Authentication.JwtBearer.Test/TokenKeyResolverTest.cs
+++ b/src/Security/test/Authentication.JwtBearer.Test/TokenKeyResolverTest.cs
@@ -115,7 +115,7 @@ public sealed class TokenKeyResolverTest
         using var httpClient = new HttpClient(handler);
         var resolver = new TokenKeyResolver("https://foo.bar", httpClient);
 
-        JsonWebKeySet? result = await resolver.FetchKeySetAsync(CancellationToken.None);
+        JsonWebKeySet? result = await resolver.FetchKeySetAsync(TestContext.Current.CancellationToken);
 
         result.Should().NotBeNull();
         result.Keys.Should().NotBeEmpty();

--- a/src/Security/test/Authentication.OpenIdConnect.Test/TokenKeyResolverTest.cs
+++ b/src/Security/test/Authentication.OpenIdConnect.Test/TokenKeyResolverTest.cs
@@ -115,7 +115,7 @@ public sealed class TokenKeyResolverTest
         using var httpClient = new HttpClient(handler);
         var resolver = new TokenKeyResolver("https://foo.bar", httpClient);
 
-        JsonWebKeySet? result = await resolver.FetchKeySetAsync(CancellationToken.None);
+        JsonWebKeySet? result = await resolver.FetchKeySetAsync(TestContext.Current.CancellationToken);
 
         result.Should().NotBeNull();
         result.Keys.Should().NotBeEmpty();

--- a/src/Security/test/Authorization.Certificate.Test/CertificateAuthorizationTest.cs
+++ b/src/Security/test/Authorization.Certificate.Test/CertificateAuthorizationTest.cs
@@ -21,10 +21,10 @@ public sealed class CertificateAuthorizationTest
     public async Task CertificateAuth_ForbiddenWithoutCert()
     {
         var requestUri = new Uri($"http://localhost/{CertificateAuthorizationPolicies.SameSpace}");
-        using IHost host = await GetHostBuilder().StartAsync();
+        using IHost host = await GetHostBuilder().StartAsync(TestContext.Current.CancellationToken);
         using HttpClient httpClient = host.GetTestClient();
 
-        using HttpResponseMessage response = await httpClient.GetAsync(requestUri);
+        using HttpResponseMessage response = await httpClient.GetAsync(requestUri, TestContext.Current.CancellationToken);
 
         Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
     }
@@ -33,12 +33,12 @@ public sealed class CertificateAuthorizationTest
     public async Task CertificateAuth_AcceptsSameOrg()
     {
         var requestUri = new Uri($"https://localhost/{CertificateAuthorizationPolicies.SameOrg}");
-        using IHost host = await GetHostBuilder().StartAsync();
+        using IHost host = await GetHostBuilder().StartAsync(TestContext.Current.CancellationToken);
         var optionsMonitor = host.Services.GetRequiredService<IOptionsMonitor<CertificateOptions>>();
         X509Certificate2 certificate = optionsMonitor.Get(CertificateConfigurationExtensions.AppInstanceIdentityCertificateName).Certificate!;
         using HttpClient httpClient = ClientWithCertificate(host.GetTestClient(), certificate);
 
-        using HttpResponseMessage response = await httpClient.GetAsync(requestUri);
+        using HttpResponseMessage response = await httpClient.GetAsync(requestUri, TestContext.Current.CancellationToken);
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
     }
@@ -47,12 +47,12 @@ public sealed class CertificateAuthorizationTest
     public async Task CertificateAuth_AcceptsSameSpace()
     {
         var requestUri = new Uri($"https://localhost/{CertificateAuthorizationPolicies.SameSpace}");
-        using IHost host = await GetHostBuilder().StartAsync();
+        using IHost host = await GetHostBuilder().StartAsync(TestContext.Current.CancellationToken);
         var optionsMonitor = host.Services.GetRequiredService<IOptionsMonitor<CertificateOptions>>();
         X509Certificate2 certificate = optionsMonitor.Get(CertificateConfigurationExtensions.AppInstanceIdentityCertificateName).Certificate!;
         using HttpClient httpClient = ClientWithCertificate(host.GetTestClient(), certificate);
 
-        using HttpResponseMessage response = await httpClient.GetAsync(requestUri);
+        using HttpResponseMessage response = await httpClient.GetAsync(requestUri, TestContext.Current.CancellationToken);
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
     }
@@ -61,10 +61,10 @@ public sealed class CertificateAuthorizationTest
     public async Task CertificateAuth_RejectsOrgMismatch()
     {
         var requestUri = new Uri($"https://localhost/{CertificateAuthorizationPolicies.SameOrg}");
-        using IHost host = await GetHostBuilder().StartAsync();
+        using IHost host = await GetHostBuilder().StartAsync(TestContext.Current.CancellationToken);
         using HttpClient httpClient = ClientWithCertificate(host.GetTestClient(), Certificates.SpaceMatch);
 
-        using HttpResponseMessage response = await httpClient.GetAsync(requestUri);
+        using HttpResponseMessage response = await httpClient.GetAsync(requestUri, TestContext.Current.CancellationToken);
 
         Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
     }
@@ -73,10 +73,10 @@ public sealed class CertificateAuthorizationTest
     public async Task CertificateAuth_RejectsSpaceMismatch()
     {
         var requestUri = new Uri($"https://localhost/{CertificateAuthorizationPolicies.SameSpace}");
-        using IHost host = await GetHostBuilder().StartAsync();
+        using IHost host = await GetHostBuilder().StartAsync(TestContext.Current.CancellationToken);
         using HttpClient httpClient = ClientWithCertificate(host.GetTestClient(), Certificates.OrgMatch);
 
-        using HttpResponseMessage response = await httpClient.GetAsync(requestUri);
+        using HttpResponseMessage response = await httpClient.GetAsync(requestUri, TestContext.Current.CancellationToken);
 
         Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
     }
@@ -89,10 +89,10 @@ public sealed class CertificateAuthorizationTest
         using var certScope = new EnvironmentVariableScope("CF_INSTANCE_CERT", "instance.crt");
         using var keyScope = new EnvironmentVariableScope("CF_INSTANCE_KEY", "instance.key");
         using var caScope = new EnvironmentVariableScope("CF_SYSTEM_CERT_PATH", Path.Join(LocalCertificateWriter.AppBasePath, "root_certificates"));
-        using IHost host = await GetHostBuilder().StartAsync();
+        using IHost host = await GetHostBuilder().StartAsync(TestContext.Current.CancellationToken);
         using HttpClient httpClient = ClientWithCertificate(host.GetTestClient(), Certificates.FromDiego);
 
-        using HttpResponseMessage response = await httpClient.GetAsync(requestUri);
+        using HttpResponseMessage response = await httpClient.GetAsync(requestUri, TestContext.Current.CancellationToken);
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
     }
@@ -105,10 +105,10 @@ public sealed class CertificateAuthorizationTest
         using var certScope = new EnvironmentVariableScope("CF_INSTANCE_CERT", "instance.crt");
         using var keyScope = new EnvironmentVariableScope("CF_INSTANCE_KEY", "instance.key");
         using var caScope = new EnvironmentVariableScope("CF_SYSTEM_CERT_PATH", Path.Join(LocalCertificateWriter.AppBasePath, "root_certificates"));
-        using IHost host = await GetHostBuilder().StartAsync();
+        using IHost host = await GetHostBuilder().StartAsync(TestContext.Current.CancellationToken);
         using HttpClient httpClient = ClientWithCertificate(host.GetTestClient(), Certificates.FromDiego);
 
-        using HttpResponseMessage response = await httpClient.GetAsync(requestUri);
+        using HttpResponseMessage response = await httpClient.GetAsync(requestUri, TestContext.Current.CancellationToken);
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
     }
@@ -127,12 +127,12 @@ public sealed class CertificateAuthorizationTest
         await using WebApplication application = builder.Build();
         application.UseCertificateAuthorization();
         application.MapGet("/request", () => "response").RequireAuthorization();
-        await application.StartAsync();
+        await application.StartAsync(TestContext.Current.CancellationToken);
         var optionsMonitor = application.Services.GetRequiredService<IOptionsMonitor<CertificateOptions>>();
         X509Certificate2 certificate = optionsMonitor.Get(CertificateConfigurationExtensions.AppInstanceIdentityCertificateName).Certificate!;
         using HttpClient httpClient = ClientWithCertificate(application.GetTestClient(), certificate);
 
-        using HttpResponseMessage response = await httpClient.GetAsync(requestUri);
+        using HttpResponseMessage response = await httpClient.GetAsync(requestUri, TestContext.Current.CancellationToken);
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
     }
@@ -151,12 +151,12 @@ public sealed class CertificateAuthorizationTest
         await using WebApplication application = builder.Build();
         application.UseCertificateAuthorization();
         application.MapGet("/request", () => "response").RequireAuthorization();
-        await application.StartAsync();
+        await application.StartAsync(TestContext.Current.CancellationToken);
         var optionsMonitor = application.Services.GetRequiredService<IOptionsMonitor<CertificateOptions>>();
         X509Certificate2 certificate = optionsMonitor.Get(CertificateConfigurationExtensions.AppInstanceIdentityCertificateName).Certificate!;
         using HttpClient httpClient = ClientWithCertificate(application.GetTestClient(), certificate);
 
-        using HttpResponseMessage response = await httpClient.GetAsync(requestUri);
+        using HttpResponseMessage response = await httpClient.GetAsync(requestUri, TestContext.Current.CancellationToken);
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
     }
@@ -175,12 +175,12 @@ public sealed class CertificateAuthorizationTest
         await using WebApplication application = builder.Build();
         application.UseCertificateAuthorization();
         application.MapGet("/request", () => "response").RequireAuthorization();
-        await application.StartAsync();
+        await application.StartAsync(TestContext.Current.CancellationToken);
         var optionsMonitor = application.Services.GetRequiredService<IOptionsMonitor<CertificateOptions>>();
         X509Certificate2 certificate = optionsMonitor.Get(CertificateConfigurationExtensions.AppInstanceIdentityCertificateName).Certificate!;
         using HttpClient httpClient = ClientWithCertificate(application.GetTestClient(), certificate, "a-custom-header");
 
-        using HttpResponseMessage response = await httpClient.GetAsync(requestUri);
+        using HttpResponseMessage response = await httpClient.GetAsync(requestUri, TestContext.Current.CancellationToken);
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
     }

--- a/src/Security/test/Authorization.Certificate.Test/CertificateHttpClientBuilderExtensionsTest.cs
+++ b/src/Security/test/Authorization.Certificate.Test/CertificateHttpClientBuilderExtensionsTest.cs
@@ -19,7 +19,7 @@ public sealed class CertificateHttpClientBuilderExtensionsTest
         using var appScope = new EnvironmentVariableScope("VCAP_APPLICATION", "not empty");
         using var certScope = new EnvironmentVariableScope("CF_INSTANCE_CERT", "instance.crt");
         using var keyScope = new EnvironmentVariableScope("CF_INSTANCE_KEY", "instance.key");
-        using IHost host = await GetHostBuilder().StartAsync();
+        using IHost host = await GetHostBuilder().StartAsync(TestContext.Current.CancellationToken);
         var factory = host.Services.GetRequiredService<IHttpClientFactory>();
         using HttpClient client = factory.CreateClient("test");
 
@@ -37,7 +37,7 @@ public sealed class CertificateHttpClientBuilderExtensionsTest
         using var appScope = new EnvironmentVariableScope("VCAP_APPLICATION", "not empty");
         using var certScope = new EnvironmentVariableScope("CF_INSTANCE_CERT", "instance.crt");
         using var keyScope = new EnvironmentVariableScope("CF_INSTANCE_KEY", "instance.key");
-        using IHost host = await GetHostBuilder(customCertificateHeader).StartAsync();
+        using IHost host = await GetHostBuilder(customCertificateHeader).StartAsync(TestContext.Current.CancellationToken);
         var factory = host.Services.GetRequiredService<IHttpClientFactory>();
         using HttpClient client = factory.CreateClient("test");
 


### PR DESCRIPTION
## Description

Prepare for update to xUnit v3, which includes a new analyzer for passing a `CancellationToken` in tests.

This PR puts a temporary `TestContext` stub in place, so the bulk of the changes (tests passing a cancellation token) can be merged before the actual update to v3, which depends on upcoming Resharper support.

Contributes to #1420.

## Quality checklist

- [x] Your code complies with our [Coding Style](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-code-style.md).
- [x] You've updated unit and/or integration tests for your change, where applicable.
- [ ] You've updated documentation for your change, where applicable.
      If your change affects other repositories, such as [Documentation](https://github.com/SteeltoeOSS/Documentation), [Samples](https://github.com/SteeltoeOSS/Samples) and/or [MainSite](https://github.com/SteeltoeOSS/MainSite), add linked PRs here.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
- [ ] You've added required license files and/or file headers (explaining where the code came from with proper attribution), where code is copied from StackOverflow, a blog, or OSS.
