### PR TITLE
Fix transitive vulnerable dependencies 3x

### DIFF
--- a/.github/workflows/scan-vulnerable-dependencies.yml
+++ b/.github/workflows/scan-vulnerable-dependencies.yml
@@ -1,0 +1,40 @@
+name: Scan vulnerable dependencies
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+    - '3.x'
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  DOTNET_CLI_TELEMETRY_OPTOUT: 1
+  DOTNET_NOLOGO: true
+  SOLUTION_FILE: 'src/Steeltoe.All.sln'
+
+jobs:
+  scan:
+    name: Scan
+    timeout-minutes: 15
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: |
+          6.0.*
+          8.0.*
+
+    - name: Git checkout
+      uses: actions/checkout@v4
+
+    - name: Report vulnerable dependencies
+      run: dotnet restore ${{ env.SOLUTION_FILE }} --verbosity minimal /p:NuGetAudit=true /p:NuGetAuditMode=all /p:NuGetAuditLevel=low /p:TreatWarningsAsErrors=True

--- a/sharedproject.props
+++ b/sharedproject.props
@@ -22,17 +22,21 @@
     <NoWarn>$(NoWarn);SA1101;SA1124;S1128;SA1201;SA1309;SA1310;SA1314;SA1401;SA1402;SA1413;SA1600;SA1629;SA1652;1591;S101;S1075;S1854;S4792;S3011;IDE1006;IDE0017;IDE0130;IDE0150;IDE0090;CA2252;ASP0019;S4487</NoWarn>
     <CodeAnalysisRuleSet>..\..\..\..\Steeltoe.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
+
   <PropertyGroup>
     <LangVersion>10.0</LangVersion>
     <EnablePreviewFeatures>false</EnablePreviewFeatures>
   </PropertyGroup>
+
   <PropertyGroup Condition="'$(BUILD_PACKAGES)' == 'true'">
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
   </PropertyGroup>
+
   <ItemGroup Condition="'$(BUILD_PACKAGES)' == 'true'">
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="$(SourceLinkGitHubVersion)" PrivateAssets="All"/>
   </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="SonarAnalyzer.CSharp" Version="$(SonarAnalyzerVersion)">
       <PrivateAssets>all</PrivateAssets>
@@ -42,13 +46,20 @@
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
   </ItemGroup>
+
   <ItemGroup>
     <AdditionalFiles Include="..\..\..\..\stylecop.json">
       <Link>stylecop.json</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </AdditionalFiles>
   </ItemGroup>
+
   <ItemGroup>
     <None Include="..\..\..\..\build\icon.png" Pack="true" PackagePath="\"/>
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- All versions of Microsoft.Rest.ClientRuntime are vulnerable, but all higher versions of KubernetesClient without breaking changes depend on it. -->
+    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-whph-446h-6m9v" />
   </ItemGroup>
 </Project>

--- a/sharedtest.props
+++ b/sharedtest.props
@@ -2,23 +2,28 @@
   <PropertyGroup>
     <NoWarn>$(NoWarn);SA0001;SA1101;SA1124;SA1200;SA1201;SA1208;SA1309;SA1310;SA1314;SA1401;SA1402;SA1413;SA1600;SA1629;SA1652;1591;CS8002;CA1018;CA1031;CA1063;CA1041;CA1802;CA1822;CA2211;CA2213;CA2235;CA2237;IDE1006;IDE0052;IDE0059;IDE0060;IDE0090;IDE0130;IDE0150;S4792;ASP0016;ASP0019</NoWarn>
   </PropertyGroup>
+
   <PropertyGroup>
     <LangVersion>10.0</LangVersion>
     <EnablePreviewFeatures>true</EnablePreviewFeatures>
   </PropertyGroup>
+  
   <PropertyGroup Condition="'$(TF_BUILD)' == 'true'">
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
   </PropertyGroup>
+  
   <ItemGroup>
     <AdditionalFiles Include="..\..\..\..\stylecop.json">
       <Link>stylecop.json</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </AdditionalFiles>
   </ItemGroup>
+  
   <ItemGroup>
     <ProjectReference Include="..\..\..\Common\test\Common.TestResources\Steeltoe.Common.TestResources.csproj" />
   </ItemGroup>
+  
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
     <PackageReference Include="xunit" Version="$(XunitVersion)" />
@@ -31,5 +36,10 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- All versions of Microsoft.Rest.ClientRuntime are vulnerable, but all higher versions of KubernetesClient without breaking changes depend on it. -->
+    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-whph-446h-6m9v" />
   </ItemGroup>
 </Project>

--- a/src/Bootstrap/test/Autoconfig.Test/Steeltoe.Bootstrap.Autoconfig.Test.csproj
+++ b/src/Bootstrap/test/Autoconfig.Test/Steeltoe.Bootstrap.Autoconfig.Test.csproj
@@ -35,6 +35,7 @@
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Google.Protobuf" Version="$(GoogleProtobufVersion)" />
     <PackageReference Include="MySql.Data" Version="$(MySqlV8)" />
+    <PackageReference Include="System.Drawing.Common" Version="$(SystemDrawingCommonVersion)" />
     <PackageReference Include="MongoDB.Driver" Version="$(MongoDbClientVersion)" />
     <PackageReference Include="Oracle.ManagedDataAccess.Core" Version="$(OracleManagedDataAccessCoreVersion)" />
     <PackageReference Include="Npgsql" Version="$(NpgsqlVersion)" />

--- a/src/Bootstrap/test/Autoconfig.Test/Steeltoe.Bootstrap.Autoconfig.Test.csproj
+++ b/src/Bootstrap/test/Autoconfig.Test/Steeltoe.Bootstrap.Autoconfig.Test.csproj
@@ -42,6 +42,7 @@
     <PackageReference Include="RabbitMQ.Client" Version="$(RabbitClientVersion)" />
     <PackageReference Include="StackExchange.Redis" Version="$(StackExchangeVersion)" />
     <PackageReference Include="System.Data.SqlClient" Version="$(SqlClientVersion)" />
+    <PackageReference Include="SSH.NET" Version="$(SshNetVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/Bootstrap/test/Autoconfig.Test/Steeltoe.Bootstrap.Autoconfig.Test.csproj
+++ b/src/Bootstrap/test/Autoconfig.Test/Steeltoe.Bootstrap.Autoconfig.Test.csproj
@@ -33,7 +33,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="$(AspNetCoreVersion)" />
-
+    <PackageReference Include="Google.Protobuf" Version="$(GoogleProtobufVersion)" />
     <PackageReference Include="MySql.Data" Version="$(MySqlV8)" />
     <PackageReference Include="MongoDB.Driver" Version="$(MongoDbClientVersion)" />
     <PackageReference Include="Oracle.ManagedDataAccess.Core" Version="$(OracleManagedDataAccessCoreVersion)" />

