### PR TITLE
Test upcoming switch of macos-latest to macos-15

### DIFF
--- a/.github/workflows/Steeltoe.All.yml
+++ b/.github/workflows/Steeltoe.All.yml
@@ -31,13 +31,13 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-15]
         include:
         - os: ubuntu-latest
           runDockerContainers: true
         - os: windows-latest
           skipFilter: Category!=Integration
-        - os: macos-latest
+        - os: macos-15
           skipFilter: Category!=Integration&Category!=SkipOnMacOS
     runs-on: ${{ matrix.os }}
     continue-on-error: true
@@ -66,7 +66,7 @@ jobs:
           9.0.*
 
     - name: Turn off dev certificate (macOS only)
-      if: ${{ matrix.os == 'macos-latest' }}
+      if: ${{ matrix.os == 'macos-15' }}
       # Setting DOTNET_GENERATE_ASPNET_CERTIFICATE to "false" makes it easier to determine which test failed on macOS when it tried to start a web server with https enabled.
       # Without setting this, the following message appears in the logs:
       #   The application is trying to access the ASP.NET Core developer certificate key. A prompt might appear to ask for permission to access the key.
@@ -78,7 +78,7 @@ jobs:
       run: echo "DOTNET_GENERATE_ASPNET_CERTIFICATE=false" >> $GITHUB_ENV
 
     - name: Install Nerdbank.GitVersioning (macOS only)
-      if: ${{ matrix.os == 'macos-latest' }}
+      if: ${{ matrix.os == 'macos-15' }}
       run: dotnet tool install --global nbgv
 
     - name: Git checkout


### PR DESCRIPTION
## Description

Updates `macos-latest` to `macos-15`, to test whether everything works. See announcement at https://github.com/actions/runner-images/issues/12520:

> [macOS] macos-latest YAML-label will use macos-15 in August 2025

This PR is intended for testing; do not merge.

---

Outcome: all builds are green.