### PR TITLE
Try nightly build of dotnet-gcdump

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -1,8 +1,10 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
     <!-- Required for .NET Aspire Configuration Schema Generator, which needs System.CommandLine. -->
     <add key="dotnet-libraries" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-libraries/nuget/v3/index.json" />
+    <!-- Used for nightly builds of dotnet-gcdump and Microsoft.Diagnostics.NETCore.Client. -->
+    <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
     <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
 </configuration>

--- a/versions.props
+++ b/versions.props
@@ -49,7 +49,7 @@
 
     <BouncyCastleVersion>2.2.*</BouncyCastleVersion>
     <ConsulVersion>1.7.14.*</ConsulVersion>
-    <DotnetGCDumpVersion>9.0.621003</DotnetGCDumpVersion>
+    <DotnetGCDumpVersion>9.0.637201</DotnetGCDumpVersion>
     <EntityFrameworkCoreVersion>8.0.*</EntityFrameworkCoreVersion>
     <FoundationalVersion>
       <!--
@@ -59,8 +59,8 @@
       9.0.*
     </FoundationalVersion>
     <MicrosoftIdentityModelVersion>8.12.*</MicrosoftIdentityModelVersion>
-    <MicrosoftDiagnosticsNETCoreClientVersion>0.2.621003</MicrosoftDiagnosticsNETCoreClientVersion>
-    <MicrosoftDiagnosticsTracingTraceEventVersion>3.1.16</MicrosoftDiagnosticsTracingTraceEventVersion>
+    <MicrosoftDiagnosticsNETCoreClientVersion>0.2.637201</MicrosoftDiagnosticsNETCoreClientVersion>
+    <MicrosoftDiagnosticsTracingTraceEventVersion>3.1.23</MicrosoftDiagnosticsTracingTraceEventVersion>
     <OpenTelemetryExporterPrometheusVersion>1.12.*-*</OpenTelemetryExporterPrometheusVersion>
     <OpenTelemetryVersion>1.12.*</OpenTelemetryVersion>
     <SerilogVersion>9.0.*</SerilogVersion>


### PR DESCRIPTION
## Description

Builds against nightly builds of `dotnet-gcdump` and `Microsoft.Diagnostics.NETCore.Client`, along with a higher stable version of `Microsoft.Diagnostics.Tracing.TraceEvent`. These all depend on `Microsoft.Diagnostics.FastSerialization.dll` v3.1.23.0.

This should fix the random off-by-one errors when taking a gcdump via its management endpoint.

> [!NOTE]
> This PR exists for compatibility testing only, do not merge.

_Update: after getting a green build [more than 50 times](https://github.com/SteeltoeOSS/Steeltoe/actions/runs/16470219607), this is considered stable now._

## Quality checklist

- [x] Your code complies with our [Coding Style](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-code-style.md).
- [ ] You've updated unit and/or integration tests for your change, where applicable.
- [ ] You've updated documentation for your change, where applicable.
      If your change affects other repositories, such as [Documentation](https://github.com/SteeltoeOSS/Documentation), [Samples](https://github.com/SteeltoeOSS/Samples) and/or [MainSite](https://github.com/SteeltoeOSS/MainSite), add linked PRs here.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
- [ ] You've added required license files and/or file headers (explaining where the code came from with proper attribution), where code is copied from StackOverflow, a blog, or OSS.
