### PR TITLE
Add empty package workflow

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,0 +1,23 @@
+name: Package
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+    - main
+    - '[0-9]+.x'
+    - 'release/*'
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  empty:
+    name: Empty job
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Empty step
+      run: echo "Packaging using GitHub Actions is not yet implemented."


### PR DESCRIPTION
## Description

Adds an empty GitHub Actions workflow for creating NuGet packages. This allows PRs to be manually triggered by their branch name (because this includes a `workflow_dispatch` trigger).