--- a/src/Common/src/Common.Kubernetes/Steeltoe.Common.Kubernetes.csproj
+++ b/src/Common/src/Common.Kubernetes/Steeltoe.Common.Kubernetes.csproj
@@ -10,6 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="KubernetesClient" Version="$(KubernetesClientVersion)" />
+    <PackageReference Include="Newtonsoft.Json" Version="$(JsonNetVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Common/src/Common.Kubernetes/Steeltoe.Common.Kubernetes.csproj
+++ b/src/Common/src/Common.Kubernetes/Steeltoe.Common.Kubernetes.csproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <PackageReference Include="KubernetesClient" Version="$(KubernetesClientVersion)" />
     <PackageReference Include="Newtonsoft.Json" Version="$(JsonNetVersion)" />
+    <PackageReference Include="System.Net.Http" Version="$(SystemNetHttpVersion)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="$(SystemTextRegularExpressionsVersion)" />
   </ItemGroup>
 

--- a/src/Common/src/Common.Kubernetes/Steeltoe.Common.Kubernetes.csproj
+++ b/src/Common/src/Common.Kubernetes/Steeltoe.Common.Kubernetes.csproj
@@ -13,6 +13,8 @@
     <PackageReference Include="Newtonsoft.Json" Version="$(JsonNetVersion)" />
     <PackageReference Include="System.Net.Http" Version="$(SystemNetHttpVersion)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="$(SystemTextRegularExpressionsVersion)" />
