### PR TITLE
Remove explicit package versions from project files

### DIFF
--- a/src/Common/src/Common.Kubernetes/Steeltoe.Common.Kubernetes.csproj
+++ b/src/Common/src/Common.Kubernetes/Steeltoe.Common.Kubernetes.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.1;netstandard2.0</TargetFrameworks>
     <Description>Steeltoe common library for Kubernetes</Description>
@@ -8,16 +8,11 @@
   <Import Project="..\..\..\..\versions.props" />
   <Import Project="..\..\..\..\sharedproject.props" />
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="KubernetesClient" Version="2.0.16" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
+  <ItemGroup>
     <PackageReference Include="KubernetesClient" Version="$(KubernetesClientVersion)" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Common\Steeltoe.Common.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/Common/test/Common.TestResources/Steeltoe.Common.TestResources.csproj
+++ b/src/Common/test/Common.TestResources/Steeltoe.Common.TestResources.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="$(ExtensionsVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="$(ExtensionsVersion)" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="$(ExtensionsVersion)" />
-    <PackageReference Include="xunit.abstractions" Version="2.0.3" />
+    <PackageReference Include="xunit.abstractions" Version="$(XunitAbstractionsVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Configuration/src/ConfigServerBase/Steeltoe.Extensions.Configuration.ConfigServerBase.csproj
+++ b/src/Configuration/src/ConfigServerBase/Steeltoe.Extensions.Configuration.ConfigServerBase.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.1;netstandard2.0</TargetFrameworks>
     <RootNamespace>Steeltoe.Extensions.Configuration.ConfigServer</RootNamespace>
@@ -10,7 +10,7 @@
   <Import Project="..\..\..\..\sharedproject.props" />
 
   <ItemGroup>
-    <PackageReference Include="System.Net.Http.Json" Version="3.2.1" />
+    <PackageReference Include="System.Net.Http.Json" Version="$(SystemNetHttpJsonVersion)" />
   </ItemGroup>
   
   <ItemGroup>

--- a/src/Connectors/src/ConnectorBase/CosmosDb/CosmosDbTypeLocator.cs
+++ b/src/Connectors/src/ConnectorBase/CosmosDb/CosmosDbTypeLocator.cs
@@ -15,14 +15,14 @@ public static class CosmosDbTypeLocator
     /// <summary>
     /// Gets a list of supported CosmosDbDB assemblies
     /// </summary>
-    public static string[] Assemblies { get; internal set; } = new string[] { "Azure.Cosmos", "Microsoft.Azure.Cosmos.Client" };
+    public static string[] Assemblies { get; internal set; } = new string[] { "Microsoft.Azure.Cosmos.Client" };
 
     /// <summary>
     /// Gets a list of supported CosmosDbDB client types
     /// </summary>
-    public static string[] ConnectionTypeNames { get; internal set; } = new string[] { "Azure.Cosmos.CosmosClient", "Microsoft.Azure.Cosmos.CosmosClient" };
+    public static string[] ConnectionTypeNames { get; internal set; } = new string[] { "Microsoft.Azure.Cosmos.CosmosClient" };
 
-    public static string[] ClientOptionsTypeNames { get; internal set; } = new string[] { "Azure.Cosmos.CosmosClientOptions", "Microsoft.Azure.Cosmos.CosmosClientOptions" };
+    public static string[] ClientOptionsTypeNames { get; internal set; } = new string[] { "Microsoft.Azure.Cosmos.CosmosClientOptions" };
 
     /// <summary>
     /// Gets CosmosDbClient from CosmosDbDB Library

--- a/src/Connectors/test/ConnectorBase.Test/CosmosDb/CosmosDbConnectorFactoryTest.cs
+++ b/src/Connectors/test/ConnectorBase.Test/CosmosDb/CosmosDbConnectorFactoryTest.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-using Azure.Cosmos;
+using Microsoft.Azure.Cosmos;
 using Steeltoe.Connector.Services;
 using System;
 using Xunit;
