### PR TITLE
Fix broken Azure DevOps release train

### DIFF
--- a/src/Tools/test/ConfigurationSchemaGenerator.Tests/ConfigurationSchemaGenerator.Tests.csproj
+++ b/src/Tools/test/ConfigurationSchemaGenerator.Tests/ConfigurationSchemaGenerator.Tests.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <IsPackable>false</IsPackable>
     <ImplicitUsings>enable</ImplicitUsings>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PreserveCompilationContext>true</PreserveCompilationContext>


### PR DESCRIPTION
## Description

This PR fixes the Azure DevOps release train by not generating a NuGet package for a test project, which led to the following error:

> The nuget command failed with exit code(1) and error(Response status code does not indicate success: 409 (Conflict - The feed already contains 'ConfigurationSchemaGenerator.Tests 1.0.0'. (DevOps Activity ID: 33067C31-1827-4243-B244-A760FC1E3162)).

Before:

![image](https://github.com/user-attachments/assets/52b4509d-a27c-4327-983f-48a76d887878)

After:

![image](https://github.com/user-attachments/assets/b5126e69-0e6f-4534-8825-95d9904165b7)

## Quality checklist

- [ ] Your code complies with our [Coding Style](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-code-style.md).
- [ ] You've updated unit and/or integration tests for your change, where applicable.
- [ ] You've updated documentation for your change, where applicable.
      If your change affects other repositories, such as [Documentation](https://github.com/SteeltoeOSS/Documentation), [Samples](https://github.com/SteeltoeOSS/Samples) and/or [MainSite](https://github.com/SteeltoeOSS/MainSite), add linked PRs here.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
- [ ] You've added required license files and/or file headers (explaining where the code came from with proper attribution), where code is copied from StackOverflow, a blog, or OSS.
