### PR TITLE
Fix generation of local certificate files when running from publish directory

### DIFF
--- a/src/Common/src/Certificates/LocalCertificateWriter.cs
+++ b/src/Common/src/Certificates/LocalCertificateWriter.cs
@@ -10,17 +10,13 @@ namespace Steeltoe.Common.Certificates;
 internal sealed class LocalCertificateWriter
 {
     internal const string CertificateDirectoryName = "GeneratedCertificates";
-
     internal const string CertificateFilenamePrefix = "SteeltoeAppInstance";
-
-    internal static readonly string AppBasePath =
-        AppContext.BaseDirectory[..AppContext.BaseDirectory.LastIndexOf($"{Path.DirectorySeparatorChar}bin", StringComparison.Ordinal)];
-
+    internal static readonly string AppBasePath = GetAppBasePath();
     private static readonly string ParentPath = Directory.GetParent(AppBasePath)?.ToString() ?? string.Empty;
 
     internal static readonly string RootCaPfxPath = Path.Combine(ParentPath, CertificateDirectoryName, "SteeltoeCA.pfx");
-
     internal static readonly string IntermediatePfxPath = Path.Combine(ParentPath, CertificateDirectoryName, "SteeltoeIntermediate.pfx");
+
     private readonly TimeProvider _timeProvider;
 
     public LocalCertificateWriter(TimeProvider timeProvider)
@@ -28,6 +24,17 @@ internal sealed class LocalCertificateWriter
         ArgumentNullException.ThrowIfNull(timeProvider);
 
         _timeProvider = timeProvider;
+    }
+
+    private static string GetAppBasePath()
+    {
+        if (AppContext.BaseDirectory.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.Ordinal))
+        {
+            // Traverse up to the project directory, if running from IDE. Strips off a sub-path like: \bin\Debug\net8.0\win-x64\
+            return AppContext.BaseDirectory[..AppContext.BaseDirectory.LastIndexOf($"{Path.DirectorySeparatorChar}bin", StringComparison.Ordinal)];
+        }
+
+        return AppContext.BaseDirectory[..^1];
     }
 
     public void Write(Guid orgId, Guid spaceId)


### PR DESCRIPTION
## Description

Bugfix: AuthApi sample crashes at startup when running from publish directory.

```
C:\Test\Api> .\Steeltoe.Samples.AuthApi.exe
Unhandled exception. System.TypeInitializationException: The type initializer for 'Steeltoe.Common.Certificates.LocalCertificateWriter' threw an exception.
 ---> System.ArgumentOutOfRangeException: length ('-1') must be a non-negative value. (Parameter 'length')
Actual value was -1.
   at System.ArgumentOutOfRangeException.ThrowNegative[T](T value, String paramName)
   at System.ArgumentOutOfRangeException.ThrowIfNegative[T](T value, String paramName)
   at System.String.ThrowSubstringArgumentOutOfRange(Int32 startIndex, Int32 length)
   at System.String.Substring(Int32 startIndex, Int32 length)
   at Steeltoe.Common.Certificates.LocalCertificateWriter..cctor() in C:\Source\Repos\Steeltoe\src\Common\src\Certificates\LocalCertificateWriter.cs:line 16
   --- End of inner exception stack trace ---
   at Steeltoe.Common.Certificates.LocalCertificateWriter.Write(Guid orgId, Guid spaceId) in C:\Source\Repos\Steeltoe\src\Common\src\Certificates\LocalCertificateWriter.cs:line 46
   at Steeltoe.Common.Certificates.CertificateConfigurationExtensions.AddAppInstanceIdentityCertificate(IConfigurationBuilder builder, TimeProvider timeProvider, Nullable`1 orgId, Nullable`1 spaceId) in C:\Source\Repos\Steeltoe\src\Common\src\Certificates\CertificateConfigurationExtensions.cs:line 135
   at Steeltoe.Common.Certificates.CertificateConfigurationExtensions.AddAppInstanceIdentityCertificate(IConfigurationBuilder builder, Nullable`1 orgId, Nullable`1 spaceId) in C:\Source\Repos\Steeltoe\src\Common\src\Certificates\CertificateConfigurationExtensions.cs:line 97
   at Program.<Main>$(String[] args) in C:\Source\Repos\Samples\Security\src\AuthApi\Program.cs:line 27
```

It crashes because `bin` is not in the current directory path.

## Quality checklist

- [x] Your code complies with our [Coding Style](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-code-style.md).
- [ ] You've updated unit and/or integration tests for your change, where applicable.
- [ ] You've updated documentation for your change, where applicable.
      If your change affects other repositories, such as [Documentation](https://github.com/SteeltoeOSS/Documentation), [Samples](https://github.com/SteeltoeOSS/Samples) and/or [MainSite](https://github.com/SteeltoeOSS/MainSite), add linked PRs here.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
- [ ] You've added required license files and/or file headers (explaining where the code came from with proper attribution), where code is copied from StackOverflow, a blog, or OSS.