+    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="$(JwtTokensVersion)" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="$(JwtTokensVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Common/src/Common.Kubernetes/Steeltoe.Common.Kubernetes.csproj
+++ b/src/Common/src/Common.Kubernetes/Steeltoe.Common.Kubernetes.csproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <PackageReference Include="KubernetesClient" Version="$(KubernetesClientVersion)" />
     <PackageReference Include="Newtonsoft.Json" Version="$(JsonNetVersion)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="$(SystemTextRegularExpressionsVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Common/test/Common.TestResources/Steeltoe.Common.TestResources.csproj
+++ b/src/Common/test/Common.TestResources/Steeltoe.Common.TestResources.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="$(JsonNetVersion)" />
     <PackageReference Include="System.Formats.Asn1" Version="$(SystemFormatsAsn1Version)" />
     <PackageReference Include="System.Text.Json" Version="$(SystemJsonVersion)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="$(SystemTextRegularExpressionsVersion)" />
     <PackageReference Include="xunit.abstractions" Version="$(XunitAbstractionsVersion)" />
   </ItemGroup>
 

--- a/src/Common/test/Common.TestResources/Steeltoe.Common.TestResources.csproj
+++ b/src/Common/test/Common.TestResources/Steeltoe.Common.TestResources.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
@@ -14,6 +14,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="$(ExtensionsVersion)" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="$(ExtensionsVersion)" />
     <PackageReference Include="Newtonsoft.Json" Version="$(JsonNetVersion)" />
+    <PackageReference Include="System.Formats.Asn1" Version="$(SystemFormatsAsn1Version)" />
     <PackageReference Include="System.Text.Json" Version="$(SystemJsonVersion)" />
     <PackageReference Include="xunit.abstractions" Version="$(XunitAbstractionsVersion)" />
   </ItemGroup>

--- a/src/Common/test/Common.TestResources/Steeltoe.Common.TestResources.csproj
+++ b/src/Common/test/Common.TestResources/Steeltoe.Common.TestResources.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="Microsoft.Extensions.Options" Version="$(ExtensionsVersion)" />
     <PackageReference Include="Newtonsoft.Json" Version="$(JsonNetVersion)" />
     <PackageReference Include="System.Formats.Asn1" Version="$(SystemFormatsAsn1Version)" />
+    <PackageReference Include="System.Net.Http" Version="$(SystemNetHttpVersion)" />
     <PackageReference Include="System.Text.Json" Version="$(SystemJsonVersion)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="$(SystemTextRegularExpressionsVersion)" />
     <PackageReference Include="xunit.abstractions" Version="$(XunitAbstractionsVersion)" />

--- a/src/Common/test/Common.TestResources/Steeltoe.Common.TestResources.csproj
+++ b/src/Common/test/Common.TestResources/Steeltoe.Common.TestResources.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="$(ExtensionsVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="$(ExtensionsVersion)" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="$(ExtensionsVersion)" />
+    <PackageReference Include="System.Text.Json" Version="$(SystemJsonVersion)" />
     <PackageReference Include="xunit.abstractions" Version="$(XunitAbstractionsVersion)" />
   </ItemGroup>
 

--- a/src/Common/test/Common.TestResources/Steeltoe.Common.TestResources.csproj
+++ b/src/Common/test/Common.TestResources/Steeltoe.Common.TestResources.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="$(ExtensionsVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="$(ExtensionsVersion)" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="$(ExtensionsVersion)" />
+    <PackageReference Include="Newtonsoft.Json" Version="$(JsonNetVersion)" />
     <PackageReference Include="System.Text.Json" Version="$(SystemJsonVersion)" />
     <PackageReference Include="xunit.abstractions" Version="$(XunitAbstractionsVersion)" />
   </ItemGroup>

--- a/src/Configuration/src/KubernetesBase/Steeltoe.Extensions.Configuration.KubernetesBase.csproj
+++ b/src/Configuration/src/KubernetesBase/Steeltoe.Extensions.Configuration.KubernetesBase.csproj
@@ -18,5 +18,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="$(ExtensionsVersion)" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="$(ExtensionsVersion)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="$(SystemTextRegularExpressionsVersion)" />
   </ItemGroup>
 </Project>

--- a/src/Configuration/src/SpringBootBase/Steeltoe.Extensions.Configuration.SpringBootBase.csproj
+++ b/src/Configuration/src/SpringBootBase/Steeltoe.Extensions.Configuration.SpringBootBase.csproj
@@ -13,5 +13,6 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="$(ExtensionsVersion)" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="$(ExtensionsVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(ExtensionsVersion)" />
+    <PackageReference Include="System.Text.Json" Version="$(SystemJsonVersion)" />
   </ItemGroup>
 </Project>

--- a/src/Connectors/src/Connector.EFCore/Steeltoe.Connector.EFCore.csproj
+++ b/src/Connectors/src/Connector.EFCore/Steeltoe.Connector.EFCore.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <Description>Package for using Steeltoe Connectors with Entity Framework Core</Description>
@@ -11,6 +11,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="$(EFCoreVersion)" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="$(EFCoreVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="$(ExtensionsCachingMemoryVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Connectors/test/Connector.EF6Core.Test/Steeltoe.Connector.EF6Core.Test.csproj
+++ b/src/Connectors/test/Connector.EF6Core.Test/Steeltoe.Connector.EF6Core.Test.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="Google.Protobuf" Version="$(GoogleProtobufVersion)" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(ExtensionsVersion)" />
     <PackageReference Include="MySql.Data.EntityFramework" Version="$(MySqlV8)" />
+    <PackageReference Include="System.Drawing.Common" Version="$(SystemDrawingCommonVersion)" />
     <PackageReference Include="Oracle.ManagedDataAccess.Core" Version="$(OracleManagedDataAccessCoreVersion)" />
     <PackageReference Include="System.Data.SqlClient" Version="$(SqlClientVersion)" />
   </ItemGroup>

--- a/src/Connectors/test/Connector.EF6Core.Test/Steeltoe.Connector.EF6Core.Test.csproj
+++ b/src/Connectors/test/Connector.EF6Core.Test/Steeltoe.Connector.EF6Core.Test.csproj
@@ -13,6 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Google.Protobuf" Version="$(GoogleProtobufVersion)" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(ExtensionsVersion)" />
     <PackageReference Include="MySql.Data.EntityFramework" Version="$(MySqlV8)" />
     <PackageReference Include="Oracle.ManagedDataAccess.Core" Version="$(OracleManagedDataAccessCoreVersion)" />

--- a/src/Connectors/test/Connector.EF6Core.Test/Steeltoe.Connector.EF6Core.Test.csproj
+++ b/src/Connectors/test/Connector.EF6Core.Test/Steeltoe.Connector.EF6Core.Test.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(ExtensionsVersion)" />
     <PackageReference Include="MySql.Data.EntityFramework" Version="$(MySqlV8)" />
     <PackageReference Include="Oracle.ManagedDataAccess.Core" Version="$(OracleManagedDataAccessCoreVersion)" />
+    <PackageReference Include="System.Data.SqlClient" Version="$(SqlClientVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Connectors/test/Connector.EF6Core.Test/Steeltoe.Connector.EF6Core.Test.csproj
+++ b/src/Connectors/test/Connector.EF6Core.Test/Steeltoe.Connector.EF6Core.Test.csproj
@@ -19,6 +19,7 @@
     <PackageReference Include="System.Drawing.Common" Version="$(SystemDrawingCommonVersion)" />
     <PackageReference Include="Oracle.ManagedDataAccess.Core" Version="$(OracleManagedDataAccessCoreVersion)" />
     <PackageReference Include="System.Data.SqlClient" Version="$(SqlClientVersion)" />
+    <PackageReference Include="SSH.NET" Version="$(SshNetVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Connectors/test/Connector.EFCore.Test/Steeltoe.Connector.EFCore.Test.csproj
+++ b/src/Connectors/test/Connector.EFCore.Test/Steeltoe.Connector.EFCore.Test.csproj
@@ -22,6 +22,7 @@
     <PackageReference Include="System.Drawing.Common" Version="$(SystemDrawingCommonVersion)" />
     <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="$(JwtTokensVersion)" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="$(JwtTokensVersion)" />
+    <PackageReference Include="Azure.Identity" Version="$(AzureIdentityVersion)" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">

--- a/src/Connectors/test/Connector.EFCore.Test/Steeltoe.Connector.EFCore.Test.csproj
+++ b/src/Connectors/test/Connector.EFCore.Test/Steeltoe.Connector.EFCore.Test.csproj
@@ -20,6 +20,8 @@
     <PackageReference Include="Oracle.EntityFrameworkCore" Version="$(OracleEFCoreVersion)" />
     <PackageReference Include="Oracle.ManagedDataAccess.Core" Version="$(OracleManagedDataAccessCoreVersion)" />
     <PackageReference Include="System.Drawing.Common" Version="$(SystemDrawingCommonVersion)" />
+    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="$(JwtTokensVersion)" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="$(JwtTokensVersion)" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">

--- a/src/Connectors/test/Connector.EFCore.Test/Steeltoe.Connector.EFCore.Test.csproj
+++ b/src/Connectors/test/Connector.EFCore.Test/Steeltoe.Connector.EFCore.Test.csproj
@@ -15,6 +15,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Data.SqlClient" Version="$(MicrosoftSqlClientVersion)" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="$(EFCoreTestVersion)" />
+    <PackageReference Include="Npgsql" Version="$(NpgsqlVersion)" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="$(NpgsqlEFCoreVersion)" />
     <PackageReference Include="Oracle.EntityFrameworkCore" Version="$(OracleEFCoreVersion)" />
   </ItemGroup>

--- a/src/Connectors/test/Connector.EFCore.Test/Steeltoe.Connector.EFCore.Test.csproj
+++ b/src/Connectors/test/Connector.EFCore.Test/Steeltoe.Connector.EFCore.Test.csproj
@@ -19,6 +19,7 @@
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="$(NpgsqlEFCoreVersion)" />
     <PackageReference Include="Oracle.EntityFrameworkCore" Version="$(OracleEFCoreVersion)" />
     <PackageReference Include="Oracle.ManagedDataAccess.Core" Version="$(OracleManagedDataAccessCoreVersion)" />
+    <PackageReference Include="System.Drawing.Common" Version="$(SystemDrawingCommonVersion)" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">

--- a/src/Connectors/test/Connector.EFCore.Test/Steeltoe.Connector.EFCore.Test.csproj
+++ b/src/Connectors/test/Connector.EFCore.Test/Steeltoe.Connector.EFCore.Test.csproj
@@ -13,6 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="$(MicrosoftSqlClientVersion)" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="$(EFCoreTestVersion)" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="$(NpgsqlEFCoreVersion)" />
     <PackageReference Include="Oracle.EntityFrameworkCore" Version="$(OracleEFCoreVersion)" />

--- a/src/Connectors/test/Connector.EFCore.Test/Steeltoe.Connector.EFCore.Test.csproj
+++ b/src/Connectors/test/Connector.EFCore.Test/Steeltoe.Connector.EFCore.Test.csproj
@@ -23,6 +23,7 @@
     <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="$(JwtTokensVersion)" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="$(JwtTokensVersion)" />
     <PackageReference Include="Azure.Identity" Version="$(AzureIdentityVersion)" />
+    <PackageReference Include="BouncyCastle.Cryptography" Version="$(BouncyCastleCryptographyVersion)" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">

--- a/src/Connectors/test/Connector.EFCore.Test/Steeltoe.Connector.EFCore.Test.csproj
+++ b/src/Connectors/test/Connector.EFCore.Test/Steeltoe.Connector.EFCore.Test.csproj
@@ -18,6 +18,7 @@
     <PackageReference Include="Npgsql" Version="$(NpgsqlVersion)" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="$(NpgsqlEFCoreVersion)" />
     <PackageReference Include="Oracle.EntityFrameworkCore" Version="$(OracleEFCoreVersion)" />
+    <PackageReference Include="Oracle.ManagedDataAccess.Core" Version="$(OracleManagedDataAccessCoreVersion)" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">

--- a/src/Connectors/test/ConnectorBase.Test/Steeltoe.Connector.ConnectorBase.Test.csproj
+++ b/src/Connectors/test/ConnectorBase.Test/Steeltoe.Connector.ConnectorBase.Test.csproj
@@ -27,6 +27,8 @@
     <!--<PackageReference Include="MySql.Data" Version="$(MySqlV8)" />-->
     <PackageReference Include="Npgsql" Version="$(NpgsqlVersion)" />
     <PackageReference Include="RabbitMQ.Client" Version="$(RabbitClientVersion)" />
+    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="$(JwtTokensVersion)" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="$(JwtTokensVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Connectors/test/ConnectorBase.Test/Steeltoe.Connector.ConnectorBase.Test.csproj
+++ b/src/Connectors/test/ConnectorBase.Test/Steeltoe.Connector.ConnectorBase.Test.csproj
@@ -29,6 +29,7 @@
     <PackageReference Include="RabbitMQ.Client" Version="$(RabbitClientVersion)" />
     <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="$(JwtTokensVersion)" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="$(JwtTokensVersion)" />
+    <PackageReference Include="Azure.Identity" Version="$(AzureIdentityVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Connectors/test/ConnectorCore.Test/Steeltoe.Connector.ConnectorCore.Test.csproj
+++ b/src/Connectors/test/ConnectorCore.Test/Steeltoe.Connector.ConnectorCore.Test.csproj
@@ -20,6 +20,7 @@
     
     <!--<PackageReference Include="MySqlConnector" Version="$(MySqlConnectorVersion)" />-->
     <PackageReference Include="MySql.Data" Version="$(MySqlV8)" />
+    <PackageReference Include="System.Drawing.Common" Version="$(SystemDrawingCommonVersion)" />
 
     <PackageReference Include="AspNetCore.HealthChecks.MySql" Version="$(HealthChecksMySqlVersion)" />
     <PackageReference Include="AspNetCore.HealthChecks.MongoDb" Version="$(HealthChecksMongoDbVersion)" />

--- a/src/Connectors/test/ConnectorCore.Test/Steeltoe.Connector.ConnectorCore.Test.csproj
+++ b/src/Connectors/test/ConnectorCore.Test/Steeltoe.Connector.ConnectorCore.Test.csproj
@@ -13,6 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Google.Protobuf" Version="$(GoogleProtobufVersion)" />
     <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="$(MicrosoftExtensionsRedisVersion)" />
     <PackageReference Include="MongoDB.Driver" Version="$(MongoDbClientVersion)" />
     <PackageReference Include="Npgsql" Version="$(NpgsqlVersion)" />

--- a/src/Connectors/test/ConnectorCore.Test/Steeltoe.Connector.ConnectorCore.Test.csproj
+++ b/src/Connectors/test/ConnectorCore.Test/Steeltoe.Connector.ConnectorCore.Test.csproj
@@ -21,6 +21,7 @@
     <!--<PackageReference Include="MySqlConnector" Version="$(MySqlConnectorVersion)" />-->
     <PackageReference Include="MySql.Data" Version="$(MySqlV8)" />
     <PackageReference Include="System.Drawing.Common" Version="$(SystemDrawingCommonVersion)" />
+    <PackageReference Include="SSH.NET" Version="$(SshNetVersion)" />
 
     <PackageReference Include="AspNetCore.HealthChecks.MySql" Version="$(HealthChecksMySqlVersion)" />
     <PackageReference Include="AspNetCore.HealthChecks.MongoDb" Version="$(HealthChecksMongoDbVersion)" />

--- a/src/Connectors/test/ConnectorCore.Test/Steeltoe.Connector.ConnectorCore.Test.csproj
+++ b/src/Connectors/test/ConnectorCore.Test/Steeltoe.Connector.ConnectorCore.Test.csproj
@@ -32,6 +32,7 @@
     <!--<PackageReference Include="StackExchange.Redis" Version="$(StackExchangeVersion)" />-->
     <PackageReference Include="System.Data.SqlClient" Version="$(SqlClientVersion)" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(ExtensionsVersion)" />
+    <PackageReference Include="System.Net.Security" Version="$(SystemNetSecurityVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Discovery/src/Consul/Steeltoe.Discovery.Consul.csproj
+++ b/src/Discovery/src/Consul/Steeltoe.Discovery.Consul.csproj
@@ -10,6 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Consul" Version="$(ConsulVersion)" />
+    <PackageReference Include="Newtonsoft.Json" Version="$(JsonNetVersion)" />
     <PackageReference Include="System.Net.Http.WinHttpHandler" Version="$(WinHttpHandlerVersion)" />
   </ItemGroup>
 

--- a/src/Integration/test/Benchmark/Benchmark.csproj
+++ b/src/Integration/test/Benchmark/Benchmark.csproj
@@ -10,6 +10,7 @@
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="$(BenchmarkDotNetVersion)" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(ExtensionsVersion)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="$(SystemTextRegularExpressionsVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Logging/src/DynamicSerilogBase/Steeltoe.Extensions.Logging.DynamicSerilogBase.csproj
+++ b/src/Logging/src/DynamicSerilogBase/Steeltoe.Extensions.Logging.DynamicSerilogBase.csproj
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="$(ExtensionsVersion)" />
+    <PackageReference Include="Newtonsoft.Json" Version="$(JsonNetVersion)" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="$(SerilogVersion)" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="$(SerilogVersion)" />
     <PackageReference Include="Serilog.Sinks.Console" Version="$(SerilogSinksConsoleVersion)" />

--- a/src/Logging/src/DynamicSerilogBase/Steeltoe.Extensions.Logging.DynamicSerilogBase.csproj
+++ b/src/Logging/src/DynamicSerilogBase/Steeltoe.Extensions.Logging.DynamicSerilogBase.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="Serilog.Extensions.Logging" Version="$(SerilogVersion)" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="$(SerilogVersion)" />
     <PackageReference Include="Serilog.Sinks.Console" Version="$(SerilogSinksConsoleVersion)" />
+    <PackageReference Include="System.Text.Json" Version="$(SystemJsonVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Management/src/EndpointBase/Steeltoe.Management.EndpointBase.csproj
+++ b/src/Management/src/EndpointBase/Steeltoe.Management.EndpointBase.csproj
@@ -19,6 +19,7 @@
     <PackageReference Include="Microsoft.DiaSymReader" Version="$(SymReaderVersion)" />
     <PackageReference Include="Microsoft.DiaSymReader.PortablePdb" Version="$(SymReaderPortableVersion)" />
     <PackageReference Include="System.IO.FileSystem.DriveInfo" Version="$(DriveInfoVersion)" />
+    <PackageReference Include="System.Net.Http" Version="$(SystemNetHttpVersion)" />
     <PackageReference Include="System.Net.Http.Json" Version="$(SystemNetHttpJsonVersion)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="$(SystemTextRegularExpressionsVersion)" />
   </ItemGroup>

--- a/src/Management/src/EndpointBase/Steeltoe.Management.EndpointBase.csproj
+++ b/src/Management/src/EndpointBase/Steeltoe.Management.EndpointBase.csproj
@@ -20,6 +20,7 @@
     <PackageReference Include="Microsoft.DiaSymReader.PortablePdb" Version="$(SymReaderPortableVersion)" />
     <PackageReference Include="System.IO.FileSystem.DriveInfo" Version="$(DriveInfoVersion)" />
     <PackageReference Include="System.Net.Http.Json" Version="$(SystemNetHttpJsonVersion)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="$(SystemTextRegularExpressionsVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Management/test/EndpointBase.Test/Steeltoe.Management.EndpointBase.Test.csproj
+++ b/src/Management/test/EndpointBase.Test/Steeltoe.Management.EndpointBase.Test.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <RootNamespace>Steeltoe.Management.Endpoint.Test</RootNamespace>
@@ -39,6 +39,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="$(EFCoreTestVersion)" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="$(EFCoreTestVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="$(ExtensionsCachingMemoryVersion)" />
     <PackageReference Include="NSubstitute" Version="$(NSubstituteVersion)" />
     <PackageReference Include="RichardSzalay.MockHttp" Version="$(MockHttpVersion)" />
   </ItemGroup>

--- a/src/Management/test/EndpointCore.Test/Steeltoe.Management.EndpointCore.Test.csproj
+++ b/src/Management/test/EndpointCore.Test/Steeltoe.Management.EndpointCore.Test.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <AssemblyName>Steeltoe.Management.EndpointCore.Test</AssemblyName>
@@ -45,6 +45,7 @@
     <PackageReference Include="AspNetCore.HealthChecks.System" Version="$(AspNetCoreHealthChecksVersion)" />
     <PackageReference Include="FluentAssertions.Json" Version="$(FluentAssertionsJsonVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="$(AspNetCoreVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="$(ExtensionsCachingMemoryVersion)" />
     <PackageReference Include="OpenTelemetry.Exporter.Console" Version="$(OpenTelemetryVersion)" />
   </ItemGroup>
 </Project>

--- a/src/Management/test/KubernetesCore.Test/Steeltoe.Management.KubernetesCore.Test.csproj
+++ b/src/Management/test/KubernetesCore.Test/Steeltoe.Management.KubernetesCore.Test.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
@@ -14,6 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="$(AspNetCoreVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="$(ExtensionsCachingMemoryVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/Messaging/test/Benchmarks/Channel/ChannelBenchmark.csproj
+++ b/src/Messaging/test/Benchmarks/Channel/ChannelBenchmark.csproj
@@ -10,6 +10,7 @@
   
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="$(BenchmarkDotNetVersion)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="$(SystemTextRegularExpressionsVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Security/src/Authentication.CloudFoundryBase/Steeltoe.Security.Authentication.CloudFoundryBase.csproj
+++ b/src/Security/src/Authentication.CloudFoundryBase/Steeltoe.Security.Authentication.CloudFoundryBase.csproj
@@ -19,5 +19,6 @@
     <PackageReference Include="Newtonsoft.Json" Version="$(JsonNetVersion)" />
     <PackageReference Include="System.Net.Http" Version="$(SystemNetHttpVersion)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="$(SystemTextRegularExpressionsVersion)" />
+    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="$(JwtTokensVersion)" />
   </ItemGroup>
 </Project>

--- a/src/Security/src/Authentication.CloudFoundryBase/Steeltoe.Security.Authentication.CloudFoundryBase.csproj
+++ b/src/Security/src/Authentication.CloudFoundryBase/Steeltoe.Security.Authentication.CloudFoundryBase.csproj
@@ -16,5 +16,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="$(JwtTokensVersion)" />
+    <PackageReference Include="Newtonsoft.Json" Version="$(JsonNetVersion)" />
   </ItemGroup>
 </Project>

--- a/src/Security/src/Authentication.CloudFoundryBase/Steeltoe.Security.Authentication.CloudFoundryBase.csproj
+++ b/src/Security/src/Authentication.CloudFoundryBase/Steeltoe.Security.Authentication.CloudFoundryBase.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <RootNamespace>Steeltoe.Security.Authentication.CloudFoundry</RootNamespace>
@@ -17,6 +17,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="$(JwtTokensVersion)" />
     <PackageReference Include="Newtonsoft.Json" Version="$(JsonNetVersion)" />
+    <PackageReference Include="System.Net.Http" Version="$(SystemNetHttpVersion)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="$(SystemTextRegularExpressionsVersion)" />
   </ItemGroup>
 </Project>

--- a/src/Security/src/Authentication.CloudFoundryBase/Steeltoe.Security.Authentication.CloudFoundryBase.csproj
+++ b/src/Security/src/Authentication.CloudFoundryBase/Steeltoe.Security.Authentication.CloudFoundryBase.csproj
@@ -17,5 +17,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="$(JwtTokensVersion)" />
     <PackageReference Include="Newtonsoft.Json" Version="$(JsonNetVersion)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="$(SystemTextRegularExpressionsVersion)" />
   </ItemGroup>
 </Project>

--- a/src/Security/src/Authentication.CloudFoundryCore/Steeltoe.Security.Authentication.CloudFoundryCore.csproj
+++ b/src/Security/src/Authentication.CloudFoundryCore/Steeltoe.Security.Authentication.CloudFoundryCore.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="$(ExtensionsCachingMemoryVersion)" />
+    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="$(JwtTokensVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Security/src/Authentication.CloudFoundryCore/Steeltoe.Security.Authentication.CloudFoundryCore.csproj
+++ b/src/Security/src/Authentication.CloudFoundryCore/Steeltoe.Security.Authentication.CloudFoundryCore.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <RootNamespace>Steeltoe.Security.Authentication.CloudFoundry</RootNamespace>
@@ -12,7 +12,9 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="$(AspNetCoreVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="$(ExtensionsCachingMemoryVersion)" />
   </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\..\Connectors\src\CloudFoundry\Steeltoe.Connector.CloudFoundry.csproj" />
     <ProjectReference Include="..\Authentication.CloudFoundryBase\Steeltoe.Security.Authentication.CloudFoundryBase.csproj" />

--- a/src/Security/src/Authentication.MtlsCore/Steeltoe.Security.Authentication.MtlsCore.csproj
+++ b/src/Security/src/Authentication.MtlsCore/Steeltoe.Security.Authentication.MtlsCore.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <RootNamespace>Steeltoe.Security.Authentication.Mtls</RootNamespace>
@@ -14,6 +14,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Certificate" Version="$(AspNetCoreVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="$(ExtensionsCachingMemoryVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Security/src/DataProtection.RedisCore/Steeltoe.Security.DataProtection.RedisCore.csproj
+++ b/src/Security/src/DataProtection.RedisCore/Steeltoe.Security.DataProtection.RedisCore.csproj
@@ -12,5 +12,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="$(ExtensionsVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.DataProtection.StackExchangeRedis" Version="$(ExtensionsVersion)" />
+    <PackageReference Include="System.Formats.Asn1" Version="$(SystemFormatsAsn1Version)" />
   </ItemGroup>
 </Project>

--- a/src/Security/test/Authentication.CloudFoundryBase.Test/CloudFoundryTokenKeyResolverTest.cs
+++ b/src/Security/test/Authentication.CloudFoundryBase.Test/CloudFoundryTokenKeyResolverTest.cs
@@ -24,7 +24,7 @@ public class CloudFoundryTokenKeyResolverTest
     {
         var token = "eyJhbGciOiJSUzI1NiIsImtpZCI6ImxlZ2FjeS10b2tlbi1rZXkiLCJ0eXAiOiJKV1QifQ.eyJqdGkiOiI0YjM2NmY4MDdlMjU0MzlmYmRkOTEwZDc4ZjcwYzlhMSIsInN1YiI6ImZlNmExYmUyLWM5MTEtNDM3OC05Y2MxLTVhY2Y1NjA1Y2ZjMiIsInNjb3BlIjpbImNsb3VkX2NvbnRyb2xsZXIucmVhZCIsImNsb3VkX2NvbnRyb2xsZXJfc2VydmljZV9wZXJtaXNzaW9ucy5yZWFkIiwidGVzdGdyb3VwIiwib3BlbmlkIl0sImNsaWVudF9pZCI6Im15VGVzdEFwcCIsImNpZCI6Im15VGVzdEFwcCIsImF6cCI6Im15VGVzdEFwcCIsImdyYW50X3R5cGUiOiJhdXRob3JpemF0aW9uX2NvZGUiLCJ1c2VyX2lkIjoiZmU2YTFiZTItYzkxMS00Mzc4LTljYzEtNWFjZjU2MDVjZmMyIiwib3JpZ2luIjoidWFhIiwidXNlcl9uYW1lIjoiZGF2ZSIsImVtYWlsIjoiZGF2ZSIsImF1dGhfdGltZSI6MTQ3MzYxNTU0MSwicmV2X3NpZyI6IjEwZDM1NzEyIiwiaWF0IjoxNDczNjI0MjU1LCJleHAiOjE0NzM2Njc0NTUsImlzcyI6Imh0dHBzOi8vdWFhLnN5c3RlbS50ZXN0Y2xvdWQuY29tL29hdXRoL3Rva2VuIiwiemlkIjoidWFhIiwiYXVkIjpbImNsb3VkX2NvbnRyb2xsZXIiLCJteVRlc3RBcHAiLCJvcGVuaWQiLCJjbG91ZF9jb250cm9sbGVyX3NlcnZpY2VfcGVybWlzc2lvbnMiXX0.Hth_SXpMAyiTf--U75r40qODlSUr60U730IW28K2VidEltW3lN3_CE7HkSjolRGr-DYuWHRvy3i_EwBfj1WTkBaXL373UzPVvNBnat9Gi-vjz07LwmBohk3baG1mmlL8IoGbQwtsmfUPhmO5C6_M4s9wKmTf9XIZPVo_w7zPJadrXfHLfx6iQob7CYpTTix2VBWya29iL7kmD1J1UDT5YRg2J9XT30iFuL6BvPQTkuGnX3ivDuUOSdxM8Z451i0VJmc0LYFBCLJ-Tz6bJ2d0wrtfsbCfuNtxjmGJevcL2jKQbEoiliYj60qNtZdT-ijGUdZjE9caxQ2nOkDkowacpw";
         var keyset = "{ 'keys':[{'kid':'legacy-token-key','alg':'SHA256withRSA','value':'-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAk+7xH35bYBppsn54cBW+\nFlrveTe+3L4xl7ix13XK8eBcCmNOyBhNzhks6toDiRjrgw5QW76cFirVRFIVQkiZ\nsUwDyGOax3q8NOJyBFXiplIUScrx8aI0jkY/Yd6ixAc5yBSBfXThy4EF9T0xCyt4\nxWLYNXMRwe88Y+i+MEoLNXWRbhjJm76LN7rsdIxALbS0vJNWUDALWjtE6FeYX6uU\nL9msAzlCQkdnSvwMmr8Ij2O3IVMxHDJXOZinFqt9zVfXwO11o7ZmiskZnRz1/V0f\nvbUQAadkcDEUt1gk9cbrAhiipg8VWDMsC7VUXuekJZjme5f8oWTwpsgP6cTUzwSS\n6wIDAQAB\n-----END PUBLIC KEY-----','kty':'RSA','use':'sig','n':'AJPu8R9+W2AaabJ+eHAVvhZa73k3vty+MZe4sdd1yvHgXApjTsgYTc4ZLOraA4kY64MOUFu+nBYq1URSFUJImbFMA8hjmsd6vDTicgRV4qZSFEnK8fGiNI5GP2HeosQHOcgUgX104cuBBfU9MQsreMVi2DVzEcHvPGPovjBKCzV1kW4YyZu+ize67HSMQC20tLyTVlAwC1o7ROhXmF+rlC/ZrAM5QkJHZ0r8DJq/CI9jtyFTMRwyVzmYpxarfc1X18DtdaO2ZorJGZ0c9f1dH721EAGnZHAxFLdYJPXG6wIYoqYPFVgzLAu1VF7npCWY5nuX/KFk8KbID+nE1M8Ekus=','e':'AQAB'}]}";
-        var keys = JsonWebKeySet.Create(keyset);
+        var keys = JsonWebKeySet.Create(FixBrokenJson(keyset));
         var webKey = keys.Keys[0];
 
         CloudFoundryTokenKeyResolver.Resolved.Clear();
@@ -44,7 +44,7 @@ public class CloudFoundryTokenKeyResolverTest
         var handler = new TestMessageHandler();
         var response = new HttpResponseMessage(System.Net.HttpStatusCode.OK)
         {
-            Content = new StringContent(keyset)
+            Content = new StringContent(FixBrokenJson(keyset))
         };
         handler.Response = response;
 
@@ -65,7 +65,7 @@ public class CloudFoundryTokenKeyResolverTest
         var handler = new TestMessageHandler();
         var response = new HttpResponseMessage(System.Net.HttpStatusCode.OK)
         {
-            Content = new StringContent(keyset)
+            Content = new StringContent(FixBrokenJson(keyset))
         };
         handler.Response = response;
 
@@ -85,7 +85,7 @@ public class CloudFoundryTokenKeyResolverTest
         var handler = new TestMessageHandler();
         var response = new HttpResponseMessage(System.Net.HttpStatusCode.OK)
         {
-            Content = new StringContent(keyset)
+            Content = new StringContent(FixBrokenJson(keyset))
         };
         handler.Response = response;
 
@@ -103,7 +103,7 @@ public class CloudFoundryTokenKeyResolverTest
 
         var webKey = @"{'keys':[{'kid':'legacy-token-key','alg':'SHA256withRSA','value':'-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAk+7xH35bYBppsn54cBW+\nFlrveTe+3L4xl7ix13XK8eBcCmNOyBhNzhks6toDiRjrgw5QW76cFirVRFIVQkiZ\nsUwDyGOax3q8NOJyBFXiplIUScrx8aI0jkY/Yd6ixAc5yBSBfXThy4EF9T0xCyt4\nxWLYNXMRwe88Y+i+MEoLNXWRbhjJm76LN7rsdIxALbS0vJNWUDALWjtE6FeYX6uU\nL9msAzlCQkdnSvwMmr8Ij2O3IVMxHDJXOZinFqt9zVfXwO11o7ZmiskZnRz1/V0f\nvbUQAadkcDEUt1gk9cbrAhiipg8VWDMsC7VUXuekJZjme5f8oWTwpsgP6cTUzwSS\n6wIDAQAB\n-----END PUBLIC KEY-----','kty':'RSA','use':'sig','n':'AJPu8R9+W2AaabJ+eHAVvhZa73k3vty+MZe4sdd1yvHgXApjTsgYTc4ZLOraA4kY64MOUFu+nBYq1URSFUJImbFMA8hjmsd6vDTicgRV4qZSFEnK8fGiNI5GP2HeosQHOcgUgX104cuBBfU9MQsreMVi2DVzEcHvPGPovjBKCzV1kW4YyZu+ize67HSMQC20tLyTVlAwC1o7ROhXmF+rlC/ZrAM5QkJHZ0r8DJq/CI9jtyFTMRwyVzmYpxarfc1X18DtdaO2ZorJGZ0c9f1dH721EAGnZHAxFLdYJPXG6wIYoqYPFVgzLAu1VF7npCWY5nuX/KFk8KbID+nE1M8Ekus=','e':'AQAB'}]}";
         var resolver = new CloudFoundryTokenKeyResolver("https://foo.bar", null, false);
-        var webKeySet = resolver.GetJsonWebKeySet(webKey);
+        var webKeySet = resolver.GetJsonWebKeySet(FixBrokenJson(webKey));
         Assert.NotNull(webKeySet);
         Assert.NotNull(webKeySet.Keys);
         Assert.Equal(1, webKeySet.Keys.Count);
@@ -127,5 +127,10 @@ public class CloudFoundryTokenKeyResolverTest
         var client = resolver.GetHttpClient();
 
         Assert.True(client.Timeout >= TimeSpan.FromSeconds(100));
+    }
+
+    private static string FixBrokenJson(string json)
+    {
+        return json.Replace('\'', '"').Replace("\n", "\\n");
     }
 }

--- a/src/Stream/src/StreamBase/Steeltoe.Stream.StreamBase.csproj
+++ b/src/Stream/src/StreamBase/Steeltoe.Stream.StreamBase.csproj
@@ -21,6 +21,7 @@
   <ItemGroup>
     <PackageReference Include="Castle.Core" Version="$(CastleCoreVersion)" />
     <PackageReference Include="System.Runtime.Loader" Version="$(RuntimeLoaderVersion)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="$(SystemTextRegularExpressionsVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/Stream/src/StreamBase/Steeltoe.Stream.StreamBase.csproj
+++ b/src/Stream/src/StreamBase/Steeltoe.Stream.StreamBase.csproj
@@ -21,6 +21,7 @@
   <ItemGroup>
     <PackageReference Include="Castle.Core" Version="$(CastleCoreVersion)" />
     <PackageReference Include="System.Runtime.Loader" Version="$(RuntimeLoaderVersion)" />
+    <PackageReference Include="System.Net.Http" Version="$(SystemNetHttpVersion)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="$(SystemTextRegularExpressionsVersion)" />
   </ItemGroup>
 

--- a/versions.props
+++ b/versions.props
@@ -56,6 +56,7 @@
     <MicrosoftAzureCosmosVersion>3.52.1</MicrosoftAzureCosmosVersion>
     <StackExchangeVersion>2.0.593</StackExchangeVersion>
     <AzureIdentityVersion>1.14.2</AzureIdentityVersion>
+    <BouncyCastleCryptographyVersion>2.4.0</BouncyCastleCryptographyVersion>
     <CoverletVersion>6.0.4</CoverletVersion>
     <FluentAssertionsJsonVersion>6.1.0</FluentAssertionsJsonVersion>
     <FluentAssertionsVersion>7.2.0</FluentAssertionsVersion>

--- a/versions.props
+++ b/versions.props
@@ -49,6 +49,7 @@
     <MySqlConnectorVersion>0.49.3</MySqlConnectorVersion>
     <MySqlV8>8.0.23</MySqlV8>
     <SystemDrawingCommonVersion>8.0.19</SystemDrawingCommonVersion>
+    <SshNetVersion>2024.2.0</SshNetVersion>
     <SqlClientVersion>4.8.6</SqlClientVersion>
     <MicrosoftSqlClientVersion>5.1.3</MicrosoftSqlClientVersion>
     <EasyNetQVersion>1.3.0</EasyNetQVersion>

--- a/versions.props
+++ b/versions.props
@@ -9,7 +9,7 @@
     <!-- Exposed dependencies, observable by Steeltoe library consumers. Only update when vulnerable. -->
     <DriveInfoVersion>4.3.1</DriveInfoVersion>
     <WinHttpHandlerVersion>4.7.0</WinHttpHandlerVersion>
-    <JwtTokensVersion>5.2.2</JwtTokensVersion>
+    <JwtTokensVersion>7.7.1</JwtTokensVersion>
     <SymReaderVersion>1.2.0</SymReaderVersion>
     <SymReaderPortableVersion>1.4.0</SymReaderPortableVersion>
     <SystemDiagnosticsVersion>8.0.0</SystemDiagnosticsVersion>

--- a/versions.props
+++ b/versions.props
@@ -45,7 +45,6 @@
     <MongoDbClientVersion>3.0.0</MongoDbClientVersion>
     <MySqlConnectorVersion>0.49.3</MySqlConnectorVersion>
     <MySqlV8>8.0.23</MySqlV8>
-    <NpgsqlVersion>4.0.14</NpgsqlVersion>
     <SqlClientVersion>4.8.6</SqlClientVersion>
     <MicrosoftSqlClientVersion>5.1.3</MicrosoftSqlClientVersion>
     <OracleManagedDataAccessCoreVersion>3.21.90</OracleManagedDataAccessCoreVersion>
@@ -96,6 +95,7 @@
     <!-- Non-exposed dependencies, only referenced from test projects, build infrastructure and internal tools. -->
     <EFCoreTestVersion>6.0.0</EFCoreTestVersion>
     <MySqlEFCoreVersion>6.0.0</MySqlEFCoreVersion>
+    <NpgsqlVersion>6.0.11</NpgsqlVersion>
     <NpgsqlEFCoreVersion>6.0.0</NpgsqlEFCoreVersion>
     <OracleEFCoreVersion>6.21.5</OracleEFCoreVersion>
     <PomeloEFCoreVersion>6.0.0</PomeloEFCoreVersion>
@@ -111,6 +111,7 @@
     <!-- Non-exposed dependencies, only referenced from test projects, build infrastructure and internal tools. -->
     <EFCoreTestVersion>8.0.0</EFCoreTestVersion>
     <MySqlEFCoreVersion>8.0.0</MySqlEFCoreVersion>
+    <NpgsqlVersion>8.0.3</NpgsqlVersion>
     <NpgsqlEFCoreVersion>8.0.0</NpgsqlEFCoreVersion>
     <OracleEFCoreVersion>8.23.90</OracleEFCoreVersion>
     <PomeloEFCoreVersion>8.0.0</PomeloEFCoreVersion>

--- a/versions.props
+++ b/versions.props
@@ -70,6 +70,7 @@
     <SerilogEnrichersThreadVersion>3.1.0</SerilogEnrichersThreadVersion>
     <SerilogExceptionsVersion>5.0.0</SerilogExceptionsVersion>
     <SerilogSinksDebugVersion>2.0.0</SerilogSinksDebugVersion>
+    <SystemNetSecurityVersion>4.3.1</SystemNetSecurityVersion>
     <SonarAnalyzerVersion>8.32.0.39516</SonarAnalyzerVersion>
     <SourceLinkGitHubVersion>1.1.1</SourceLinkGitHubVersion>
     <StyleCopVersion>1.1.118</StyleCopVersion>

--- a/versions.props
+++ b/versions.props
@@ -72,6 +72,7 @@
     <SerilogExceptionsVersion>5.0.0</SerilogExceptionsVersion>
     <SerilogSinksDebugVersion>2.0.0</SerilogSinksDebugVersion>
     <SystemNetSecurityVersion>4.3.1</SystemNetSecurityVersion>
+    <GoogleProtobufVersion>3.15.0</GoogleProtobufVersion>
     <SonarAnalyzerVersion>8.32.0.39516</SonarAnalyzerVersion>
     <SourceLinkGitHubVersion>1.1.1</SourceLinkGitHubVersion>
     <StyleCopVersion>1.1.118</StyleCopVersion>

--- a/versions.props
+++ b/versions.props
@@ -48,6 +48,7 @@
     <MongoDbClientVersion>3.0.0</MongoDbClientVersion>
     <MySqlConnectorVersion>0.49.3</MySqlConnectorVersion>
     <MySqlV8>8.0.23</MySqlV8>
+    <SystemDrawingCommonVersion>8.0.19</SystemDrawingCommonVersion>
     <SqlClientVersion>4.8.6</SqlClientVersion>
     <MicrosoftSqlClientVersion>5.1.3</MicrosoftSqlClientVersion>
     <EasyNetQVersion>1.3.0</EasyNetQVersion>

--- a/versions.props
+++ b/versions.props
@@ -41,6 +41,7 @@
     <SerilogVersion>3.0.1</SerilogVersion>
     <SystemFormatsAsn1Version>8.0.1</SystemFormatsAsn1Version>
     <SystemTextRegularExpressionsVersion>4.3.1</SystemTextRegularExpressionsVersion>
+    <SystemNetHttpVersion>4.3.4</SystemNetHttpVersion>
 
     <!-- Non-exposed dependencies, only referenced from test projects, build infrastructure and internal tools. -->
     <BenchmarkDotNetVersion>0.12.0</BenchmarkDotNetVersion>

--- a/versions.props
+++ b/versions.props
@@ -40,6 +40,7 @@
     <SerilogSinksConsoleVersion>3.1.1</SerilogSinksConsoleVersion>
     <SerilogVersion>3.0.1</SerilogVersion>
     <SystemFormatsAsn1Version>8.0.1</SystemFormatsAsn1Version>
+    <SystemTextRegularExpressionsVersion>4.3.1</SystemTextRegularExpressionsVersion>
 
     <!-- Non-exposed dependencies, only referenced from test projects, build infrastructure and internal tools. -->
     <BenchmarkDotNetVersion>0.12.0</BenchmarkDotNetVersion>

--- a/versions.props
+++ b/versions.props
@@ -47,7 +47,6 @@
     <MySqlV8>8.0.23</MySqlV8>
     <SqlClientVersion>4.8.6</SqlClientVersion>
     <MicrosoftSqlClientVersion>5.1.3</MicrosoftSqlClientVersion>
-    <OracleManagedDataAccessCoreVersion>3.21.90</OracleManagedDataAccessCoreVersion>
     <EasyNetQVersion>1.3.0</EasyNetQVersion>
     <MicrosoftAzureCosmosVersion>3.52.1</MicrosoftAzureCosmosVersion>
     <StackExchangeVersion>2.0.593</StackExchangeVersion>
@@ -97,6 +96,7 @@
     <MySqlEFCoreVersion>6.0.0</MySqlEFCoreVersion>
     <NpgsqlVersion>6.0.11</NpgsqlVersion>
     <NpgsqlEFCoreVersion>6.0.0</NpgsqlEFCoreVersion>
+    <OracleManagedDataAccessCoreVersion>3.21.90</OracleManagedDataAccessCoreVersion>
     <OracleEFCoreVersion>6.21.5</OracleEFCoreVersion>
     <PomeloEFCoreVersion>6.0.0</PomeloEFCoreVersion>
     <MicrosoftExtensionsRedisVersion>6.0.0</MicrosoftExtensionsRedisVersion>
@@ -113,6 +113,7 @@
     <MySqlEFCoreVersion>8.0.0</MySqlEFCoreVersion>
     <NpgsqlVersion>8.0.3</NpgsqlVersion>
     <NpgsqlEFCoreVersion>8.0.0</NpgsqlEFCoreVersion>
+    <OracleManagedDataAccessCoreVersion>23.9.0</OracleManagedDataAccessCoreVersion>
     <OracleEFCoreVersion>8.23.90</OracleEFCoreVersion>
     <PomeloEFCoreVersion>8.0.0</PomeloEFCoreVersion>
     <MicrosoftExtensionsRedisVersion>8.0.0</MicrosoftExtensionsRedisVersion>

--- a/versions.props
+++ b/versions.props
@@ -55,6 +55,7 @@
     <EasyNetQVersion>1.3.0</EasyNetQVersion>
     <MicrosoftAzureCosmosVersion>3.52.1</MicrosoftAzureCosmosVersion>
     <StackExchangeVersion>2.0.593</StackExchangeVersion>
+    <AzureIdentityVersion>1.14.2</AzureIdentityVersion>
     <CoverletVersion>6.0.4</CoverletVersion>
     <FluentAssertionsJsonVersion>6.1.0</FluentAssertionsJsonVersion>
     <FluentAssertionsVersion>7.2.0</FluentAssertionsVersion>

--- a/versions.props
+++ b/versions.props
@@ -39,6 +39,7 @@
     <DiagnosticsTracingTraceEventVersion>2.0.64</DiagnosticsTracingTraceEventVersion>
     <SerilogSinksConsoleVersion>3.1.1</SerilogSinksConsoleVersion>
     <SerilogVersion>3.0.1</SerilogVersion>
+    <SystemFormatsAsn1Version>8.0.1</SystemFormatsAsn1Version>
 
     <!-- Non-exposed dependencies, only referenced from test projects, build infrastructure and internal tools. -->
     <BenchmarkDotNetVersion>0.12.0</BenchmarkDotNetVersion>


### PR DESCRIPTION
## Description

Adds explicit package references for transient packages that are reported as vulnerable.
Includes a GitHub Actions workflow to detect future vulnerabilities.

The higher versions mostly affect test dependencies, except for the following:
- `Microsoft.IdentityModel.JsonWebTokens` (replacement for `System.IdentityModel.Tokens.Jwt`): Bumped both from 5.2.2 to 7.7.1

The warnings caused by `KubernetesClient` are suppressed, because there's no non-breaking solution. The lowest version without transitive vulnerabilities no longer targets `netstandard2.0`, which breaks upstream Steeltoe packages. Furthermore, that version has breaking API changes that are non-trivial to fix. The suppression works in the .NET CLI, but Visual Studio Package Manager ignores it.

## Quality checklist

- [x] Your code complies with our [Coding Style](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-code-style.md).
- [x] You've updated unit and/or integration tests for your change, where applicable.
- [ ] You've updated documentation for your change, where applicable.
      If your change affects other repositories, such as [Documentation](https://github.com/SteeltoeOSS/Documentation), [Samples](https://github.com/SteeltoeOSS/Samples) and/or [MainSite](https://github.com/SteeltoeOSS/MainSite), add linked PRs here.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
- [ ] You've added required license files and/or file headers (explaining where the code came from with proper attribution), where code is copied from StackOverflow, a blog, or OSS.