@@ -53,7 +53,7 @@ public class CosmosDbConnectorFactoryTest
     public void Create_ReturnsCosmosDbConnection_v3()
     {
         var optionsTypes = CosmosDbTypeLocator.ClientOptionsTypeNames;
-        CosmosDbTypeLocator.ClientOptionsTypeNames = new string[] { CosmosDbTypeLocator.ClientOptionsTypeNames[1] };
+        CosmosDbTypeLocator.ClientOptionsTypeNames = new string[] { CosmosDbTypeLocator.ClientOptionsTypeNames[0] };
 
         var si = new CosmosDbServiceInfo("MyId")
         {

--- a/src/Connectors/test/ConnectorBase.Test/Steeltoe.Connector.ConnectorBase.Test.csproj
+++ b/src/Connectors/test/ConnectorBase.Test/Steeltoe.Connector.ConnectorBase.Test.csproj
@@ -15,8 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="Moq" Version="$(MoqVersion)" />
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.7.0" />
-    <PackageReference Include="Azure.Cosmos" Version="4.0.0-preview3" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="$(MicrosoftAzureCosmosVersion)" />
     <PackageReference Include="Oracle.ManagedDataAccess.Core" Version="$(OracleManagedDataAccessCoreVersion)" />
     <PackageReference Include="System.Data.SqlClient" Version="$(SqlClientVersion)" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="$(MicrosoftSqlClientVersion)" />

--- a/src/Discovery/src/Eureka/Steeltoe.Discovery.Eureka.csproj
+++ b/src/Discovery/src/Eureka/Steeltoe.Discovery.Eureka.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <Description>Client for service discovery and registration with Neflix Eureka</Description>
@@ -9,7 +9,7 @@
   <Import Project="..\..\..\..\sharedproject.props" />
 
   <ItemGroup>
-    <PackageReference Include="System.Net.Http.Json" Version="3.2.1" />
+    <PackageReference Include="System.Net.Http.Json" Version="$(SystemNetHttpJsonVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Integration/test/Benchmark/Benchmark.csproj
+++ b/src/Integration/test/Benchmark/Benchmark.csproj
@@ -8,7 +8,7 @@
   <Import Project="..\..\..\..\versions.props" />
   
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.12.0" />
+    <PackageReference Include="BenchmarkDotNet" Version="$(BenchmarkDotNetVersion)" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(ExtensionsVersion)" />
   </ItemGroup>
 

--- a/src/Logging/src/DynamicSerilogBase/Steeltoe.Extensions.Logging.DynamicSerilogBase.csproj
+++ b/src/Logging/src/DynamicSerilogBase/Steeltoe.Extensions.Logging.DynamicSerilogBase.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <Description>Steeltoe library for enabling dynamic management of Serilog.</Description>
@@ -11,9 +11,9 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="$(ExtensionsVersion)" />
-    <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1" />
-    <PackageReference Include="Serilog.Settings.Configuration" Version="3.0.1" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="$(SerilogVersion)" />
+    <PackageReference Include="Serilog.Settings.Configuration" Version="$(SerilogVersion)" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="$(SerilogSinksConsoleVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Logging/test/DynamicSerilogBase.Test/Steeltoe.Extensions.Logging.DynamicSerilogBase.Test.csproj
+++ b/src/Logging/test/DynamicSerilogBase.Test/Steeltoe.Extensions.Logging.DynamicSerilogBase.Test.csproj
@@ -17,9 +17,9 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="$(AspNetCoreVersion)" />
-    <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
+    <PackageReference Include="Serilog.Enrichers.Thread" Version="$(SerilogEnrichersThreadVersion)" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="$(ExtensionsVersion)" />
-    <PackageReference Include="Serilog.Exceptions" Version="5.0.0" />
+    <PackageReference Include="Serilog.Exceptions" Version="$(SerilogExceptionsVersion)" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\DynamicSerilogBase\Steeltoe.Extensions.Logging.DynamicSerilogBase.csproj" />

--- a/src/Logging/test/DynamicSerilogCore.Test/Steeltoe.Extensions.Logging.DynamicSerilogCore.Test.csproj
+++ b/src/Logging/test/DynamicSerilogCore.Test/Steeltoe.Extensions.Logging.DynamicSerilogCore.Test.csproj
@@ -19,9 +19,9 @@
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="$(ExtensionsVersion)" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="$(ExtensionsVersion)" />
-    <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
-    <PackageReference Include="Serilog.Exceptions" Version="5.0.0" />
-    <PackageReference Include="Serilog.Sinks.Debug" Version="2.0.0" />
+    <PackageReference Include="Serilog.Enrichers.Thread" Version="$(SerilogEnrichersThreadVersion)" />
+    <PackageReference Include="Serilog.Exceptions" Version="$(SerilogExceptionsVersion)" />
+    <PackageReference Include="Serilog.Sinks.Debug" Version="$(SerilogSinksDebugVersion)" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\DynamicSerilogCore\Steeltoe.Extensions.Logging.DynamicSerilogCore.csproj" />

--- a/src/Management/src/EndpointBase/Steeltoe.Management.EndpointBase.csproj
+++ b/src/Management/src/EndpointBase/Steeltoe.Management.EndpointBase.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.1</TargetFrameworks>
     <RootNamespace>Steeltoe.Management.Endpoint</RootNamespace>
@@ -11,8 +11,8 @@
   <Import Project="..\..\..\..\sharedproject.props" />
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Diagnostics.NETCore.Client" Version="0.2.236902" />
-    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="2.0.64" />
+    <PackageReference Include="Microsoft.Diagnostics.NETCore.Client" Version="$(DiagnosticsNETCoreClientVersion)" />
+    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="$(DiagnosticsTracingTraceEventVersion)" />
     <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="$(ExtensionsVersion)" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(ExtensionsVersion)" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="$(ExtensionsVersion)" />

--- a/src/Management/test/EndpointBase.Test/Steeltoe.Management.EndpointBase.Test.csproj
+++ b/src/Management/test/EndpointBase.Test/Steeltoe.Management.EndpointBase.Test.csproj
@@ -39,7 +39,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="$(EFCoreTestVersion)" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="$(EFCoreTestVersion)" />
-    <PackageReference Include="NSubstitute" Version="4.2.0" />
+    <PackageReference Include="NSubstitute" Version="$(NSubstituteVersion)" />
     <PackageReference Include="RichardSzalay.MockHttp" Version="$(MockHttpVersion)" />
   </ItemGroup>
 </Project>

--- a/src/Management/test/EndpointCore.Test/Steeltoe.Management.EndpointCore.Test.csproj
+++ b/src/Management/test/EndpointCore.Test/Steeltoe.Management.EndpointCore.Test.csproj
@@ -42,8 +42,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AspNetCore.HealthChecks.System" Version="3.1.2" />
-    <PackageReference Include="FluentAssertions.Json" Version="5.5.0" />
+    <PackageReference Include="AspNetCore.HealthChecks.System" Version="$(AspNetCoreHealthChecksVersion)" />
+    <PackageReference Include="FluentAssertions.Json" Version="$(FluentAssertionsJsonVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="OpenTelemetry.Exporter.Console" Version="$(OpenTelemetryVersion)" />
   </ItemGroup>

--- a/src/Messaging/src/RabbitMQ/Steeltoe.Messaging.RabbitMQ.csproj
+++ b/src/Messaging/src/RabbitMQ/Steeltoe.Messaging.RabbitMQ.csproj
@@ -23,7 +23,7 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="$(JsonNetVersion)" />
-    <PackageReference Include="RabbitMQ.Client" Version="5.1.2" />
+    <PackageReference Include="RabbitMQ.Client" Version="$(RabbitClientVersion)" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="$(ExtensionsVersion)" />
   </ItemGroup>
   

--- a/src/Messaging/test/Benchmarks/Channel/ChannelBenchmark.csproj
+++ b/src/Messaging/test/Benchmarks/Channel/ChannelBenchmark.csproj
@@ -9,7 +9,7 @@
   <Import Project="..\..\..\..\..\versions.props" />
   
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.12.0" />
+    <PackageReference Include="BenchmarkDotNet" Version="$(BenchmarkDotNetVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Stream/test/BinderRabbitMQ.Test/Steeltoe.Stream.Binder.RabbitMQ.Test.csproj
+++ b/src/Stream/test/BinderRabbitMQ.Test/Steeltoe.Stream.Binder.RabbitMQ.Test.csproj
@@ -17,7 +17,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\BinderTests\Steeltoe.Stream.BinderTests.csproj" />
-    <PackageReference Include="EasyNetQ.Management.Client" Version="1.3.0" />
+    <PackageReference Include="EasyNetQ.Management.Client" Version="$(EasyNetQVersion)" />
     <PackageReference Include="Moq" Version="$(MoqVersion)" />
   </ItemGroup>
 

--- a/versions.props
+++ b/versions.props
@@ -16,7 +16,6 @@
     <SystemJsonVersion>8.0.5</SystemJsonVersion>
     <SystemNetHttpJsonVersion>3.2.1</SystemNetHttpJsonVersion>
     <SystemReflectionVersion>4.6.0</SystemReflectionVersion>
-    <KubernetesClientVersion>5.0.13</KubernetesClientVersion>
     <BouncyCastleVersion>1.8.4</BouncyCastleVersion>
     <ConsulVersion>1.6.10.3</ConsulVersion>
     <HdrHistogramVersion>2.0.0</HdrHistogramVersion>
@@ -25,7 +24,7 @@
     <JsonNetVersion>13.0.1</JsonNetVersion>
     <OpenTelemetryVersion>1.8.1</OpenTelemetryVersion>
     <WavefrontSdkVersion>1.8.0-beta</WavefrontSdkVersion>
-    <RabbitClientVersion>5.0.1</RabbitClientVersion>
+    <RabbitClientVersion>5.1.2</RabbitClientVersion>
     <ReactiveVersion>4.1.5</ReactiveVersion>
     <PollyVersion>7.1.1</PollyVersion>
     <PollyContribVersion>1.0.0</PollyContribVersion>
@@ -36,8 +35,13 @@
     <HealthChecksVersion>3.1.0</HealthChecksVersion>
     <LoggingVersion>3.1.0</LoggingVersion>
     <LightweightEmitVersion>4.7.0</LightweightEmitVersion>
+    <DiagnosticsNETCoreClientVersion>0.2.236902</DiagnosticsNETCoreClientVersion>
+    <DiagnosticsTracingTraceEventVersion>2.0.64</DiagnosticsTracingTraceEventVersion>
+    <SerilogSinksConsoleVersion>3.1.1</SerilogSinksConsoleVersion>
+    <SerilogVersion>3.0.1</SerilogVersion>
 
     <!-- Non-exposed dependencies, only referenced from test projects, build infrastructure and internal tools. -->
+    <BenchmarkDotNetVersion>0.12.0</BenchmarkDotNetVersion>
     <MongoDbClientVersion>3.0.0</MongoDbClientVersion>
     <MySqlConnectorVersion>0.49.3</MySqlConnectorVersion>
     <MySqlV8>8.0.23</MySqlV8>
@@ -45,23 +49,42 @@
     <SqlClientVersion>4.8.6</SqlClientVersion>
     <MicrosoftSqlClientVersion>5.1.3</MicrosoftSqlClientVersion>
     <OracleManagedDataAccessCoreVersion>3.21.90</OracleManagedDataAccessCoreVersion>
+    <EasyNetQVersion>1.3.0</EasyNetQVersion>
+    <MicrosoftAzureCosmosVersion>3.52.1</MicrosoftAzureCosmosVersion>
     <StackExchangeVersion>2.0.593</StackExchangeVersion>
     <CoverletVersion>6.0.4</CoverletVersion>
+    <FluentAssertionsJsonVersion>6.1.0</FluentAssertionsJsonVersion>
     <FluentAssertionsVersion>7.2.0</FluentAssertionsVersion>
     <MockHttpVersion>6.0.0</MockHttpVersion>
     <MoqVersion>4.13.1</MoqVersion>
+    <NSubstituteVersion>4.2.0</NSubstituteVersion>
     <TestSdkVersion>17.0.0</TestSdkVersion>
     <XunitVersion>2.4.1</XunitVersion>
+    <XunitAbstractionsVersion>2.0.3</XunitAbstractionsVersion>
     <XunitStudioVersion>2.4.3</XunitStudioVersion>
+    <AspNetCoreHealthChecksVersion>3.1.2</AspNetCoreHealthChecksVersion>
     <HealthChecksMySqlVersion>2.2.0</HealthChecksMySqlVersion>
     <HealthChecksMongoDbVersion>9.0.0</HealthChecksMongoDbVersion>
     <HealthChecksNpgSqlVersion>2.2.0</HealthChecksNpgSqlVersion>
     <HealthChecksRabbitmqVersion>2.2.1</HealthChecksRabbitmqVersion>
     <HealthChecksRedisVersion>2.2.3</HealthChecksRedisVersion>
     <HealthChecksSqlServerVersion>2.2.0</HealthChecksSqlServerVersion>
+    <SerilogEnrichersThreadVersion>3.1.0</SerilogEnrichersThreadVersion>
+    <SerilogExceptionsVersion>5.0.0</SerilogExceptionsVersion>
+    <SerilogSinksDebugVersion>2.0.0</SerilogSinksDebugVersion>
     <SonarAnalyzerVersion>8.32.0.39516</SonarAnalyzerVersion>
     <SourceLinkGitHubVersion>1.1.1</SourceLinkGitHubVersion>
     <StyleCopVersion>1.1.118</StyleCopVersion>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <!-- Exposed dependencies, observable by Steeltoe library consumers. Only update when vulnerable. -->
+    <KubernetesClientVersion>2.0.16</KubernetesClientVersion>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
+    <!-- Exposed dependencies, observable by Steeltoe library consumers. Only update when vulnerable. -->
+    <KubernetesClientVersion>5.0.13</KubernetesClientVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'net6.0'">


### PR DESCRIPTION
## Description

Replace all explicit package versions from project files with a version variable. The following versions were changed:

- [EXPOSED] `RabbitMQ.Client`: Bumped from 5.0.1 to 5.1.2 (5.1.2 was already used at some places)
- [NON-EXPOSED] `Azure.Cosmos`: Removed (was at 4.0.0-preview3), because the package has been unlisted on nuget.org
- [NON-EXPOSED] `Microsoft.Azure.Cosmos`: Bumped from 3.7.0 to 3.52.1
- [NON-EXPOSED] `FluentAssertions.Json`: Bumped from 5.5.0 to 6.1.0

## Quality checklist

- [x] Your code complies with our [Coding Style](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-code-style.md).
- [x] You've updated unit and/or integration tests for your change, where applicable.
- [ ] You've updated documentation for your change, where applicable.
      If your change affects other repositories, such as [Documentation](https://github.com/SteeltoeOSS/Documentation), [Samples](https://github.com/SteeltoeOSS/Samples) and/or [MainSite](https://github.com/SteeltoeOSS/MainSite), add linked PRs here.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
- [ ] You've added required license files and/or file headers (explaining where the code came from with proper attribution), where code is copied from StackOverflow, a blog, or OSS.
