### PR TITLE
Allow network share paths with disk health contributor, better exceptions for WindowsNetworkFileShare 

### DIFF
--- a/src/Common/src/Net/WindowsNetworkFileShare.cs
+++ b/src/Common/src/Net/WindowsNetworkFileShare.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
+using System.ComponentModel;
 using System.Net;
 
 namespace Steeltoe.Common.Net;
@@ -12,57 +13,6 @@ namespace Steeltoe.Common.Net;
 public sealed class WindowsNetworkFileShare : IDisposable
 {
     private const int NoError = 0;
-    private const int ErrorAccessDenied = 5;
-    private const int ErrorAlreadyAssigned = 85;
-    private const int ErrorPathNotFound = 53;
-    private const int ErrorBadDevice = 1200;
-    private const int ErrorBadNetName = 67;
-    private const int ErrorBadProvider = 1204;
-    private const int ErrorCancelled = 1223;
-    private const int ErrorExtendedError = 1208;
-    private const int ErrorInvalidAddress = 487;
-    private const int ErrorInvalidParameter = 87;
-    private const int ErrorInvalidPassword = 86;
-    private const int ErrorInvalidPasswordName = 1216;
-    private const int ErrorMoreData = 234;
-    private const int ErrorNoMoreItems = 259;
-    private const int ErrorNoNetOrBadPath = 1203;
-    private const int ErrorNoNetwork = 1222;
-    private const int ErrorBadProfile = 1206;
-    private const int ErrorCannotOpenProfile = 1205;
-    private const int ErrorDeviceInUse = 2404;
-    private const int ErrorNotConnected = 2250;
-    private const int ErrorOpenFiles = 2401;
-    private const int ErrorLogonFailure = 1326;
-
-    // Created with excel formula:
-    // ="new ErrorClass("&A1&", """&PROPER(SUBSTITUTE(MID(A1,7,LEN(A1)-6), "_", " "))&"""), "
-    private static readonly Dictionary<int, string> ErrorMessageLookupTable = new()
-    {
-        [ErrorAccessDenied] = "Error: Access Denied",
-        [ErrorAlreadyAssigned] = "Error: Already Assigned",
-        [ErrorBadDevice] = "Error: Bad Device",
-        [ErrorBadNetName] = "Error: Bad Net Name",
-        [ErrorBadProvider] = "Error: Bad Provider",
-        [ErrorCancelled] = "Error: Cancelled",
-        [ErrorExtendedError] = "Error: Extended Error",
-        [ErrorInvalidAddress] = "Error: Invalid Address",
-        [ErrorInvalidParameter] = "Error: Invalid Parameter",
-        [ErrorInvalidPassword] = "Error: Invalid Password",
-        [ErrorInvalidPasswordName] = "Error: Invalid Password Format",
-        [ErrorMoreData] = "Error: More Data",
-        [ErrorNoMoreItems] = "Error: No More Items",
-        [ErrorNoNetOrBadPath] = "Error: No Net Or Bad Path",
-        [ErrorNoNetwork] = "Error: No Network",
-        [ErrorBadProfile] = "Error: Bad Profile",
-        [ErrorCannotOpenProfile] = "Error: Cannot Open Profile",
-        [ErrorDeviceInUse] = "Error: Device In Use",
-        [ErrorNotConnected] = "Error: Not Connected",
-        [ErrorOpenFiles] = "Error: Open Files",
-        [ErrorLogonFailure] = "The user name or password is incorrect",
-        [ErrorPathNotFound] = "The network path not found"
-    };
-
     private readonly string _networkName;
     private readonly IMultipleProviderRouter _multipleProviderRouter;
 
@@ -118,12 +68,9 @@ public sealed class WindowsNetworkFileShare : IDisposable
     {
         if (errorNumber != NoError)
         {
-            if (ErrorMessageLookupTable.TryGetValue(errorNumber, out string? errorMessage))
-            {
-                throw new IOException($"Failed to {operation} with error {errorNumber}: {errorMessage}.");
-            }
+            var innerException = new Win32Exception(errorNumber);
 
-            throw new IOException($"Failed to {operation} with error {errorNumber}.");
+            throw new IOException($"Failed to {operation}.", innerException);
         }
     }
 }

--- a/src/Common/test/Net.Test/WindowsNetworkFileShareTest.cs
+++ b/src/Common/test/Net.Test/WindowsNetworkFileShareTest.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
+using System.ComponentModel;
 using System.Net;
 
 namespace Steeltoe.Common.Net.Test;
