### PR TITLE
Sync up message from Aspire schema generator

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -122,10 +122,8 @@
       <GeneratedConfigurationSchemaFileContent>$([System.IO.File]::ReadAllText('$(GeneratedConfigurationSchemaOutputPath)'))</GeneratedConfigurationSchemaFileContent>
     </PropertyGroup>
 
-    <Warning Condition="'$(CurrentConfigurationSchemaFileContent)' != '$(GeneratedConfigurationSchemaFileContent)' And '$(Configuration)' == 'Debug'"
-           Text="ConfigurationSchema.json in project $(MSBuildProjectName) is out of date. Run 'dotnet build --no-incremental /p:UpdateConfigurationSchema=true' to update it." />
-    <Error Condition="'$(CurrentConfigurationSchemaFileContent)' != '$(GeneratedConfigurationSchemaFileContent)' And '$(Configuration)' != 'Debug'"
-           Text="ConfigurationSchema.json in project $(MSBuildProjectName) is out of date. Run 'dotnet build --no-incremental /p:UpdateConfigurationSchema=true' to update it." />
+    <Warning Condition="'$(CurrentConfigurationSchemaFileContent)' != '$(GeneratedConfigurationSchemaFileContent)'"
+      Text="ConfigurationSchema.json is out of date for $(MSBuildProjectFile). Run 'dotnet build --no-incremental /p:UpdateConfigurationSchema=true' to update it." />
   </Target>
 
 </Project>

--- a/shared.props
+++ b/shared.props
@@ -26,6 +26,7 @@
 
   <PropertyGroup Condition="'$(Configuration)' == 'Release'">
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <MSBuildTreatWarningsAsErrors>true</MSBuildTreatWarningsAsErrors>
     <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)\Steeltoe.Release.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 


### PR DESCRIPTION
## Description

Sync up the build message for Aspire's Config Schema Generator with the text at https://github.com/dotnet/aspire/blob/main/src/Components/Directory.Build.targets#L118.

Move the toggle between warn/error to a central place, to reduce the diff with Aspire. I was unaware of the existence of `MSBuildTreatWarningsAsErrors`, which is documented at https://learn.microsoft.com/en-us/visualstudio/msbuild/common-msbuild-project-properties?view=vs-2022.

Output from a release build:
![image](https://github.com/user-attachments/assets/84e8bed5-9cb1-4d3e-9c2f-e15c976e77bb)

## Quality checklist

- [x] Your code complies with our [Coding Style](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-code-style.md).
- [ ] You've updated unit and/or integration tests for your change, where applicable.
- [ ] You've updated documentation for your change, where applicable.
      If your change affects other repositories, such as [Documentation](https://github.com/SteeltoeOSS/Documentation), [Samples](https://github.com/SteeltoeOSS/Samples) and/or [MainSite](https://github.com/SteeltoeOSS/MainSite), add linked PRs here.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
- [ ] You've added required license files and/or file headers (explaining where the code came from with proper attribution), where code is copied from StackOverflow, a blog, or OSS.