@@ -12,17 +13,23 @@ public sealed class WindowsNetworkFileShareTest
     public void GetErrorForKnownNumber_ReturnsKnownError()
     {
         Action action = () => WindowsNetworkFileShare.ThrowForNonZeroResult(5, "execute");
-        action.Should().ThrowExactly<IOException>().WithMessage("*Error: Access Denied*");
+
+        action.Should().ThrowExactly<IOException>().WithInnerException<Win32Exception>()
+            .WithMessage(Platform.IsWindows ? "Access is Denied*" : "Input/output error");
 
         action = () => WindowsNetworkFileShare.ThrowForNonZeroResult(1222, "execute");
-        action.Should().ThrowExactly<IOException>().WithMessage("*Error: No Network*");
+
+        action.Should().ThrowExactly<IOException>().WithInnerException<Win32Exception>()
+            .WithMessage(Platform.IsWindows ? "The network is not present or not started." : "Unknown error 1222");
     }
 
     [Fact]
     public void GetErrorForUnknownNumber_ReturnsUnKnownError()
     {
         Action action = () => WindowsNetworkFileShare.ThrowForNonZeroResult(9999, "execute");
-        action.Should().ThrowExactly<IOException>().WithMessage("Failed to execute with error 9999.");
+
+        action.Should().ThrowExactly<IOException>().WithInnerException<Win32Exception>()
+            .WithMessage(Platform.IsWindows ? "Unknown error (0x270f)" : "Unknown error 9999");
     }
 
     [Fact]
@@ -55,7 +62,8 @@ public sealed class WindowsNetworkFileShareTest
         var router = new FakeMultipleProviderRouter(false);
 
         var exception = Assert.Throws<IOException>(() => new WindowsNetworkFileShare("doesn't-matter", new NetworkCredential("user", "password"), router));
+        Assert.NotNull(exception.InnerException);
 
-        Assert.Equal("Failed to connect to network share with error 1200: Error: Bad Device.", exception.Message);
+        Assert.Equal(Platform.IsWindows ? "The specified device name is invalid." : "Unknown error 1200", exception.InnerException.Message);
     }
 }

--- a/src/Management/src/Endpoint/Actuators/Health/Contributors/DiskSpaceHealthContributor.cs
+++ b/src/Management/src/Endpoint/Actuators/Health/Contributors/DiskSpaceHealthContributor.cs
@@ -38,16 +38,15 @@ internal sealed class DiskSpaceHealthContributor : IHealthContributor
 
         if (!string.IsNullOrEmpty(options.Path))
         {
-            if (Platform.IsWindows && options.Path.StartsWith(@"\\", StringComparison.OrdinalIgnoreCase))
+            if (Platform.IsWindows && options.Path.StartsWith(@"\\", StringComparison.Ordinal))
             {
                 bool directoryExists = Directory.Exists(options.Path);
 
-                if (directoryExists && NativeMethods.GetDiskFreeSpaceEx(options.Path, out ulong freeBytesAvailable, out ulong totalNumberOfBytes,
-                    out ulong totalNumberOfFreeBytes))
+                if (directoryExists && NativeMethods.GetDiskFreeSpaceEx(options.Path, out ulong freeBytesAvailable, out ulong totalNumberOfBytes, out _))
                 {
                     return new HealthCheckResult
                     {
-                        Status = totalNumberOfFreeBytes >= (ulong)options.Threshold ? HealthStatus.Up : HealthStatus.Down,
+                        Status = freeBytesAvailable >= (ulong)options.Threshold ? HealthStatus.Up : HealthStatus.Down,
                         Details =
                         {
                             ["total"] = totalNumberOfBytes,

--- a/src/Management/src/Endpoint/Actuators/Health/Contributors/NativeMethods.cs
+++ b/src/Management/src/Endpoint/Actuators/Health/Contributors/NativeMethods.cs
@@ -1,0 +1,15 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.InteropServices;
+
+namespace Steeltoe.Management.Endpoint.Actuators.Health.Contributors;
+
+internal static partial class NativeMethods
+{
+    [LibraryImport("kernel32.dll", EntryPoint = "GetDiskFreeSpaceExW", StringMarshalling = StringMarshalling.Utf16, SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    public static partial bool GetDiskFreeSpaceEx(string lpDirectoryName, out ulong lpFreeBytesAvailableToCaller, out ulong lpTotalNumberOfBytes,
+        out ulong lpTotalNumberOfFreeBytes);
+}


### PR DESCRIPTION


<!-- Thank you for submitting a pull request! -->

<!-- If this is your first PR in this repo, please read our [Contributing Guidelines (https://github.com/SteeltoeOSS/.github/blob/master/CONTRIBUTING.md) and remember to sign the [Contributor License Agreement](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-license.md). Our bot will notify you shortly after the PR has been created. -->

## Description

- Embed `Win32Exceptions` for `WindowsNetworkFileShare` connection errors
- Enhance `DiskSpaceHealthContributor` to work with Windows network share paths

Resolves #1501, Resolves #1502 

## Quality checklist

<!-- Please run through the checklist below to ensure a smooth review and merge process for your PR. -->

- [x] Your code complies with our [Coding Style](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-code-style.md).
- [x] You've updated unit and/or integration tests for your change, where applicable.
- [ ] You've updated documentation for your change, where applicable.
      If your change affects other repositories, such as [Documentation](https://github.com/SteeltoeOSS/Documentation), [Samples](https://github.com/SteeltoeOSS/Samples) and/or [MainSite](https://github.com/SteeltoeOSS/MainSite), add linked PRs here.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
- [ ] You've added required license files and/or file headers (explaining where the code came from with proper attribution), where code is copied from StackOverflow, a blog, or OSS.
