### PR TITLE
Add projects for obsolete/replaced packages

### DIFF
--- a/.github/workflows/Steeltoe.All.yml
+++ b/.github/workflows/Steeltoe.All.yml
@@ -81,7 +81,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Restore packages
-      run: dotnet restore ${{ env.SOLUTION_FILE }} --verbosity minimal
+      run: dotnet restore ${{ env.SOLUTION_FILE }} /p:Configuration=Release --verbosity minimal
 
     - name: Build solution
       run: dotnet build ${{ env.SOLUTION_FILE }} --no-restore --configuration Release --verbosity minimal

--- a/.github/workflows/component-shared-workflow.yml
+++ b/.github/workflows/component-shared-workflow.yml
@@ -78,7 +78,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Restore packages
-      run: dotnet restore ${{ env.SOLUTION_FILE }} --verbosity minimal
+      run: dotnet restore ${{ env.SOLUTION_FILE }} /p:Configuration=Release --verbosity minimal
 
     - name: Build solution
       run: dotnet build ${{ env.SOLUTION_FILE }} --no-restore --configuration Release --verbosity minimal

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -42,7 +42,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Restore packages
-      run: dotnet restore ${{ env.SOLUTION_FILE }} --verbosity minimal
+      run: dotnet restore ${{ env.SOLUTION_FILE }} /p:Configuration=Release --verbosity minimal
 
     - name: Calculate package version (for release)
       if: ${{ github.event_name == 'release' }}

--- a/.github/workflows/sonarcube.yml
+++ b/.github/workflows/sonarcube.yml
@@ -64,7 +64,7 @@ jobs:
         fetch-depth: 0
 
     - name: Restore packages
-      run: dotnet restore ${{ env.SOLUTION_FILE }} --verbosity minimal
+      run: dotnet restore ${{ env.SOLUTION_FILE }} /p:Configuration=Release --verbosity minimal
 
     - name: Begin Sonar .NET scanner
       id: sonar_begin

--- a/.github/workflows/verify-code-style.yml
+++ b/.github/workflows/verify-code-style.yml
@@ -42,7 +42,7 @@ jobs:
       run: dotnet tool restore --verbosity minimal
 
     - name: Restore packages
-      run: dotnet restore ${{ env.SOLUTION_FILE }} --verbosity minimal
+      run: dotnet restore ${{ env.SOLUTION_FILE }} /p:Configuration=Release --verbosity minimal
 
     - name: CleanupCode (on PR diff)
       if: ${{ github.event_name == 'pull_request' }}

--- a/src/Common/src/Hosting/Steeltoe.Common.Hosting.csproj
+++ b/src/Common/src/Hosting/Steeltoe.Common.Hosting.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
     <Description>Steeltoe library for commonly-used ASP.NET Core hosting-related functions.</Description>
-    <PackageTags>hosting;</PackageTags>
+    <PackageTags>hosting</PackageTags>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 

--- a/src/Common/src/Http/Steeltoe.Common.Http.csproj
+++ b/src/Common/src/Http/Steeltoe.Common.Http.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
     <Description>Shared code related to HTTP, primarily for working with HttpClient.</Description>
-    <PackageTags>http;</PackageTags>
+    <PackageTags>http</PackageTags>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 

--- a/src/Common/src/Logging/Steeltoe.Common.Logging.csproj
+++ b/src/Common/src/Logging/Steeltoe.Common.Logging.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
     <Description>Abstractions and code for bootstrap logging, before the IoC container is built. Bootstrap logging is replaced by the runtime logging (what the rest of your application is using) after the IoC container is built.</Description>
-    <PackageTags>bootstrap;logging;</PackageTags>
+    <PackageTags>bootstrap;logging</PackageTags>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 

--- a/src/Configuration/src/RandomValue/Steeltoe.Configuration.RandomValue.csproj
+++ b/src/Configuration/src/RandomValue/Steeltoe.Configuration.RandomValue.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
     <Description>Configuration provider for generating random values.</Description>
-    <PackageTags>configuration;ConfigurationProvider;random;</PackageTags>
+    <PackageTags>configuration;ConfigurationProvider;random</PackageTags>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 

--- a/src/Logging/src/Abstractions/Steeltoe.Logging.Abstractions.csproj
+++ b/src/Logging/src/Abstractions/Steeltoe.Logging.Abstractions.csproj
@@ -3,7 +3,7 @@
     <TargetFrameworks>net8.0</TargetFrameworks>
     <RootNamespace>Steeltoe.Logging</RootNamespace>
     <Description>Abstractions for managing minimum logging levels at runtime.</Description>
-    <PackageTags>abstractions;logging;dynamic-logging;log-management;</PackageTags>
+    <PackageTags>abstractions;logging;dynamic-logging;log-management</PackageTags>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 

--- a/src/Management/src/Prometheus/Steeltoe.Management.Prometheus.csproj
+++ b/src/Management/src/Prometheus/Steeltoe.Management.Prometheus.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
     <Description>Adds Prometheus support for Steeltoe management endpoints.</Description>
-    <PackageTags>actuator;actuators;management;monitoring;metrics;prometheus;tanzu;appmetrics;aspnetcore;</PackageTags>
+    <PackageTags>actuator;actuators;management;monitoring;metrics;prometheus;tanzu;appmetrics;aspnetcore</PackageTags>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 

--- a/src/Management/src/Tracing/Steeltoe.Management.Tracing.csproj
+++ b/src/Management/src/Tracing/Steeltoe.Management.Tracing.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
     <Description>Adds trace information to logging output in distributed systems.</Description>
-    <PackageTags>management;monitoring;distributed;tracing;</PackageTags>
+    <PackageTags>management;monitoring;distributed;tracing</PackageTags>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 

--- a/src/Obsolete/Steeltoe.Bootstrap.Autoconfig/Build/Steeltoe.Bootstrap.Autoconfig.targets
+++ b/src/Obsolete/Steeltoe.Bootstrap.Autoconfig/Build/Steeltoe.Bootstrap.Autoconfig.targets
@@ -1,5 +1,6 @@
 <Project>
   <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
-    <Error Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Bootstrap.AutoConfiguration instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+    <Error
+      Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Bootstrap.AutoConfiguration instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 </Project>

--- a/src/Obsolete/Steeltoe.Bootstrap.Autoconfig/Build/Steeltoe.Bootstrap.Autoconfig.targets
+++ b/src/Obsolete/Steeltoe.Bootstrap.Autoconfig/Build/Steeltoe.Bootstrap.Autoconfig.targets
@@ -1,5 +1,5 @@
 <Project>
-  <Target Name="Warn_SteeltoeBootstrapAutoconfig" BeforeTargets="BeforeResolveReferences">
+  <Target Name="Warn_SteeltoeBootstrapAutoconfig" AfterTargets="AfterResolveReferences">
     <Warning
       Text="The NuGet package Steeltoe.Bootstrap.Autoconfig has been replaced in Steeltoe v4. Reference Steeltoe.Bootstrap.AutoConfiguration instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>

--- a/src/Obsolete/Steeltoe.Bootstrap.Autoconfig/Build/Steeltoe.Bootstrap.Autoconfig.targets
+++ b/src/Obsolete/Steeltoe.Bootstrap.Autoconfig/Build/Steeltoe.Bootstrap.Autoconfig.targets
@@ -1,7 +1,7 @@
 <Project>
   <Target Name="Warn_SteeltoeBootstrapAutoconfig" BeforeTargets="BeforeResolveReferences">
     <Warning
-      Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Bootstrap.AutoConfiguration instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+      Text="The NuGet package Steeltoe.Bootstrap.Autoconfig has been replaced in Steeltoe v4. Reference Steeltoe.Bootstrap.AutoConfiguration instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.Bootstrap.Autoconfig/Build/Steeltoe.Bootstrap.Autoconfig.targets
+++ b/src/Obsolete/Steeltoe.Bootstrap.Autoconfig/Build/Steeltoe.Bootstrap.Autoconfig.targets
@@ -1,7 +1,7 @@
 <Project>
   <Target Name="Warn_SteeltoeBootstrapAutoconfig" AfterTargets="AfterResolveReferences">
     <Warning
-      Text="The NuGet package Steeltoe.Bootstrap.Autoconfig has been replaced in Steeltoe v4. Reference Steeltoe.Bootstrap.AutoConfiguration instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+      Text="The NuGet package Steeltoe.Bootstrap.Autoconfig has been superseded in Steeltoe v4. Reference Steeltoe.Bootstrap.AutoConfiguration instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.Bootstrap.Autoconfig/Build/Steeltoe.Bootstrap.Autoconfig.targets
+++ b/src/Obsolete/Steeltoe.Bootstrap.Autoconfig/Build/Steeltoe.Bootstrap.Autoconfig.targets
@@ -1,6 +1,10 @@
 <Project>
-  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
-    <Error
+  <Target Name="Warn_SteeltoeBootstrapAutoconfig" BeforeTargets="BeforeResolveReferences">
+    <Warning
       Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Bootstrap.AutoConfiguration instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+
+  <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="One or more Steeltoe package dependencies need attention. See the build warnings for details." />
   </Target>
 </Project>

--- a/src/Obsolete/Steeltoe.Bootstrap.Autoconfig/Build/Steeltoe.Bootstrap.Autoconfig.targets
+++ b/src/Obsolete/Steeltoe.Bootstrap.Autoconfig/Build/Steeltoe.Bootstrap.Autoconfig.targets
@@ -1,0 +1,5 @@
+<Project>
+  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Bootstrap.AutoConfiguration instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+</Project>

--- a/src/Obsolete/Steeltoe.Bootstrap.Autoconfig/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.Bootstrap.Autoconfig/PackageReadme.md
@@ -1,0 +1,17 @@
+# Steeltoe
+
+> [!IMPORTANT]
+> This package has been replaced in Steeltoe v4. Reference `Steeltoe.Bootstrap.AutoConfiguration` instead.
+> See <https://steeltoe.io/docs/v3/obsolete> for details.
+
+[Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).
+
+Key features include:
+
+- External (optionally encrypted) configuration using [Spring Cloud Config Server](https://docs.spring.io/spring-cloud-config/docs/current/reference/html/)
+- Service discovery with [Netflix Eureka](https://spring.io/projects/spring-cloud-netflix) and [HashiCorp Consul](https://www.consul.io/)
+- Management endpoints (compatible with [actuators](https://docs.spring.io/spring-boot/docs/current/reference/html/actuator.html)), providing system info (such as versions, configuration, service container contents, mapped routes and HTTP traffic), heap/thread dumps, health checks, exporting metrics to [Prometheus](https://prometheus.io/), and changing log levels at runtime.
+- Connectivity to databases (such as [SQL Server](https://www.microsoft.com/sql-server)/[Azure SQL](https://azure.microsoft.com/products/azure-sql), [Cosmos DB](https://azure.microsoft.com/products/cosmos-db/), [MongoDB](https://www.mongodb.com/), [Redis](https://redis.io/), [RabbitMQ](https://www.rabbitmq.com/), [PostgreSQL](https://www.postgresql.org/), and [MySQL](https://www.mysql.com/)), including support for [Entity Framework Core](https://learn.microsoft.com/ef/core/)
+- Single sign-on, JWT and Certificate auth with [Cloud Foundry](https://www.cloudfoundry.org/)
+
+For more information and to get started, please visit [Steeltoe on GitHub](https://github.com/SteeltoeOSS/Steeltoe) or the [documentation](https://steeltoe.io/docs).

--- a/src/Obsolete/Steeltoe.Bootstrap.Autoconfig/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.Bootstrap.Autoconfig/PackageReadme.md
@@ -1,7 +1,7 @@
 # Steeltoe
 
 > [!IMPORTANT]
-> This package has been replaced in Steeltoe v4. Reference `Steeltoe.Bootstrap.AutoConfiguration` instead.
+> This package has been superseded in Steeltoe v4. Reference `Steeltoe.Bootstrap.AutoConfiguration` instead.
 > See <https://steeltoe.io/docs/v3/obsolete> for details.
 
 [Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).

--- a/src/Obsolete/Steeltoe.Bootstrap.Autoconfig/Steeltoe.Bootstrap.Autoconfig.csproj
+++ b/src/Obsolete/Steeltoe.Bootstrap.Autoconfig/Steeltoe.Bootstrap.Autoconfig.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net8.0</TargetFrameworks>
+    <Description>TODO: Fill package description.</Description>
+    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
+  <Import Project="..\..\..\shared.props" />
+
+  <ItemGroup>
+    <None Include="Build\*.props" Pack="True" PackagePath="build" />
+    <None Include="Build\*.targets" Pack="True" PackagePath="build" />
+  </ItemGroup>
+</Project>

--- a/src/Obsolete/Steeltoe.Bootstrap.Autoconfig/Steeltoe.Bootstrap.Autoconfig.csproj
+++ b/src/Obsolete/Steeltoe.Bootstrap.Autoconfig/Steeltoe.Bootstrap.Autoconfig.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
-    <Description>TODO: Fill package description.</Description>
-    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <Description>Package for automatically configuring Steeltoe packages that have separately been added to a project.</Description>
+    <PackageTags>Autoconfiguration;automatic configuration;application bootstrapping</PackageTags>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 

--- a/src/Obsolete/Steeltoe.CircuitBreaker.Abstractions/Build/Steeltoe.CircuitBreaker.Abstractions.targets
+++ b/src/Obsolete/Steeltoe.CircuitBreaker.Abstractions/Build/Steeltoe.CircuitBreaker.Abstractions.targets
@@ -1,5 +1,5 @@
 <Project>
-  <Target Name="Warn_SteeltoeCircuitBreakerAbstractions" BeforeTargets="BeforeResolveReferences">
+  <Target Name="Warn_SteeltoeCircuitBreakerAbstractions" AfterTargets="AfterResolveReferences">
     <Warning
       Text="The NuGet package Steeltoe.CircuitBreaker.Abstractions is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>

--- a/src/Obsolete/Steeltoe.CircuitBreaker.Abstractions/Build/Steeltoe.CircuitBreaker.Abstractions.targets
+++ b/src/Obsolete/Steeltoe.CircuitBreaker.Abstractions/Build/Steeltoe.CircuitBreaker.Abstractions.targets
@@ -1,7 +1,7 @@
 <Project>
   <Target Name="Warn_SteeltoeCircuitBreakerAbstractions" AfterTargets="AfterResolveReferences">
     <Warning
-      Text="The NuGet package Steeltoe.CircuitBreaker.Abstractions is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+      Text="The NuGet package Steeltoe.CircuitBreaker.Abstractions has been removed from Steeltoe in v4. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.CircuitBreaker.Abstractions/Build/Steeltoe.CircuitBreaker.Abstractions.targets
+++ b/src/Obsolete/Steeltoe.CircuitBreaker.Abstractions/Build/Steeltoe.CircuitBreaker.Abstractions.targets
@@ -1,0 +1,5 @@
+<Project>
+  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="This feature is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+</Project>

--- a/src/Obsolete/Steeltoe.CircuitBreaker.Abstractions/Build/Steeltoe.CircuitBreaker.Abstractions.targets
+++ b/src/Obsolete/Steeltoe.CircuitBreaker.Abstractions/Build/Steeltoe.CircuitBreaker.Abstractions.targets
@@ -1,5 +1,9 @@
 <Project>
-  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
-    <Error Text="This feature is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+  <Target Name="Warn_SteeltoeCircuitBreakerAbstractions" BeforeTargets="BeforeResolveReferences">
+    <Warning Text="This feature is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+
+  <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="One or more Steeltoe package dependencies need attention. See the build warnings for details." />
   </Target>
 </Project>

--- a/src/Obsolete/Steeltoe.CircuitBreaker.Abstractions/Build/Steeltoe.CircuitBreaker.Abstractions.targets
+++ b/src/Obsolete/Steeltoe.CircuitBreaker.Abstractions/Build/Steeltoe.CircuitBreaker.Abstractions.targets
@@ -1,6 +1,7 @@
 <Project>
   <Target Name="Warn_SteeltoeCircuitBreakerAbstractions" BeforeTargets="BeforeResolveReferences">
-    <Warning Text="This feature is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+    <Warning
+      Text="The NuGet package Steeltoe.CircuitBreaker.Abstractions is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.CircuitBreaker.Abstractions/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.CircuitBreaker.Abstractions/PackageReadme.md
@@ -1,0 +1,17 @@
+# Steeltoe
+
+> [!IMPORTANT]
+> This feature is no longer available in Steeltoe v4.
+> See <https://steeltoe.io/docs/v3/obsolete> for details.
+
+[Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).
+
+Key features include:
+
+- External (optionally encrypted) configuration using [Spring Cloud Config Server](https://docs.spring.io/spring-cloud-config/docs/current/reference/html/)
+- Service discovery with [Netflix Eureka](https://spring.io/projects/spring-cloud-netflix) and [HashiCorp Consul](https://www.consul.io/)
+- Management endpoints (compatible with [actuators](https://docs.spring.io/spring-boot/docs/current/reference/html/actuator.html)), providing system info (such as versions, configuration, service container contents, mapped routes and HTTP traffic), heap/thread dumps, health checks, exporting metrics to [Prometheus](https://prometheus.io/), and changing log levels at runtime.
+- Connectivity to databases (such as [SQL Server](https://www.microsoft.com/sql-server)/[Azure SQL](https://azure.microsoft.com/products/azure-sql), [Cosmos DB](https://azure.microsoft.com/products/cosmos-db/), [MongoDB](https://www.mongodb.com/), [Redis](https://redis.io/), [RabbitMQ](https://www.rabbitmq.com/), [PostgreSQL](https://www.postgresql.org/), and [MySQL](https://www.mysql.com/)), including support for [Entity Framework Core](https://learn.microsoft.com/ef/core/)
+- Single sign-on, JWT and Certificate auth with [Cloud Foundry](https://www.cloudfoundry.org/)
+
+For more information and to get started, please visit [Steeltoe on GitHub](https://github.com/SteeltoeOSS/Steeltoe) or the [documentation](https://steeltoe.io/docs).

--- a/src/Obsolete/Steeltoe.CircuitBreaker.Abstractions/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.CircuitBreaker.Abstractions/PackageReadme.md
@@ -1,7 +1,7 @@
 # Steeltoe
 
 > [!IMPORTANT]
-> This feature is no longer available in Steeltoe v4.
+> This package has been removed from Steeltoe in v4.
 > See <https://steeltoe.io/docs/v3/obsolete> for details.
 
 [Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).

--- a/src/Obsolete/Steeltoe.CircuitBreaker.Abstractions/Steeltoe.CircuitBreaker.Abstractions.csproj
+++ b/src/Obsolete/Steeltoe.CircuitBreaker.Abstractions/Steeltoe.CircuitBreaker.Abstractions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
-    <Description>TODO: Fill package description.</Description>
+    <Description>Circuit breaker abstractions.</Description>
     <PackageTags>TODO: Fill package tags.</PackageTags>
     <IsPackable>true</IsPackable>
   </PropertyGroup>

--- a/src/Obsolete/Steeltoe.CircuitBreaker.Abstractions/Steeltoe.CircuitBreaker.Abstractions.csproj
+++ b/src/Obsolete/Steeltoe.CircuitBreaker.Abstractions/Steeltoe.CircuitBreaker.Abstractions.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
     <Description>Circuit breaker abstractions.</Description>
-    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <PackageTags>Spring Cloud;Hystrix Client;Circuit Breaker</PackageTags>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 

--- a/src/Obsolete/Steeltoe.CircuitBreaker.Abstractions/Steeltoe.CircuitBreaker.Abstractions.csproj
+++ b/src/Obsolete/Steeltoe.CircuitBreaker.Abstractions/Steeltoe.CircuitBreaker.Abstractions.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net8.0</TargetFrameworks>
+    <Description>TODO: Fill package description.</Description>
+    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
+  <Import Project="..\..\..\shared.props" />
+
+  <ItemGroup>
+    <None Include="Build\*.props" Pack="True" PackagePath="build" />
+    <None Include="Build\*.targets" Pack="True" PackagePath="build" />
+  </ItemGroup>
+</Project>

--- a/src/Obsolete/Steeltoe.CircuitBreaker.Hystrix.MetricsEventsCore/Build/Steeltoe.CircuitBreaker.Hystrix.MetricsEventsCore.targets
+++ b/src/Obsolete/Steeltoe.CircuitBreaker.Hystrix.MetricsEventsCore/Build/Steeltoe.CircuitBreaker.Hystrix.MetricsEventsCore.targets
@@ -1,5 +1,5 @@
 <Project>
-  <Target Name="Warn_SteeltoeCircuitBreakerHystrixMetricsEventsCore" BeforeTargets="BeforeResolveReferences">
+  <Target Name="Warn_SteeltoeCircuitBreakerHystrixMetricsEventsCore" AfterTargets="AfterResolveReferences">
     <Warning
       Text="The NuGet package Steeltoe.CircuitBreaker.Hystrix.MetricsEventsCore is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>

--- a/src/Obsolete/Steeltoe.CircuitBreaker.Hystrix.MetricsEventsCore/Build/Steeltoe.CircuitBreaker.Hystrix.MetricsEventsCore.targets
+++ b/src/Obsolete/Steeltoe.CircuitBreaker.Hystrix.MetricsEventsCore/Build/Steeltoe.CircuitBreaker.Hystrix.MetricsEventsCore.targets
@@ -1,0 +1,5 @@
+<Project>
+  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="This feature is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+</Project>

--- a/src/Obsolete/Steeltoe.CircuitBreaker.Hystrix.MetricsEventsCore/Build/Steeltoe.CircuitBreaker.Hystrix.MetricsEventsCore.targets
+++ b/src/Obsolete/Steeltoe.CircuitBreaker.Hystrix.MetricsEventsCore/Build/Steeltoe.CircuitBreaker.Hystrix.MetricsEventsCore.targets
@@ -1,7 +1,7 @@
 <Project>
   <Target Name="Warn_SteeltoeCircuitBreakerHystrixMetricsEventsCore" AfterTargets="AfterResolveReferences">
     <Warning
-      Text="The NuGet package Steeltoe.CircuitBreaker.Hystrix.MetricsEventsCore is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+      Text="The NuGet package Steeltoe.CircuitBreaker.Hystrix.MetricsEventsCore has been removed from Steeltoe in v4. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.CircuitBreaker.Hystrix.MetricsEventsCore/Build/Steeltoe.CircuitBreaker.Hystrix.MetricsEventsCore.targets
+++ b/src/Obsolete/Steeltoe.CircuitBreaker.Hystrix.MetricsEventsCore/Build/Steeltoe.CircuitBreaker.Hystrix.MetricsEventsCore.targets
@@ -1,6 +1,7 @@
 <Project>
   <Target Name="Warn_SteeltoeCircuitBreakerHystrixMetricsEventsCore" BeforeTargets="BeforeResolveReferences">
-    <Warning Text="This feature is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+    <Warning
+      Text="The NuGet package Steeltoe.CircuitBreaker.Hystrix.MetricsEventsCore is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.CircuitBreaker.Hystrix.MetricsEventsCore/Build/Steeltoe.CircuitBreaker.Hystrix.MetricsEventsCore.targets
+++ b/src/Obsolete/Steeltoe.CircuitBreaker.Hystrix.MetricsEventsCore/Build/Steeltoe.CircuitBreaker.Hystrix.MetricsEventsCore.targets
@@ -1,5 +1,9 @@
 <Project>
-  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
-    <Error Text="This feature is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+  <Target Name="Warn_SteeltoeCircuitBreakerHystrixMetricsEventsCore" BeforeTargets="BeforeResolveReferences">
+    <Warning Text="This feature is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+
+  <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="One or more Steeltoe package dependencies need attention. See the build warnings for details." />
   </Target>
 </Project>

--- a/src/Obsolete/Steeltoe.CircuitBreaker.Hystrix.MetricsEventsCore/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.CircuitBreaker.Hystrix.MetricsEventsCore/PackageReadme.md
@@ -1,0 +1,17 @@
+# Steeltoe
+
+> [!IMPORTANT]
+> This feature is no longer available in Steeltoe v4.
+> See <https://steeltoe.io/docs/v3/obsolete> for details.
+
+[Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).
+
+Key features include:
+
+- External (optionally encrypted) configuration using [Spring Cloud Config Server](https://docs.spring.io/spring-cloud-config/docs/current/reference/html/)
+- Service discovery with [Netflix Eureka](https://spring.io/projects/spring-cloud-netflix) and [HashiCorp Consul](https://www.consul.io/)
+- Management endpoints (compatible with [actuators](https://docs.spring.io/spring-boot/docs/current/reference/html/actuator.html)), providing system info (such as versions, configuration, service container contents, mapped routes and HTTP traffic), heap/thread dumps, health checks, exporting metrics to [Prometheus](https://prometheus.io/), and changing log levels at runtime.
+- Connectivity to databases (such as [SQL Server](https://www.microsoft.com/sql-server)/[Azure SQL](https://azure.microsoft.com/products/azure-sql), [Cosmos DB](https://azure.microsoft.com/products/cosmos-db/), [MongoDB](https://www.mongodb.com/), [Redis](https://redis.io/), [RabbitMQ](https://www.rabbitmq.com/), [PostgreSQL](https://www.postgresql.org/), and [MySQL](https://www.mysql.com/)), including support for [Entity Framework Core](https://learn.microsoft.com/ef/core/)
+- Single sign-on, JWT and Certificate auth with [Cloud Foundry](https://www.cloudfoundry.org/)
+
+For more information and to get started, please visit [Steeltoe on GitHub](https://github.com/SteeltoeOSS/Steeltoe) or the [documentation](https://steeltoe.io/docs).

--- a/src/Obsolete/Steeltoe.CircuitBreaker.Hystrix.MetricsEventsCore/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.CircuitBreaker.Hystrix.MetricsEventsCore/PackageReadme.md
@@ -1,7 +1,7 @@
 # Steeltoe
 
 > [!IMPORTANT]
-> This feature is no longer available in Steeltoe v4.
+> This package has been removed from Steeltoe in v4.
 > See <https://steeltoe.io/docs/v3/obsolete> for details.
 
 [Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).

--- a/src/Obsolete/Steeltoe.CircuitBreaker.Hystrix.MetricsEventsCore/Steeltoe.CircuitBreaker.Hystrix.MetricsEventsCore.csproj
+++ b/src/Obsolete/Steeltoe.CircuitBreaker.Hystrix.MetricsEventsCore/Steeltoe.CircuitBreaker.Hystrix.MetricsEventsCore.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net8.0</TargetFrameworks>
+    <Description>TODO: Fill package description.</Description>
+    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
+  <Import Project="..\..\..\shared.props" />
+
+  <ItemGroup>
+    <None Include="Build\*.props" Pack="True" PackagePath="build" />
+    <None Include="Build\*.targets" Pack="True" PackagePath="build" />
+  </ItemGroup>
+</Project>

--- a/src/Obsolete/Steeltoe.CircuitBreaker.Hystrix.MetricsEventsCore/Steeltoe.CircuitBreaker.Hystrix.MetricsEventsCore.csproj
+++ b/src/Obsolete/Steeltoe.CircuitBreaker.Hystrix.MetricsEventsCore/Steeltoe.CircuitBreaker.Hystrix.MetricsEventsCore.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
-    <Description>TODO: Fill package description.</Description>
-    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <Description>Steeltoe Netflix Hystrix Metrics Event Stream ASP.NET Core.</Description>
+    <PackageTags>aspnetcore;Circuit Breaker;Spring;Spring Cloud;Spring Cloud Hystrix;Hystrix</PackageTags>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 

--- a/src/Obsolete/Steeltoe.CircuitBreaker.Hystrix.MetricsStreamCore/Build/Steeltoe.CircuitBreaker.Hystrix.MetricsStreamCore.targets
+++ b/src/Obsolete/Steeltoe.CircuitBreaker.Hystrix.MetricsStreamCore/Build/Steeltoe.CircuitBreaker.Hystrix.MetricsStreamCore.targets
@@ -1,5 +1,5 @@
 <Project>
-  <Target Name="Warn_SteeltoeCircuitBreakerHystrixMetricsStreamCore" BeforeTargets="BeforeResolveReferences">
+  <Target Name="Warn_SteeltoeCircuitBreakerHystrixMetricsStreamCore" AfterTargets="AfterResolveReferences">
     <Warning
       Text="The NuGet package Steeltoe.CircuitBreaker.Hystrix.MetricsStreamCore is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>

--- a/src/Obsolete/Steeltoe.CircuitBreaker.Hystrix.MetricsStreamCore/Build/Steeltoe.CircuitBreaker.Hystrix.MetricsStreamCore.targets
+++ b/src/Obsolete/Steeltoe.CircuitBreaker.Hystrix.MetricsStreamCore/Build/Steeltoe.CircuitBreaker.Hystrix.MetricsStreamCore.targets
@@ -1,0 +1,5 @@
+<Project>
+  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="This feature is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+</Project>

--- a/src/Obsolete/Steeltoe.CircuitBreaker.Hystrix.MetricsStreamCore/Build/Steeltoe.CircuitBreaker.Hystrix.MetricsStreamCore.targets
+++ b/src/Obsolete/Steeltoe.CircuitBreaker.Hystrix.MetricsStreamCore/Build/Steeltoe.CircuitBreaker.Hystrix.MetricsStreamCore.targets
@@ -1,7 +1,7 @@
 <Project>
   <Target Name="Warn_SteeltoeCircuitBreakerHystrixMetricsStreamCore" AfterTargets="AfterResolveReferences">
     <Warning
-      Text="The NuGet package Steeltoe.CircuitBreaker.Hystrix.MetricsStreamCore is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+      Text="The NuGet package Steeltoe.CircuitBreaker.Hystrix.MetricsStreamCore has been removed from Steeltoe in v4. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.CircuitBreaker.Hystrix.MetricsStreamCore/Build/Steeltoe.CircuitBreaker.Hystrix.MetricsStreamCore.targets
+++ b/src/Obsolete/Steeltoe.CircuitBreaker.Hystrix.MetricsStreamCore/Build/Steeltoe.CircuitBreaker.Hystrix.MetricsStreamCore.targets
@@ -1,6 +1,7 @@
 <Project>
   <Target Name="Warn_SteeltoeCircuitBreakerHystrixMetricsStreamCore" BeforeTargets="BeforeResolveReferences">
-    <Warning Text="This feature is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+    <Warning
+      Text="The NuGet package Steeltoe.CircuitBreaker.Hystrix.MetricsStreamCore is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.CircuitBreaker.Hystrix.MetricsStreamCore/Build/Steeltoe.CircuitBreaker.Hystrix.MetricsStreamCore.targets
+++ b/src/Obsolete/Steeltoe.CircuitBreaker.Hystrix.MetricsStreamCore/Build/Steeltoe.CircuitBreaker.Hystrix.MetricsStreamCore.targets
@@ -1,5 +1,9 @@
 <Project>
-  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
-    <Error Text="This feature is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+  <Target Name="Warn_SteeltoeCircuitBreakerHystrixMetricsStreamCore" BeforeTargets="BeforeResolveReferences">
+    <Warning Text="This feature is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+
+  <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="One or more Steeltoe package dependencies need attention. See the build warnings for details." />
   </Target>
 </Project>

--- a/src/Obsolete/Steeltoe.CircuitBreaker.Hystrix.MetricsStreamCore/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.CircuitBreaker.Hystrix.MetricsStreamCore/PackageReadme.md
@@ -1,0 +1,17 @@
+# Steeltoe
+
+> [!IMPORTANT]
+> This feature is no longer available in Steeltoe v4.
+> See <https://steeltoe.io/docs/v3/obsolete> for details.
+
+[Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).
+
+Key features include:
+
+- External (optionally encrypted) configuration using [Spring Cloud Config Server](https://docs.spring.io/spring-cloud-config/docs/current/reference/html/)
+- Service discovery with [Netflix Eureka](https://spring.io/projects/spring-cloud-netflix) and [HashiCorp Consul](https://www.consul.io/)
+- Management endpoints (compatible with [actuators](https://docs.spring.io/spring-boot/docs/current/reference/html/actuator.html)), providing system info (such as versions, configuration, service container contents, mapped routes and HTTP traffic), heap/thread dumps, health checks, exporting metrics to [Prometheus](https://prometheus.io/), and changing log levels at runtime.
+- Connectivity to databases (such as [SQL Server](https://www.microsoft.com/sql-server)/[Azure SQL](https://azure.microsoft.com/products/azure-sql), [Cosmos DB](https://azure.microsoft.com/products/cosmos-db/), [MongoDB](https://www.mongodb.com/), [Redis](https://redis.io/), [RabbitMQ](https://www.rabbitmq.com/), [PostgreSQL](https://www.postgresql.org/), and [MySQL](https://www.mysql.com/)), including support for [Entity Framework Core](https://learn.microsoft.com/ef/core/)
+- Single sign-on, JWT and Certificate auth with [Cloud Foundry](https://www.cloudfoundry.org/)
+
+For more information and to get started, please visit [Steeltoe on GitHub](https://github.com/SteeltoeOSS/Steeltoe) or the [documentation](https://steeltoe.io/docs).

--- a/src/Obsolete/Steeltoe.CircuitBreaker.Hystrix.MetricsStreamCore/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.CircuitBreaker.Hystrix.MetricsStreamCore/PackageReadme.md
@@ -1,7 +1,7 @@
 # Steeltoe
 
 > [!IMPORTANT]
-> This feature is no longer available in Steeltoe v4.
+> This package has been removed from Steeltoe in v4.
 > See <https://steeltoe.io/docs/v3/obsolete> for details.
 
 [Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).

--- a/src/Obsolete/Steeltoe.CircuitBreaker.Hystrix.MetricsStreamCore/Steeltoe.CircuitBreaker.Hystrix.MetricsStreamCore.csproj
+++ b/src/Obsolete/Steeltoe.CircuitBreaker.Hystrix.MetricsStreamCore/Steeltoe.CircuitBreaker.Hystrix.MetricsStreamCore.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
-    <Description>TODO: Fill package description.</Description>
-    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <Description>Netflix Hystrix metrics event stream for ASP.NET Core over RabbitMQ.</Description>
+    <PackageTags>aspnetcore;Circuit Breaker;Spring;Spring Cloud;Spring Cloud Hystrix;Hystrix;turbine;cloudfoundry</PackageTags>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 

--- a/src/Obsolete/Steeltoe.CircuitBreaker.Hystrix.MetricsStreamCore/Steeltoe.CircuitBreaker.Hystrix.MetricsStreamCore.csproj
+++ b/src/Obsolete/Steeltoe.CircuitBreaker.Hystrix.MetricsStreamCore/Steeltoe.CircuitBreaker.Hystrix.MetricsStreamCore.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net8.0</TargetFrameworks>
+    <Description>TODO: Fill package description.</Description>
+    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
+  <Import Project="..\..\..\shared.props" />
+
+  <ItemGroup>
+    <None Include="Build\*.props" Pack="True" PackagePath="build" />
+    <None Include="Build\*.targets" Pack="True" PackagePath="build" />
+  </ItemGroup>
+</Project>

--- a/src/Obsolete/Steeltoe.CircuitBreaker.HystrixBase/Build/Steeltoe.CircuitBreaker.HystrixBase.targets
+++ b/src/Obsolete/Steeltoe.CircuitBreaker.HystrixBase/Build/Steeltoe.CircuitBreaker.HystrixBase.targets
@@ -1,7 +1,7 @@
 <Project>
   <Target Name="Warn_SteeltoeCircuitBreakerHystrixBase" AfterTargets="AfterResolveReferences">
     <Warning
-      Text="The NuGet package Steeltoe.CircuitBreaker.HystrixBase is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+      Text="The NuGet package Steeltoe.CircuitBreaker.HystrixBase has been removed from Steeltoe in v4. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.CircuitBreaker.HystrixBase/Build/Steeltoe.CircuitBreaker.HystrixBase.targets
+++ b/src/Obsolete/Steeltoe.CircuitBreaker.HystrixBase/Build/Steeltoe.CircuitBreaker.HystrixBase.targets
@@ -1,6 +1,7 @@
 <Project>
   <Target Name="Warn_SteeltoeCircuitBreakerHystrixBase" BeforeTargets="BeforeResolveReferences">
-    <Warning Text="This feature is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+    <Warning
+      Text="The NuGet package Steeltoe.CircuitBreaker.HystrixBase is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.CircuitBreaker.HystrixBase/Build/Steeltoe.CircuitBreaker.HystrixBase.targets
+++ b/src/Obsolete/Steeltoe.CircuitBreaker.HystrixBase/Build/Steeltoe.CircuitBreaker.HystrixBase.targets
@@ -1,5 +1,5 @@
 <Project>
-  <Target Name="Warn_SteeltoeCircuitBreakerHystrixBase" BeforeTargets="BeforeResolveReferences">
+  <Target Name="Warn_SteeltoeCircuitBreakerHystrixBase" AfterTargets="AfterResolveReferences">
     <Warning
       Text="The NuGet package Steeltoe.CircuitBreaker.HystrixBase is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>

--- a/src/Obsolete/Steeltoe.CircuitBreaker.HystrixBase/Build/Steeltoe.CircuitBreaker.HystrixBase.targets
+++ b/src/Obsolete/Steeltoe.CircuitBreaker.HystrixBase/Build/Steeltoe.CircuitBreaker.HystrixBase.targets
@@ -1,0 +1,5 @@
+<Project>
+  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="This feature is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+</Project>

--- a/src/Obsolete/Steeltoe.CircuitBreaker.HystrixBase/Build/Steeltoe.CircuitBreaker.HystrixBase.targets
+++ b/src/Obsolete/Steeltoe.CircuitBreaker.HystrixBase/Build/Steeltoe.CircuitBreaker.HystrixBase.targets
@@ -1,5 +1,9 @@
 <Project>
-  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
-    <Error Text="This feature is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+  <Target Name="Warn_SteeltoeCircuitBreakerHystrixBase" BeforeTargets="BeforeResolveReferences">
+    <Warning Text="This feature is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+
+  <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="One or more Steeltoe package dependencies need attention. See the build warnings for details." />
   </Target>
 </Project>

--- a/src/Obsolete/Steeltoe.CircuitBreaker.HystrixBase/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.CircuitBreaker.HystrixBase/PackageReadme.md
@@ -1,0 +1,17 @@
+# Steeltoe
+
+> [!IMPORTANT]
+> This feature is no longer available in Steeltoe v4.
+> See <https://steeltoe.io/docs/v3/obsolete> for details.
+
+[Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).
+
+Key features include:
+
+- External (optionally encrypted) configuration using [Spring Cloud Config Server](https://docs.spring.io/spring-cloud-config/docs/current/reference/html/)
+- Service discovery with [Netflix Eureka](https://spring.io/projects/spring-cloud-netflix) and [HashiCorp Consul](https://www.consul.io/)
+- Management endpoints (compatible with [actuators](https://docs.spring.io/spring-boot/docs/current/reference/html/actuator.html)), providing system info (such as versions, configuration, service container contents, mapped routes and HTTP traffic), heap/thread dumps, health checks, exporting metrics to [Prometheus](https://prometheus.io/), and changing log levels at runtime.
+- Connectivity to databases (such as [SQL Server](https://www.microsoft.com/sql-server)/[Azure SQL](https://azure.microsoft.com/products/azure-sql), [Cosmos DB](https://azure.microsoft.com/products/cosmos-db/), [MongoDB](https://www.mongodb.com/), [Redis](https://redis.io/), [RabbitMQ](https://www.rabbitmq.com/), [PostgreSQL](https://www.postgresql.org/), and [MySQL](https://www.mysql.com/)), including support for [Entity Framework Core](https://learn.microsoft.com/ef/core/)
+- Single sign-on, JWT and Certificate auth with [Cloud Foundry](https://www.cloudfoundry.org/)
+
+For more information and to get started, please visit [Steeltoe on GitHub](https://github.com/SteeltoeOSS/Steeltoe) or the [documentation](https://steeltoe.io/docs).

--- a/src/Obsolete/Steeltoe.CircuitBreaker.HystrixBase/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.CircuitBreaker.HystrixBase/PackageReadme.md
@@ -1,7 +1,7 @@
 # Steeltoe
 
 > [!IMPORTANT]
-> This feature is no longer available in Steeltoe v4.
+> This package has been removed from Steeltoe in v4.
 > See <https://steeltoe.io/docs/v3/obsolete> for details.
 
 [Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).

--- a/src/Obsolete/Steeltoe.CircuitBreaker.HystrixBase/Steeltoe.CircuitBreaker.HystrixBase.csproj
+++ b/src/Obsolete/Steeltoe.CircuitBreaker.HystrixBase/Steeltoe.CircuitBreaker.HystrixBase.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net8.0</TargetFrameworks>
+    <Description>TODO: Fill package description.</Description>
+    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
+  <Import Project="..\..\..\shared.props" />
+
+  <ItemGroup>
+    <None Include="Build\*.props" Pack="True" PackagePath="build" />
+    <None Include="Build\*.targets" Pack="True" PackagePath="build" />
+  </ItemGroup>
+</Project>

--- a/src/Obsolete/Steeltoe.CircuitBreaker.HystrixBase/Steeltoe.CircuitBreaker.HystrixBase.csproj
+++ b/src/Obsolete/Steeltoe.CircuitBreaker.HystrixBase/Steeltoe.CircuitBreaker.HystrixBase.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
-    <Description>TODO: Fill package description.</Description>
-    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <Description>Steeltoe's implementation of Netflix's Hystrix, for .NET.</Description>
+    <PackageTags>Spring Cloud;Netflix;Hystrix Client;Circuit Breaker</PackageTags>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 

--- a/src/Obsolete/Steeltoe.CircuitBreaker.HystrixCore/Build/Steeltoe.CircuitBreaker.HystrixCore.targets
+++ b/src/Obsolete/Steeltoe.CircuitBreaker.HystrixCore/Build/Steeltoe.CircuitBreaker.HystrixCore.targets
@@ -1,5 +1,5 @@
 <Project>
-  <Target Name="Warn_SteeltoeCircuitBreakerHystrixCore" BeforeTargets="BeforeResolveReferences">
+  <Target Name="Warn_SteeltoeCircuitBreakerHystrixCore" AfterTargets="AfterResolveReferences">
     <Warning
       Text="The NuGet package Steeltoe.CircuitBreaker.HystrixCore is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>

--- a/src/Obsolete/Steeltoe.CircuitBreaker.HystrixCore/Build/Steeltoe.CircuitBreaker.HystrixCore.targets
+++ b/src/Obsolete/Steeltoe.CircuitBreaker.HystrixCore/Build/Steeltoe.CircuitBreaker.HystrixCore.targets
@@ -1,0 +1,5 @@
+<Project>
+  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="This feature is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+</Project>

--- a/src/Obsolete/Steeltoe.CircuitBreaker.HystrixCore/Build/Steeltoe.CircuitBreaker.HystrixCore.targets
+++ b/src/Obsolete/Steeltoe.CircuitBreaker.HystrixCore/Build/Steeltoe.CircuitBreaker.HystrixCore.targets
@@ -1,7 +1,7 @@
 <Project>
   <Target Name="Warn_SteeltoeCircuitBreakerHystrixCore" AfterTargets="AfterResolveReferences">
     <Warning
-      Text="The NuGet package Steeltoe.CircuitBreaker.HystrixCore is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+      Text="The NuGet package Steeltoe.CircuitBreaker.HystrixCore has been removed from Steeltoe in v4. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.CircuitBreaker.HystrixCore/Build/Steeltoe.CircuitBreaker.HystrixCore.targets
+++ b/src/Obsolete/Steeltoe.CircuitBreaker.HystrixCore/Build/Steeltoe.CircuitBreaker.HystrixCore.targets
@@ -1,5 +1,9 @@
 <Project>
-  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
-    <Error Text="This feature is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+  <Target Name="Warn_SteeltoeCircuitBreakerHystrixCore" BeforeTargets="BeforeResolveReferences">
+    <Warning Text="This feature is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+
+  <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="One or more Steeltoe package dependencies need attention. See the build warnings for details." />
   </Target>
 </Project>

--- a/src/Obsolete/Steeltoe.CircuitBreaker.HystrixCore/Build/Steeltoe.CircuitBreaker.HystrixCore.targets
+++ b/src/Obsolete/Steeltoe.CircuitBreaker.HystrixCore/Build/Steeltoe.CircuitBreaker.HystrixCore.targets
@@ -1,6 +1,7 @@
 <Project>
   <Target Name="Warn_SteeltoeCircuitBreakerHystrixCore" BeforeTargets="BeforeResolveReferences">
-    <Warning Text="This feature is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+    <Warning
+      Text="The NuGet package Steeltoe.CircuitBreaker.HystrixCore is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.CircuitBreaker.HystrixCore/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.CircuitBreaker.HystrixCore/PackageReadme.md
@@ -1,0 +1,17 @@
+# Steeltoe
+
+> [!IMPORTANT]
+> This feature is no longer available in Steeltoe v4.
+> See <https://steeltoe.io/docs/v3/obsolete> for details.
+
+[Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).
+
+Key features include:
+
+- External (optionally encrypted) configuration using [Spring Cloud Config Server](https://docs.spring.io/spring-cloud-config/docs/current/reference/html/)
+- Service discovery with [Netflix Eureka](https://spring.io/projects/spring-cloud-netflix) and [HashiCorp Consul](https://www.consul.io/)
+- Management endpoints (compatible with [actuators](https://docs.spring.io/spring-boot/docs/current/reference/html/actuator.html)), providing system info (such as versions, configuration, service container contents, mapped routes and HTTP traffic), heap/thread dumps, health checks, exporting metrics to [Prometheus](https://prometheus.io/), and changing log levels at runtime.
+- Connectivity to databases (such as [SQL Server](https://www.microsoft.com/sql-server)/[Azure SQL](https://azure.microsoft.com/products/azure-sql), [Cosmos DB](https://azure.microsoft.com/products/cosmos-db/), [MongoDB](https://www.mongodb.com/), [Redis](https://redis.io/), [RabbitMQ](https://www.rabbitmq.com/), [PostgreSQL](https://www.postgresql.org/), and [MySQL](https://www.mysql.com/)), including support for [Entity Framework Core](https://learn.microsoft.com/ef/core/)
+- Single sign-on, JWT and Certificate auth with [Cloud Foundry](https://www.cloudfoundry.org/)
+
+For more information and to get started, please visit [Steeltoe on GitHub](https://github.com/SteeltoeOSS/Steeltoe) or the [documentation](https://steeltoe.io/docs).

--- a/src/Obsolete/Steeltoe.CircuitBreaker.HystrixCore/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.CircuitBreaker.HystrixCore/PackageReadme.md
@@ -1,7 +1,7 @@
 # Steeltoe
 
 > [!IMPORTANT]
-> This feature is no longer available in Steeltoe v4.
+> This package has been removed from Steeltoe in v4.
 > See <https://steeltoe.io/docs/v3/obsolete> for details.
 
 [Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).

--- a/src/Obsolete/Steeltoe.CircuitBreaker.HystrixCore/Steeltoe.CircuitBreaker.HystrixCore.csproj
+++ b/src/Obsolete/Steeltoe.CircuitBreaker.HystrixCore/Steeltoe.CircuitBreaker.HystrixCore.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
-    <Description>TODO: Fill package description.</Description>
-    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <Description>Package for adding Steeltoe Hystrix to ASP.NET Core applications.</Description>
+    <PackageTags>aspnetcore;Spring Cloud;Netflix;Hystrix Client;Circuit Breaker</PackageTags>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 

--- a/src/Obsolete/Steeltoe.CircuitBreaker.HystrixCore/Steeltoe.CircuitBreaker.HystrixCore.csproj
+++ b/src/Obsolete/Steeltoe.CircuitBreaker.HystrixCore/Steeltoe.CircuitBreaker.HystrixCore.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net8.0</TargetFrameworks>
+    <Description>TODO: Fill package description.</Description>
+    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
+  <Import Project="..\..\..\shared.props" />
+
+  <ItemGroup>
+    <None Include="Build\*.props" Pack="True" PackagePath="build" />
+    <None Include="Build\*.targets" Pack="True" PackagePath="build" />
+  </ItemGroup>
+</Project>

--- a/src/Obsolete/Steeltoe.Common.Abstractions/Build/Steeltoe.Common.Abstractions.targets
+++ b/src/Obsolete/Steeltoe.Common.Abstractions/Build/Steeltoe.Common.Abstractions.targets
@@ -1,5 +1,9 @@
 <Project>
-  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
-    <Error Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Common instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+  <Target Name="Warn_SteeltoeCommonAbstractions" BeforeTargets="BeforeResolveReferences">
+    <Warning Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Common instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+
+  <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="One or more Steeltoe package dependencies need attention. See the build warnings for details." />
   </Target>
 </Project>

--- a/src/Obsolete/Steeltoe.Common.Abstractions/Build/Steeltoe.Common.Abstractions.targets
+++ b/src/Obsolete/Steeltoe.Common.Abstractions/Build/Steeltoe.Common.Abstractions.targets
@@ -1,5 +1,5 @@
 <Project>
-  <Target Name="Warn_SteeltoeCommonAbstractions" BeforeTargets="BeforeResolveReferences">
+  <Target Name="Warn_SteeltoeCommonAbstractions" AfterTargets="AfterResolveReferences">
     <Warning
       Text="The NuGet package Steeltoe.Common.Abstractions has been replaced in Steeltoe v4. Reference Steeltoe.Common instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>

--- a/src/Obsolete/Steeltoe.Common.Abstractions/Build/Steeltoe.Common.Abstractions.targets
+++ b/src/Obsolete/Steeltoe.Common.Abstractions/Build/Steeltoe.Common.Abstractions.targets
@@ -1,7 +1,7 @@
 <Project>
   <Target Name="Warn_SteeltoeCommonAbstractions" AfterTargets="AfterResolveReferences">
     <Warning
-      Text="The NuGet package Steeltoe.Common.Abstractions has been replaced in Steeltoe v4. Reference Steeltoe.Common instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+      Text="The NuGet package Steeltoe.Common.Abstractions has been superseded in Steeltoe v4. Reference Steeltoe.Common instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.Common.Abstractions/Build/Steeltoe.Common.Abstractions.targets
+++ b/src/Obsolete/Steeltoe.Common.Abstractions/Build/Steeltoe.Common.Abstractions.targets
@@ -1,6 +1,7 @@
 <Project>
   <Target Name="Warn_SteeltoeCommonAbstractions" BeforeTargets="BeforeResolveReferences">
-    <Warning Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Common instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+    <Warning
+      Text="The NuGet package Steeltoe.Common.Abstractions has been replaced in Steeltoe v4. Reference Steeltoe.Common instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.Common.Abstractions/Build/Steeltoe.Common.Abstractions.targets
+++ b/src/Obsolete/Steeltoe.Common.Abstractions/Build/Steeltoe.Common.Abstractions.targets
@@ -1,0 +1,5 @@
+<Project>
+  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Common instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+</Project>

--- a/src/Obsolete/Steeltoe.Common.Abstractions/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.Common.Abstractions/PackageReadme.md
@@ -1,0 +1,17 @@
+# Steeltoe
+
+> [!IMPORTANT]
+> This package has been replaced in Steeltoe v4. Reference `Steeltoe.Common` instead.
+> See <https://steeltoe.io/docs/v3/obsolete> for details.
+
+[Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).
+
+Key features include:
+
+- External (optionally encrypted) configuration using [Spring Cloud Config Server](https://docs.spring.io/spring-cloud-config/docs/current/reference/html/)
+- Service discovery with [Netflix Eureka](https://spring.io/projects/spring-cloud-netflix) and [HashiCorp Consul](https://www.consul.io/)
+- Management endpoints (compatible with [actuators](https://docs.spring.io/spring-boot/docs/current/reference/html/actuator.html)), providing system info (such as versions, configuration, service container contents, mapped routes and HTTP traffic), heap/thread dumps, health checks, exporting metrics to [Prometheus](https://prometheus.io/), and changing log levels at runtime.
+- Connectivity to databases (such as [SQL Server](https://www.microsoft.com/sql-server)/[Azure SQL](https://azure.microsoft.com/products/azure-sql), [Cosmos DB](https://azure.microsoft.com/products/cosmos-db/), [MongoDB](https://www.mongodb.com/), [Redis](https://redis.io/), [RabbitMQ](https://www.rabbitmq.com/), [PostgreSQL](https://www.postgresql.org/), and [MySQL](https://www.mysql.com/)), including support for [Entity Framework Core](https://learn.microsoft.com/ef/core/)
+- Single sign-on, JWT and Certificate auth with [Cloud Foundry](https://www.cloudfoundry.org/)
+
+For more information and to get started, please visit [Steeltoe on GitHub](https://github.com/SteeltoeOSS/Steeltoe) or the [documentation](https://steeltoe.io/docs).

--- a/src/Obsolete/Steeltoe.Common.Abstractions/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.Common.Abstractions/PackageReadme.md
@@ -1,7 +1,7 @@
 # Steeltoe
 
 > [!IMPORTANT]
-> This package has been replaced in Steeltoe v4. Reference `Steeltoe.Common` instead.
+> This package has been superseded in Steeltoe v4. Reference `Steeltoe.Common` instead.
 > See <https://steeltoe.io/docs/v3/obsolete> for details.
 
 [Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).

--- a/src/Obsolete/Steeltoe.Common.Abstractions/Steeltoe.Common.Abstractions.csproj
+++ b/src/Obsolete/Steeltoe.Common.Abstractions/Steeltoe.Common.Abstractions.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net8.0</TargetFrameworks>
+    <Description>TODO: Fill package description.</Description>
+    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
+  <Import Project="..\..\..\shared.props" />
+
+  <ItemGroup>
+    <None Include="Build\*.props" Pack="True" PackagePath="build" />
+    <None Include="Build\*.targets" Pack="True" PackagePath="build" />
+  </ItemGroup>
+</Project>

--- a/src/Obsolete/Steeltoe.Common.Abstractions/Steeltoe.Common.Abstractions.csproj
+++ b/src/Obsolete/Steeltoe.Common.Abstractions/Steeltoe.Common.Abstractions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
-    <Description>TODO: Fill package description.</Description>
+    <Description>Abstractions commonly used across Steeltoe components.</Description>
     <PackageTags>TODO: Fill package tags.</PackageTags>
     <IsPackable>true</IsPackable>
   </PropertyGroup>

--- a/src/Obsolete/Steeltoe.Common.Abstractions/Steeltoe.Common.Abstractions.csproj
+++ b/src/Obsolete/Steeltoe.Common.Abstractions/Steeltoe.Common.Abstractions.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
     <Description>Abstractions commonly used across Steeltoe components.</Description>
-    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <PackageTags>Steeltoe</PackageTags>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 

--- a/src/Obsolete/Steeltoe.Common.Expression/Build/Steeltoe.Common.Expression.targets
+++ b/src/Obsolete/Steeltoe.Common.Expression/Build/Steeltoe.Common.Expression.targets
@@ -1,5 +1,9 @@
 <Project>
-  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
-    <Error Text="This feature is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+  <Target Name="Warn_SteeltoeCommonExpression" BeforeTargets="BeforeResolveReferences">
+    <Warning Text="This feature is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+
+  <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="One or more Steeltoe package dependencies need attention. See the build warnings for details." />
   </Target>
 </Project>

--- a/src/Obsolete/Steeltoe.Common.Expression/Build/Steeltoe.Common.Expression.targets
+++ b/src/Obsolete/Steeltoe.Common.Expression/Build/Steeltoe.Common.Expression.targets
@@ -1,0 +1,5 @@
+<Project>
+  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="This feature is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+</Project>

--- a/src/Obsolete/Steeltoe.Common.Expression/Build/Steeltoe.Common.Expression.targets
+++ b/src/Obsolete/Steeltoe.Common.Expression/Build/Steeltoe.Common.Expression.targets
@@ -1,6 +1,6 @@
 <Project>
   <Target Name="Warn_SteeltoeCommonExpression" AfterTargets="AfterResolveReferences">
-    <Warning Text="The NuGet package Steeltoe.Common.Expression is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+    <Warning Text="The NuGet package Steeltoe.Common.Expression has been removed from Steeltoe in v4. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.Common.Expression/Build/Steeltoe.Common.Expression.targets
+++ b/src/Obsolete/Steeltoe.Common.Expression/Build/Steeltoe.Common.Expression.targets
@@ -1,5 +1,5 @@
 <Project>
-  <Target Name="Warn_SteeltoeCommonExpression" BeforeTargets="BeforeResolveReferences">
+  <Target Name="Warn_SteeltoeCommonExpression" AfterTargets="AfterResolveReferences">
     <Warning Text="The NuGet package Steeltoe.Common.Expression is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 

--- a/src/Obsolete/Steeltoe.Common.Expression/Build/Steeltoe.Common.Expression.targets
+++ b/src/Obsolete/Steeltoe.Common.Expression/Build/Steeltoe.Common.Expression.targets
@@ -1,6 +1,6 @@
 <Project>
   <Target Name="Warn_SteeltoeCommonExpression" BeforeTargets="BeforeResolveReferences">
-    <Warning Text="This feature is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+    <Warning Text="The NuGet package Steeltoe.Common.Expression is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.Common.Expression/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.Common.Expression/PackageReadme.md
@@ -1,0 +1,17 @@
+# Steeltoe
+
+> [!IMPORTANT]
+> This feature is no longer available in Steeltoe v4.
+> See <https://steeltoe.io/docs/v3/obsolete> for details.
+
+[Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).
+
+Key features include:
+
+- External (optionally encrypted) configuration using [Spring Cloud Config Server](https://docs.spring.io/spring-cloud-config/docs/current/reference/html/)
+- Service discovery with [Netflix Eureka](https://spring.io/projects/spring-cloud-netflix) and [HashiCorp Consul](https://www.consul.io/)
+- Management endpoints (compatible with [actuators](https://docs.spring.io/spring-boot/docs/current/reference/html/actuator.html)), providing system info (such as versions, configuration, service container contents, mapped routes and HTTP traffic), heap/thread dumps, health checks, exporting metrics to [Prometheus](https://prometheus.io/), and changing log levels at runtime.
+- Connectivity to databases (such as [SQL Server](https://www.microsoft.com/sql-server)/[Azure SQL](https://azure.microsoft.com/products/azure-sql), [Cosmos DB](https://azure.microsoft.com/products/cosmos-db/), [MongoDB](https://www.mongodb.com/), [Redis](https://redis.io/), [RabbitMQ](https://www.rabbitmq.com/), [PostgreSQL](https://www.postgresql.org/), and [MySQL](https://www.mysql.com/)), including support for [Entity Framework Core](https://learn.microsoft.com/ef/core/)
+- Single sign-on, JWT and Certificate auth with [Cloud Foundry](https://www.cloudfoundry.org/)
+
+For more information and to get started, please visit [Steeltoe on GitHub](https://github.com/SteeltoeOSS/Steeltoe) or the [documentation](https://steeltoe.io/docs).

--- a/src/Obsolete/Steeltoe.Common.Expression/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.Common.Expression/PackageReadme.md
@@ -1,7 +1,7 @@
 # Steeltoe
 
 > [!IMPORTANT]
-> This feature is no longer available in Steeltoe v4.
+> This package has been removed from Steeltoe in v4.
 > See <https://steeltoe.io/docs/v3/obsolete> for details.
 
 [Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).

--- a/src/Obsolete/Steeltoe.Common.Expression/Steeltoe.Common.Expression.csproj
+++ b/src/Obsolete/Steeltoe.Common.Expression/Steeltoe.Common.Expression.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
-    <Description>TODO: Fill package description.</Description>
-    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <Description>Steeltoe common expression language library.</Description>
+    <PackageTags>NET Core;Expression;SPEL</PackageTags>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 

--- a/src/Obsolete/Steeltoe.Common.Expression/Steeltoe.Common.Expression.csproj
+++ b/src/Obsolete/Steeltoe.Common.Expression/Steeltoe.Common.Expression.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net8.0</TargetFrameworks>
+    <Description>TODO: Fill package description.</Description>
+    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
+  <Import Project="..\..\..\shared.props" />
+
+  <ItemGroup>
+    <None Include="Build\*.props" Pack="True" PackagePath="build" />
+    <None Include="Build\*.targets" Pack="True" PackagePath="build" />
+  </ItemGroup>
+</Project>

--- a/src/Obsolete/Steeltoe.Common.Kubernetes/Build/Steeltoe.Common.Kubernetes.targets
+++ b/src/Obsolete/Steeltoe.Common.Kubernetes/Build/Steeltoe.Common.Kubernetes.targets
@@ -1,6 +1,6 @@
 <Project>
   <Target Name="Warn_SteeltoeCommonKubernetes" BeforeTargets="BeforeResolveReferences">
-    <Warning Text="This feature is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+    <Warning Text="The NuGet package Steeltoe.Common.Kubernetes is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.Common.Kubernetes/Build/Steeltoe.Common.Kubernetes.targets
+++ b/src/Obsolete/Steeltoe.Common.Kubernetes/Build/Steeltoe.Common.Kubernetes.targets
@@ -1,6 +1,6 @@
 <Project>
   <Target Name="Warn_SteeltoeCommonKubernetes" AfterTargets="AfterResolveReferences">
-    <Warning Text="The NuGet package Steeltoe.Common.Kubernetes is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+    <Warning Text="The NuGet package Steeltoe.Common.Kubernetes has been removed from Steeltoe in v4. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.Common.Kubernetes/Build/Steeltoe.Common.Kubernetes.targets
+++ b/src/Obsolete/Steeltoe.Common.Kubernetes/Build/Steeltoe.Common.Kubernetes.targets
@@ -1,0 +1,5 @@
+<Project>
+  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="This feature is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+</Project>

--- a/src/Obsolete/Steeltoe.Common.Kubernetes/Build/Steeltoe.Common.Kubernetes.targets
+++ b/src/Obsolete/Steeltoe.Common.Kubernetes/Build/Steeltoe.Common.Kubernetes.targets
@@ -1,5 +1,9 @@
 <Project>
-  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
-    <Error Text="This feature is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+  <Target Name="Warn_SteeltoeCommonKubernetes" BeforeTargets="BeforeResolveReferences">
+    <Warning Text="This feature is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+
+  <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="One or more Steeltoe package dependencies need attention. See the build warnings for details." />
   </Target>
 </Project>

--- a/src/Obsolete/Steeltoe.Common.Kubernetes/Build/Steeltoe.Common.Kubernetes.targets
+++ b/src/Obsolete/Steeltoe.Common.Kubernetes/Build/Steeltoe.Common.Kubernetes.targets
@@ -1,5 +1,5 @@
 <Project>
-  <Target Name="Warn_SteeltoeCommonKubernetes" BeforeTargets="BeforeResolveReferences">
+  <Target Name="Warn_SteeltoeCommonKubernetes" AfterTargets="AfterResolveReferences">
     <Warning Text="The NuGet package Steeltoe.Common.Kubernetes is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 

--- a/src/Obsolete/Steeltoe.Common.Kubernetes/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.Common.Kubernetes/PackageReadme.md
@@ -1,0 +1,17 @@
+# Steeltoe
+
+> [!IMPORTANT]
+> This feature is no longer available in Steeltoe v4.
+> See <https://steeltoe.io/docs/v3/obsolete> for details.
+
+[Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).
+
+Key features include:
+
+- External (optionally encrypted) configuration using [Spring Cloud Config Server](https://docs.spring.io/spring-cloud-config/docs/current/reference/html/)
+- Service discovery with [Netflix Eureka](https://spring.io/projects/spring-cloud-netflix) and [HashiCorp Consul](https://www.consul.io/)
+- Management endpoints (compatible with [actuators](https://docs.spring.io/spring-boot/docs/current/reference/html/actuator.html)), providing system info (such as versions, configuration, service container contents, mapped routes and HTTP traffic), heap/thread dumps, health checks, exporting metrics to [Prometheus](https://prometheus.io/), and changing log levels at runtime.
+- Connectivity to databases (such as [SQL Server](https://www.microsoft.com/sql-server)/[Azure SQL](https://azure.microsoft.com/products/azure-sql), [Cosmos DB](https://azure.microsoft.com/products/cosmos-db/), [MongoDB](https://www.mongodb.com/), [Redis](https://redis.io/), [RabbitMQ](https://www.rabbitmq.com/), [PostgreSQL](https://www.postgresql.org/), and [MySQL](https://www.mysql.com/)), including support for [Entity Framework Core](https://learn.microsoft.com/ef/core/)
+- Single sign-on, JWT and Certificate auth with [Cloud Foundry](https://www.cloudfoundry.org/)
+
+For more information and to get started, please visit [Steeltoe on GitHub](https://github.com/SteeltoeOSS/Steeltoe) or the [documentation](https://steeltoe.io/docs).

--- a/src/Obsolete/Steeltoe.Common.Kubernetes/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.Common.Kubernetes/PackageReadme.md
@@ -1,7 +1,7 @@
 # Steeltoe
 
 > [!IMPORTANT]
-> This feature is no longer available in Steeltoe v4.
+> This package has been removed from Steeltoe in v4.
 > See <https://steeltoe.io/docs/v3/obsolete> for details.
 
 [Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).

--- a/src/Obsolete/Steeltoe.Common.Kubernetes/Steeltoe.Common.Kubernetes.csproj
+++ b/src/Obsolete/Steeltoe.Common.Kubernetes/Steeltoe.Common.Kubernetes.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
-    <Description>TODO: Fill package description.</Description>
-    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <Description>Steeltoe common library for Kubernetes.</Description>
+    <PackageTags>Kubernetes</PackageTags>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 

--- a/src/Obsolete/Steeltoe.Common.Kubernetes/Steeltoe.Common.Kubernetes.csproj
+++ b/src/Obsolete/Steeltoe.Common.Kubernetes/Steeltoe.Common.Kubernetes.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net8.0</TargetFrameworks>
+    <Description>TODO: Fill package description.</Description>
+    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
+  <Import Project="..\..\..\shared.props" />
+
+  <ItemGroup>
+    <None Include="Build\*.props" Pack="True" PackagePath="build" />
+    <None Include="Build\*.targets" Pack="True" PackagePath="build" />
+  </ItemGroup>
+</Project>

--- a/src/Obsolete/Steeltoe.Common.Retry/Build/Steeltoe.Common.Retry.targets
+++ b/src/Obsolete/Steeltoe.Common.Retry/Build/Steeltoe.Common.Retry.targets
@@ -1,5 +1,5 @@
 <Project>
-  <Target Name="Warn_SteeltoeCommonRetry" BeforeTargets="BeforeResolveReferences">
+  <Target Name="Warn_SteeltoeCommonRetry" AfterTargets="AfterResolveReferences">
     <Warning Text="The NuGet package Steeltoe.Common.Retry is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 

--- a/src/Obsolete/Steeltoe.Common.Retry/Build/Steeltoe.Common.Retry.targets
+++ b/src/Obsolete/Steeltoe.Common.Retry/Build/Steeltoe.Common.Retry.targets
@@ -1,0 +1,5 @@
+<Project>
+  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="This feature is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+</Project>

--- a/src/Obsolete/Steeltoe.Common.Retry/Build/Steeltoe.Common.Retry.targets
+++ b/src/Obsolete/Steeltoe.Common.Retry/Build/Steeltoe.Common.Retry.targets
@@ -1,6 +1,6 @@
 <Project>
   <Target Name="Warn_SteeltoeCommonRetry" AfterTargets="AfterResolveReferences">
-    <Warning Text="The NuGet package Steeltoe.Common.Retry is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+    <Warning Text="The NuGet package Steeltoe.Common.Retry has been removed from Steeltoe in v4. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.Common.Retry/Build/Steeltoe.Common.Retry.targets
+++ b/src/Obsolete/Steeltoe.Common.Retry/Build/Steeltoe.Common.Retry.targets
@@ -1,6 +1,6 @@
 <Project>
   <Target Name="Warn_SteeltoeCommonRetry" BeforeTargets="BeforeResolveReferences">
-    <Warning Text="This feature is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+    <Warning Text="The NuGet package Steeltoe.Common.Retry is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.Common.Retry/Build/Steeltoe.Common.Retry.targets
+++ b/src/Obsolete/Steeltoe.Common.Retry/Build/Steeltoe.Common.Retry.targets
@@ -1,5 +1,9 @@
 <Project>
-  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
-    <Error Text="This feature is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+  <Target Name="Warn_SteeltoeCommonRetry" BeforeTargets="BeforeResolveReferences">
+    <Warning Text="This feature is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+
+  <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="One or more Steeltoe package dependencies need attention. See the build warnings for details." />
   </Target>
 </Project>

--- a/src/Obsolete/Steeltoe.Common.Retry/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.Common.Retry/PackageReadme.md
@@ -1,0 +1,17 @@
+# Steeltoe
+
+> [!IMPORTANT]
+> This feature is no longer available in Steeltoe v4.
+> See <https://steeltoe.io/docs/v3/obsolete> for details.
+
+[Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).
+
+Key features include:
+
+- External (optionally encrypted) configuration using [Spring Cloud Config Server](https://docs.spring.io/spring-cloud-config/docs/current/reference/html/)
+- Service discovery with [Netflix Eureka](https://spring.io/projects/spring-cloud-netflix) and [HashiCorp Consul](https://www.consul.io/)
+- Management endpoints (compatible with [actuators](https://docs.spring.io/spring-boot/docs/current/reference/html/actuator.html)), providing system info (such as versions, configuration, service container contents, mapped routes and HTTP traffic), heap/thread dumps, health checks, exporting metrics to [Prometheus](https://prometheus.io/), and changing log levels at runtime.
+- Connectivity to databases (such as [SQL Server](https://www.microsoft.com/sql-server)/[Azure SQL](https://azure.microsoft.com/products/azure-sql), [Cosmos DB](https://azure.microsoft.com/products/cosmos-db/), [MongoDB](https://www.mongodb.com/), [Redis](https://redis.io/), [RabbitMQ](https://www.rabbitmq.com/), [PostgreSQL](https://www.postgresql.org/), and [MySQL](https://www.mysql.com/)), including support for [Entity Framework Core](https://learn.microsoft.com/ef/core/)
+- Single sign-on, JWT and Certificate auth with [Cloud Foundry](https://www.cloudfoundry.org/)
+
+For more information and to get started, please visit [Steeltoe on GitHub](https://github.com/SteeltoeOSS/Steeltoe) or the [documentation](https://steeltoe.io/docs).

--- a/src/Obsolete/Steeltoe.Common.Retry/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.Common.Retry/PackageReadme.md
@@ -1,7 +1,7 @@
 # Steeltoe
 
 > [!IMPORTANT]
-> This feature is no longer available in Steeltoe v4.
+> This package has been removed from Steeltoe in v4.
 > See <https://steeltoe.io/docs/v3/obsolete> for details.
 
 [Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).

--- a/src/Obsolete/Steeltoe.Common.Retry/Steeltoe.Common.Retry.csproj
+++ b/src/Obsolete/Steeltoe.Common.Retry/Steeltoe.Common.Retry.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
-    <Description>TODO: Fill package description.</Description>
-    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <Description>Retries for circuit breaker.</Description>
+    <PackageTags>retries;circuit breaker.</PackageTags>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 

--- a/src/Obsolete/Steeltoe.Common.Retry/Steeltoe.Common.Retry.csproj
+++ b/src/Obsolete/Steeltoe.Common.Retry/Steeltoe.Common.Retry.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net8.0</TargetFrameworks>
+    <Description>TODO: Fill package description.</Description>
+    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
+  <Import Project="..\..\..\shared.props" />
+
+  <ItemGroup>
+    <None Include="Build\*.props" Pack="True" PackagePath="build" />
+    <None Include="Build\*.targets" Pack="True" PackagePath="build" />
+  </ItemGroup>
+</Project>

--- a/src/Obsolete/Steeltoe.Common.Security/Build/Steeltoe.Common.Security.targets
+++ b/src/Obsolete/Steeltoe.Common.Security/Build/Steeltoe.Common.Security.targets
@@ -1,5 +1,6 @@
 <Project>
   <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
-    <Error Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Common.Certificates instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+    <Error
+      Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Common.Certificates instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 </Project>

--- a/src/Obsolete/Steeltoe.Common.Security/Build/Steeltoe.Common.Security.targets
+++ b/src/Obsolete/Steeltoe.Common.Security/Build/Steeltoe.Common.Security.targets
@@ -1,6 +1,10 @@
 <Project>
-  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
-    <Error
+  <Target Name="Warn_SteeltoeCommonSecurity" BeforeTargets="BeforeResolveReferences">
+    <Warning
       Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Common.Certificates instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+
+  <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="One or more Steeltoe package dependencies need attention. See the build warnings for details." />
   </Target>
 </Project>

--- a/src/Obsolete/Steeltoe.Common.Security/Build/Steeltoe.Common.Security.targets
+++ b/src/Obsolete/Steeltoe.Common.Security/Build/Steeltoe.Common.Security.targets
@@ -1,0 +1,5 @@
+<Project>
+  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Common.Certificates instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+</Project>

--- a/src/Obsolete/Steeltoe.Common.Security/Build/Steeltoe.Common.Security.targets
+++ b/src/Obsolete/Steeltoe.Common.Security/Build/Steeltoe.Common.Security.targets
@@ -1,7 +1,7 @@
 <Project>
   <Target Name="Warn_SteeltoeCommonSecurity" BeforeTargets="BeforeResolveReferences">
     <Warning
-      Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Common.Certificates instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+      Text="The NuGet package Steeltoe.Common.Security has been replaced in Steeltoe v4. Reference Steeltoe.Common.Certificates instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.Common.Security/Build/Steeltoe.Common.Security.targets
+++ b/src/Obsolete/Steeltoe.Common.Security/Build/Steeltoe.Common.Security.targets
@@ -1,5 +1,5 @@
 <Project>
-  <Target Name="Warn_SteeltoeCommonSecurity" BeforeTargets="BeforeResolveReferences">
+  <Target Name="Warn_SteeltoeCommonSecurity" AfterTargets="AfterResolveReferences">
     <Warning
       Text="The NuGet package Steeltoe.Common.Security has been replaced in Steeltoe v4. Reference Steeltoe.Common.Certificates instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>

--- a/src/Obsolete/Steeltoe.Common.Security/Build/Steeltoe.Common.Security.targets
+++ b/src/Obsolete/Steeltoe.Common.Security/Build/Steeltoe.Common.Security.targets
@@ -1,7 +1,7 @@
 <Project>
   <Target Name="Warn_SteeltoeCommonSecurity" AfterTargets="AfterResolveReferences">
     <Warning
-      Text="The NuGet package Steeltoe.Common.Security has been replaced in Steeltoe v4. Reference Steeltoe.Common.Certificates instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+      Text="The NuGet package Steeltoe.Common.Security has been superseded in Steeltoe v4. Reference Steeltoe.Common.Certificates instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.Common.Security/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.Common.Security/PackageReadme.md
@@ -1,0 +1,17 @@
+# Steeltoe
+
+> [!IMPORTANT]
+> This package has been replaced in Steeltoe v4. Reference `Steeltoe.Common.Certificates` instead.
+> See <https://steeltoe.io/docs/v3/obsolete> for details.
+
+[Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).
+
+Key features include:
+
+- External (optionally encrypted) configuration using [Spring Cloud Config Server](https://docs.spring.io/spring-cloud-config/docs/current/reference/html/)
+- Service discovery with [Netflix Eureka](https://spring.io/projects/spring-cloud-netflix) and [HashiCorp Consul](https://www.consul.io/)
+- Management endpoints (compatible with [actuators](https://docs.spring.io/spring-boot/docs/current/reference/html/actuator.html)), providing system info (such as versions, configuration, service container contents, mapped routes and HTTP traffic), heap/thread dumps, health checks, exporting metrics to [Prometheus](https://prometheus.io/), and changing log levels at runtime.
+- Connectivity to databases (such as [SQL Server](https://www.microsoft.com/sql-server)/[Azure SQL](https://azure.microsoft.com/products/azure-sql), [Cosmos DB](https://azure.microsoft.com/products/cosmos-db/), [MongoDB](https://www.mongodb.com/), [Redis](https://redis.io/), [RabbitMQ](https://www.rabbitmq.com/), [PostgreSQL](https://www.postgresql.org/), and [MySQL](https://www.mysql.com/)), including support for [Entity Framework Core](https://learn.microsoft.com/ef/core/)
+- Single sign-on, JWT and Certificate auth with [Cloud Foundry](https://www.cloudfoundry.org/)
+
+For more information and to get started, please visit [Steeltoe on GitHub](https://github.com/SteeltoeOSS/Steeltoe) or the [documentation](https://steeltoe.io/docs).

--- a/src/Obsolete/Steeltoe.Common.Security/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.Common.Security/PackageReadme.md
@@ -1,7 +1,7 @@
 # Steeltoe
 
 > [!IMPORTANT]
-> This package has been replaced in Steeltoe v4. Reference `Steeltoe.Common.Certificates` instead.
+> This package has been superseded in Steeltoe v4. Reference `Steeltoe.Common.Certificates` instead.
 > See <https://steeltoe.io/docs/v3/obsolete> for details.
 
 [Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).

--- a/src/Obsolete/Steeltoe.Common.Security/Steeltoe.Common.Security.csproj
+++ b/src/Obsolete/Steeltoe.Common.Security/Steeltoe.Common.Security.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net8.0</TargetFrameworks>
+    <Description>TODO: Fill package description.</Description>
+    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
+  <Import Project="..\..\..\shared.props" />
+
+  <ItemGroup>
+    <None Include="Build\*.props" Pack="True" PackagePath="build" />
+    <None Include="Build\*.targets" Pack="True" PackagePath="build" />
+  </ItemGroup>
+</Project>

--- a/src/Obsolete/Steeltoe.Common.Security/Steeltoe.Common.Security.csproj
+++ b/src/Obsolete/Steeltoe.Common.Security/Steeltoe.Common.Security.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
-    <Description>TODO: Fill package description.</Description>
+    <Description>Steeltoe common library for security.</Description>
     <PackageTags>TODO: Fill package tags.</PackageTags>
     <IsPackable>true</IsPackable>
   </PropertyGroup>

--- a/src/Obsolete/Steeltoe.Common.Security/Steeltoe.Common.Security.csproj
+++ b/src/Obsolete/Steeltoe.Common.Security/Steeltoe.Common.Security.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
     <Description>Steeltoe common library for security.</Description>
-    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <PackageTags>Steeltoe;security</PackageTags>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 

--- a/src/Obsolete/Steeltoe.Common.Utils/Build/Steeltoe.Common.Utils.targets
+++ b/src/Obsolete/Steeltoe.Common.Utils/Build/Steeltoe.Common.Utils.targets
@@ -1,5 +1,9 @@
 <Project>
-  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
-    <Error Text="This feature is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+  <Target Name="Warn_SteeltoeCommonUtils" BeforeTargets="BeforeResolveReferences">
+    <Warning Text="This feature is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+
+  <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="One or more Steeltoe package dependencies need attention. See the build warnings for details." />
   </Target>
 </Project>

--- a/src/Obsolete/Steeltoe.Common.Utils/Build/Steeltoe.Common.Utils.targets
+++ b/src/Obsolete/Steeltoe.Common.Utils/Build/Steeltoe.Common.Utils.targets
@@ -1,0 +1,5 @@
+<Project>
+  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="This feature is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+</Project>

--- a/src/Obsolete/Steeltoe.Common.Utils/Build/Steeltoe.Common.Utils.targets
+++ b/src/Obsolete/Steeltoe.Common.Utils/Build/Steeltoe.Common.Utils.targets
@@ -1,5 +1,5 @@
 <Project>
-  <Target Name="Warn_SteeltoeCommonUtils" BeforeTargets="BeforeResolveReferences">
+  <Target Name="Warn_SteeltoeCommonUtils" AfterTargets="AfterResolveReferences">
     <Warning Text="The NuGet package Steeltoe.Common.Utils is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 

--- a/src/Obsolete/Steeltoe.Common.Utils/Build/Steeltoe.Common.Utils.targets
+++ b/src/Obsolete/Steeltoe.Common.Utils/Build/Steeltoe.Common.Utils.targets
@@ -1,6 +1,6 @@
 <Project>
   <Target Name="Warn_SteeltoeCommonUtils" BeforeTargets="BeforeResolveReferences">
-    <Warning Text="This feature is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+    <Warning Text="The NuGet package Steeltoe.Common.Utils is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.Common.Utils/Build/Steeltoe.Common.Utils.targets
+++ b/src/Obsolete/Steeltoe.Common.Utils/Build/Steeltoe.Common.Utils.targets
@@ -1,6 +1,6 @@
 <Project>
   <Target Name="Warn_SteeltoeCommonUtils" AfterTargets="AfterResolveReferences">
-    <Warning Text="The NuGet package Steeltoe.Common.Utils is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+    <Warning Text="The NuGet package Steeltoe.Common.Utils has been removed from Steeltoe in v4. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.Common.Utils/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.Common.Utils/PackageReadme.md
@@ -1,0 +1,17 @@
+# Steeltoe
+
+> [!IMPORTANT]
+> This feature is no longer available in Steeltoe v4.
+> See <https://steeltoe.io/docs/v3/obsolete> for details.
+
+[Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).
+
+Key features include:
+
+- External (optionally encrypted) configuration using [Spring Cloud Config Server](https://docs.spring.io/spring-cloud-config/docs/current/reference/html/)
+- Service discovery with [Netflix Eureka](https://spring.io/projects/spring-cloud-netflix) and [HashiCorp Consul](https://www.consul.io/)
+- Management endpoints (compatible with [actuators](https://docs.spring.io/spring-boot/docs/current/reference/html/actuator.html)), providing system info (such as versions, configuration, service container contents, mapped routes and HTTP traffic), heap/thread dumps, health checks, exporting metrics to [Prometheus](https://prometheus.io/), and changing log levels at runtime.
+- Connectivity to databases (such as [SQL Server](https://www.microsoft.com/sql-server)/[Azure SQL](https://azure.microsoft.com/products/azure-sql), [Cosmos DB](https://azure.microsoft.com/products/cosmos-db/), [MongoDB](https://www.mongodb.com/), [Redis](https://redis.io/), [RabbitMQ](https://www.rabbitmq.com/), [PostgreSQL](https://www.postgresql.org/), and [MySQL](https://www.mysql.com/)), including support for [Entity Framework Core](https://learn.microsoft.com/ef/core/)
+- Single sign-on, JWT and Certificate auth with [Cloud Foundry](https://www.cloudfoundry.org/)
+
+For more information and to get started, please visit [Steeltoe on GitHub](https://github.com/SteeltoeOSS/Steeltoe) or the [documentation](https://steeltoe.io/docs).

--- a/src/Obsolete/Steeltoe.Common.Utils/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.Common.Utils/PackageReadme.md
@@ -1,7 +1,7 @@
 # Steeltoe
 
 > [!IMPORTANT]
-> This feature is no longer available in Steeltoe v4.
+> This package has been removed from Steeltoe in v4.
 > See <https://steeltoe.io/docs/v3/obsolete> for details.
 
 [Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).

--- a/src/Obsolete/Steeltoe.Common.Utils/Steeltoe.Common.Utils.csproj
+++ b/src/Obsolete/Steeltoe.Common.Utils/Steeltoe.Common.Utils.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net8.0</TargetFrameworks>
+    <Description>TODO: Fill package description.</Description>
+    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
+  <Import Project="..\..\..\shared.props" />
+
+  <ItemGroup>
+    <None Include="Build\*.props" Pack="True" PackagePath="build" />
+    <None Include="Build\*.targets" Pack="True" PackagePath="build" />
+  </ItemGroup>
+</Project>

--- a/src/Obsolete/Steeltoe.Common.Utils/Steeltoe.Common.Utils.csproj
+++ b/src/Obsolete/Steeltoe.Common.Utils/Steeltoe.Common.Utils.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
-    <Description>TODO: Fill package description.</Description>
+    <Description>Steeltoe common utility libraries.</Description>
     <PackageTags>TODO: Fill package tags.</PackageTags>
     <IsPackable>true</IsPackable>
   </PropertyGroup>

--- a/src/Obsolete/Steeltoe.Common.Utils/Steeltoe.Common.Utils.csproj
+++ b/src/Obsolete/Steeltoe.Common.Utils/Steeltoe.Common.Utils.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
     <Description>Steeltoe common utility libraries.</Description>
-    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <PackageTags>Steeltoe</PackageTags>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 

--- a/src/Obsolete/Steeltoe.Connector.Abstractions/Build/Steeltoe.Connector.Abstractions.targets
+++ b/src/Obsolete/Steeltoe.Connector.Abstractions/Build/Steeltoe.Connector.Abstractions.targets
@@ -1,0 +1,5 @@
+<Project>
+  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Connectors instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+</Project>

--- a/src/Obsolete/Steeltoe.Connector.Abstractions/Build/Steeltoe.Connector.Abstractions.targets
+++ b/src/Obsolete/Steeltoe.Connector.Abstractions/Build/Steeltoe.Connector.Abstractions.targets
@@ -1,7 +1,7 @@
 <Project>
   <Target Name="Warn_SteeltoeConnectorAbstractions" AfterTargets="AfterResolveReferences">
     <Warning
-      Text="The NuGet package Steeltoe.Connector.Abstractions has been replaced in Steeltoe v4. Reference Steeltoe.Connectors instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+      Text="The NuGet package Steeltoe.Connector.Abstractions has been superseded in Steeltoe v4. Reference Steeltoe.Connectors instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.Connector.Abstractions/Build/Steeltoe.Connector.Abstractions.targets
+++ b/src/Obsolete/Steeltoe.Connector.Abstractions/Build/Steeltoe.Connector.Abstractions.targets
@@ -1,5 +1,5 @@
 <Project>
-  <Target Name="Warn_SteeltoeConnectorAbstractions" BeforeTargets="BeforeResolveReferences">
+  <Target Name="Warn_SteeltoeConnectorAbstractions" AfterTargets="AfterResolveReferences">
     <Warning
       Text="The NuGet package Steeltoe.Connector.Abstractions has been replaced in Steeltoe v4. Reference Steeltoe.Connectors instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>

--- a/src/Obsolete/Steeltoe.Connector.Abstractions/Build/Steeltoe.Connector.Abstractions.targets
+++ b/src/Obsolete/Steeltoe.Connector.Abstractions/Build/Steeltoe.Connector.Abstractions.targets
@@ -1,6 +1,7 @@
 <Project>
   <Target Name="Warn_SteeltoeConnectorAbstractions" BeforeTargets="BeforeResolveReferences">
-    <Warning Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Connectors instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+    <Warning
+      Text="The NuGet package Steeltoe.Connector.Abstractions has been replaced in Steeltoe v4. Reference Steeltoe.Connectors instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.Connector.Abstractions/Build/Steeltoe.Connector.Abstractions.targets
+++ b/src/Obsolete/Steeltoe.Connector.Abstractions/Build/Steeltoe.Connector.Abstractions.targets
@@ -1,5 +1,9 @@
 <Project>
-  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
-    <Error Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Connectors instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+  <Target Name="Warn_SteeltoeConnectorAbstractions" BeforeTargets="BeforeResolveReferences">
+    <Warning Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Connectors instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+
+  <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="One or more Steeltoe package dependencies need attention. See the build warnings for details." />
   </Target>
 </Project>

--- a/src/Obsolete/Steeltoe.Connector.Abstractions/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.Connector.Abstractions/PackageReadme.md
@@ -1,7 +1,7 @@
 # Steeltoe
 
 > [!IMPORTANT]
-> This package has been replaced in Steeltoe v4. Reference `Steeltoe.Connectors` instead.
+> This package has been superseded in Steeltoe v4. Reference `Steeltoe.Connectors` instead.
 > See <https://steeltoe.io/docs/v3/obsolete> for details.
 
 [Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).

--- a/src/Obsolete/Steeltoe.Connector.Abstractions/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.Connector.Abstractions/PackageReadme.md
@@ -1,0 +1,17 @@
+# Steeltoe
+
+> [!IMPORTANT]
+> This package has been replaced in Steeltoe v4. Reference `Steeltoe.Connectors` instead.
+> See <https://steeltoe.io/docs/v3/obsolete> for details.
+
+[Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).
+
+Key features include:
+
+- External (optionally encrypted) configuration using [Spring Cloud Config Server](https://docs.spring.io/spring-cloud-config/docs/current/reference/html/)
+- Service discovery with [Netflix Eureka](https://spring.io/projects/spring-cloud-netflix) and [HashiCorp Consul](https://www.consul.io/)
+- Management endpoints (compatible with [actuators](https://docs.spring.io/spring-boot/docs/current/reference/html/actuator.html)), providing system info (such as versions, configuration, service container contents, mapped routes and HTTP traffic), heap/thread dumps, health checks, exporting metrics to [Prometheus](https://prometheus.io/), and changing log levels at runtime.
+- Connectivity to databases (such as [SQL Server](https://www.microsoft.com/sql-server)/[Azure SQL](https://azure.microsoft.com/products/azure-sql), [Cosmos DB](https://azure.microsoft.com/products/cosmos-db/), [MongoDB](https://www.mongodb.com/), [Redis](https://redis.io/), [RabbitMQ](https://www.rabbitmq.com/), [PostgreSQL](https://www.postgresql.org/), and [MySQL](https://www.mysql.com/)), including support for [Entity Framework Core](https://learn.microsoft.com/ef/core/)
+- Single sign-on, JWT and Certificate auth with [Cloud Foundry](https://www.cloudfoundry.org/)
+
+For more information and to get started, please visit [Steeltoe on GitHub](https://github.com/SteeltoeOSS/Steeltoe) or the [documentation](https://steeltoe.io/docs).

--- a/src/Obsolete/Steeltoe.Connector.Abstractions/Steeltoe.Connector.Abstractions.csproj
+++ b/src/Obsolete/Steeltoe.Connector.Abstractions/Steeltoe.Connector.Abstractions.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
     <Description>Abstractions for working with backing services.</Description>
-    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <PackageTags>connectors;services</PackageTags>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 

--- a/src/Obsolete/Steeltoe.Connector.Abstractions/Steeltoe.Connector.Abstractions.csproj
+++ b/src/Obsolete/Steeltoe.Connector.Abstractions/Steeltoe.Connector.Abstractions.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net8.0</TargetFrameworks>
+    <Description>TODO: Fill package description.</Description>
+    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
+  <Import Project="..\..\..\shared.props" />
+
+  <ItemGroup>
+    <None Include="Build\*.props" Pack="True" PackagePath="build" />
+    <None Include="Build\*.targets" Pack="True" PackagePath="build" />
+  </ItemGroup>
+</Project>

--- a/src/Obsolete/Steeltoe.Connector.Abstractions/Steeltoe.Connector.Abstractions.csproj
+++ b/src/Obsolete/Steeltoe.Connector.Abstractions/Steeltoe.Connector.Abstractions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
-    <Description>TODO: Fill package description.</Description>
+    <Description>Abstractions for working with backing services.</Description>
     <PackageTags>TODO: Fill package tags.</PackageTags>
     <IsPackable>true</IsPackable>
   </PropertyGroup>

--- a/src/Obsolete/Steeltoe.Connector.CloudFoundry/Build/Steeltoe.Connector.CloudFoundry.targets
+++ b/src/Obsolete/Steeltoe.Connector.CloudFoundry/Build/Steeltoe.Connector.CloudFoundry.targets
@@ -1,0 +1,5 @@
+<Project>
+  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Connectors instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+</Project>

--- a/src/Obsolete/Steeltoe.Connector.CloudFoundry/Build/Steeltoe.Connector.CloudFoundry.targets
+++ b/src/Obsolete/Steeltoe.Connector.CloudFoundry/Build/Steeltoe.Connector.CloudFoundry.targets
@@ -1,6 +1,7 @@
 <Project>
   <Target Name="Warn_SteeltoeConnectorCloudFoundry" BeforeTargets="BeforeResolveReferences">
-    <Warning Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Connectors instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+    <Warning
+      Text="The NuGet package Steeltoe.Connector.CloudFoundry has been replaced in Steeltoe v4. Reference Steeltoe.Connectors instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.Connector.CloudFoundry/Build/Steeltoe.Connector.CloudFoundry.targets
+++ b/src/Obsolete/Steeltoe.Connector.CloudFoundry/Build/Steeltoe.Connector.CloudFoundry.targets
@@ -1,5 +1,9 @@
 <Project>
-  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
-    <Error Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Connectors instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+  <Target Name="Warn_SteeltoeConnectorCloudFoundry" BeforeTargets="BeforeResolveReferences">
+    <Warning Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Connectors instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+
+  <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="One or more Steeltoe package dependencies need attention. See the build warnings for details." />
   </Target>
 </Project>

--- a/src/Obsolete/Steeltoe.Connector.CloudFoundry/Build/Steeltoe.Connector.CloudFoundry.targets
+++ b/src/Obsolete/Steeltoe.Connector.CloudFoundry/Build/Steeltoe.Connector.CloudFoundry.targets
@@ -1,5 +1,5 @@
 <Project>
-  <Target Name="Warn_SteeltoeConnectorCloudFoundry" BeforeTargets="BeforeResolveReferences">
+  <Target Name="Warn_SteeltoeConnectorCloudFoundry" AfterTargets="AfterResolveReferences">
     <Warning
       Text="The NuGet package Steeltoe.Connector.CloudFoundry has been replaced in Steeltoe v4. Reference Steeltoe.Connectors instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>

--- a/src/Obsolete/Steeltoe.Connector.CloudFoundry/Build/Steeltoe.Connector.CloudFoundry.targets
+++ b/src/Obsolete/Steeltoe.Connector.CloudFoundry/Build/Steeltoe.Connector.CloudFoundry.targets
@@ -1,7 +1,7 @@
 <Project>
   <Target Name="Warn_SteeltoeConnectorCloudFoundry" AfterTargets="AfterResolveReferences">
     <Warning
-      Text="The NuGet package Steeltoe.Connector.CloudFoundry has been replaced in Steeltoe v4. Reference Steeltoe.Connectors instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+      Text="The NuGet package Steeltoe.Connector.CloudFoundry has been superseded in Steeltoe v4. Reference Steeltoe.Connectors instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.Connector.CloudFoundry/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.Connector.CloudFoundry/PackageReadme.md
@@ -1,7 +1,7 @@
 # Steeltoe
 
 > [!IMPORTANT]
-> This package has been replaced in Steeltoe v4. Reference `Steeltoe.Connectors` instead.
+> This package has been superseded in Steeltoe v4. Reference `Steeltoe.Connectors` instead.
 > See <https://steeltoe.io/docs/v3/obsolete> for details.
 
 [Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).

--- a/src/Obsolete/Steeltoe.Connector.CloudFoundry/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.Connector.CloudFoundry/PackageReadme.md
@@ -1,0 +1,17 @@
+# Steeltoe
+
+> [!IMPORTANT]
+> This package has been replaced in Steeltoe v4. Reference `Steeltoe.Connectors` instead.
+> See <https://steeltoe.io/docs/v3/obsolete> for details.
+
+[Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).
+
+Key features include:
+
+- External (optionally encrypted) configuration using [Spring Cloud Config Server](https://docs.spring.io/spring-cloud-config/docs/current/reference/html/)
+- Service discovery with [Netflix Eureka](https://spring.io/projects/spring-cloud-netflix) and [HashiCorp Consul](https://www.consul.io/)
+- Management endpoints (compatible with [actuators](https://docs.spring.io/spring-boot/docs/current/reference/html/actuator.html)), providing system info (such as versions, configuration, service container contents, mapped routes and HTTP traffic), heap/thread dumps, health checks, exporting metrics to [Prometheus](https://prometheus.io/), and changing log levels at runtime.
+- Connectivity to databases (such as [SQL Server](https://www.microsoft.com/sql-server)/[Azure SQL](https://azure.microsoft.com/products/azure-sql), [Cosmos DB](https://azure.microsoft.com/products/cosmos-db/), [MongoDB](https://www.mongodb.com/), [Redis](https://redis.io/), [RabbitMQ](https://www.rabbitmq.com/), [PostgreSQL](https://www.postgresql.org/), and [MySQL](https://www.mysql.com/)), including support for [Entity Framework Core](https://learn.microsoft.com/ef/core/)
+- Single sign-on, JWT and Certificate auth with [Cloud Foundry](https://www.cloudfoundry.org/)
+
+For more information and to get started, please visit [Steeltoe on GitHub](https://github.com/SteeltoeOSS/Steeltoe) or the [documentation](https://steeltoe.io/docs).

--- a/src/Obsolete/Steeltoe.Connector.CloudFoundry/Steeltoe.Connector.CloudFoundry.csproj
+++ b/src/Obsolete/Steeltoe.Connector.CloudFoundry/Steeltoe.Connector.CloudFoundry.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net8.0</TargetFrameworks>
+    <Description>TODO: Fill package description.</Description>
+    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
+  <Import Project="..\..\..\shared.props" />
+
+  <ItemGroup>
+    <None Include="Build\*.props" Pack="True" PackagePath="build" />
+    <None Include="Build\*.targets" Pack="True" PackagePath="build" />
+  </ItemGroup>
+</Project>

--- a/src/Obsolete/Steeltoe.Connector.CloudFoundry/Steeltoe.Connector.CloudFoundry.csproj
+++ b/src/Obsolete/Steeltoe.Connector.CloudFoundry/Steeltoe.Connector.CloudFoundry.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
-    <Description>TODO: Fill package description.</Description>
-    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <Description>Package for enabling Steeltoe Connectors on Cloud Foundry.</Description>
+    <PackageTags>CloudFoundry;vcap;connectors</PackageTags>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 

--- a/src/Obsolete/Steeltoe.Connector.ConnectorBase/Build/Steeltoe.Connector.ConnectorBase.targets
+++ b/src/Obsolete/Steeltoe.Connector.ConnectorBase/Build/Steeltoe.Connector.ConnectorBase.targets
@@ -1,0 +1,5 @@
+<Project>
+  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Connectors instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+</Project>

--- a/src/Obsolete/Steeltoe.Connector.ConnectorBase/Build/Steeltoe.Connector.ConnectorBase.targets
+++ b/src/Obsolete/Steeltoe.Connector.ConnectorBase/Build/Steeltoe.Connector.ConnectorBase.targets
@@ -1,5 +1,9 @@
 <Project>
-  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
-    <Error Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Connectors instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+  <Target Name="Warn_SteeltoeConnectorConnectorBase" BeforeTargets="BeforeResolveReferences">
+    <Warning Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Connectors instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+
+  <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="One or more Steeltoe package dependencies need attention. See the build warnings for details." />
   </Target>
 </Project>

--- a/src/Obsolete/Steeltoe.Connector.ConnectorBase/Build/Steeltoe.Connector.ConnectorBase.targets
+++ b/src/Obsolete/Steeltoe.Connector.ConnectorBase/Build/Steeltoe.Connector.ConnectorBase.targets
@@ -1,7 +1,7 @@
 <Project>
   <Target Name="Warn_SteeltoeConnectorConnectorBase" AfterTargets="AfterResolveReferences">
     <Warning
-      Text="The NuGet package Steeltoe.Connector.ConnectorBase has been replaced in Steeltoe v4. Reference Steeltoe.Connectors instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+      Text="The NuGet package Steeltoe.Connector.ConnectorBase has been superseded in Steeltoe v4. Reference Steeltoe.Connectors instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.Connector.ConnectorBase/Build/Steeltoe.Connector.ConnectorBase.targets
+++ b/src/Obsolete/Steeltoe.Connector.ConnectorBase/Build/Steeltoe.Connector.ConnectorBase.targets
@@ -1,6 +1,7 @@
 <Project>
   <Target Name="Warn_SteeltoeConnectorConnectorBase" BeforeTargets="BeforeResolveReferences">
-    <Warning Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Connectors instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+    <Warning
+      Text="The NuGet package Steeltoe.Connector.ConnectorBase has been replaced in Steeltoe v4. Reference Steeltoe.Connectors instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.Connector.ConnectorBase/Build/Steeltoe.Connector.ConnectorBase.targets
+++ b/src/Obsolete/Steeltoe.Connector.ConnectorBase/Build/Steeltoe.Connector.ConnectorBase.targets
@@ -1,5 +1,5 @@
 <Project>
-  <Target Name="Warn_SteeltoeConnectorConnectorBase" BeforeTargets="BeforeResolveReferences">
+  <Target Name="Warn_SteeltoeConnectorConnectorBase" AfterTargets="AfterResolveReferences">
     <Warning
       Text="The NuGet package Steeltoe.Connector.ConnectorBase has been replaced in Steeltoe v4. Reference Steeltoe.Connectors instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>

--- a/src/Obsolete/Steeltoe.Connector.ConnectorBase/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.Connector.ConnectorBase/PackageReadme.md
@@ -1,7 +1,7 @@
 # Steeltoe
 
 > [!IMPORTANT]
-> This package has been replaced in Steeltoe v4. Reference `Steeltoe.Connectors` instead.
+> This package has been superseded in Steeltoe v4. Reference `Steeltoe.Connectors` instead.
 > See <https://steeltoe.io/docs/v3/obsolete> for details.
 
 [Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).

--- a/src/Obsolete/Steeltoe.Connector.ConnectorBase/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.Connector.ConnectorBase/PackageReadme.md
@@ -1,0 +1,17 @@
+# Steeltoe
+
+> [!IMPORTANT]
+> This package has been replaced in Steeltoe v4. Reference `Steeltoe.Connectors` instead.
+> See <https://steeltoe.io/docs/v3/obsolete> for details.
+
+[Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).
+
+Key features include:
+
+- External (optionally encrypted) configuration using [Spring Cloud Config Server](https://docs.spring.io/spring-cloud-config/docs/current/reference/html/)
+- Service discovery with [Netflix Eureka](https://spring.io/projects/spring-cloud-netflix) and [HashiCorp Consul](https://www.consul.io/)
+- Management endpoints (compatible with [actuators](https://docs.spring.io/spring-boot/docs/current/reference/html/actuator.html)), providing system info (such as versions, configuration, service container contents, mapped routes and HTTP traffic), heap/thread dumps, health checks, exporting metrics to [Prometheus](https://prometheus.io/), and changing log levels at runtime.
+- Connectivity to databases (such as [SQL Server](https://www.microsoft.com/sql-server)/[Azure SQL](https://azure.microsoft.com/products/azure-sql), [Cosmos DB](https://azure.microsoft.com/products/cosmos-db/), [MongoDB](https://www.mongodb.com/), [Redis](https://redis.io/), [RabbitMQ](https://www.rabbitmq.com/), [PostgreSQL](https://www.postgresql.org/), and [MySQL](https://www.mysql.com/)), including support for [Entity Framework Core](https://learn.microsoft.com/ef/core/)
+- Single sign-on, JWT and Certificate auth with [Cloud Foundry](https://www.cloudfoundry.org/)
+
+For more information and to get started, please visit [Steeltoe on GitHub](https://github.com/SteeltoeOSS/Steeltoe) or the [documentation](https://steeltoe.io/docs).

--- a/src/Obsolete/Steeltoe.Connector.ConnectorBase/Steeltoe.Connector.ConnectorBase.csproj
+++ b/src/Obsolete/Steeltoe.Connector.ConnectorBase/Steeltoe.Connector.ConnectorBase.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
-    <Description>TODO: Fill package description.</Description>
-    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <Description>Connectors for using service bindings in your application.</Description>
+    <PackageTags>connectors;services</PackageTags>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 

--- a/src/Obsolete/Steeltoe.Connector.ConnectorBase/Steeltoe.Connector.ConnectorBase.csproj
+++ b/src/Obsolete/Steeltoe.Connector.ConnectorBase/Steeltoe.Connector.ConnectorBase.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net8.0</TargetFrameworks>
+    <Description>TODO: Fill package description.</Description>
+    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
+  <Import Project="..\..\..\shared.props" />
+
+  <ItemGroup>
+    <None Include="Build\*.props" Pack="True" PackagePath="build" />
+    <None Include="Build\*.targets" Pack="True" PackagePath="build" />
+  </ItemGroup>
+</Project>

--- a/src/Obsolete/Steeltoe.Connector.ConnectorCore/Build/Steeltoe.Connector.ConnectorCore.targets
+++ b/src/Obsolete/Steeltoe.Connector.ConnectorCore/Build/Steeltoe.Connector.ConnectorCore.targets
@@ -1,6 +1,7 @@
 <Project>
   <Target Name="Warn_SteeltoeConnectorConnectorCore" BeforeTargets="BeforeResolveReferences">
-    <Warning Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Connectors instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+    <Warning
+      Text="The NuGet package Steeltoe.Connector.ConnectorCore has been replaced in Steeltoe v4. Reference Steeltoe.Connectors instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.Connector.ConnectorCore/Build/Steeltoe.Connector.ConnectorCore.targets
+++ b/src/Obsolete/Steeltoe.Connector.ConnectorCore/Build/Steeltoe.Connector.ConnectorCore.targets
@@ -1,0 +1,5 @@
+<Project>
+  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Connectors instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+</Project>

--- a/src/Obsolete/Steeltoe.Connector.ConnectorCore/Build/Steeltoe.Connector.ConnectorCore.targets
+++ b/src/Obsolete/Steeltoe.Connector.ConnectorCore/Build/Steeltoe.Connector.ConnectorCore.targets
@@ -1,5 +1,5 @@
 <Project>
-  <Target Name="Warn_SteeltoeConnectorConnectorCore" BeforeTargets="BeforeResolveReferences">
+  <Target Name="Warn_SteeltoeConnectorConnectorCore" AfterTargets="AfterResolveReferences">
     <Warning
       Text="The NuGet package Steeltoe.Connector.ConnectorCore has been replaced in Steeltoe v4. Reference Steeltoe.Connectors instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>

--- a/src/Obsolete/Steeltoe.Connector.ConnectorCore/Build/Steeltoe.Connector.ConnectorCore.targets
+++ b/src/Obsolete/Steeltoe.Connector.ConnectorCore/Build/Steeltoe.Connector.ConnectorCore.targets
@@ -1,7 +1,7 @@
 <Project>
   <Target Name="Warn_SteeltoeConnectorConnectorCore" AfterTargets="AfterResolveReferences">
     <Warning
-      Text="The NuGet package Steeltoe.Connector.ConnectorCore has been replaced in Steeltoe v4. Reference Steeltoe.Connectors instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+      Text="The NuGet package Steeltoe.Connector.ConnectorCore has been superseded in Steeltoe v4. Reference Steeltoe.Connectors instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.Connector.ConnectorCore/Build/Steeltoe.Connector.ConnectorCore.targets
+++ b/src/Obsolete/Steeltoe.Connector.ConnectorCore/Build/Steeltoe.Connector.ConnectorCore.targets
@@ -1,5 +1,9 @@
 <Project>
-  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
-    <Error Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Connectors instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+  <Target Name="Warn_SteeltoeConnectorConnectorCore" BeforeTargets="BeforeResolveReferences">
+    <Warning Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Connectors instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+
+  <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="One or more Steeltoe package dependencies need attention. See the build warnings for details." />
   </Target>
 </Project>

--- a/src/Obsolete/Steeltoe.Connector.ConnectorCore/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.Connector.ConnectorCore/PackageReadme.md
@@ -1,7 +1,7 @@
 # Steeltoe
 
 > [!IMPORTANT]
-> This package has been replaced in Steeltoe v4. Reference `Steeltoe.Connectors` instead.
+> This package has been superseded in Steeltoe v4. Reference `Steeltoe.Connectors` instead.
 > See <https://steeltoe.io/docs/v3/obsolete> for details.
 
 [Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).

--- a/src/Obsolete/Steeltoe.Connector.ConnectorCore/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.Connector.ConnectorCore/PackageReadme.md
@@ -1,0 +1,17 @@
+# Steeltoe
+
+> [!IMPORTANT]
+> This package has been replaced in Steeltoe v4. Reference `Steeltoe.Connectors` instead.
+> See <https://steeltoe.io/docs/v3/obsolete> for details.
+
+[Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).
+
+Key features include:
+
+- External (optionally encrypted) configuration using [Spring Cloud Config Server](https://docs.spring.io/spring-cloud-config/docs/current/reference/html/)
+- Service discovery with [Netflix Eureka](https://spring.io/projects/spring-cloud-netflix) and [HashiCorp Consul](https://www.consul.io/)
+- Management endpoints (compatible with [actuators](https://docs.spring.io/spring-boot/docs/current/reference/html/actuator.html)), providing system info (such as versions, configuration, service container contents, mapped routes and HTTP traffic), heap/thread dumps, health checks, exporting metrics to [Prometheus](https://prometheus.io/), and changing log levels at runtime.
+- Connectivity to databases (such as [SQL Server](https://www.microsoft.com/sql-server)/[Azure SQL](https://azure.microsoft.com/products/azure-sql), [Cosmos DB](https://azure.microsoft.com/products/cosmos-db/), [MongoDB](https://www.mongodb.com/), [Redis](https://redis.io/), [RabbitMQ](https://www.rabbitmq.com/), [PostgreSQL](https://www.postgresql.org/), and [MySQL](https://www.mysql.com/)), including support for [Entity Framework Core](https://learn.microsoft.com/ef/core/)
+- Single sign-on, JWT and Certificate auth with [Cloud Foundry](https://www.cloudfoundry.org/)
+
+For more information and to get started, please visit [Steeltoe on GitHub](https://github.com/SteeltoeOSS/Steeltoe) or the [documentation](https://steeltoe.io/docs).

--- a/src/Obsolete/Steeltoe.Connector.ConnectorCore/Steeltoe.Connector.ConnectorCore.csproj
+++ b/src/Obsolete/Steeltoe.Connector.ConnectorCore/Steeltoe.Connector.ConnectorCore.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net8.0</TargetFrameworks>
+    <Description>TODO: Fill package description.</Description>
+    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
+  <Import Project="..\..\..\shared.props" />
+
+  <ItemGroup>
+    <None Include="Build\*.props" Pack="True" PackagePath="build" />
+    <None Include="Build\*.targets" Pack="True" PackagePath="build" />
+  </ItemGroup>
+</Project>

--- a/src/Obsolete/Steeltoe.Connector.ConnectorCore/Steeltoe.Connector.ConnectorCore.csproj
+++ b/src/Obsolete/Steeltoe.Connector.ConnectorCore/Steeltoe.Connector.ConnectorCore.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
-    <Description>TODO: Fill package description.</Description>
-    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <Description>Package for using service connectors in your .NET Core application.</Description>
+    <PackageTags>connectors;aspnetcore;services</PackageTags>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 

--- a/src/Obsolete/Steeltoe.Connector.EF6Core/Build/Steeltoe.Connector.EF6Core.targets
+++ b/src/Obsolete/Steeltoe.Connector.EF6Core/Build/Steeltoe.Connector.EF6Core.targets
@@ -1,0 +1,5 @@
+<Project>
+  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="This feature is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+</Project>

--- a/src/Obsolete/Steeltoe.Connector.EF6Core/Build/Steeltoe.Connector.EF6Core.targets
+++ b/src/Obsolete/Steeltoe.Connector.EF6Core/Build/Steeltoe.Connector.EF6Core.targets
@@ -1,5 +1,5 @@
 <Project>
-  <Target Name="Warn_SteeltoeConnectorEF6Core" BeforeTargets="BeforeResolveReferences">
+  <Target Name="Warn_SteeltoeConnectorEF6Core" AfterTargets="AfterResolveReferences">
     <Warning Text="The NuGet package Steeltoe.Connector.EF6Core is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 

--- a/src/Obsolete/Steeltoe.Connector.EF6Core/Build/Steeltoe.Connector.EF6Core.targets
+++ b/src/Obsolete/Steeltoe.Connector.EF6Core/Build/Steeltoe.Connector.EF6Core.targets
@@ -1,6 +1,6 @@
 <Project>
   <Target Name="Warn_SteeltoeConnectorEF6Core" AfterTargets="AfterResolveReferences">
-    <Warning Text="The NuGet package Steeltoe.Connector.EF6Core is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+    <Warning Text="The NuGet package Steeltoe.Connector.EF6Core has been removed from Steeltoe in v4. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.Connector.EF6Core/Build/Steeltoe.Connector.EF6Core.targets
+++ b/src/Obsolete/Steeltoe.Connector.EF6Core/Build/Steeltoe.Connector.EF6Core.targets
@@ -1,5 +1,9 @@
 <Project>
-  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
-    <Error Text="This feature is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+  <Target Name="Warn_SteeltoeConnectorEF6Core" BeforeTargets="BeforeResolveReferences">
+    <Warning Text="This feature is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+
+  <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="One or more Steeltoe package dependencies need attention. See the build warnings for details." />
   </Target>
 </Project>

--- a/src/Obsolete/Steeltoe.Connector.EF6Core/Build/Steeltoe.Connector.EF6Core.targets
+++ b/src/Obsolete/Steeltoe.Connector.EF6Core/Build/Steeltoe.Connector.EF6Core.targets
@@ -1,6 +1,6 @@
 <Project>
   <Target Name="Warn_SteeltoeConnectorEF6Core" BeforeTargets="BeforeResolveReferences">
-    <Warning Text="This feature is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+    <Warning Text="The NuGet package Steeltoe.Connector.EF6Core is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.Connector.EF6Core/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.Connector.EF6Core/PackageReadme.md
@@ -1,0 +1,17 @@
+# Steeltoe
+
+> [!IMPORTANT]
+> This feature is no longer available in Steeltoe v4.
+> See <https://steeltoe.io/docs/v3/obsolete> for details.
+
+[Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).
+
+Key features include:
+
+- External (optionally encrypted) configuration using [Spring Cloud Config Server](https://docs.spring.io/spring-cloud-config/docs/current/reference/html/)
+- Service discovery with [Netflix Eureka](https://spring.io/projects/spring-cloud-netflix) and [HashiCorp Consul](https://www.consul.io/)
+- Management endpoints (compatible with [actuators](https://docs.spring.io/spring-boot/docs/current/reference/html/actuator.html)), providing system info (such as versions, configuration, service container contents, mapped routes and HTTP traffic), heap/thread dumps, health checks, exporting metrics to [Prometheus](https://prometheus.io/), and changing log levels at runtime.
+- Connectivity to databases (such as [SQL Server](https://www.microsoft.com/sql-server)/[Azure SQL](https://azure.microsoft.com/products/azure-sql), [Cosmos DB](https://azure.microsoft.com/products/cosmos-db/), [MongoDB](https://www.mongodb.com/), [Redis](https://redis.io/), [RabbitMQ](https://www.rabbitmq.com/), [PostgreSQL](https://www.postgresql.org/), and [MySQL](https://www.mysql.com/)), including support for [Entity Framework Core](https://learn.microsoft.com/ef/core/)
+- Single sign-on, JWT and Certificate auth with [Cloud Foundry](https://www.cloudfoundry.org/)
+
+For more information and to get started, please visit [Steeltoe on GitHub](https://github.com/SteeltoeOSS/Steeltoe) or the [documentation](https://steeltoe.io/docs).

--- a/src/Obsolete/Steeltoe.Connector.EF6Core/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.Connector.EF6Core/PackageReadme.md
@@ -1,7 +1,7 @@
 # Steeltoe
 
 > [!IMPORTANT]
-> This feature is no longer available in Steeltoe v4.
+> This package has been removed from Steeltoe in v4.
 > See <https://steeltoe.io/docs/v3/obsolete> for details.
 
 [Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).

--- a/src/Obsolete/Steeltoe.Connector.EF6Core/Steeltoe.Connector.EF6Core.csproj
+++ b/src/Obsolete/Steeltoe.Connector.EF6Core/Steeltoe.Connector.EF6Core.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net8.0</TargetFrameworks>
+    <Description>TODO: Fill package description.</Description>
+    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
+  <Import Project="..\..\..\shared.props" />
+
+  <ItemGroup>
+    <None Include="Build\*.props" Pack="True" PackagePath="build" />
+    <None Include="Build\*.targets" Pack="True" PackagePath="build" />
+  </ItemGroup>
+</Project>

--- a/src/Obsolete/Steeltoe.Connector.EF6Core/Steeltoe.Connector.EF6Core.csproj
+++ b/src/Obsolete/Steeltoe.Connector.EF6Core/Steeltoe.Connector.EF6Core.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
-    <Description>TODO: Fill package description.</Description>
-    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <Description>Connector Extensions for Entity Framework.</Description>
+    <PackageTags>connectors;EntityFramework;aspnetcore;services</PackageTags>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 

--- a/src/Obsolete/Steeltoe.Connector.EFCore/Build/Steeltoe.Connector.EFCore.targets
+++ b/src/Obsolete/Steeltoe.Connector.EFCore/Build/Steeltoe.Connector.EFCore.targets
@@ -1,7 +1,7 @@
 <Project>
   <Target Name="Warn_SteeltoeConnectorEFCore" BeforeTargets="BeforeResolveReferences">
     <Warning
-      Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Connectors.EntityFrameworkCore instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+      Text="The NuGet package Steeltoe.Connector.EFCore has been replaced in Steeltoe v4. Reference Steeltoe.Connectors.EntityFrameworkCore instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.Connector.EFCore/Build/Steeltoe.Connector.EFCore.targets
+++ b/src/Obsolete/Steeltoe.Connector.EFCore/Build/Steeltoe.Connector.EFCore.targets
@@ -1,6 +1,10 @@
 <Project>
-  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
-    <Error
+  <Target Name="Warn_SteeltoeConnectorEFCore" BeforeTargets="BeforeResolveReferences">
+    <Warning
       Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Connectors.EntityFrameworkCore instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+
+  <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="One or more Steeltoe package dependencies need attention. See the build warnings for details." />
   </Target>
 </Project>

--- a/src/Obsolete/Steeltoe.Connector.EFCore/Build/Steeltoe.Connector.EFCore.targets
+++ b/src/Obsolete/Steeltoe.Connector.EFCore/Build/Steeltoe.Connector.EFCore.targets
@@ -1,0 +1,5 @@
+<Project>
+  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Connectors.EntityFrameworkCore instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+</Project>

--- a/src/Obsolete/Steeltoe.Connector.EFCore/Build/Steeltoe.Connector.EFCore.targets
+++ b/src/Obsolete/Steeltoe.Connector.EFCore/Build/Steeltoe.Connector.EFCore.targets
@@ -1,5 +1,6 @@
 <Project>
   <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
-    <Error Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Connectors.EntityFrameworkCore instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+    <Error
+      Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Connectors.EntityFrameworkCore instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 </Project>

--- a/src/Obsolete/Steeltoe.Connector.EFCore/Build/Steeltoe.Connector.EFCore.targets
+++ b/src/Obsolete/Steeltoe.Connector.EFCore/Build/Steeltoe.Connector.EFCore.targets
@@ -1,7 +1,7 @@
 <Project>
   <Target Name="Warn_SteeltoeConnectorEFCore" AfterTargets="AfterResolveReferences">
     <Warning
-      Text="The NuGet package Steeltoe.Connector.EFCore has been replaced in Steeltoe v4. Reference Steeltoe.Connectors.EntityFrameworkCore instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+      Text="The NuGet package Steeltoe.Connector.EFCore has been superseded in Steeltoe v4. Reference Steeltoe.Connectors.EntityFrameworkCore instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.Connector.EFCore/Build/Steeltoe.Connector.EFCore.targets
+++ b/src/Obsolete/Steeltoe.Connector.EFCore/Build/Steeltoe.Connector.EFCore.targets
@@ -1,5 +1,5 @@
 <Project>
-  <Target Name="Warn_SteeltoeConnectorEFCore" BeforeTargets="BeforeResolveReferences">
+  <Target Name="Warn_SteeltoeConnectorEFCore" AfterTargets="AfterResolveReferences">
     <Warning
       Text="The NuGet package Steeltoe.Connector.EFCore has been replaced in Steeltoe v4. Reference Steeltoe.Connectors.EntityFrameworkCore instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>

--- a/src/Obsolete/Steeltoe.Connector.EFCore/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.Connector.EFCore/PackageReadme.md
@@ -1,0 +1,17 @@
+# Steeltoe
+
+> [!IMPORTANT]
+> This package has been replaced in Steeltoe v4. Reference `Steeltoe.Connectors.EntityFrameworkCore` instead.
+> See <https://steeltoe.io/docs/v3/obsolete> for details.
+
+[Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).
+
+Key features include:
+
+- External (optionally encrypted) configuration using [Spring Cloud Config Server](https://docs.spring.io/spring-cloud-config/docs/current/reference/html/)
+- Service discovery with [Netflix Eureka](https://spring.io/projects/spring-cloud-netflix) and [HashiCorp Consul](https://www.consul.io/)
+- Management endpoints (compatible with [actuators](https://docs.spring.io/spring-boot/docs/current/reference/html/actuator.html)), providing system info (such as versions, configuration, service container contents, mapped routes and HTTP traffic), heap/thread dumps, health checks, exporting metrics to [Prometheus](https://prometheus.io/), and changing log levels at runtime.
+- Connectivity to databases (such as [SQL Server](https://www.microsoft.com/sql-server)/[Azure SQL](https://azure.microsoft.com/products/azure-sql), [Cosmos DB](https://azure.microsoft.com/products/cosmos-db/), [MongoDB](https://www.mongodb.com/), [Redis](https://redis.io/), [RabbitMQ](https://www.rabbitmq.com/), [PostgreSQL](https://www.postgresql.org/), and [MySQL](https://www.mysql.com/)), including support for [Entity Framework Core](https://learn.microsoft.com/ef/core/)
+- Single sign-on, JWT and Certificate auth with [Cloud Foundry](https://www.cloudfoundry.org/)
+
+For more information and to get started, please visit [Steeltoe on GitHub](https://github.com/SteeltoeOSS/Steeltoe) or the [documentation](https://steeltoe.io/docs).

--- a/src/Obsolete/Steeltoe.Connector.EFCore/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.Connector.EFCore/PackageReadme.md
@@ -1,7 +1,7 @@
 # Steeltoe
 
 > [!IMPORTANT]
-> This package has been replaced in Steeltoe v4. Reference `Steeltoe.Connectors.EntityFrameworkCore` instead.
+> This package has been superseded in Steeltoe v4. Reference `Steeltoe.Connectors.EntityFrameworkCore` instead.
 > See <https://steeltoe.io/docs/v3/obsolete> for details.
 
 [Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).

--- a/src/Obsolete/Steeltoe.Connector.EFCore/Steeltoe.Connector.EFCore.csproj
+++ b/src/Obsolete/Steeltoe.Connector.EFCore/Steeltoe.Connector.EFCore.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
-    <Description>TODO: Fill package description.</Description>
-    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <Description>Package for using Steeltoe Connectors with Entity Framework Core.</Description>
+    <PackageTags>connectors;EFCore;EntityFrameworkCore;EF;Entity Framework Core;entity-framework-core;services</PackageTags>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 

--- a/src/Obsolete/Steeltoe.Connector.EFCore/Steeltoe.Connector.EFCore.csproj
+++ b/src/Obsolete/Steeltoe.Connector.EFCore/Steeltoe.Connector.EFCore.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net8.0</TargetFrameworks>
+    <Description>TODO: Fill package description.</Description>
+    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
+  <Import Project="..\..\..\shared.props" />
+
+  <ItemGroup>
+    <None Include="Build\*.props" Pack="True" PackagePath="build" />
+    <None Include="Build\*.targets" Pack="True" PackagePath="build" />
+  </ItemGroup>
+</Project>

--- a/src/Obsolete/Steeltoe.Discovery.Abstractions/Build/Steeltoe.Discovery.Abstractions.targets
+++ b/src/Obsolete/Steeltoe.Discovery.Abstractions/Build/Steeltoe.Discovery.Abstractions.targets
@@ -1,5 +1,5 @@
 <Project>
-  <Target Name="Warn_SteeltoeDiscoveryAbstractions" BeforeTargets="BeforeResolveReferences">
+  <Target Name="Warn_SteeltoeDiscoveryAbstractions" AfterTargets="AfterResolveReferences">
     <Warning
       Text="The NuGet package Steeltoe.Discovery.Abstractions has been replaced in Steeltoe v4. Reference Steeltoe.Common instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>

--- a/src/Obsolete/Steeltoe.Discovery.Abstractions/Build/Steeltoe.Discovery.Abstractions.targets
+++ b/src/Obsolete/Steeltoe.Discovery.Abstractions/Build/Steeltoe.Discovery.Abstractions.targets
@@ -1,7 +1,7 @@
 <Project>
   <Target Name="Warn_SteeltoeDiscoveryAbstractions" AfterTargets="AfterResolveReferences">
     <Warning
-      Text="The NuGet package Steeltoe.Discovery.Abstractions has been replaced in Steeltoe v4. Reference Steeltoe.Common instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+      Text="The NuGet package Steeltoe.Discovery.Abstractions has been superseded in Steeltoe v4. Reference Steeltoe.Common instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.Discovery.Abstractions/Build/Steeltoe.Discovery.Abstractions.targets
+++ b/src/Obsolete/Steeltoe.Discovery.Abstractions/Build/Steeltoe.Discovery.Abstractions.targets
@@ -1,6 +1,7 @@
 <Project>
   <Target Name="Warn_SteeltoeDiscoveryAbstractions" BeforeTargets="BeforeResolveReferences">
-    <Warning Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Common instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+    <Warning
+      Text="The NuGet package Steeltoe.Discovery.Abstractions has been replaced in Steeltoe v4. Reference Steeltoe.Common instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.Discovery.Abstractions/Build/Steeltoe.Discovery.Abstractions.targets
+++ b/src/Obsolete/Steeltoe.Discovery.Abstractions/Build/Steeltoe.Discovery.Abstractions.targets
@@ -1,5 +1,9 @@
 <Project>
-  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
-    <Error Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Common instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+  <Target Name="Warn_SteeltoeDiscoveryAbstractions" BeforeTargets="BeforeResolveReferences">
+    <Warning Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Common instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+
+  <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="One or more Steeltoe package dependencies need attention. See the build warnings for details." />
   </Target>
 </Project>

--- a/src/Obsolete/Steeltoe.Discovery.Abstractions/Build/Steeltoe.Discovery.Abstractions.targets
+++ b/src/Obsolete/Steeltoe.Discovery.Abstractions/Build/Steeltoe.Discovery.Abstractions.targets
@@ -1,0 +1,5 @@
+<Project>
+  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Common instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+</Project>

--- a/src/Obsolete/Steeltoe.Discovery.Abstractions/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.Discovery.Abstractions/PackageReadme.md
@@ -1,0 +1,17 @@
+# Steeltoe
+
+> [!IMPORTANT]
+> This package has been replaced in Steeltoe v4. Reference `Steeltoe.Common` instead.
+> See <https://steeltoe.io/docs/v3/obsolete> for details.
+
+[Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).
+
+Key features include:
+
+- External (optionally encrypted) configuration using [Spring Cloud Config Server](https://docs.spring.io/spring-cloud-config/docs/current/reference/html/)
+- Service discovery with [Netflix Eureka](https://spring.io/projects/spring-cloud-netflix) and [HashiCorp Consul](https://www.consul.io/)
+- Management endpoints (compatible with [actuators](https://docs.spring.io/spring-boot/docs/current/reference/html/actuator.html)), providing system info (such as versions, configuration, service container contents, mapped routes and HTTP traffic), heap/thread dumps, health checks, exporting metrics to [Prometheus](https://prometheus.io/), and changing log levels at runtime.
+- Connectivity to databases (such as [SQL Server](https://www.microsoft.com/sql-server)/[Azure SQL](https://azure.microsoft.com/products/azure-sql), [Cosmos DB](https://azure.microsoft.com/products/cosmos-db/), [MongoDB](https://www.mongodb.com/), [Redis](https://redis.io/), [RabbitMQ](https://www.rabbitmq.com/), [PostgreSQL](https://www.postgresql.org/), and [MySQL](https://www.mysql.com/)), including support for [Entity Framework Core](https://learn.microsoft.com/ef/core/)
+- Single sign-on, JWT and Certificate auth with [Cloud Foundry](https://www.cloudfoundry.org/)
+
+For more information and to get started, please visit [Steeltoe on GitHub](https://github.com/SteeltoeOSS/Steeltoe) or the [documentation](https://steeltoe.io/docs).

--- a/src/Obsolete/Steeltoe.Discovery.Abstractions/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.Discovery.Abstractions/PackageReadme.md
@@ -1,7 +1,7 @@
 # Steeltoe
 
 > [!IMPORTANT]
-> This package has been replaced in Steeltoe v4. Reference `Steeltoe.Common` instead.
+> This package has been superseded in Steeltoe v4. Reference `Steeltoe.Common` instead.
 > See <https://steeltoe.io/docs/v3/obsolete> for details.
 
 [Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).

--- a/src/Obsolete/Steeltoe.Discovery.Abstractions/Steeltoe.Discovery.Abstractions.csproj
+++ b/src/Obsolete/Steeltoe.Discovery.Abstractions/Steeltoe.Discovery.Abstractions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
-    <Description>TODO: Fill package description.</Description>
+    <Description>Abstractions for service registration and discovery.</Description>
     <PackageTags>TODO: Fill package tags.</PackageTags>
     <IsPackable>true</IsPackable>
   </PropertyGroup>

--- a/src/Obsolete/Steeltoe.Discovery.Abstractions/Steeltoe.Discovery.Abstractions.csproj
+++ b/src/Obsolete/Steeltoe.Discovery.Abstractions/Steeltoe.Discovery.Abstractions.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net8.0</TargetFrameworks>
+    <Description>TODO: Fill package description.</Description>
+    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
+  <Import Project="..\..\..\shared.props" />
+
+  <ItemGroup>
+    <None Include="Build\*.props" Pack="True" PackagePath="build" />
+    <None Include="Build\*.targets" Pack="True" PackagePath="build" />
+  </ItemGroup>
+</Project>

--- a/src/Obsolete/Steeltoe.Discovery.Abstractions/Steeltoe.Discovery.Abstractions.csproj
+++ b/src/Obsolete/Steeltoe.Discovery.Abstractions/Steeltoe.Discovery.Abstractions.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
     <Description>Abstractions for service registration and discovery.</Description>
-    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <PackageTags>service discovery;service registry;Spring Cloud</PackageTags>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 

--- a/src/Obsolete/Steeltoe.Discovery.ClientBase/Build/Steeltoe.Discovery.ClientBase.targets
+++ b/src/Obsolete/Steeltoe.Discovery.ClientBase/Build/Steeltoe.Discovery.ClientBase.targets
@@ -1,6 +1,10 @@
 <Project>
-  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
-    <Error
+  <Target Name="Warn_SteeltoeDiscoveryClientBase" BeforeTargets="BeforeResolveReferences">
+    <Warning
       Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Discovery.Configuration instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+
+  <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="One or more Steeltoe package dependencies need attention. See the build warnings for details." />
   </Target>
 </Project>

--- a/src/Obsolete/Steeltoe.Discovery.ClientBase/Build/Steeltoe.Discovery.ClientBase.targets
+++ b/src/Obsolete/Steeltoe.Discovery.ClientBase/Build/Steeltoe.Discovery.ClientBase.targets
@@ -1,7 +1,7 @@
 <Project>
   <Target Name="Warn_SteeltoeDiscoveryClientBase" AfterTargets="AfterResolveReferences">
     <Warning
-      Text="The NuGet package Steeltoe.Discovery.ClientBase has been replaced in Steeltoe v4. Reference Steeltoe.Discovery.Configuration instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+      Text="The NuGet package Steeltoe.Discovery.ClientBase has been superseded in Steeltoe v4. Reference Steeltoe.Discovery.Configuration instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.Discovery.ClientBase/Build/Steeltoe.Discovery.ClientBase.targets
+++ b/src/Obsolete/Steeltoe.Discovery.ClientBase/Build/Steeltoe.Discovery.ClientBase.targets
@@ -1,7 +1,7 @@
 <Project>
   <Target Name="Warn_SteeltoeDiscoveryClientBase" BeforeTargets="BeforeResolveReferences">
     <Warning
-      Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Discovery.Configuration instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+      Text="The NuGet package Steeltoe.Discovery.ClientBase has been replaced in Steeltoe v4. Reference Steeltoe.Discovery.Configuration instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.Discovery.ClientBase/Build/Steeltoe.Discovery.ClientBase.targets
+++ b/src/Obsolete/Steeltoe.Discovery.ClientBase/Build/Steeltoe.Discovery.ClientBase.targets
@@ -1,5 +1,6 @@
 <Project>
   <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
-    <Error Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Discovery.Configuration instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+    <Error
+      Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Discovery.Configuration instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 </Project>

--- a/src/Obsolete/Steeltoe.Discovery.ClientBase/Build/Steeltoe.Discovery.ClientBase.targets
+++ b/src/Obsolete/Steeltoe.Discovery.ClientBase/Build/Steeltoe.Discovery.ClientBase.targets
@@ -1,5 +1,5 @@
 <Project>
-  <Target Name="Warn_SteeltoeDiscoveryClientBase" BeforeTargets="BeforeResolveReferences">
+  <Target Name="Warn_SteeltoeDiscoveryClientBase" AfterTargets="AfterResolveReferences">
     <Warning
       Text="The NuGet package Steeltoe.Discovery.ClientBase has been replaced in Steeltoe v4. Reference Steeltoe.Discovery.Configuration instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>

--- a/src/Obsolete/Steeltoe.Discovery.ClientBase/Build/Steeltoe.Discovery.ClientBase.targets
+++ b/src/Obsolete/Steeltoe.Discovery.ClientBase/Build/Steeltoe.Discovery.ClientBase.targets
@@ -1,0 +1,5 @@
+<Project>
+  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Discovery.Configuration instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+</Project>

--- a/src/Obsolete/Steeltoe.Discovery.ClientBase/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.Discovery.ClientBase/PackageReadme.md
@@ -1,7 +1,7 @@
 # Steeltoe
 
 > [!IMPORTANT]
-> This package has been replaced in Steeltoe v4. Reference `Steeltoe.Discovery.Configuration` instead.
+> This package has been superseded in Steeltoe v4. Reference `Steeltoe.Discovery.Configuration` instead.
 > See <https://steeltoe.io/docs/v3/obsolete> for details.
 
 [Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).

--- a/src/Obsolete/Steeltoe.Discovery.ClientBase/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.Discovery.ClientBase/PackageReadme.md
@@ -1,0 +1,17 @@
+# Steeltoe
+
+> [!IMPORTANT]
+> This package has been replaced in Steeltoe v4. Reference `Steeltoe.Discovery.Configuration` instead.
+> See <https://steeltoe.io/docs/v3/obsolete> for details.
+
+[Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).
+
+Key features include:
+
+- External (optionally encrypted) configuration using [Spring Cloud Config Server](https://docs.spring.io/spring-cloud-config/docs/current/reference/html/)
+- Service discovery with [Netflix Eureka](https://spring.io/projects/spring-cloud-netflix) and [HashiCorp Consul](https://www.consul.io/)
+- Management endpoints (compatible with [actuators](https://docs.spring.io/spring-boot/docs/current/reference/html/actuator.html)), providing system info (such as versions, configuration, service container contents, mapped routes and HTTP traffic), heap/thread dumps, health checks, exporting metrics to [Prometheus](https://prometheus.io/), and changing log levels at runtime.
+- Connectivity to databases (such as [SQL Server](https://www.microsoft.com/sql-server)/[Azure SQL](https://azure.microsoft.com/products/azure-sql), [Cosmos DB](https://azure.microsoft.com/products/cosmos-db/), [MongoDB](https://www.mongodb.com/), [Redis](https://redis.io/), [RabbitMQ](https://www.rabbitmq.com/), [PostgreSQL](https://www.postgresql.org/), and [MySQL](https://www.mysql.com/)), including support for [Entity Framework Core](https://learn.microsoft.com/ef/core/)
+- Single sign-on, JWT and Certificate auth with [Cloud Foundry](https://www.cloudfoundry.org/)
+
+For more information and to get started, please visit [Steeltoe on GitHub](https://github.com/SteeltoeOSS/Steeltoe) or the [documentation](https://steeltoe.io/docs).

--- a/src/Obsolete/Steeltoe.Discovery.ClientBase/Steeltoe.Discovery.ClientBase.csproj
+++ b/src/Obsolete/Steeltoe.Discovery.ClientBase/Steeltoe.Discovery.ClientBase.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net8.0</TargetFrameworks>
+    <Description>TODO: Fill package description.</Description>
+    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
+  <Import Project="..\..\..\shared.props" />
+
+  <ItemGroup>
+    <None Include="Build\*.props" Pack="True" PackagePath="build" />
+    <None Include="Build\*.targets" Pack="True" PackagePath="build" />
+  </ItemGroup>
+</Project>

--- a/src/Obsolete/Steeltoe.Discovery.ClientBase/Steeltoe.Discovery.ClientBase.csproj
+++ b/src/Obsolete/Steeltoe.Discovery.ClientBase/Steeltoe.Discovery.ClientBase.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
-    <Description>TODO: Fill package description.</Description>
-    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <Description>Base package for using Steeltoe Service Discovery.</Description>
+    <PackageTags>service discovery;service registry;Spring Cloud;eureka;consul;kubernetes</PackageTags>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 

--- a/src/Obsolete/Steeltoe.Discovery.ClientCore/Build/Steeltoe.Discovery.ClientCore.targets
+++ b/src/Obsolete/Steeltoe.Discovery.ClientCore/Build/Steeltoe.Discovery.ClientCore.targets
@@ -1,6 +1,10 @@
 <Project>
-  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
-    <Error
+  <Target Name="Warn_SteeltoeDiscoveryClientCore" BeforeTargets="BeforeResolveReferences">
+    <Warning
       Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Discovery.Configuration instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+
+  <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="One or more Steeltoe package dependencies need attention. See the build warnings for details." />
   </Target>
 </Project>

--- a/src/Obsolete/Steeltoe.Discovery.ClientCore/Build/Steeltoe.Discovery.ClientCore.targets
+++ b/src/Obsolete/Steeltoe.Discovery.ClientCore/Build/Steeltoe.Discovery.ClientCore.targets
@@ -1,7 +1,7 @@
 <Project>
   <Target Name="Warn_SteeltoeDiscoveryClientCore" AfterTargets="AfterResolveReferences">
     <Warning
-      Text="The NuGet package Steeltoe.Discovery.ClientCore has been replaced in Steeltoe v4. Reference Steeltoe.Discovery.Configuration instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+      Text="The NuGet package Steeltoe.Discovery.ClientCore has been superseded in Steeltoe v4. Reference Steeltoe.Discovery.Configuration instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.Discovery.ClientCore/Build/Steeltoe.Discovery.ClientCore.targets
+++ b/src/Obsolete/Steeltoe.Discovery.ClientCore/Build/Steeltoe.Discovery.ClientCore.targets
@@ -1,5 +1,6 @@
 <Project>
   <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
-    <Error Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Discovery.Configuration instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+    <Error
+      Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Discovery.Configuration instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 </Project>

--- a/src/Obsolete/Steeltoe.Discovery.ClientCore/Build/Steeltoe.Discovery.ClientCore.targets
+++ b/src/Obsolete/Steeltoe.Discovery.ClientCore/Build/Steeltoe.Discovery.ClientCore.targets
@@ -1,7 +1,7 @@
 <Project>
   <Target Name="Warn_SteeltoeDiscoveryClientCore" BeforeTargets="BeforeResolveReferences">
     <Warning
-      Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Discovery.Configuration instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+      Text="The NuGet package Steeltoe.Discovery.ClientCore has been replaced in Steeltoe v4. Reference Steeltoe.Discovery.Configuration instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.Discovery.ClientCore/Build/Steeltoe.Discovery.ClientCore.targets
+++ b/src/Obsolete/Steeltoe.Discovery.ClientCore/Build/Steeltoe.Discovery.ClientCore.targets
@@ -1,5 +1,5 @@
 <Project>
-  <Target Name="Warn_SteeltoeDiscoveryClientCore" BeforeTargets="BeforeResolveReferences">
+  <Target Name="Warn_SteeltoeDiscoveryClientCore" AfterTargets="AfterResolveReferences">
     <Warning
       Text="The NuGet package Steeltoe.Discovery.ClientCore has been replaced in Steeltoe v4. Reference Steeltoe.Discovery.Configuration instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>

--- a/src/Obsolete/Steeltoe.Discovery.ClientCore/Build/Steeltoe.Discovery.ClientCore.targets
+++ b/src/Obsolete/Steeltoe.Discovery.ClientCore/Build/Steeltoe.Discovery.ClientCore.targets
@@ -1,0 +1,5 @@
+<Project>
+  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Discovery.Configuration instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+</Project>

--- a/src/Obsolete/Steeltoe.Discovery.ClientCore/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.Discovery.ClientCore/PackageReadme.md
@@ -1,7 +1,7 @@
 # Steeltoe
 
 > [!IMPORTANT]
-> This package has been replaced in Steeltoe v4. Reference `Steeltoe.Discovery.Configuration` instead.
+> This package has been superseded in Steeltoe v4. Reference `Steeltoe.Discovery.Configuration` instead.
 > See <https://steeltoe.io/docs/v3/obsolete> for details.
 
 [Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).

--- a/src/Obsolete/Steeltoe.Discovery.ClientCore/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.Discovery.ClientCore/PackageReadme.md
@@ -1,0 +1,17 @@
+# Steeltoe
+
+> [!IMPORTANT]
+> This package has been replaced in Steeltoe v4. Reference `Steeltoe.Discovery.Configuration` instead.
+> See <https://steeltoe.io/docs/v3/obsolete> for details.
+
+[Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).
+
+Key features include:
+
+- External (optionally encrypted) configuration using [Spring Cloud Config Server](https://docs.spring.io/spring-cloud-config/docs/current/reference/html/)
+- Service discovery with [Netflix Eureka](https://spring.io/projects/spring-cloud-netflix) and [HashiCorp Consul](https://www.consul.io/)
+- Management endpoints (compatible with [actuators](https://docs.spring.io/spring-boot/docs/current/reference/html/actuator.html)), providing system info (such as versions, configuration, service container contents, mapped routes and HTTP traffic), heap/thread dumps, health checks, exporting metrics to [Prometheus](https://prometheus.io/), and changing log levels at runtime.
+- Connectivity to databases (such as [SQL Server](https://www.microsoft.com/sql-server)/[Azure SQL](https://azure.microsoft.com/products/azure-sql), [Cosmos DB](https://azure.microsoft.com/products/cosmos-db/), [MongoDB](https://www.mongodb.com/), [Redis](https://redis.io/), [RabbitMQ](https://www.rabbitmq.com/), [PostgreSQL](https://www.postgresql.org/), and [MySQL](https://www.mysql.com/)), including support for [Entity Framework Core](https://learn.microsoft.com/ef/core/)
+- Single sign-on, JWT and Certificate auth with [Cloud Foundry](https://www.cloudfoundry.org/)
+
+For more information and to get started, please visit [Steeltoe on GitHub](https://github.com/SteeltoeOSS/Steeltoe) or the [documentation](https://steeltoe.io/docs).

--- a/src/Obsolete/Steeltoe.Discovery.ClientCore/Steeltoe.Discovery.ClientCore.csproj
+++ b/src/Obsolete/Steeltoe.Discovery.ClientCore/Steeltoe.Discovery.ClientCore.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net8.0</TargetFrameworks>
+    <Description>TODO: Fill package description.</Description>
+    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
+  <Import Project="..\..\..\shared.props" />
+
+  <ItemGroup>
+    <None Include="Build\*.props" Pack="True" PackagePath="build" />
+    <None Include="Build\*.targets" Pack="True" PackagePath="build" />
+  </ItemGroup>
+</Project>

--- a/src/Obsolete/Steeltoe.Discovery.ClientCore/Steeltoe.Discovery.ClientCore.csproj
+++ b/src/Obsolete/Steeltoe.Discovery.ClientCore/Steeltoe.Discovery.ClientCore.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
-    <Description>TODO: Fill package description.</Description>
-    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <Description>Package for using Steeltoe Service Discovery Client in ASP.NET Core applications.</Description>
+    <PackageTags>aspnetcore;service discovery;service registry;Spring Cloud;eureka;consul;kubernetes</PackageTags>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 

--- a/src/Obsolete/Steeltoe.Discovery.Kubernetes/Build/Steeltoe.Discovery.Kubernetes.targets
+++ b/src/Obsolete/Steeltoe.Discovery.Kubernetes/Build/Steeltoe.Discovery.Kubernetes.targets
@@ -1,7 +1,6 @@
 <Project>
   <Target Name="Warn_SteeltoeDiscoveryKubernetes" AfterTargets="AfterResolveReferences">
-    <Warning
-      Text="The NuGet package Steeltoe.Discovery.Kubernetes is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+    <Warning Text="The NuGet package Steeltoe.Discovery.Kubernetes has been removed from Steeltoe in v4. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.Discovery.Kubernetes/Build/Steeltoe.Discovery.Kubernetes.targets
+++ b/src/Obsolete/Steeltoe.Discovery.Kubernetes/Build/Steeltoe.Discovery.Kubernetes.targets
@@ -1,0 +1,5 @@
+<Project>
+  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="This feature is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+</Project>

--- a/src/Obsolete/Steeltoe.Discovery.Kubernetes/Build/Steeltoe.Discovery.Kubernetes.targets
+++ b/src/Obsolete/Steeltoe.Discovery.Kubernetes/Build/Steeltoe.Discovery.Kubernetes.targets
@@ -1,5 +1,9 @@
 <Project>
-  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
-    <Error Text="This feature is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+  <Target Name="Warn_SteeltoeDiscoveryKubernetes" BeforeTargets="BeforeResolveReferences">
+    <Warning Text="This feature is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+
+  <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="One or more Steeltoe package dependencies need attention. See the build warnings for details." />
   </Target>
 </Project>

--- a/src/Obsolete/Steeltoe.Discovery.Kubernetes/Build/Steeltoe.Discovery.Kubernetes.targets
+++ b/src/Obsolete/Steeltoe.Discovery.Kubernetes/Build/Steeltoe.Discovery.Kubernetes.targets
@@ -1,5 +1,5 @@
 <Project>
-  <Target Name="Warn_SteeltoeDiscoveryKubernetes" BeforeTargets="BeforeResolveReferences">
+  <Target Name="Warn_SteeltoeDiscoveryKubernetes" AfterTargets="AfterResolveReferences">
     <Warning
       Text="The NuGet package Steeltoe.Discovery.Kubernetes is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>

--- a/src/Obsolete/Steeltoe.Discovery.Kubernetes/Build/Steeltoe.Discovery.Kubernetes.targets
+++ b/src/Obsolete/Steeltoe.Discovery.Kubernetes/Build/Steeltoe.Discovery.Kubernetes.targets
@@ -1,6 +1,7 @@
 <Project>
   <Target Name="Warn_SteeltoeDiscoveryKubernetes" BeforeTargets="BeforeResolveReferences">
-    <Warning Text="This feature is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+    <Warning
+      Text="The NuGet package Steeltoe.Discovery.Kubernetes is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.Discovery.Kubernetes/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.Discovery.Kubernetes/PackageReadme.md
@@ -1,0 +1,17 @@
+# Steeltoe
+
+> [!IMPORTANT]
+> This feature is no longer available in Steeltoe v4.
+> See <https://steeltoe.io/docs/v3/obsolete> for details.
+
+[Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).
+
+Key features include:
+
+- External (optionally encrypted) configuration using [Spring Cloud Config Server](https://docs.spring.io/spring-cloud-config/docs/current/reference/html/)
+- Service discovery with [Netflix Eureka](https://spring.io/projects/spring-cloud-netflix) and [HashiCorp Consul](https://www.consul.io/)
+- Management endpoints (compatible with [actuators](https://docs.spring.io/spring-boot/docs/current/reference/html/actuator.html)), providing system info (such as versions, configuration, service container contents, mapped routes and HTTP traffic), heap/thread dumps, health checks, exporting metrics to [Prometheus](https://prometheus.io/), and changing log levels at runtime.
+- Connectivity to databases (such as [SQL Server](https://www.microsoft.com/sql-server)/[Azure SQL](https://azure.microsoft.com/products/azure-sql), [Cosmos DB](https://azure.microsoft.com/products/cosmos-db/), [MongoDB](https://www.mongodb.com/), [Redis](https://redis.io/), [RabbitMQ](https://www.rabbitmq.com/), [PostgreSQL](https://www.postgresql.org/), and [MySQL](https://www.mysql.com/)), including support for [Entity Framework Core](https://learn.microsoft.com/ef/core/)
+- Single sign-on, JWT and Certificate auth with [Cloud Foundry](https://www.cloudfoundry.org/)
+
+For more information and to get started, please visit [Steeltoe on GitHub](https://github.com/SteeltoeOSS/Steeltoe) or the [documentation](https://steeltoe.io/docs).

--- a/src/Obsolete/Steeltoe.Discovery.Kubernetes/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.Discovery.Kubernetes/PackageReadme.md
@@ -1,7 +1,7 @@
 # Steeltoe
 
 > [!IMPORTANT]
-> This feature is no longer available in Steeltoe v4.
+> This package has been removed from Steeltoe in v4.
 > See <https://steeltoe.io/docs/v3/obsolete> for details.
 
 [Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).

--- a/src/Obsolete/Steeltoe.Discovery.Kubernetes/Steeltoe.Discovery.Kubernetes.csproj
+++ b/src/Obsolete/Steeltoe.Discovery.Kubernetes/Steeltoe.Discovery.Kubernetes.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net8.0</TargetFrameworks>
+    <Description>TODO: Fill package description.</Description>
+    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
+  <Import Project="..\..\..\shared.props" />
+
+  <ItemGroup>
+    <None Include="Build\*.props" Pack="True" PackagePath="build" />
+    <None Include="Build\*.targets" Pack="True" PackagePath="build" />
+  </ItemGroup>
+</Project>

--- a/src/Obsolete/Steeltoe.Discovery.Kubernetes/Steeltoe.Discovery.Kubernetes.csproj
+++ b/src/Obsolete/Steeltoe.Discovery.Kubernetes/Steeltoe.Discovery.Kubernetes.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
-    <Description>TODO: Fill package description.</Description>
-    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <Description>Client for service discovery with Kubernetes native service discovery.</Description>
+    <PackageTags>aspnetcore;Kubernetes;Spring;Spring Cloud</PackageTags>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.Abstractions/Build/Steeltoe.Extensions.Configuration.Abstractions.targets
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.Abstractions/Build/Steeltoe.Extensions.Configuration.Abstractions.targets
@@ -1,0 +1,5 @@
+<Project>
+  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Configuration.Abstractions instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+</Project>

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.Abstractions/Build/Steeltoe.Extensions.Configuration.Abstractions.targets
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.Abstractions/Build/Steeltoe.Extensions.Configuration.Abstractions.targets
@@ -1,6 +1,10 @@
 <Project>
-  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
-    <Error
+  <Target Name="Warn_SteeltoeExtensionsConfigurationAbstractions" BeforeTargets="BeforeResolveReferences">
+    <Warning
       Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Configuration.Abstractions instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+
+  <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="One or more Steeltoe package dependencies need attention. See the build warnings for details." />
   </Target>
 </Project>

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.Abstractions/Build/Steeltoe.Extensions.Configuration.Abstractions.targets
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.Abstractions/Build/Steeltoe.Extensions.Configuration.Abstractions.targets
@@ -1,7 +1,7 @@
 <Project>
   <Target Name="Warn_SteeltoeExtensionsConfigurationAbstractions" AfterTargets="AfterResolveReferences">
     <Warning
-      Text="The NuGet package Steeltoe.Extensions.Configuration.Abstractions has been replaced in Steeltoe v4. Reference Steeltoe.Configuration.Abstractions instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+      Text="The NuGet package Steeltoe.Extensions.Configuration.Abstractions has been superseded in Steeltoe v4. Reference Steeltoe.Configuration.Abstractions instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.Abstractions/Build/Steeltoe.Extensions.Configuration.Abstractions.targets
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.Abstractions/Build/Steeltoe.Extensions.Configuration.Abstractions.targets
@@ -1,5 +1,6 @@
 <Project>
   <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
-    <Error Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Configuration.Abstractions instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+    <Error
+      Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Configuration.Abstractions instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 </Project>

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.Abstractions/Build/Steeltoe.Extensions.Configuration.Abstractions.targets
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.Abstractions/Build/Steeltoe.Extensions.Configuration.Abstractions.targets
@@ -1,5 +1,5 @@
 <Project>
-  <Target Name="Warn_SteeltoeExtensionsConfigurationAbstractions" BeforeTargets="BeforeResolveReferences">
+  <Target Name="Warn_SteeltoeExtensionsConfigurationAbstractions" AfterTargets="AfterResolveReferences">
     <Warning
       Text="The NuGet package Steeltoe.Extensions.Configuration.Abstractions has been replaced in Steeltoe v4. Reference Steeltoe.Configuration.Abstractions instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.Abstractions/Build/Steeltoe.Extensions.Configuration.Abstractions.targets
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.Abstractions/Build/Steeltoe.Extensions.Configuration.Abstractions.targets
@@ -1,7 +1,7 @@
 <Project>
   <Target Name="Warn_SteeltoeExtensionsConfigurationAbstractions" BeforeTargets="BeforeResolveReferences">
     <Warning
-      Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Configuration.Abstractions instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+      Text="The NuGet package Steeltoe.Extensions.Configuration.Abstractions has been replaced in Steeltoe v4. Reference Steeltoe.Configuration.Abstractions instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.Abstractions/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.Abstractions/PackageReadme.md
@@ -1,0 +1,17 @@
+# Steeltoe
+
+> [!IMPORTANT]
+> This package has been replaced in Steeltoe v4. Reference `Steeltoe.Configuration.Abstractions` instead.
+> See <https://steeltoe.io/docs/v3/obsolete> for details.
+
+[Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).
+
+Key features include:
+
+- External (optionally encrypted) configuration using [Spring Cloud Config Server](https://docs.spring.io/spring-cloud-config/docs/current/reference/html/)
+- Service discovery with [Netflix Eureka](https://spring.io/projects/spring-cloud-netflix) and [HashiCorp Consul](https://www.consul.io/)
+- Management endpoints (compatible with [actuators](https://docs.spring.io/spring-boot/docs/current/reference/html/actuator.html)), providing system info (such as versions, configuration, service container contents, mapped routes and HTTP traffic), heap/thread dumps, health checks, exporting metrics to [Prometheus](https://prometheus.io/), and changing log levels at runtime.
+- Connectivity to databases (such as [SQL Server](https://www.microsoft.com/sql-server)/[Azure SQL](https://azure.microsoft.com/products/azure-sql), [Cosmos DB](https://azure.microsoft.com/products/cosmos-db/), [MongoDB](https://www.mongodb.com/), [Redis](https://redis.io/), [RabbitMQ](https://www.rabbitmq.com/), [PostgreSQL](https://www.postgresql.org/), and [MySQL](https://www.mysql.com/)), including support for [Entity Framework Core](https://learn.microsoft.com/ef/core/)
+- Single sign-on, JWT and Certificate auth with [Cloud Foundry](https://www.cloudfoundry.org/)
+
+For more information and to get started, please visit [Steeltoe on GitHub](https://github.com/SteeltoeOSS/Steeltoe) or the [documentation](https://steeltoe.io/docs).

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.Abstractions/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.Abstractions/PackageReadme.md
@@ -1,7 +1,7 @@
 # Steeltoe
 
 > [!IMPORTANT]
-> This package has been replaced in Steeltoe v4. Reference `Steeltoe.Configuration.Abstractions` instead.
+> This package has been superseded in Steeltoe v4. Reference `Steeltoe.Configuration.Abstractions` instead.
 > See <https://steeltoe.io/docs/v3/obsolete> for details.
 
 [Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.Abstractions/Steeltoe.Extensions.Configuration.Abstractions.csproj
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.Abstractions/Steeltoe.Extensions.Configuration.Abstractions.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net8.0</TargetFrameworks>
+    <Description>TODO: Fill package description.</Description>
+    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
+  <Import Project="..\..\..\shared.props" />
+
+  <ItemGroup>
+    <None Include="Build\*.props" Pack="True" PackagePath="build" />
+    <None Include="Build\*.targets" Pack="True" PackagePath="build" />
+  </ItemGroup>
+</Project>

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.Abstractions/Steeltoe.Extensions.Configuration.Abstractions.csproj
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.Abstractions/Steeltoe.Extensions.Configuration.Abstractions.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
     <Description>Abstractions used in Steeltoe Configuration libraries.</Description>
-    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <PackageTags>configuration;spring boot</PackageTags>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.Abstractions/Steeltoe.Extensions.Configuration.Abstractions.csproj
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.Abstractions/Steeltoe.Extensions.Configuration.Abstractions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
-    <Description>TODO: Fill package description.</Description>
+    <Description>Abstractions used in Steeltoe Configuration libraries.</Description>
     <PackageTags>TODO: Fill package tags.</PackageTags>
     <IsPackable>true</IsPackable>
   </PropertyGroup>

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.CloudFoundryBase/Build/Steeltoe.Extensions.Configuration.CloudFoundryBase.targets
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.CloudFoundryBase/Build/Steeltoe.Extensions.Configuration.CloudFoundryBase.targets
@@ -1,7 +1,7 @@
 <Project>
   <Target Name="Warn_SteeltoeExtensionsConfigurationCloudFoundryBase" BeforeTargets="BeforeResolveReferences">
     <Warning
-      Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Configuration.CloudFoundry instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+      Text="The NuGet package Steeltoe.Extensions.Configuration.CloudFoundryBase has been replaced in Steeltoe v4. Reference Steeltoe.Configuration.CloudFoundry instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.CloudFoundryBase/Build/Steeltoe.Extensions.Configuration.CloudFoundryBase.targets
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.CloudFoundryBase/Build/Steeltoe.Extensions.Configuration.CloudFoundryBase.targets
@@ -1,0 +1,5 @@
+<Project>
+  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Configuration.CloudFoundry instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+</Project>

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.CloudFoundryBase/Build/Steeltoe.Extensions.Configuration.CloudFoundryBase.targets
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.CloudFoundryBase/Build/Steeltoe.Extensions.Configuration.CloudFoundryBase.targets
@@ -1,7 +1,7 @@
 <Project>
   <Target Name="Warn_SteeltoeExtensionsConfigurationCloudFoundryBase" AfterTargets="AfterResolveReferences">
     <Warning
-      Text="The NuGet package Steeltoe.Extensions.Configuration.CloudFoundryBase has been replaced in Steeltoe v4. Reference Steeltoe.Configuration.CloudFoundry instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+      Text="The NuGet package Steeltoe.Extensions.Configuration.CloudFoundryBase has been superseded in Steeltoe v4. Reference Steeltoe.Configuration.CloudFoundry instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.CloudFoundryBase/Build/Steeltoe.Extensions.Configuration.CloudFoundryBase.targets
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.CloudFoundryBase/Build/Steeltoe.Extensions.Configuration.CloudFoundryBase.targets
@@ -1,5 +1,5 @@
 <Project>
-  <Target Name="Warn_SteeltoeExtensionsConfigurationCloudFoundryBase" BeforeTargets="BeforeResolveReferences">
+  <Target Name="Warn_SteeltoeExtensionsConfigurationCloudFoundryBase" AfterTargets="AfterResolveReferences">
     <Warning
       Text="The NuGet package Steeltoe.Extensions.Configuration.CloudFoundryBase has been replaced in Steeltoe v4. Reference Steeltoe.Configuration.CloudFoundry instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.CloudFoundryBase/Build/Steeltoe.Extensions.Configuration.CloudFoundryBase.targets
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.CloudFoundryBase/Build/Steeltoe.Extensions.Configuration.CloudFoundryBase.targets
@@ -1,5 +1,6 @@
 <Project>
   <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
-    <Error Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Configuration.CloudFoundry instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+    <Error
+      Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Configuration.CloudFoundry instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 </Project>

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.CloudFoundryBase/Build/Steeltoe.Extensions.Configuration.CloudFoundryBase.targets
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.CloudFoundryBase/Build/Steeltoe.Extensions.Configuration.CloudFoundryBase.targets
@@ -1,6 +1,10 @@
 <Project>
-  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
-    <Error
+  <Target Name="Warn_SteeltoeExtensionsConfigurationCloudFoundryBase" BeforeTargets="BeforeResolveReferences">
+    <Warning
       Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Configuration.CloudFoundry instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+
+  <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="One or more Steeltoe package dependencies need attention. See the build warnings for details." />
   </Target>
 </Project>

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.CloudFoundryBase/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.CloudFoundryBase/PackageReadme.md
@@ -1,7 +1,7 @@
 # Steeltoe
 
 > [!IMPORTANT]
-> This package has been replaced in Steeltoe v4. Reference `Steeltoe.Configuration.CloudFoundry` instead.
+> This package has been superseded in Steeltoe v4. Reference `Steeltoe.Configuration.CloudFoundry` instead.
 > See <https://steeltoe.io/docs/v3/obsolete> for details.
 
 [Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.CloudFoundryBase/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.CloudFoundryBase/PackageReadme.md
@@ -1,0 +1,17 @@
+# Steeltoe
+
+> [!IMPORTANT]
+> This package has been replaced in Steeltoe v4. Reference `Steeltoe.Configuration.CloudFoundry` instead.
+> See <https://steeltoe.io/docs/v3/obsolete> for details.
+
+[Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).
+
+Key features include:
+
+- External (optionally encrypted) configuration using [Spring Cloud Config Server](https://docs.spring.io/spring-cloud-config/docs/current/reference/html/)
+- Service discovery with [Netflix Eureka](https://spring.io/projects/spring-cloud-netflix) and [HashiCorp Consul](https://www.consul.io/)
+- Management endpoints (compatible with [actuators](https://docs.spring.io/spring-boot/docs/current/reference/html/actuator.html)), providing system info (such as versions, configuration, service container contents, mapped routes and HTTP traffic), heap/thread dumps, health checks, exporting metrics to [Prometheus](https://prometheus.io/), and changing log levels at runtime.
+- Connectivity to databases (such as [SQL Server](https://www.microsoft.com/sql-server)/[Azure SQL](https://azure.microsoft.com/products/azure-sql), [Cosmos DB](https://azure.microsoft.com/products/cosmos-db/), [MongoDB](https://www.mongodb.com/), [Redis](https://redis.io/), [RabbitMQ](https://www.rabbitmq.com/), [PostgreSQL](https://www.postgresql.org/), and [MySQL](https://www.mysql.com/)), including support for [Entity Framework Core](https://learn.microsoft.com/ef/core/)
+- Single sign-on, JWT and Certificate auth with [Cloud Foundry](https://www.cloudfoundry.org/)
+
+For more information and to get started, please visit [Steeltoe on GitHub](https://github.com/SteeltoeOSS/Steeltoe) or the [documentation](https://steeltoe.io/docs).

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.CloudFoundryBase/Steeltoe.Extensions.Configuration.CloudFoundryBase.csproj
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.CloudFoundryBase/Steeltoe.Extensions.Configuration.CloudFoundryBase.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net8.0</TargetFrameworks>
+    <Description>TODO: Fill package description.</Description>
+    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
+  <Import Project="..\..\..\shared.props" />
+
+  <ItemGroup>
+    <None Include="Build\*.props" Pack="True" PackagePath="build" />
+    <None Include="Build\*.targets" Pack="True" PackagePath="build" />
+  </ItemGroup>
+</Project>

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.CloudFoundryBase/Steeltoe.Extensions.Configuration.CloudFoundryBase.csproj
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.CloudFoundryBase/Steeltoe.Extensions.Configuration.CloudFoundryBase.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
-    <Description>TODO: Fill package description.</Description>
-    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <Description>Configuration Provider for reading Cloud Foundry Environment Variables.</Description>
+    <PackageTags>configuration;CloudFoundry;vcap</PackageTags>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.CloudFoundryCore/Build/Steeltoe.Extensions.Configuration.CloudFoundryCore.targets
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.CloudFoundryCore/Build/Steeltoe.Extensions.Configuration.CloudFoundryCore.targets
@@ -1,5 +1,5 @@
 <Project>
-  <Target Name="Warn_SteeltoeExtensionsConfigurationCloudFoundryCore" BeforeTargets="BeforeResolveReferences">
+  <Target Name="Warn_SteeltoeExtensionsConfigurationCloudFoundryCore" AfterTargets="AfterResolveReferences">
     <Warning
       Text="The NuGet package Steeltoe.Extensions.Configuration.CloudFoundryCore has been replaced in Steeltoe v4. Reference Steeltoe.Configuration.CloudFoundry instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.CloudFoundryCore/Build/Steeltoe.Extensions.Configuration.CloudFoundryCore.targets
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.CloudFoundryCore/Build/Steeltoe.Extensions.Configuration.CloudFoundryCore.targets
@@ -1,7 +1,7 @@
 <Project>
   <Target Name="Warn_SteeltoeExtensionsConfigurationCloudFoundryCore" AfterTargets="AfterResolveReferences">
     <Warning
-      Text="The NuGet package Steeltoe.Extensions.Configuration.CloudFoundryCore has been replaced in Steeltoe v4. Reference Steeltoe.Configuration.CloudFoundry instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+      Text="The NuGet package Steeltoe.Extensions.Configuration.CloudFoundryCore has been superseded in Steeltoe v4. Reference Steeltoe.Configuration.CloudFoundry instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.CloudFoundryCore/Build/Steeltoe.Extensions.Configuration.CloudFoundryCore.targets
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.CloudFoundryCore/Build/Steeltoe.Extensions.Configuration.CloudFoundryCore.targets
@@ -1,0 +1,5 @@
+<Project>
+  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Configuration.CloudFoundry instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+</Project>

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.CloudFoundryCore/Build/Steeltoe.Extensions.Configuration.CloudFoundryCore.targets
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.CloudFoundryCore/Build/Steeltoe.Extensions.Configuration.CloudFoundryCore.targets
@@ -1,6 +1,10 @@
 <Project>
-  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
-    <Error
+  <Target Name="Warn_SteeltoeExtensionsConfigurationCloudFoundryCore" BeforeTargets="BeforeResolveReferences">
+    <Warning
       Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Configuration.CloudFoundry instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+
+  <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="One or more Steeltoe package dependencies need attention. See the build warnings for details." />
   </Target>
 </Project>

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.CloudFoundryCore/Build/Steeltoe.Extensions.Configuration.CloudFoundryCore.targets
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.CloudFoundryCore/Build/Steeltoe.Extensions.Configuration.CloudFoundryCore.targets
@@ -1,7 +1,7 @@
 <Project>
   <Target Name="Warn_SteeltoeExtensionsConfigurationCloudFoundryCore" BeforeTargets="BeforeResolveReferences">
     <Warning
-      Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Configuration.CloudFoundry instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+      Text="The NuGet package Steeltoe.Extensions.Configuration.CloudFoundryCore has been replaced in Steeltoe v4. Reference Steeltoe.Configuration.CloudFoundry instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.CloudFoundryCore/Build/Steeltoe.Extensions.Configuration.CloudFoundryCore.targets
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.CloudFoundryCore/Build/Steeltoe.Extensions.Configuration.CloudFoundryCore.targets
@@ -1,5 +1,6 @@
 <Project>
   <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
-    <Error Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Configuration.CloudFoundry instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+    <Error
+      Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Configuration.CloudFoundry instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 </Project>

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.CloudFoundryCore/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.CloudFoundryCore/PackageReadme.md
@@ -1,7 +1,7 @@
 # Steeltoe
 
 > [!IMPORTANT]
-> This package has been replaced in Steeltoe v4. Reference `Steeltoe.Configuration.CloudFoundry` instead.
+> This package has been superseded in Steeltoe v4. Reference `Steeltoe.Configuration.CloudFoundry` instead.
 > See <https://steeltoe.io/docs/v3/obsolete> for details.
 
 [Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.CloudFoundryCore/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.CloudFoundryCore/PackageReadme.md
@@ -1,0 +1,17 @@
+# Steeltoe
+
+> [!IMPORTANT]
+> This package has been replaced in Steeltoe v4. Reference `Steeltoe.Configuration.CloudFoundry` instead.
+> See <https://steeltoe.io/docs/v3/obsolete> for details.
+
+[Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).
+
+Key features include:
+
+- External (optionally encrypted) configuration using [Spring Cloud Config Server](https://docs.spring.io/spring-cloud-config/docs/current/reference/html/)
+- Service discovery with [Netflix Eureka](https://spring.io/projects/spring-cloud-netflix) and [HashiCorp Consul](https://www.consul.io/)
+- Management endpoints (compatible with [actuators](https://docs.spring.io/spring-boot/docs/current/reference/html/actuator.html)), providing system info (such as versions, configuration, service container contents, mapped routes and HTTP traffic), heap/thread dumps, health checks, exporting metrics to [Prometheus](https://prometheus.io/), and changing log levels at runtime.
+- Connectivity to databases (such as [SQL Server](https://www.microsoft.com/sql-server)/[Azure SQL](https://azure.microsoft.com/products/azure-sql), [Cosmos DB](https://azure.microsoft.com/products/cosmos-db/), [MongoDB](https://www.mongodb.com/), [Redis](https://redis.io/), [RabbitMQ](https://www.rabbitmq.com/), [PostgreSQL](https://www.postgresql.org/), and [MySQL](https://www.mysql.com/)), including support for [Entity Framework Core](https://learn.microsoft.com/ef/core/)
+- Single sign-on, JWT and Certificate auth with [Cloud Foundry](https://www.cloudfoundry.org/)
+
+For more information and to get started, please visit [Steeltoe on GitHub](https://github.com/SteeltoeOSS/Steeltoe) or the [documentation](https://steeltoe.io/docs).

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.CloudFoundryCore/Steeltoe.Extensions.Configuration.CloudFoundryCore.csproj
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.CloudFoundryCore/Steeltoe.Extensions.Configuration.CloudFoundryCore.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net8.0</TargetFrameworks>
+    <Description>TODO: Fill package description.</Description>
+    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
+  <Import Project="..\..\..\shared.props" />
+
+  <ItemGroup>
+    <None Include="Build\*.props" Pack="True" PackagePath="build" />
+    <None Include="Build\*.targets" Pack="True" PackagePath="build" />
+  </ItemGroup>
+</Project>

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.CloudFoundryCore/Steeltoe.Extensions.Configuration.CloudFoundryCore.csproj
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.CloudFoundryCore/Steeltoe.Extensions.Configuration.CloudFoundryCore.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
-    <Description>TODO: Fill package description.</Description>
-    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <Description>Package for adding Cloud Foundry environment variable configuration provider to ASP.NET Core applications.</Description>
+    <PackageTags>aspnetcore;CloudFoundry;Spring;Spring Cloud;vcap</PackageTags>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.ConfigServerBase/Build/Steeltoe.Extensions.Configuration.ConfigServerBase.targets
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.ConfigServerBase/Build/Steeltoe.Extensions.Configuration.ConfigServerBase.targets
@@ -1,7 +1,7 @@
 <Project>
   <Target Name="Warn_SteeltoeExtensionsConfigurationConfigServerBase" BeforeTargets="BeforeResolveReferences">
     <Warning
-      Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Configuration.ConfigServer instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+      Text="The NuGet package Steeltoe.Extensions.Configuration.ConfigServerBase has been replaced in Steeltoe v4. Reference Steeltoe.Configuration.ConfigServer instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.ConfigServerBase/Build/Steeltoe.Extensions.Configuration.ConfigServerBase.targets
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.ConfigServerBase/Build/Steeltoe.Extensions.Configuration.ConfigServerBase.targets
@@ -1,7 +1,7 @@
 <Project>
   <Target Name="Warn_SteeltoeExtensionsConfigurationConfigServerBase" AfterTargets="AfterResolveReferences">
     <Warning
-      Text="The NuGet package Steeltoe.Extensions.Configuration.ConfigServerBase has been replaced in Steeltoe v4. Reference Steeltoe.Configuration.ConfigServer instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+      Text="The NuGet package Steeltoe.Extensions.Configuration.ConfigServerBase has been superseded in Steeltoe v4. Reference Steeltoe.Configuration.ConfigServer instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.ConfigServerBase/Build/Steeltoe.Extensions.Configuration.ConfigServerBase.targets
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.ConfigServerBase/Build/Steeltoe.Extensions.Configuration.ConfigServerBase.targets
@@ -1,5 +1,6 @@
 <Project>
   <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
-    <Error Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Configuration.ConfigServer instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+    <Error
+      Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Configuration.ConfigServer instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 </Project>

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.ConfigServerBase/Build/Steeltoe.Extensions.Configuration.ConfigServerBase.targets
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.ConfigServerBase/Build/Steeltoe.Extensions.Configuration.ConfigServerBase.targets
@@ -1,5 +1,5 @@
 <Project>
-  <Target Name="Warn_SteeltoeExtensionsConfigurationConfigServerBase" BeforeTargets="BeforeResolveReferences">
+  <Target Name="Warn_SteeltoeExtensionsConfigurationConfigServerBase" AfterTargets="AfterResolveReferences">
     <Warning
       Text="The NuGet package Steeltoe.Extensions.Configuration.ConfigServerBase has been replaced in Steeltoe v4. Reference Steeltoe.Configuration.ConfigServer instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.ConfigServerBase/Build/Steeltoe.Extensions.Configuration.ConfigServerBase.targets
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.ConfigServerBase/Build/Steeltoe.Extensions.Configuration.ConfigServerBase.targets
@@ -1,6 +1,10 @@
 <Project>
-  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
-    <Error
+  <Target Name="Warn_SteeltoeExtensionsConfigurationConfigServerBase" BeforeTargets="BeforeResolveReferences">
+    <Warning
       Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Configuration.ConfigServer instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+
+  <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="One or more Steeltoe package dependencies need attention. See the build warnings for details." />
   </Target>
 </Project>

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.ConfigServerBase/Build/Steeltoe.Extensions.Configuration.ConfigServerBase.targets
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.ConfigServerBase/Build/Steeltoe.Extensions.Configuration.ConfigServerBase.targets
@@ -1,0 +1,5 @@
+<Project>
+  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Configuration.ConfigServer instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+</Project>

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.ConfigServerBase/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.ConfigServerBase/PackageReadme.md
@@ -1,0 +1,17 @@
+# Steeltoe
+
+> [!IMPORTANT]
+> This package has been replaced in Steeltoe v4. Reference `Steeltoe.Configuration.ConfigServer` instead.
+> See <https://steeltoe.io/docs/v3/obsolete> for details.
+
+[Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).
+
+Key features include:
+
+- External (optionally encrypted) configuration using [Spring Cloud Config Server](https://docs.spring.io/spring-cloud-config/docs/current/reference/html/)
+- Service discovery with [Netflix Eureka](https://spring.io/projects/spring-cloud-netflix) and [HashiCorp Consul](https://www.consul.io/)
+- Management endpoints (compatible with [actuators](https://docs.spring.io/spring-boot/docs/current/reference/html/actuator.html)), providing system info (such as versions, configuration, service container contents, mapped routes and HTTP traffic), heap/thread dumps, health checks, exporting metrics to [Prometheus](https://prometheus.io/), and changing log levels at runtime.
+- Connectivity to databases (such as [SQL Server](https://www.microsoft.com/sql-server)/[Azure SQL](https://azure.microsoft.com/products/azure-sql), [Cosmos DB](https://azure.microsoft.com/products/cosmos-db/), [MongoDB](https://www.mongodb.com/), [Redis](https://redis.io/), [RabbitMQ](https://www.rabbitmq.com/), [PostgreSQL](https://www.postgresql.org/), and [MySQL](https://www.mysql.com/)), including support for [Entity Framework Core](https://learn.microsoft.com/ef/core/)
+- Single sign-on, JWT and Certificate auth with [Cloud Foundry](https://www.cloudfoundry.org/)
+
+For more information and to get started, please visit [Steeltoe on GitHub](https://github.com/SteeltoeOSS/Steeltoe) or the [documentation](https://steeltoe.io/docs).

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.ConfigServerBase/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.ConfigServerBase/PackageReadme.md
@@ -1,7 +1,7 @@
 # Steeltoe
 
 > [!IMPORTANT]
-> This package has been replaced in Steeltoe v4. Reference `Steeltoe.Configuration.ConfigServer` instead.
+> This package has been superseded in Steeltoe v4. Reference `Steeltoe.Configuration.ConfigServer` instead.
 > See <https://steeltoe.io/docs/v3/obsolete> for details.
 
 [Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.ConfigServerBase/Steeltoe.Extensions.Configuration.ConfigServerBase.csproj
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.ConfigServerBase/Steeltoe.Extensions.Configuration.ConfigServerBase.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
-    <Description>TODO: Fill package description.</Description>
-    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <Description>Configuration provider for reading from Spring Cloud Config Server.</Description>
+    <PackageTags>configuration;Spring Cloud;Spring Cloud Config Server</PackageTags>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.ConfigServerBase/Steeltoe.Extensions.Configuration.ConfigServerBase.csproj
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.ConfigServerBase/Steeltoe.Extensions.Configuration.ConfigServerBase.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net8.0</TargetFrameworks>
+    <Description>TODO: Fill package description.</Description>
+    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
+  <Import Project="..\..\..\shared.props" />
+
+  <ItemGroup>
+    <None Include="Build\*.props" Pack="True" PackagePath="build" />
+    <None Include="Build\*.targets" Pack="True" PackagePath="build" />
+  </ItemGroup>
+</Project>

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.ConfigServerCore/Build/Steeltoe.Extensions.Configuration.ConfigServerCore.targets
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.ConfigServerCore/Build/Steeltoe.Extensions.Configuration.ConfigServerCore.targets
@@ -1,6 +1,10 @@
 <Project>
-  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
-    <Error
+  <Target Name="Warn_SteeltoeExtensionsConfigurationConfigServerCore" BeforeTargets="BeforeResolveReferences">
+    <Warning
       Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Configuration.ConfigServer instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+
+  <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="One or more Steeltoe package dependencies need attention. See the build warnings for details." />
   </Target>
 </Project>

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.ConfigServerCore/Build/Steeltoe.Extensions.Configuration.ConfigServerCore.targets
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.ConfigServerCore/Build/Steeltoe.Extensions.Configuration.ConfigServerCore.targets
@@ -1,5 +1,5 @@
 <Project>
-  <Target Name="Warn_SteeltoeExtensionsConfigurationConfigServerCore" BeforeTargets="BeforeResolveReferences">
+  <Target Name="Warn_SteeltoeExtensionsConfigurationConfigServerCore" AfterTargets="AfterResolveReferences">
     <Warning
       Text="The NuGet package Steeltoe.Extensions.Configuration.ConfigServerCore has been replaced in Steeltoe v4. Reference Steeltoe.Configuration.ConfigServer instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.ConfigServerCore/Build/Steeltoe.Extensions.Configuration.ConfigServerCore.targets
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.ConfigServerCore/Build/Steeltoe.Extensions.Configuration.ConfigServerCore.targets
@@ -1,5 +1,6 @@
 <Project>
   <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
-    <Error Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Configuration.ConfigServer instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+    <Error
+      Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Configuration.ConfigServer instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 </Project>

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.ConfigServerCore/Build/Steeltoe.Extensions.Configuration.ConfigServerCore.targets
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.ConfigServerCore/Build/Steeltoe.Extensions.Configuration.ConfigServerCore.targets
@@ -1,7 +1,7 @@
 <Project>
   <Target Name="Warn_SteeltoeExtensionsConfigurationConfigServerCore" BeforeTargets="BeforeResolveReferences">
     <Warning
-      Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Configuration.ConfigServer instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+      Text="The NuGet package Steeltoe.Extensions.Configuration.ConfigServerCore has been replaced in Steeltoe v4. Reference Steeltoe.Configuration.ConfigServer instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.ConfigServerCore/Build/Steeltoe.Extensions.Configuration.ConfigServerCore.targets
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.ConfigServerCore/Build/Steeltoe.Extensions.Configuration.ConfigServerCore.targets
@@ -1,0 +1,5 @@
+<Project>
+  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Configuration.ConfigServer instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+</Project>

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.ConfigServerCore/Build/Steeltoe.Extensions.Configuration.ConfigServerCore.targets
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.ConfigServerCore/Build/Steeltoe.Extensions.Configuration.ConfigServerCore.targets
@@ -1,7 +1,7 @@
 <Project>
   <Target Name="Warn_SteeltoeExtensionsConfigurationConfigServerCore" AfterTargets="AfterResolveReferences">
     <Warning
-      Text="The NuGet package Steeltoe.Extensions.Configuration.ConfigServerCore has been replaced in Steeltoe v4. Reference Steeltoe.Configuration.ConfigServer instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+      Text="The NuGet package Steeltoe.Extensions.Configuration.ConfigServerCore has been superseded in Steeltoe v4. Reference Steeltoe.Configuration.ConfigServer instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.ConfigServerCore/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.ConfigServerCore/PackageReadme.md
@@ -1,0 +1,17 @@
+# Steeltoe
+
+> [!IMPORTANT]
+> This package has been replaced in Steeltoe v4. Reference `Steeltoe.Configuration.ConfigServer` instead.
+> See <https://steeltoe.io/docs/v3/obsolete> for details.
+
+[Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).
+
+Key features include:
+
+- External (optionally encrypted) configuration using [Spring Cloud Config Server](https://docs.spring.io/spring-cloud-config/docs/current/reference/html/)
+- Service discovery with [Netflix Eureka](https://spring.io/projects/spring-cloud-netflix) and [HashiCorp Consul](https://www.consul.io/)
+- Management endpoints (compatible with [actuators](https://docs.spring.io/spring-boot/docs/current/reference/html/actuator.html)), providing system info (such as versions, configuration, service container contents, mapped routes and HTTP traffic), heap/thread dumps, health checks, exporting metrics to [Prometheus](https://prometheus.io/), and changing log levels at runtime.
+- Connectivity to databases (such as [SQL Server](https://www.microsoft.com/sql-server)/[Azure SQL](https://azure.microsoft.com/products/azure-sql), [Cosmos DB](https://azure.microsoft.com/products/cosmos-db/), [MongoDB](https://www.mongodb.com/), [Redis](https://redis.io/), [RabbitMQ](https://www.rabbitmq.com/), [PostgreSQL](https://www.postgresql.org/), and [MySQL](https://www.mysql.com/)), including support for [Entity Framework Core](https://learn.microsoft.com/ef/core/)
+- Single sign-on, JWT and Certificate auth with [Cloud Foundry](https://www.cloudfoundry.org/)
+
+For more information and to get started, please visit [Steeltoe on GitHub](https://github.com/SteeltoeOSS/Steeltoe) or the [documentation](https://steeltoe.io/docs).

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.ConfigServerCore/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.ConfigServerCore/PackageReadme.md
@@ -1,7 +1,7 @@
 # Steeltoe
 
 > [!IMPORTANT]
-> This package has been replaced in Steeltoe v4. Reference `Steeltoe.Configuration.ConfigServer` instead.
+> This package has been superseded in Steeltoe v4. Reference `Steeltoe.Configuration.ConfigServer` instead.
 > See <https://steeltoe.io/docs/v3/obsolete> for details.
 
 [Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.ConfigServerCore/Steeltoe.Extensions.Configuration.ConfigServerCore.csproj
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.ConfigServerCore/Steeltoe.Extensions.Configuration.ConfigServerCore.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net8.0</TargetFrameworks>
+    <Description>TODO: Fill package description.</Description>
+    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
+  <Import Project="..\..\..\shared.props" />
+
+  <ItemGroup>
+    <None Include="Build\*.props" Pack="True" PackagePath="build" />
+    <None Include="Build\*.targets" Pack="True" PackagePath="build" />
+  </ItemGroup>
+</Project>

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.ConfigServerCore/Steeltoe.Extensions.Configuration.ConfigServerCore.csproj
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.ConfigServerCore/Steeltoe.Extensions.Configuration.ConfigServerCore.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
-    <Description>TODO: Fill package description.</Description>
-    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <Description>Package for adding Spring Cloud Config Server configuration provider to ASP.NET Core applications.</Description>
+    <PackageTags>aspnetcore;Spring Cloud;Spring Cloud Config Server</PackageTags>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.Kubernetes.ServiceBinding/Build/Steeltoe.Extensions.Configuration.Kubernetes.ServiceBinding.targets
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.Kubernetes.ServiceBinding/Build/Steeltoe.Extensions.Configuration.Kubernetes.ServiceBinding.targets
@@ -1,7 +1,7 @@
 <Project>
   <Target Name="Warn_SteeltoeExtensionsConfigurationKubernetesServiceBinding" BeforeTargets="BeforeResolveReferences">
     <Warning
-      Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Configuration.Kubernetes.ServiceBindings instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+      Text="The NuGet package Steeltoe.Extensions.Configuration.Kubernetes.ServiceBinding has been replaced in Steeltoe v4. Reference Steeltoe.Configuration.Kubernetes.ServiceBindings instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.Kubernetes.ServiceBinding/Build/Steeltoe.Extensions.Configuration.Kubernetes.ServiceBinding.targets
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.Kubernetes.ServiceBinding/Build/Steeltoe.Extensions.Configuration.Kubernetes.ServiceBinding.targets
@@ -1,5 +1,5 @@
 <Project>
-  <Target Name="Warn_SteeltoeExtensionsConfigurationKubernetesServiceBinding" BeforeTargets="BeforeResolveReferences">
+  <Target Name="Warn_SteeltoeExtensionsConfigurationKubernetesServiceBinding" AfterTargets="AfterResolveReferences">
     <Warning
       Text="The NuGet package Steeltoe.Extensions.Configuration.Kubernetes.ServiceBinding has been replaced in Steeltoe v4. Reference Steeltoe.Configuration.Kubernetes.ServiceBindings instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.Kubernetes.ServiceBinding/Build/Steeltoe.Extensions.Configuration.Kubernetes.ServiceBinding.targets
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.Kubernetes.ServiceBinding/Build/Steeltoe.Extensions.Configuration.Kubernetes.ServiceBinding.targets
@@ -1,0 +1,5 @@
+<Project>
+  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Configuration.Kubernetes.ServiceBindings instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+</Project>

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.Kubernetes.ServiceBinding/Build/Steeltoe.Extensions.Configuration.Kubernetes.ServiceBinding.targets
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.Kubernetes.ServiceBinding/Build/Steeltoe.Extensions.Configuration.Kubernetes.ServiceBinding.targets
@@ -1,5 +1,6 @@
 <Project>
   <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
-    <Error Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Configuration.Kubernetes.ServiceBindings instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+    <Error
+      Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Configuration.Kubernetes.ServiceBindings instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 </Project>

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.Kubernetes.ServiceBinding/Build/Steeltoe.Extensions.Configuration.Kubernetes.ServiceBinding.targets
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.Kubernetes.ServiceBinding/Build/Steeltoe.Extensions.Configuration.Kubernetes.ServiceBinding.targets
@@ -1,6 +1,10 @@
 <Project>
-  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
-    <Error
+  <Target Name="Warn_SteeltoeExtensionsConfigurationKubernetesServiceBinding" BeforeTargets="BeforeResolveReferences">
+    <Warning
       Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Configuration.Kubernetes.ServiceBindings instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+
+  <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="One or more Steeltoe package dependencies need attention. See the build warnings for details." />
   </Target>
 </Project>

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.Kubernetes.ServiceBinding/Build/Steeltoe.Extensions.Configuration.Kubernetes.ServiceBinding.targets
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.Kubernetes.ServiceBinding/Build/Steeltoe.Extensions.Configuration.Kubernetes.ServiceBinding.targets
@@ -1,7 +1,7 @@
 <Project>
   <Target Name="Warn_SteeltoeExtensionsConfigurationKubernetesServiceBinding" AfterTargets="AfterResolveReferences">
     <Warning
-      Text="The NuGet package Steeltoe.Extensions.Configuration.Kubernetes.ServiceBinding has been replaced in Steeltoe v4. Reference Steeltoe.Configuration.Kubernetes.ServiceBindings instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+      Text="The NuGet package Steeltoe.Extensions.Configuration.Kubernetes.ServiceBinding has been superseded in Steeltoe v4. Reference Steeltoe.Configuration.Kubernetes.ServiceBindings instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.Kubernetes.ServiceBinding/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.Kubernetes.ServiceBinding/PackageReadme.md
@@ -1,7 +1,7 @@
 # Steeltoe
 
 > [!IMPORTANT]
-> This package has been replaced in Steeltoe v4. Reference `Steeltoe.Configuration.Kubernetes.ServiceBindings` instead.
+> This package has been superseded in Steeltoe v4. Reference `Steeltoe.Configuration.Kubernetes.ServiceBindings` instead.
 > See <https://steeltoe.io/docs/v3/obsolete> for details.
 
 [Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.Kubernetes.ServiceBinding/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.Kubernetes.ServiceBinding/PackageReadme.md
@@ -1,0 +1,17 @@
+# Steeltoe
+
+> [!IMPORTANT]
+> This package has been replaced in Steeltoe v4. Reference `Steeltoe.Configuration.Kubernetes.ServiceBindings` instead.
+> See <https://steeltoe.io/docs/v3/obsolete> for details.
+
+[Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).
+
+Key features include:
+
+- External (optionally encrypted) configuration using [Spring Cloud Config Server](https://docs.spring.io/spring-cloud-config/docs/current/reference/html/)
+- Service discovery with [Netflix Eureka](https://spring.io/projects/spring-cloud-netflix) and [HashiCorp Consul](https://www.consul.io/)
+- Management endpoints (compatible with [actuators](https://docs.spring.io/spring-boot/docs/current/reference/html/actuator.html)), providing system info (such as versions, configuration, service container contents, mapped routes and HTTP traffic), heap/thread dumps, health checks, exporting metrics to [Prometheus](https://prometheus.io/), and changing log levels at runtime.
+- Connectivity to databases (such as [SQL Server](https://www.microsoft.com/sql-server)/[Azure SQL](https://azure.microsoft.com/products/azure-sql), [Cosmos DB](https://azure.microsoft.com/products/cosmos-db/), [MongoDB](https://www.mongodb.com/), [Redis](https://redis.io/), [RabbitMQ](https://www.rabbitmq.com/), [PostgreSQL](https://www.postgresql.org/), and [MySQL](https://www.mysql.com/)), including support for [Entity Framework Core](https://learn.microsoft.com/ef/core/)
+- Single sign-on, JWT and Certificate auth with [Cloud Foundry](https://www.cloudfoundry.org/)
+
+For more information and to get started, please visit [Steeltoe on GitHub](https://github.com/SteeltoeOSS/Steeltoe) or the [documentation](https://steeltoe.io/docs).

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.Kubernetes.ServiceBinding/Steeltoe.Extensions.Configuration.Kubernetes.ServiceBinding.csproj
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.Kubernetes.ServiceBinding/Steeltoe.Extensions.Configuration.Kubernetes.ServiceBinding.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
-    <Description>TODO: Fill package description.</Description>
-    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <Description>Configuration Provider for reading Kubernetes Service Bindings.</Description>
+    <PackageTags>Configuration;Kubernetes;Services;Bindings</PackageTags>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.Kubernetes.ServiceBinding/Steeltoe.Extensions.Configuration.Kubernetes.ServiceBinding.csproj
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.Kubernetes.ServiceBinding/Steeltoe.Extensions.Configuration.Kubernetes.ServiceBinding.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net8.0</TargetFrameworks>
+    <Description>TODO: Fill package description.</Description>
+    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
+  <Import Project="..\..\..\shared.props" />
+
+  <ItemGroup>
+    <None Include="Build\*.props" Pack="True" PackagePath="build" />
+    <None Include="Build\*.targets" Pack="True" PackagePath="build" />
+  </ItemGroup>
+</Project>

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.KubernetesBase/Build/Steeltoe.Extensions.Configuration.KubernetesBase.targets
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.KubernetesBase/Build/Steeltoe.Extensions.Configuration.KubernetesBase.targets
@@ -1,6 +1,7 @@
 <Project>
   <Target Name="Warn_SteeltoeExtensionsConfigurationKubernetesBase" BeforeTargets="BeforeResolveReferences">
-    <Warning Text="This feature is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+    <Warning
+      Text="The NuGet package Steeltoe.Extensions.Configuration.KubernetesBase is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.KubernetesBase/Build/Steeltoe.Extensions.Configuration.KubernetesBase.targets
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.KubernetesBase/Build/Steeltoe.Extensions.Configuration.KubernetesBase.targets
@@ -1,0 +1,5 @@
+<Project>
+  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="This feature is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+</Project>

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.KubernetesBase/Build/Steeltoe.Extensions.Configuration.KubernetesBase.targets
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.KubernetesBase/Build/Steeltoe.Extensions.Configuration.KubernetesBase.targets
@@ -1,5 +1,5 @@
 <Project>
-  <Target Name="Warn_SteeltoeExtensionsConfigurationKubernetesBase" BeforeTargets="BeforeResolveReferences">
+  <Target Name="Warn_SteeltoeExtensionsConfigurationKubernetesBase" AfterTargets="AfterResolveReferences">
     <Warning
       Text="The NuGet package Steeltoe.Extensions.Configuration.KubernetesBase is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.KubernetesBase/Build/Steeltoe.Extensions.Configuration.KubernetesBase.targets
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.KubernetesBase/Build/Steeltoe.Extensions.Configuration.KubernetesBase.targets
@@ -1,5 +1,9 @@
 <Project>
-  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
-    <Error Text="This feature is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+  <Target Name="Warn_SteeltoeExtensionsConfigurationKubernetesBase" BeforeTargets="BeforeResolveReferences">
+    <Warning Text="This feature is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+
+  <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="One or more Steeltoe package dependencies need attention. See the build warnings for details." />
   </Target>
 </Project>

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.KubernetesBase/Build/Steeltoe.Extensions.Configuration.KubernetesBase.targets
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.KubernetesBase/Build/Steeltoe.Extensions.Configuration.KubernetesBase.targets
@@ -1,7 +1,7 @@
 <Project>
   <Target Name="Warn_SteeltoeExtensionsConfigurationKubernetesBase" AfterTargets="AfterResolveReferences">
     <Warning
-      Text="The NuGet package Steeltoe.Extensions.Configuration.KubernetesBase is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+      Text="The NuGet package Steeltoe.Extensions.Configuration.KubernetesBase has been removed from Steeltoe in v4. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.KubernetesBase/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.KubernetesBase/PackageReadme.md
@@ -1,0 +1,17 @@
+# Steeltoe
+
+> [!IMPORTANT]
+> This feature is no longer available in Steeltoe v4.
+> See <https://steeltoe.io/docs/v3/obsolete> for details.
+
+[Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).
+
+Key features include:
+
+- External (optionally encrypted) configuration using [Spring Cloud Config Server](https://docs.spring.io/spring-cloud-config/docs/current/reference/html/)
+- Service discovery with [Netflix Eureka](https://spring.io/projects/spring-cloud-netflix) and [HashiCorp Consul](https://www.consul.io/)
+- Management endpoints (compatible with [actuators](https://docs.spring.io/spring-boot/docs/current/reference/html/actuator.html)), providing system info (such as versions, configuration, service container contents, mapped routes and HTTP traffic), heap/thread dumps, health checks, exporting metrics to [Prometheus](https://prometheus.io/), and changing log levels at runtime.
+- Connectivity to databases (such as [SQL Server](https://www.microsoft.com/sql-server)/[Azure SQL](https://azure.microsoft.com/products/azure-sql), [Cosmos DB](https://azure.microsoft.com/products/cosmos-db/), [MongoDB](https://www.mongodb.com/), [Redis](https://redis.io/), [RabbitMQ](https://www.rabbitmq.com/), [PostgreSQL](https://www.postgresql.org/), and [MySQL](https://www.mysql.com/)), including support for [Entity Framework Core](https://learn.microsoft.com/ef/core/)
+- Single sign-on, JWT and Certificate auth with [Cloud Foundry](https://www.cloudfoundry.org/)
+
+For more information and to get started, please visit [Steeltoe on GitHub](https://github.com/SteeltoeOSS/Steeltoe) or the [documentation](https://steeltoe.io/docs).

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.KubernetesBase/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.KubernetesBase/PackageReadme.md
@@ -1,7 +1,7 @@
 # Steeltoe
 
 > [!IMPORTANT]
-> This feature is no longer available in Steeltoe v4.
+> This package has been removed from Steeltoe in v4.
 > See <https://steeltoe.io/docs/v3/obsolete> for details.
 
 [Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.KubernetesBase/Steeltoe.Extensions.Configuration.KubernetesBase.csproj
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.KubernetesBase/Steeltoe.Extensions.Configuration.KubernetesBase.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net8.0</TargetFrameworks>
+    <Description>TODO: Fill package description.</Description>
+    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
+  <Import Project="..\..\..\shared.props" />
+
+  <ItemGroup>
+    <None Include="Build\*.props" Pack="True" PackagePath="build" />
+    <None Include="Build\*.targets" Pack="True" PackagePath="build" />
+  </ItemGroup>
+</Project>

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.KubernetesBase/Steeltoe.Extensions.Configuration.KubernetesBase.csproj
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.KubernetesBase/Steeltoe.Extensions.Configuration.KubernetesBase.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
-    <Description>TODO: Fill package description.</Description>
-    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <Description>Configuration Provider for reading Cloud Foundry Environment Variables.</Description>
+    <PackageTags>configuration;Kubernetes</PackageTags>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.KubernetesCore/Build/Steeltoe.Extensions.Configuration.KubernetesCore.targets
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.KubernetesCore/Build/Steeltoe.Extensions.Configuration.KubernetesCore.targets
@@ -1,5 +1,9 @@
 <Project>
-  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
-    <Error Text="This feature is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+  <Target Name="Warn_SteeltoeExtensionsConfigurationKubernetesCore" BeforeTargets="BeforeResolveReferences">
+    <Warning Text="This feature is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+
+  <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="One or more Steeltoe package dependencies need attention. See the build warnings for details." />
   </Target>
 </Project>

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.KubernetesCore/Build/Steeltoe.Extensions.Configuration.KubernetesCore.targets
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.KubernetesCore/Build/Steeltoe.Extensions.Configuration.KubernetesCore.targets
@@ -1,6 +1,7 @@
 <Project>
   <Target Name="Warn_SteeltoeExtensionsConfigurationKubernetesCore" BeforeTargets="BeforeResolveReferences">
-    <Warning Text="This feature is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+    <Warning
+      Text="The NuGet package Steeltoe.Extensions.Configuration.KubernetesCore is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.KubernetesCore/Build/Steeltoe.Extensions.Configuration.KubernetesCore.targets
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.KubernetesCore/Build/Steeltoe.Extensions.Configuration.KubernetesCore.targets
@@ -1,0 +1,5 @@
+<Project>
+  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="This feature is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+</Project>

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.KubernetesCore/Build/Steeltoe.Extensions.Configuration.KubernetesCore.targets
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.KubernetesCore/Build/Steeltoe.Extensions.Configuration.KubernetesCore.targets
@@ -1,5 +1,5 @@
 <Project>
-  <Target Name="Warn_SteeltoeExtensionsConfigurationKubernetesCore" BeforeTargets="BeforeResolveReferences">
+  <Target Name="Warn_SteeltoeExtensionsConfigurationKubernetesCore" AfterTargets="AfterResolveReferences">
     <Warning
       Text="The NuGet package Steeltoe.Extensions.Configuration.KubernetesCore is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.KubernetesCore/Build/Steeltoe.Extensions.Configuration.KubernetesCore.targets
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.KubernetesCore/Build/Steeltoe.Extensions.Configuration.KubernetesCore.targets
@@ -1,7 +1,7 @@
 <Project>
   <Target Name="Warn_SteeltoeExtensionsConfigurationKubernetesCore" AfterTargets="AfterResolveReferences">
     <Warning
-      Text="The NuGet package Steeltoe.Extensions.Configuration.KubernetesCore is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+      Text="The NuGet package Steeltoe.Extensions.Configuration.KubernetesCore has been removed from Steeltoe in v4. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.KubernetesCore/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.KubernetesCore/PackageReadme.md
@@ -1,0 +1,17 @@
+# Steeltoe
+
+> [!IMPORTANT]
+> This feature is no longer available in Steeltoe v4.
+> See <https://steeltoe.io/docs/v3/obsolete> for details.
+
+[Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).
+
+Key features include:
+
+- External (optionally encrypted) configuration using [Spring Cloud Config Server](https://docs.spring.io/spring-cloud-config/docs/current/reference/html/)
+- Service discovery with [Netflix Eureka](https://spring.io/projects/spring-cloud-netflix) and [HashiCorp Consul](https://www.consul.io/)
+- Management endpoints (compatible with [actuators](https://docs.spring.io/spring-boot/docs/current/reference/html/actuator.html)), providing system info (such as versions, configuration, service container contents, mapped routes and HTTP traffic), heap/thread dumps, health checks, exporting metrics to [Prometheus](https://prometheus.io/), and changing log levels at runtime.
+- Connectivity to databases (such as [SQL Server](https://www.microsoft.com/sql-server)/[Azure SQL](https://azure.microsoft.com/products/azure-sql), [Cosmos DB](https://azure.microsoft.com/products/cosmos-db/), [MongoDB](https://www.mongodb.com/), [Redis](https://redis.io/), [RabbitMQ](https://www.rabbitmq.com/), [PostgreSQL](https://www.postgresql.org/), and [MySQL](https://www.mysql.com/)), including support for [Entity Framework Core](https://learn.microsoft.com/ef/core/)
+- Single sign-on, JWT and Certificate auth with [Cloud Foundry](https://www.cloudfoundry.org/)
+
+For more information and to get started, please visit [Steeltoe on GitHub](https://github.com/SteeltoeOSS/Steeltoe) or the [documentation](https://steeltoe.io/docs).

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.KubernetesCore/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.KubernetesCore/PackageReadme.md
@@ -1,7 +1,7 @@
 # Steeltoe
 
 > [!IMPORTANT]
-> This feature is no longer available in Steeltoe v4.
+> This package has been removed from Steeltoe in v4.
 > See <https://steeltoe.io/docs/v3/obsolete> for details.
 
 [Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.KubernetesCore/Steeltoe.Extensions.Configuration.KubernetesCore.csproj
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.KubernetesCore/Steeltoe.Extensions.Configuration.KubernetesCore.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net8.0</TargetFrameworks>
+    <Description>TODO: Fill package description.</Description>
+    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
+  <Import Project="..\..\..\shared.props" />
+
+  <ItemGroup>
+    <None Include="Build\*.props" Pack="True" PackagePath="build" />
+    <None Include="Build\*.targets" Pack="True" PackagePath="build" />
+  </ItemGroup>
+</Project>

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.KubernetesCore/Steeltoe.Extensions.Configuration.KubernetesCore.csproj
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.KubernetesCore/Steeltoe.Extensions.Configuration.KubernetesCore.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
-    <Description>TODO: Fill package description.</Description>
-    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <Description>Package for adding Kubernetes environment variables, ConfigMaps and Secrets to .NET applications.</Description>
+    <PackageTags>Kubernetes;Spring;Spring Cloud;configuration;configmap</PackageTags>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.PlaceholderBase/Build/Steeltoe.Extensions.Configuration.PlaceholderBase.targets
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.PlaceholderBase/Build/Steeltoe.Extensions.Configuration.PlaceholderBase.targets
@@ -1,5 +1,5 @@
 <Project>
-  <Target Name="Warn_SteeltoeExtensionsConfigurationPlaceholderBase" BeforeTargets="BeforeResolveReferences">
+  <Target Name="Warn_SteeltoeExtensionsConfigurationPlaceholderBase" AfterTargets="AfterResolveReferences">
     <Warning
       Text="The NuGet package Steeltoe.Extensions.Configuration.PlaceholderBase has been replaced in Steeltoe v4. Reference Steeltoe.Configuration.Placeholder instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.PlaceholderBase/Build/Steeltoe.Extensions.Configuration.PlaceholderBase.targets
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.PlaceholderBase/Build/Steeltoe.Extensions.Configuration.PlaceholderBase.targets
@@ -1,7 +1,7 @@
 <Project>
   <Target Name="Warn_SteeltoeExtensionsConfigurationPlaceholderBase" AfterTargets="AfterResolveReferences">
     <Warning
-      Text="The NuGet package Steeltoe.Extensions.Configuration.PlaceholderBase has been replaced in Steeltoe v4. Reference Steeltoe.Configuration.Placeholder instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+      Text="The NuGet package Steeltoe.Extensions.Configuration.PlaceholderBase has been superseded in Steeltoe v4. Reference Steeltoe.Configuration.Placeholder instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.PlaceholderBase/Build/Steeltoe.Extensions.Configuration.PlaceholderBase.targets
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.PlaceholderBase/Build/Steeltoe.Extensions.Configuration.PlaceholderBase.targets
@@ -1,5 +1,6 @@
 <Project>
   <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
-    <Error Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Configuration.Placeholder instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+    <Error
+      Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Configuration.Placeholder instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 </Project>

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.PlaceholderBase/Build/Steeltoe.Extensions.Configuration.PlaceholderBase.targets
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.PlaceholderBase/Build/Steeltoe.Extensions.Configuration.PlaceholderBase.targets
@@ -1,0 +1,5 @@
+<Project>
+  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Configuration.Placeholder instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+</Project>

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.PlaceholderBase/Build/Steeltoe.Extensions.Configuration.PlaceholderBase.targets
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.PlaceholderBase/Build/Steeltoe.Extensions.Configuration.PlaceholderBase.targets
@@ -1,6 +1,10 @@
 <Project>
-  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
-    <Error
+  <Target Name="Warn_SteeltoeExtensionsConfigurationPlaceholderBase" BeforeTargets="BeforeResolveReferences">
+    <Warning
       Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Configuration.Placeholder instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+
+  <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="One or more Steeltoe package dependencies need attention. See the build warnings for details." />
   </Target>
 </Project>

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.PlaceholderBase/Build/Steeltoe.Extensions.Configuration.PlaceholderBase.targets
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.PlaceholderBase/Build/Steeltoe.Extensions.Configuration.PlaceholderBase.targets
@@ -1,7 +1,7 @@
 <Project>
   <Target Name="Warn_SteeltoeExtensionsConfigurationPlaceholderBase" BeforeTargets="BeforeResolveReferences">
     <Warning
-      Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Configuration.Placeholder instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+      Text="The NuGet package Steeltoe.Extensions.Configuration.PlaceholderBase has been replaced in Steeltoe v4. Reference Steeltoe.Configuration.Placeholder instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.PlaceholderBase/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.PlaceholderBase/PackageReadme.md
@@ -1,7 +1,7 @@
 # Steeltoe
 
 > [!IMPORTANT]
-> This package has been replaced in Steeltoe v4. Reference `Steeltoe.Configuration.Placeholder` instead.
+> This package has been superseded in Steeltoe v4. Reference `Steeltoe.Configuration.Placeholder` instead.
 > See <https://steeltoe.io/docs/v3/obsolete> for details.
 
 [Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.PlaceholderBase/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.PlaceholderBase/PackageReadme.md
@@ -1,0 +1,17 @@
+# Steeltoe
+
+> [!IMPORTANT]
+> This package has been replaced in Steeltoe v4. Reference `Steeltoe.Configuration.Placeholder` instead.
+> See <https://steeltoe.io/docs/v3/obsolete> for details.
+
+[Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).
+
+Key features include:
+
+- External (optionally encrypted) configuration using [Spring Cloud Config Server](https://docs.spring.io/spring-cloud-config/docs/current/reference/html/)
+- Service discovery with [Netflix Eureka](https://spring.io/projects/spring-cloud-netflix) and [HashiCorp Consul](https://www.consul.io/)
+- Management endpoints (compatible with [actuators](https://docs.spring.io/spring-boot/docs/current/reference/html/actuator.html)), providing system info (such as versions, configuration, service container contents, mapped routes and HTTP traffic), heap/thread dumps, health checks, exporting metrics to [Prometheus](https://prometheus.io/), and changing log levels at runtime.
+- Connectivity to databases (such as [SQL Server](https://www.microsoft.com/sql-server)/[Azure SQL](https://azure.microsoft.com/products/azure-sql), [Cosmos DB](https://azure.microsoft.com/products/cosmos-db/), [MongoDB](https://www.mongodb.com/), [Redis](https://redis.io/), [RabbitMQ](https://www.rabbitmq.com/), [PostgreSQL](https://www.postgresql.org/), and [MySQL](https://www.mysql.com/)), including support for [Entity Framework Core](https://learn.microsoft.com/ef/core/)
+- Single sign-on, JWT and Certificate auth with [Cloud Foundry](https://www.cloudfoundry.org/)
+
+For more information and to get started, please visit [Steeltoe on GitHub](https://github.com/SteeltoeOSS/Steeltoe) or the [documentation](https://steeltoe.io/docs).

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.PlaceholderBase/Steeltoe.Extensions.Configuration.PlaceholderBase.csproj
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.PlaceholderBase/Steeltoe.Extensions.Configuration.PlaceholderBase.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net8.0</TargetFrameworks>
+    <Description>TODO: Fill package description.</Description>
+    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
+  <Import Project="..\..\..\shared.props" />
+
+  <ItemGroup>
+    <None Include="Build\*.props" Pack="True" PackagePath="build" />
+    <None Include="Build\*.targets" Pack="True" PackagePath="build" />
+  </ItemGroup>
+</Project>

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.PlaceholderBase/Steeltoe.Extensions.Configuration.PlaceholderBase.csproj
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.PlaceholderBase/Steeltoe.Extensions.Configuration.PlaceholderBase.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
-    <Description>TODO: Fill package description.</Description>
-    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <Description>Configuration provider for resolving property placeholders in configuration values.</Description>
+    <PackageTags>configuration;placeholders;spring boot</PackageTags>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.PlaceholderCore/Build/Steeltoe.Extensions.Configuration.PlaceholderCore.targets
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.PlaceholderCore/Build/Steeltoe.Extensions.Configuration.PlaceholderCore.targets
@@ -1,7 +1,7 @@
 <Project>
   <Target Name="Warn_SteeltoeExtensionsConfigurationPlaceholderCore" AfterTargets="AfterResolveReferences">
     <Warning
-      Text="The NuGet package Steeltoe.Extensions.Configuration.PlaceholderCore has been replaced in Steeltoe v4. Reference Steeltoe.Configuration.Placeholder instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+      Text="The NuGet package Steeltoe.Extensions.Configuration.PlaceholderCore has been superseded in Steeltoe v4. Reference Steeltoe.Configuration.Placeholder instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.PlaceholderCore/Build/Steeltoe.Extensions.Configuration.PlaceholderCore.targets
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.PlaceholderCore/Build/Steeltoe.Extensions.Configuration.PlaceholderCore.targets
@@ -1,7 +1,7 @@
 <Project>
   <Target Name="Warn_SteeltoeExtensionsConfigurationPlaceholderCore" BeforeTargets="BeforeResolveReferences">
     <Warning
-      Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Configuration.Placeholder instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+      Text="The NuGet package Steeltoe.Extensions.Configuration.PlaceholderCore has been replaced in Steeltoe v4. Reference Steeltoe.Configuration.Placeholder instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.PlaceholderCore/Build/Steeltoe.Extensions.Configuration.PlaceholderCore.targets
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.PlaceholderCore/Build/Steeltoe.Extensions.Configuration.PlaceholderCore.targets
@@ -1,6 +1,10 @@
 <Project>
-  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
-    <Error
+  <Target Name="Warn_SteeltoeExtensionsConfigurationPlaceholderCore" BeforeTargets="BeforeResolveReferences">
+    <Warning
       Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Configuration.Placeholder instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+
+  <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="One or more Steeltoe package dependencies need attention. See the build warnings for details." />
   </Target>
 </Project>

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.PlaceholderCore/Build/Steeltoe.Extensions.Configuration.PlaceholderCore.targets
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.PlaceholderCore/Build/Steeltoe.Extensions.Configuration.PlaceholderCore.targets
@@ -1,5 +1,6 @@
 <Project>
   <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
-    <Error Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Configuration.Placeholder instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+    <Error
+      Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Configuration.Placeholder instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 </Project>

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.PlaceholderCore/Build/Steeltoe.Extensions.Configuration.PlaceholderCore.targets
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.PlaceholderCore/Build/Steeltoe.Extensions.Configuration.PlaceholderCore.targets
@@ -1,0 +1,5 @@
+<Project>
+  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Configuration.Placeholder instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+</Project>

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.PlaceholderCore/Build/Steeltoe.Extensions.Configuration.PlaceholderCore.targets
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.PlaceholderCore/Build/Steeltoe.Extensions.Configuration.PlaceholderCore.targets
@@ -1,5 +1,5 @@
 <Project>
-  <Target Name="Warn_SteeltoeExtensionsConfigurationPlaceholderCore" BeforeTargets="BeforeResolveReferences">
+  <Target Name="Warn_SteeltoeExtensionsConfigurationPlaceholderCore" AfterTargets="AfterResolveReferences">
     <Warning
       Text="The NuGet package Steeltoe.Extensions.Configuration.PlaceholderCore has been replaced in Steeltoe v4. Reference Steeltoe.Configuration.Placeholder instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.PlaceholderCore/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.PlaceholderCore/PackageReadme.md
@@ -1,7 +1,7 @@
 # Steeltoe
 
 > [!IMPORTANT]
-> This package has been replaced in Steeltoe v4. Reference `Steeltoe.Configuration.Placeholder` instead.
+> This package has been superseded in Steeltoe v4. Reference `Steeltoe.Configuration.Placeholder` instead.
 > See <https://steeltoe.io/docs/v3/obsolete> for details.
 
 [Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.PlaceholderCore/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.PlaceholderCore/PackageReadme.md
@@ -1,0 +1,17 @@
+# Steeltoe
+
+> [!IMPORTANT]
+> This package has been replaced in Steeltoe v4. Reference `Steeltoe.Configuration.Placeholder` instead.
+> See <https://steeltoe.io/docs/v3/obsolete> for details.
+
+[Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).
+
+Key features include:
+
+- External (optionally encrypted) configuration using [Spring Cloud Config Server](https://docs.spring.io/spring-cloud-config/docs/current/reference/html/)
+- Service discovery with [Netflix Eureka](https://spring.io/projects/spring-cloud-netflix) and [HashiCorp Consul](https://www.consul.io/)
+- Management endpoints (compatible with [actuators](https://docs.spring.io/spring-boot/docs/current/reference/html/actuator.html)), providing system info (such as versions, configuration, service container contents, mapped routes and HTTP traffic), heap/thread dumps, health checks, exporting metrics to [Prometheus](https://prometheus.io/), and changing log levels at runtime.
+- Connectivity to databases (such as [SQL Server](https://www.microsoft.com/sql-server)/[Azure SQL](https://azure.microsoft.com/products/azure-sql), [Cosmos DB](https://azure.microsoft.com/products/cosmos-db/), [MongoDB](https://www.mongodb.com/), [Redis](https://redis.io/), [RabbitMQ](https://www.rabbitmq.com/), [PostgreSQL](https://www.postgresql.org/), and [MySQL](https://www.mysql.com/)), including support for [Entity Framework Core](https://learn.microsoft.com/ef/core/)
+- Single sign-on, JWT and Certificate auth with [Cloud Foundry](https://www.cloudfoundry.org/)
+
+For more information and to get started, please visit [Steeltoe on GitHub](https://github.com/SteeltoeOSS/Steeltoe) or the [documentation](https://steeltoe.io/docs).

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.PlaceholderCore/Steeltoe.Extensions.Configuration.PlaceholderCore.csproj
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.PlaceholderCore/Steeltoe.Extensions.Configuration.PlaceholderCore.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
-    <Description>TODO: Fill package description.</Description>
-    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <Description>Packing for adding property placeholder resolving config provider to ASP.NET Core applications.</Description>
+    <PackageTags>configuration;placeholders;aspnetcore;spring boot</PackageTags>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.PlaceholderCore/Steeltoe.Extensions.Configuration.PlaceholderCore.csproj
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.PlaceholderCore/Steeltoe.Extensions.Configuration.PlaceholderCore.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net8.0</TargetFrameworks>
+    <Description>TODO: Fill package description.</Description>
+    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
+  <Import Project="..\..\..\shared.props" />
+
+  <ItemGroup>
+    <None Include="Build\*.props" Pack="True" PackagePath="build" />
+    <None Include="Build\*.targets" Pack="True" PackagePath="build" />
+  </ItemGroup>
+</Project>

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.PlaceholderCore/Steeltoe.Extensions.Configuration.PlaceholderCore.csproj
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.PlaceholderCore/Steeltoe.Extensions.Configuration.PlaceholderCore.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
-    <Description>Packing for adding property placeholder resolving config provider to ASP.NET Core applications.</Description>
+    <Description>Package for adding property placeholder resolving config provider to ASP.NET Core applications.</Description>
     <PackageTags>configuration;placeholders;aspnetcore;spring boot</PackageTags>
     <IsPackable>true</IsPackable>
   </PropertyGroup>

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.RandomValueBase/Build/Steeltoe.Extensions.Configuration.RandomValueBase.targets
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.RandomValueBase/Build/Steeltoe.Extensions.Configuration.RandomValueBase.targets
@@ -1,0 +1,5 @@
+<Project>
+  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Configuration.RandomValue instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+</Project>

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.RandomValueBase/Build/Steeltoe.Extensions.Configuration.RandomValueBase.targets
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.RandomValueBase/Build/Steeltoe.Extensions.Configuration.RandomValueBase.targets
@@ -1,6 +1,10 @@
 <Project>
-  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
-    <Error
+  <Target Name="Warn_SteeltoeExtensionsConfigurationRandomValueBase" BeforeTargets="BeforeResolveReferences">
+    <Warning
       Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Configuration.RandomValue instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+
+  <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="One or more Steeltoe package dependencies need attention. See the build warnings for details." />
   </Target>
 </Project>

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.RandomValueBase/Build/Steeltoe.Extensions.Configuration.RandomValueBase.targets
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.RandomValueBase/Build/Steeltoe.Extensions.Configuration.RandomValueBase.targets
@@ -1,5 +1,5 @@
 <Project>
-  <Target Name="Warn_SteeltoeExtensionsConfigurationRandomValueBase" BeforeTargets="BeforeResolveReferences">
+  <Target Name="Warn_SteeltoeExtensionsConfigurationRandomValueBase" AfterTargets="AfterResolveReferences">
     <Warning
       Text="The NuGet package Steeltoe.Extensions.Configuration.RandomValueBase has been replaced in Steeltoe v4. Reference Steeltoe.Configuration.RandomValue instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.RandomValueBase/Build/Steeltoe.Extensions.Configuration.RandomValueBase.targets
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.RandomValueBase/Build/Steeltoe.Extensions.Configuration.RandomValueBase.targets
@@ -1,7 +1,7 @@
 <Project>
   <Target Name="Warn_SteeltoeExtensionsConfigurationRandomValueBase" AfterTargets="AfterResolveReferences">
     <Warning
-      Text="The NuGet package Steeltoe.Extensions.Configuration.RandomValueBase has been replaced in Steeltoe v4. Reference Steeltoe.Configuration.RandomValue instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+      Text="The NuGet package Steeltoe.Extensions.Configuration.RandomValueBase has been superseded in Steeltoe v4. Reference Steeltoe.Configuration.RandomValue instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.RandomValueBase/Build/Steeltoe.Extensions.Configuration.RandomValueBase.targets
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.RandomValueBase/Build/Steeltoe.Extensions.Configuration.RandomValueBase.targets
@@ -1,5 +1,6 @@
 <Project>
   <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
-    <Error Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Configuration.RandomValue instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+    <Error
+      Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Configuration.RandomValue instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 </Project>

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.RandomValueBase/Build/Steeltoe.Extensions.Configuration.RandomValueBase.targets
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.RandomValueBase/Build/Steeltoe.Extensions.Configuration.RandomValueBase.targets
@@ -1,7 +1,7 @@
 <Project>
   <Target Name="Warn_SteeltoeExtensionsConfigurationRandomValueBase" BeforeTargets="BeforeResolveReferences">
     <Warning
-      Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Configuration.RandomValue instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+      Text="The NuGet package Steeltoe.Extensions.Configuration.RandomValueBase has been replaced in Steeltoe v4. Reference Steeltoe.Configuration.RandomValue instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.RandomValueBase/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.RandomValueBase/PackageReadme.md
@@ -1,0 +1,17 @@
+# Steeltoe
+
+> [!IMPORTANT]
+> This package has been replaced in Steeltoe v4. Reference `Steeltoe.Configuration.RandomValue` instead.
+> See <https://steeltoe.io/docs/v3/obsolete> for details.
+
+[Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).
+
+Key features include:
+
+- External (optionally encrypted) configuration using [Spring Cloud Config Server](https://docs.spring.io/spring-cloud-config/docs/current/reference/html/)
+- Service discovery with [Netflix Eureka](https://spring.io/projects/spring-cloud-netflix) and [HashiCorp Consul](https://www.consul.io/)
+- Management endpoints (compatible with [actuators](https://docs.spring.io/spring-boot/docs/current/reference/html/actuator.html)), providing system info (such as versions, configuration, service container contents, mapped routes and HTTP traffic), heap/thread dumps, health checks, exporting metrics to [Prometheus](https://prometheus.io/), and changing log levels at runtime.
+- Connectivity to databases (such as [SQL Server](https://www.microsoft.com/sql-server)/[Azure SQL](https://azure.microsoft.com/products/azure-sql), [Cosmos DB](https://azure.microsoft.com/products/cosmos-db/), [MongoDB](https://www.mongodb.com/), [Redis](https://redis.io/), [RabbitMQ](https://www.rabbitmq.com/), [PostgreSQL](https://www.postgresql.org/), and [MySQL](https://www.mysql.com/)), including support for [Entity Framework Core](https://learn.microsoft.com/ef/core/)
+- Single sign-on, JWT and Certificate auth with [Cloud Foundry](https://www.cloudfoundry.org/)
+
+For more information and to get started, please visit [Steeltoe on GitHub](https://github.com/SteeltoeOSS/Steeltoe) or the [documentation](https://steeltoe.io/docs).

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.RandomValueBase/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.RandomValueBase/PackageReadme.md
@@ -1,7 +1,7 @@
 # Steeltoe
 
 > [!IMPORTANT]
-> This package has been replaced in Steeltoe v4. Reference `Steeltoe.Configuration.RandomValue` instead.
+> This package has been superseded in Steeltoe v4. Reference `Steeltoe.Configuration.RandomValue` instead.
 > See <https://steeltoe.io/docs/v3/obsolete> for details.
 
 [Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.RandomValueBase/Steeltoe.Extensions.Configuration.RandomValueBase.csproj
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.RandomValueBase/Steeltoe.Extensions.Configuration.RandomValueBase.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net8.0</TargetFrameworks>
+    <Description>TODO: Fill package description.</Description>
+    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
+  <Import Project="..\..\..\shared.props" />
+
+  <ItemGroup>
+    <None Include="Build\*.props" Pack="True" PackagePath="build" />
+    <None Include="Build\*.targets" Pack="True" PackagePath="build" />
+  </ItemGroup>
+</Project>

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.RandomValueBase/Steeltoe.Extensions.Configuration.RandomValueBase.csproj
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.RandomValueBase/Steeltoe.Extensions.Configuration.RandomValueBase.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
-    <Description>TODO: Fill package description.</Description>
-    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <Description>Configuration provider for generating random values.</Description>
+    <PackageTags>configuration;random values</PackageTags>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.SpringBootBase/Build/Steeltoe.Extensions.Configuration.SpringBootBase.targets
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.SpringBootBase/Build/Steeltoe.Extensions.Configuration.SpringBootBase.targets
@@ -1,7 +1,7 @@
 <Project>
   <Target Name="Warn_SteeltoeExtensionsConfigurationSpringBootBase" AfterTargets="AfterResolveReferences">
     <Warning
-      Text="The NuGet package Steeltoe.Extensions.Configuration.SpringBootBase has been replaced in Steeltoe v4. Reference Steeltoe.Configuration.SpringBoot instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+      Text="The NuGet package Steeltoe.Extensions.Configuration.SpringBootBase has been superseded in Steeltoe v4. Reference Steeltoe.Configuration.SpringBoot instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.SpringBootBase/Build/Steeltoe.Extensions.Configuration.SpringBootBase.targets
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.SpringBootBase/Build/Steeltoe.Extensions.Configuration.SpringBootBase.targets
@@ -1,6 +1,10 @@
 <Project>
-  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
-    <Error
+  <Target Name="Warn_SteeltoeExtensionsConfigurationSpringBootBase" BeforeTargets="BeforeResolveReferences">
+    <Warning
       Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Configuration.SpringBoot instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+
+  <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="One or more Steeltoe package dependencies need attention. See the build warnings for details." />
   </Target>
 </Project>

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.SpringBootBase/Build/Steeltoe.Extensions.Configuration.SpringBootBase.targets
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.SpringBootBase/Build/Steeltoe.Extensions.Configuration.SpringBootBase.targets
@@ -1,7 +1,7 @@
 <Project>
   <Target Name="Warn_SteeltoeExtensionsConfigurationSpringBootBase" BeforeTargets="BeforeResolveReferences">
     <Warning
-      Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Configuration.SpringBoot instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+      Text="The NuGet package Steeltoe.Extensions.Configuration.SpringBootBase has been replaced in Steeltoe v4. Reference Steeltoe.Configuration.SpringBoot instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.SpringBootBase/Build/Steeltoe.Extensions.Configuration.SpringBootBase.targets
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.SpringBootBase/Build/Steeltoe.Extensions.Configuration.SpringBootBase.targets
@@ -1,5 +1,6 @@
 <Project>
   <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
-    <Error Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Configuration.SpringBoot instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+    <Error
+      Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Configuration.SpringBoot instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 </Project>

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.SpringBootBase/Build/Steeltoe.Extensions.Configuration.SpringBootBase.targets
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.SpringBootBase/Build/Steeltoe.Extensions.Configuration.SpringBootBase.targets
@@ -1,0 +1,5 @@
+<Project>
+  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Configuration.SpringBoot instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+</Project>

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.SpringBootBase/Build/Steeltoe.Extensions.Configuration.SpringBootBase.targets
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.SpringBootBase/Build/Steeltoe.Extensions.Configuration.SpringBootBase.targets
@@ -1,5 +1,5 @@
 <Project>
-  <Target Name="Warn_SteeltoeExtensionsConfigurationSpringBootBase" BeforeTargets="BeforeResolveReferences">
+  <Target Name="Warn_SteeltoeExtensionsConfigurationSpringBootBase" AfterTargets="AfterResolveReferences">
     <Warning
       Text="The NuGet package Steeltoe.Extensions.Configuration.SpringBootBase has been replaced in Steeltoe v4. Reference Steeltoe.Configuration.SpringBoot instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.SpringBootBase/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.SpringBootBase/PackageReadme.md
@@ -1,0 +1,17 @@
+# Steeltoe
+
+> [!IMPORTANT]
+> This package has been replaced in Steeltoe v4. Reference `Steeltoe.Configuration.SpringBoot` instead.
+> See <https://steeltoe.io/docs/v3/obsolete> for details.
+
+[Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).
+
+Key features include:
+
+- External (optionally encrypted) configuration using [Spring Cloud Config Server](https://docs.spring.io/spring-cloud-config/docs/current/reference/html/)
+- Service discovery with [Netflix Eureka](https://spring.io/projects/spring-cloud-netflix) and [HashiCorp Consul](https://www.consul.io/)
+- Management endpoints (compatible with [actuators](https://docs.spring.io/spring-boot/docs/current/reference/html/actuator.html)), providing system info (such as versions, configuration, service container contents, mapped routes and HTTP traffic), heap/thread dumps, health checks, exporting metrics to [Prometheus](https://prometheus.io/), and changing log levels at runtime.
+- Connectivity to databases (such as [SQL Server](https://www.microsoft.com/sql-server)/[Azure SQL](https://azure.microsoft.com/products/azure-sql), [Cosmos DB](https://azure.microsoft.com/products/cosmos-db/), [MongoDB](https://www.mongodb.com/), [Redis](https://redis.io/), [RabbitMQ](https://www.rabbitmq.com/), [PostgreSQL](https://www.postgresql.org/), and [MySQL](https://www.mysql.com/)), including support for [Entity Framework Core](https://learn.microsoft.com/ef/core/)
+- Single sign-on, JWT and Certificate auth with [Cloud Foundry](https://www.cloudfoundry.org/)
+
+For more information and to get started, please visit [Steeltoe on GitHub](https://github.com/SteeltoeOSS/Steeltoe) or the [documentation](https://steeltoe.io/docs).

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.SpringBootBase/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.SpringBootBase/PackageReadme.md
@@ -1,7 +1,7 @@
 # Steeltoe
 
 > [!IMPORTANT]
-> This package has been replaced in Steeltoe v4. Reference `Steeltoe.Configuration.SpringBoot` instead.
+> This package has been superseded in Steeltoe v4. Reference `Steeltoe.Configuration.SpringBoot` instead.
 > See <https://steeltoe.io/docs/v3/obsolete> for details.
 
 [Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.SpringBootBase/Steeltoe.Extensions.Configuration.SpringBootBase.csproj
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.SpringBootBase/Steeltoe.Extensions.Configuration.SpringBootBase.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net8.0</TargetFrameworks>
+    <Description>TODO: Fill package description.</Description>
+    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
+  <Import Project="..\..\..\shared.props" />
+
+  <ItemGroup>
+    <None Include="Build\*.props" Pack="True" PackagePath="build" />
+    <None Include="Build\*.targets" Pack="True" PackagePath="build" />
+  </ItemGroup>
+</Project>

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.SpringBootBase/Steeltoe.Extensions.Configuration.SpringBootBase.csproj
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.SpringBootBase/Steeltoe.Extensions.Configuration.SpringBootBase.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
-    <Description>TODO: Fill package description.</Description>
-    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <Description>Configuration provider for reading Spring Boot style configuration.</Description>
+    <PackageTags>configuration;springboot</PackageTags>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.SpringBootCore/Build/Steeltoe.Extensions.Configuration.SpringBootCore.targets
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.SpringBootCore/Build/Steeltoe.Extensions.Configuration.SpringBootCore.targets
@@ -1,7 +1,7 @@
 <Project>
   <Target Name="Warn_SteeltoeExtensionsConfigurationSpringBootCore" BeforeTargets="BeforeResolveReferences">
     <Warning
-      Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Configuration.SpringBoot instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+      Text="The NuGet package Steeltoe.Extensions.Configuration.SpringBootCore has been replaced in Steeltoe v4. Reference Steeltoe.Configuration.SpringBoot instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.SpringBootCore/Build/Steeltoe.Extensions.Configuration.SpringBootCore.targets
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.SpringBootCore/Build/Steeltoe.Extensions.Configuration.SpringBootCore.targets
@@ -1,5 +1,5 @@
 <Project>
-  <Target Name="Warn_SteeltoeExtensionsConfigurationSpringBootCore" BeforeTargets="BeforeResolveReferences">
+  <Target Name="Warn_SteeltoeExtensionsConfigurationSpringBootCore" AfterTargets="AfterResolveReferences">
     <Warning
       Text="The NuGet package Steeltoe.Extensions.Configuration.SpringBootCore has been replaced in Steeltoe v4. Reference Steeltoe.Configuration.SpringBoot instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.SpringBootCore/Build/Steeltoe.Extensions.Configuration.SpringBootCore.targets
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.SpringBootCore/Build/Steeltoe.Extensions.Configuration.SpringBootCore.targets
@@ -1,7 +1,7 @@
 <Project>
   <Target Name="Warn_SteeltoeExtensionsConfigurationSpringBootCore" AfterTargets="AfterResolveReferences">
     <Warning
-      Text="The NuGet package Steeltoe.Extensions.Configuration.SpringBootCore has been replaced in Steeltoe v4. Reference Steeltoe.Configuration.SpringBoot instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+      Text="The NuGet package Steeltoe.Extensions.Configuration.SpringBootCore has been superseded in Steeltoe v4. Reference Steeltoe.Configuration.SpringBoot instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.SpringBootCore/Build/Steeltoe.Extensions.Configuration.SpringBootCore.targets
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.SpringBootCore/Build/Steeltoe.Extensions.Configuration.SpringBootCore.targets
@@ -1,6 +1,10 @@
 <Project>
-  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
-    <Error
+  <Target Name="Warn_SteeltoeExtensionsConfigurationSpringBootCore" BeforeTargets="BeforeResolveReferences">
+    <Warning
       Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Configuration.SpringBoot instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+
+  <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="One or more Steeltoe package dependencies need attention. See the build warnings for details." />
   </Target>
 </Project>

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.SpringBootCore/Build/Steeltoe.Extensions.Configuration.SpringBootCore.targets
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.SpringBootCore/Build/Steeltoe.Extensions.Configuration.SpringBootCore.targets
@@ -1,5 +1,6 @@
 <Project>
   <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
-    <Error Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Configuration.SpringBoot instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+    <Error
+      Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Configuration.SpringBoot instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 </Project>

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.SpringBootCore/Build/Steeltoe.Extensions.Configuration.SpringBootCore.targets
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.SpringBootCore/Build/Steeltoe.Extensions.Configuration.SpringBootCore.targets
@@ -1,0 +1,5 @@
+<Project>
+  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Configuration.SpringBoot instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+</Project>

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.SpringBootCore/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.SpringBootCore/PackageReadme.md
@@ -1,0 +1,17 @@
+# Steeltoe
+
+> [!IMPORTANT]
+> This package has been replaced in Steeltoe v4. Reference `Steeltoe.Configuration.SpringBoot` instead.
+> See <https://steeltoe.io/docs/v3/obsolete> for details.
+
+[Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).
+
+Key features include:
+
+- External (optionally encrypted) configuration using [Spring Cloud Config Server](https://docs.spring.io/spring-cloud-config/docs/current/reference/html/)
+- Service discovery with [Netflix Eureka](https://spring.io/projects/spring-cloud-netflix) and [HashiCorp Consul](https://www.consul.io/)
+- Management endpoints (compatible with [actuators](https://docs.spring.io/spring-boot/docs/current/reference/html/actuator.html)), providing system info (such as versions, configuration, service container contents, mapped routes and HTTP traffic), heap/thread dumps, health checks, exporting metrics to [Prometheus](https://prometheus.io/), and changing log levels at runtime.
+- Connectivity to databases (such as [SQL Server](https://www.microsoft.com/sql-server)/[Azure SQL](https://azure.microsoft.com/products/azure-sql), [Cosmos DB](https://azure.microsoft.com/products/cosmos-db/), [MongoDB](https://www.mongodb.com/), [Redis](https://redis.io/), [RabbitMQ](https://www.rabbitmq.com/), [PostgreSQL](https://www.postgresql.org/), and [MySQL](https://www.mysql.com/)), including support for [Entity Framework Core](https://learn.microsoft.com/ef/core/)
+- Single sign-on, JWT and Certificate auth with [Cloud Foundry](https://www.cloudfoundry.org/)
+
+For more information and to get started, please visit [Steeltoe on GitHub](https://github.com/SteeltoeOSS/Steeltoe) or the [documentation](https://steeltoe.io/docs).

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.SpringBootCore/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.SpringBootCore/PackageReadme.md
@@ -1,7 +1,7 @@
 # Steeltoe
 
 > [!IMPORTANT]
-> This package has been replaced in Steeltoe v4. Reference `Steeltoe.Configuration.SpringBoot` instead.
+> This package has been superseded in Steeltoe v4. Reference `Steeltoe.Configuration.SpringBoot` instead.
 > See <https://steeltoe.io/docs/v3/obsolete> for details.
 
 [Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.SpringBootCore/Steeltoe.Extensions.Configuration.SpringBootCore.csproj
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.SpringBootCore/Steeltoe.Extensions.Configuration.SpringBootCore.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net8.0</TargetFrameworks>
+    <Description>TODO: Fill package description.</Description>
+    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
+  <Import Project="..\..\..\shared.props" />
+
+  <ItemGroup>
+    <None Include="Build\*.props" Pack="True" PackagePath="build" />
+    <None Include="Build\*.targets" Pack="True" PackagePath="build" />
+  </ItemGroup>
+</Project>

--- a/src/Obsolete/Steeltoe.Extensions.Configuration.SpringBootCore/Steeltoe.Extensions.Configuration.SpringBootCore.csproj
+++ b/src/Obsolete/Steeltoe.Extensions.Configuration.SpringBootCore/Steeltoe.Extensions.Configuration.SpringBootCore.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
-    <Description>TODO: Fill package description.</Description>
-    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <Description>Configuration provider for reading Spring Boot style configuration.</Description>
+    <PackageTags>configuration;springboot</PackageTags>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 

--- a/src/Obsolete/Steeltoe.Extensions.Logging.Abstractions/Build/Steeltoe.Extensions.Logging.Abstractions.targets
+++ b/src/Obsolete/Steeltoe.Extensions.Logging.Abstractions/Build/Steeltoe.Extensions.Logging.Abstractions.targets
@@ -1,5 +1,6 @@
 <Project>
   <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
-    <Error Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Logging.Abstractions instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+    <Error
+      Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Logging.Abstractions instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 </Project>

--- a/src/Obsolete/Steeltoe.Extensions.Logging.Abstractions/Build/Steeltoe.Extensions.Logging.Abstractions.targets
+++ b/src/Obsolete/Steeltoe.Extensions.Logging.Abstractions/Build/Steeltoe.Extensions.Logging.Abstractions.targets
@@ -1,0 +1,5 @@
+<Project>
+  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Logging.Abstractions instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+</Project>

--- a/src/Obsolete/Steeltoe.Extensions.Logging.Abstractions/Build/Steeltoe.Extensions.Logging.Abstractions.targets
+++ b/src/Obsolete/Steeltoe.Extensions.Logging.Abstractions/Build/Steeltoe.Extensions.Logging.Abstractions.targets
@@ -1,6 +1,10 @@
 <Project>
-  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
-    <Error
+  <Target Name="Warn_SteeltoeExtensionsLoggingAbstractions" BeforeTargets="BeforeResolveReferences">
+    <Warning
       Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Logging.Abstractions instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+
+  <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="One or more Steeltoe package dependencies need attention. See the build warnings for details." />
   </Target>
 </Project>

--- a/src/Obsolete/Steeltoe.Extensions.Logging.Abstractions/Build/Steeltoe.Extensions.Logging.Abstractions.targets
+++ b/src/Obsolete/Steeltoe.Extensions.Logging.Abstractions/Build/Steeltoe.Extensions.Logging.Abstractions.targets
@@ -1,5 +1,5 @@
 <Project>
-  <Target Name="Warn_SteeltoeExtensionsLoggingAbstractions" BeforeTargets="BeforeResolveReferences">
+  <Target Name="Warn_SteeltoeExtensionsLoggingAbstractions" AfterTargets="AfterResolveReferences">
     <Warning
       Text="The NuGet package Steeltoe.Extensions.Logging.Abstractions has been replaced in Steeltoe v4. Reference Steeltoe.Logging.Abstractions instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>

--- a/src/Obsolete/Steeltoe.Extensions.Logging.Abstractions/Build/Steeltoe.Extensions.Logging.Abstractions.targets
+++ b/src/Obsolete/Steeltoe.Extensions.Logging.Abstractions/Build/Steeltoe.Extensions.Logging.Abstractions.targets
@@ -1,7 +1,7 @@
 <Project>
   <Target Name="Warn_SteeltoeExtensionsLoggingAbstractions" AfterTargets="AfterResolveReferences">
     <Warning
-      Text="The NuGet package Steeltoe.Extensions.Logging.Abstractions has been replaced in Steeltoe v4. Reference Steeltoe.Logging.Abstractions instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+      Text="The NuGet package Steeltoe.Extensions.Logging.Abstractions has been superseded in Steeltoe v4. Reference Steeltoe.Logging.Abstractions instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.Extensions.Logging.Abstractions/Build/Steeltoe.Extensions.Logging.Abstractions.targets
+++ b/src/Obsolete/Steeltoe.Extensions.Logging.Abstractions/Build/Steeltoe.Extensions.Logging.Abstractions.targets
@@ -1,7 +1,7 @@
 <Project>
   <Target Name="Warn_SteeltoeExtensionsLoggingAbstractions" BeforeTargets="BeforeResolveReferences">
     <Warning
-      Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Logging.Abstractions instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+      Text="The NuGet package Steeltoe.Extensions.Logging.Abstractions has been replaced in Steeltoe v4. Reference Steeltoe.Logging.Abstractions instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.Extensions.Logging.Abstractions/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.Extensions.Logging.Abstractions/PackageReadme.md
@@ -1,0 +1,17 @@
+# Steeltoe
+
+> [!IMPORTANT]
+> This package has been replaced in Steeltoe v4. Reference `Steeltoe.Logging.Abstractions` instead.
+> See <https://steeltoe.io/docs/v3/obsolete> for details.
+
+[Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).
+
+Key features include:
+
+- External (optionally encrypted) configuration using [Spring Cloud Config Server](https://docs.spring.io/spring-cloud-config/docs/current/reference/html/)
+- Service discovery with [Netflix Eureka](https://spring.io/projects/spring-cloud-netflix) and [HashiCorp Consul](https://www.consul.io/)
+- Management endpoints (compatible with [actuators](https://docs.spring.io/spring-boot/docs/current/reference/html/actuator.html)), providing system info (such as versions, configuration, service container contents, mapped routes and HTTP traffic), heap/thread dumps, health checks, exporting metrics to [Prometheus](https://prometheus.io/), and changing log levels at runtime.
+- Connectivity to databases (such as [SQL Server](https://www.microsoft.com/sql-server)/[Azure SQL](https://azure.microsoft.com/products/azure-sql), [Cosmos DB](https://azure.microsoft.com/products/cosmos-db/), [MongoDB](https://www.mongodb.com/), [Redis](https://redis.io/), [RabbitMQ](https://www.rabbitmq.com/), [PostgreSQL](https://www.postgresql.org/), and [MySQL](https://www.mysql.com/)), including support for [Entity Framework Core](https://learn.microsoft.com/ef/core/)
+- Single sign-on, JWT and Certificate auth with [Cloud Foundry](https://www.cloudfoundry.org/)
+
+For more information and to get started, please visit [Steeltoe on GitHub](https://github.com/SteeltoeOSS/Steeltoe) or the [documentation](https://steeltoe.io/docs).

--- a/src/Obsolete/Steeltoe.Extensions.Logging.Abstractions/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.Extensions.Logging.Abstractions/PackageReadme.md
@@ -1,7 +1,7 @@
 # Steeltoe
 
 > [!IMPORTANT]
-> This package has been replaced in Steeltoe v4. Reference `Steeltoe.Logging.Abstractions` instead.
+> This package has been superseded in Steeltoe v4. Reference `Steeltoe.Logging.Abstractions` instead.
 > See <https://steeltoe.io/docs/v3/obsolete> for details.
 
 [Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).

--- a/src/Obsolete/Steeltoe.Extensions.Logging.Abstractions/Steeltoe.Extensions.Logging.Abstractions.csproj
+++ b/src/Obsolete/Steeltoe.Extensions.Logging.Abstractions/Steeltoe.Extensions.Logging.Abstractions.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net8.0</TargetFrameworks>
+    <Description>TODO: Fill package description.</Description>
+    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
+  <Import Project="..\..\..\shared.props" />
+
+  <ItemGroup>
+    <None Include="Build\*.props" Pack="True" PackagePath="build" />
+    <None Include="Build\*.targets" Pack="True" PackagePath="build" />
+  </ItemGroup>
+</Project>

--- a/src/Obsolete/Steeltoe.Extensions.Logging.Abstractions/Steeltoe.Extensions.Logging.Abstractions.csproj
+++ b/src/Obsolete/Steeltoe.Extensions.Logging.Abstractions/Steeltoe.Extensions.Logging.Abstractions.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
     <Description>Abstractions for use with dynamic logging.</Description>
-    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <PackageTags>logging;dynamic logging;management;monitoring;Spring Cloud</PackageTags>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 

--- a/src/Obsolete/Steeltoe.Extensions.Logging.Abstractions/Steeltoe.Extensions.Logging.Abstractions.csproj
+++ b/src/Obsolete/Steeltoe.Extensions.Logging.Abstractions/Steeltoe.Extensions.Logging.Abstractions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
-    <Description>TODO: Fill package description.</Description>
+    <Description>Abstractions for use with dynamic logging.</Description>
     <PackageTags>TODO: Fill package tags.</PackageTags>
     <IsPackable>true</IsPackable>
   </PropertyGroup>

--- a/src/Obsolete/Steeltoe.Extensions.Logging.DynamicLogger/Build/Steeltoe.Extensions.Logging.DynamicLogger.targets
+++ b/src/Obsolete/Steeltoe.Extensions.Logging.DynamicLogger/Build/Steeltoe.Extensions.Logging.DynamicLogger.targets
@@ -1,6 +1,10 @@
 <Project>
-  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
-    <Error
+  <Target Name="Warn_SteeltoeExtensionsLoggingDynamicLogger" BeforeTargets="BeforeResolveReferences">
+    <Warning
       Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Logging.DynamicConsole instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+
+  <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="One or more Steeltoe package dependencies need attention. See the build warnings for details." />
   </Target>
 </Project>

--- a/src/Obsolete/Steeltoe.Extensions.Logging.DynamicLogger/Build/Steeltoe.Extensions.Logging.DynamicLogger.targets
+++ b/src/Obsolete/Steeltoe.Extensions.Logging.DynamicLogger/Build/Steeltoe.Extensions.Logging.DynamicLogger.targets
@@ -1,7 +1,7 @@
 <Project>
   <Target Name="Warn_SteeltoeExtensionsLoggingDynamicLogger" BeforeTargets="BeforeResolveReferences">
     <Warning
-      Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Logging.DynamicConsole instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+      Text="The NuGet package Steeltoe.Extensions.Logging.DynamicLogger has been replaced in Steeltoe v4. Reference Steeltoe.Logging.DynamicConsole instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.Extensions.Logging.DynamicLogger/Build/Steeltoe.Extensions.Logging.DynamicLogger.targets
+++ b/src/Obsolete/Steeltoe.Extensions.Logging.DynamicLogger/Build/Steeltoe.Extensions.Logging.DynamicLogger.targets
@@ -1,5 +1,5 @@
 <Project>
-  <Target Name="Warn_SteeltoeExtensionsLoggingDynamicLogger" BeforeTargets="BeforeResolveReferences">
+  <Target Name="Warn_SteeltoeExtensionsLoggingDynamicLogger" AfterTargets="AfterResolveReferences">
     <Warning
       Text="The NuGet package Steeltoe.Extensions.Logging.DynamicLogger has been replaced in Steeltoe v4. Reference Steeltoe.Logging.DynamicConsole instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>

--- a/src/Obsolete/Steeltoe.Extensions.Logging.DynamicLogger/Build/Steeltoe.Extensions.Logging.DynamicLogger.targets
+++ b/src/Obsolete/Steeltoe.Extensions.Logging.DynamicLogger/Build/Steeltoe.Extensions.Logging.DynamicLogger.targets
@@ -1,7 +1,7 @@
 <Project>
   <Target Name="Warn_SteeltoeExtensionsLoggingDynamicLogger" AfterTargets="AfterResolveReferences">
     <Warning
-      Text="The NuGet package Steeltoe.Extensions.Logging.DynamicLogger has been replaced in Steeltoe v4. Reference Steeltoe.Logging.DynamicConsole instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+      Text="The NuGet package Steeltoe.Extensions.Logging.DynamicLogger has been superseded in Steeltoe v4. Reference Steeltoe.Logging.DynamicConsole instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.Extensions.Logging.DynamicLogger/Build/Steeltoe.Extensions.Logging.DynamicLogger.targets
+++ b/src/Obsolete/Steeltoe.Extensions.Logging.DynamicLogger/Build/Steeltoe.Extensions.Logging.DynamicLogger.targets
@@ -1,5 +1,6 @@
 <Project>
   <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
-    <Error Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Logging.DynamicConsole instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+    <Error
+      Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Logging.DynamicConsole instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 </Project>

--- a/src/Obsolete/Steeltoe.Extensions.Logging.DynamicLogger/Build/Steeltoe.Extensions.Logging.DynamicLogger.targets
+++ b/src/Obsolete/Steeltoe.Extensions.Logging.DynamicLogger/Build/Steeltoe.Extensions.Logging.DynamicLogger.targets
@@ -1,0 +1,5 @@
+<Project>
+  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Logging.DynamicConsole instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+</Project>

--- a/src/Obsolete/Steeltoe.Extensions.Logging.DynamicLogger/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.Extensions.Logging.DynamicLogger/PackageReadme.md
@@ -1,7 +1,7 @@
 # Steeltoe
 
 > [!IMPORTANT]
-> This package has been replaced in Steeltoe v4. Reference `Steeltoe.Logging.DynamicConsole` instead.
+> This package has been superseded in Steeltoe v4. Reference `Steeltoe.Logging.DynamicConsole` instead.
 > See <https://steeltoe.io/docs/v3/obsolete> for details.
 
 [Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).

--- a/src/Obsolete/Steeltoe.Extensions.Logging.DynamicLogger/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.Extensions.Logging.DynamicLogger/PackageReadme.md
@@ -1,0 +1,17 @@
+# Steeltoe
+
+> [!IMPORTANT]
+> This package has been replaced in Steeltoe v4. Reference `Steeltoe.Logging.DynamicConsole` instead.
+> See <https://steeltoe.io/docs/v3/obsolete> for details.
+
+[Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).
+
+Key features include:
+
+- External (optionally encrypted) configuration using [Spring Cloud Config Server](https://docs.spring.io/spring-cloud-config/docs/current/reference/html/)
+- Service discovery with [Netflix Eureka](https://spring.io/projects/spring-cloud-netflix) and [HashiCorp Consul](https://www.consul.io/)
+- Management endpoints (compatible with [actuators](https://docs.spring.io/spring-boot/docs/current/reference/html/actuator.html)), providing system info (such as versions, configuration, service container contents, mapped routes and HTTP traffic), heap/thread dumps, health checks, exporting metrics to [Prometheus](https://prometheus.io/), and changing log levels at runtime.
+- Connectivity to databases (such as [SQL Server](https://www.microsoft.com/sql-server)/[Azure SQL](https://azure.microsoft.com/products/azure-sql), [Cosmos DB](https://azure.microsoft.com/products/cosmos-db/), [MongoDB](https://www.mongodb.com/), [Redis](https://redis.io/), [RabbitMQ](https://www.rabbitmq.com/), [PostgreSQL](https://www.postgresql.org/), and [MySQL](https://www.mysql.com/)), including support for [Entity Framework Core](https://learn.microsoft.com/ef/core/)
+- Single sign-on, JWT and Certificate auth with [Cloud Foundry](https://www.cloudfoundry.org/)
+
+For more information and to get started, please visit [Steeltoe on GitHub](https://github.com/SteeltoeOSS/Steeltoe) or the [documentation](https://steeltoe.io/docs).

--- a/src/Obsolete/Steeltoe.Extensions.Logging.DynamicLogger/Steeltoe.Extensions.Logging.DynamicLogger.csproj
+++ b/src/Obsolete/Steeltoe.Extensions.Logging.DynamicLogger/Steeltoe.Extensions.Logging.DynamicLogger.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net8.0</TargetFrameworks>
+    <Description>TODO: Fill package description.</Description>
+    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
+  <Import Project="..\..\..\shared.props" />
+
+  <ItemGroup>
+    <None Include="Build\*.props" Pack="True" PackagePath="build" />
+    <None Include="Build\*.targets" Pack="True" PackagePath="build" />
+  </ItemGroup>
+</Project>

--- a/src/Obsolete/Steeltoe.Extensions.Logging.DynamicLogger/Steeltoe.Extensions.Logging.DynamicLogger.csproj
+++ b/src/Obsolete/Steeltoe.Extensions.Logging.DynamicLogger/Steeltoe.Extensions.Logging.DynamicLogger.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
-    <Description>TODO: Fill package description.</Description>
-    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <Description>Steeltoe Dynamic Console Logger.</Description>
+    <PackageTags>logging;dynamic logging;console;management;monitoring;Spring Cloud</PackageTags>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 

--- a/src/Obsolete/Steeltoe.Extensions.Logging.DynamicSerilogBase/Build/Steeltoe.Extensions.Logging.DynamicSerilogBase.targets
+++ b/src/Obsolete/Steeltoe.Extensions.Logging.DynamicSerilogBase/Build/Steeltoe.Extensions.Logging.DynamicSerilogBase.targets
@@ -1,5 +1,6 @@
 <Project>
   <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
-    <Error Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Logging.DynamicSerilog instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+    <Error
+      Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Logging.DynamicSerilog instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 </Project>

--- a/src/Obsolete/Steeltoe.Extensions.Logging.DynamicSerilogBase/Build/Steeltoe.Extensions.Logging.DynamicSerilogBase.targets
+++ b/src/Obsolete/Steeltoe.Extensions.Logging.DynamicSerilogBase/Build/Steeltoe.Extensions.Logging.DynamicSerilogBase.targets
@@ -1,7 +1,7 @@
 <Project>
   <Target Name="Warn_SteeltoeExtensionsLoggingDynamicSerilogBase" BeforeTargets="BeforeResolveReferences">
     <Warning
-      Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Logging.DynamicSerilog instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+      Text="The NuGet package Steeltoe.Extensions.Logging.DynamicSerilogBase has been replaced in Steeltoe v4. Reference Steeltoe.Logging.DynamicSerilog instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.Extensions.Logging.DynamicSerilogBase/Build/Steeltoe.Extensions.Logging.DynamicSerilogBase.targets
+++ b/src/Obsolete/Steeltoe.Extensions.Logging.DynamicSerilogBase/Build/Steeltoe.Extensions.Logging.DynamicSerilogBase.targets
@@ -1,5 +1,5 @@
 <Project>
-  <Target Name="Warn_SteeltoeExtensionsLoggingDynamicSerilogBase" BeforeTargets="BeforeResolveReferences">
+  <Target Name="Warn_SteeltoeExtensionsLoggingDynamicSerilogBase" AfterTargets="AfterResolveReferences">
     <Warning
       Text="The NuGet package Steeltoe.Extensions.Logging.DynamicSerilogBase has been replaced in Steeltoe v4. Reference Steeltoe.Logging.DynamicSerilog instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>

--- a/src/Obsolete/Steeltoe.Extensions.Logging.DynamicSerilogBase/Build/Steeltoe.Extensions.Logging.DynamicSerilogBase.targets
+++ b/src/Obsolete/Steeltoe.Extensions.Logging.DynamicSerilogBase/Build/Steeltoe.Extensions.Logging.DynamicSerilogBase.targets
@@ -1,7 +1,7 @@
 <Project>
   <Target Name="Warn_SteeltoeExtensionsLoggingDynamicSerilogBase" AfterTargets="AfterResolveReferences">
     <Warning
-      Text="The NuGet package Steeltoe.Extensions.Logging.DynamicSerilogBase has been replaced in Steeltoe v4. Reference Steeltoe.Logging.DynamicSerilog instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+      Text="The NuGet package Steeltoe.Extensions.Logging.DynamicSerilogBase has been superseded in Steeltoe v4. Reference Steeltoe.Logging.DynamicSerilog instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.Extensions.Logging.DynamicSerilogBase/Build/Steeltoe.Extensions.Logging.DynamicSerilogBase.targets
+++ b/src/Obsolete/Steeltoe.Extensions.Logging.DynamicSerilogBase/Build/Steeltoe.Extensions.Logging.DynamicSerilogBase.targets
@@ -1,0 +1,5 @@
+<Project>
+  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Logging.DynamicSerilog instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+</Project>

--- a/src/Obsolete/Steeltoe.Extensions.Logging.DynamicSerilogBase/Build/Steeltoe.Extensions.Logging.DynamicSerilogBase.targets
+++ b/src/Obsolete/Steeltoe.Extensions.Logging.DynamicSerilogBase/Build/Steeltoe.Extensions.Logging.DynamicSerilogBase.targets
@@ -1,6 +1,10 @@
 <Project>
-  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
-    <Error
+  <Target Name="Warn_SteeltoeExtensionsLoggingDynamicSerilogBase" BeforeTargets="BeforeResolveReferences">
+    <Warning
       Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Logging.DynamicSerilog instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+
+  <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="One or more Steeltoe package dependencies need attention. See the build warnings for details." />
   </Target>
 </Project>

--- a/src/Obsolete/Steeltoe.Extensions.Logging.DynamicSerilogBase/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.Extensions.Logging.DynamicSerilogBase/PackageReadme.md
@@ -1,0 +1,17 @@
+# Steeltoe
+
+> [!IMPORTANT]
+> This package has been replaced in Steeltoe v4. Reference `Steeltoe.Logging.DynamicSerilog` instead.
+> See <https://steeltoe.io/docs/v3/obsolete> for details.
+
+[Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).
+
+Key features include:
+
+- External (optionally encrypted) configuration using [Spring Cloud Config Server](https://docs.spring.io/spring-cloud-config/docs/current/reference/html/)
+- Service discovery with [Netflix Eureka](https://spring.io/projects/spring-cloud-netflix) and [HashiCorp Consul](https://www.consul.io/)
+- Management endpoints (compatible with [actuators](https://docs.spring.io/spring-boot/docs/current/reference/html/actuator.html)), providing system info (such as versions, configuration, service container contents, mapped routes and HTTP traffic), heap/thread dumps, health checks, exporting metrics to [Prometheus](https://prometheus.io/), and changing log levels at runtime.
+- Connectivity to databases (such as [SQL Server](https://www.microsoft.com/sql-server)/[Azure SQL](https://azure.microsoft.com/products/azure-sql), [Cosmos DB](https://azure.microsoft.com/products/cosmos-db/), [MongoDB](https://www.mongodb.com/), [Redis](https://redis.io/), [RabbitMQ](https://www.rabbitmq.com/), [PostgreSQL](https://www.postgresql.org/), and [MySQL](https://www.mysql.com/)), including support for [Entity Framework Core](https://learn.microsoft.com/ef/core/)
+- Single sign-on, JWT and Certificate auth with [Cloud Foundry](https://www.cloudfoundry.org/)
+
+For more information and to get started, please visit [Steeltoe on GitHub](https://github.com/SteeltoeOSS/Steeltoe) or the [documentation](https://steeltoe.io/docs).

--- a/src/Obsolete/Steeltoe.Extensions.Logging.DynamicSerilogBase/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.Extensions.Logging.DynamicSerilogBase/PackageReadme.md
@@ -1,7 +1,7 @@
 # Steeltoe
 
 > [!IMPORTANT]
-> This package has been replaced in Steeltoe v4. Reference `Steeltoe.Logging.DynamicSerilog` instead.
+> This package has been superseded in Steeltoe v4. Reference `Steeltoe.Logging.DynamicSerilog` instead.
 > See <https://steeltoe.io/docs/v3/obsolete> for details.
 
 [Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).

--- a/src/Obsolete/Steeltoe.Extensions.Logging.DynamicSerilogBase/Steeltoe.Extensions.Logging.DynamicSerilogBase.csproj
+++ b/src/Obsolete/Steeltoe.Extensions.Logging.DynamicSerilogBase/Steeltoe.Extensions.Logging.DynamicSerilogBase.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net8.0</TargetFrameworks>
+    <Description>TODO: Fill package description.</Description>
+    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
+  <Import Project="..\..\..\shared.props" />
+
+  <ItemGroup>
+    <None Include="Build\*.props" Pack="True" PackagePath="build" />
+    <None Include="Build\*.targets" Pack="True" PackagePath="build" />
+  </ItemGroup>
+</Project>

--- a/src/Obsolete/Steeltoe.Extensions.Logging.DynamicSerilogBase/Steeltoe.Extensions.Logging.DynamicSerilogBase.csproj
+++ b/src/Obsolete/Steeltoe.Extensions.Logging.DynamicSerilogBase/Steeltoe.Extensions.Logging.DynamicSerilogBase.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
-    <Description>TODO: Fill package description.</Description>
-    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <Description>Steeltoe library for enabling dynamic management of Serilog.</Description>
+    <PackageTags>logging;dynamic logging;serilog;management;monitoring;Spring Cloud</PackageTags>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 

--- a/src/Obsolete/Steeltoe.Extensions.Logging.DynamicSerilogCore/Build/Steeltoe.Extensions.Logging.DynamicSerilogCore.targets
+++ b/src/Obsolete/Steeltoe.Extensions.Logging.DynamicSerilogCore/Build/Steeltoe.Extensions.Logging.DynamicSerilogCore.targets
@@ -1,5 +1,6 @@
 <Project>
   <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
-    <Error Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Logging.DynamicSerilog instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+    <Error
+      Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Logging.DynamicSerilog instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 </Project>

--- a/src/Obsolete/Steeltoe.Extensions.Logging.DynamicSerilogCore/Build/Steeltoe.Extensions.Logging.DynamicSerilogCore.targets
+++ b/src/Obsolete/Steeltoe.Extensions.Logging.DynamicSerilogCore/Build/Steeltoe.Extensions.Logging.DynamicSerilogCore.targets
@@ -1,7 +1,7 @@
 <Project>
   <Target Name="Warn_SteeltoeExtensionsLoggingDynamicSerilogCore" BeforeTargets="BeforeResolveReferences">
     <Warning
-      Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Logging.DynamicSerilog instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+      Text="The NuGet package Steeltoe.Extensions.Logging.DynamicSerilogCore has been replaced in Steeltoe v4. Reference Steeltoe.Logging.DynamicSerilog instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.Extensions.Logging.DynamicSerilogCore/Build/Steeltoe.Extensions.Logging.DynamicSerilogCore.targets
+++ b/src/Obsolete/Steeltoe.Extensions.Logging.DynamicSerilogCore/Build/Steeltoe.Extensions.Logging.DynamicSerilogCore.targets
@@ -1,7 +1,7 @@
 <Project>
   <Target Name="Warn_SteeltoeExtensionsLoggingDynamicSerilogCore" AfterTargets="AfterResolveReferences">
     <Warning
-      Text="The NuGet package Steeltoe.Extensions.Logging.DynamicSerilogCore has been replaced in Steeltoe v4. Reference Steeltoe.Logging.DynamicSerilog instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+      Text="The NuGet package Steeltoe.Extensions.Logging.DynamicSerilogCore has been superseded in Steeltoe v4. Reference Steeltoe.Logging.DynamicSerilog instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.Extensions.Logging.DynamicSerilogCore/Build/Steeltoe.Extensions.Logging.DynamicSerilogCore.targets
+++ b/src/Obsolete/Steeltoe.Extensions.Logging.DynamicSerilogCore/Build/Steeltoe.Extensions.Logging.DynamicSerilogCore.targets
@@ -1,5 +1,5 @@
 <Project>
-  <Target Name="Warn_SteeltoeExtensionsLoggingDynamicSerilogCore" BeforeTargets="BeforeResolveReferences">
+  <Target Name="Warn_SteeltoeExtensionsLoggingDynamicSerilogCore" AfterTargets="AfterResolveReferences">
     <Warning
       Text="The NuGet package Steeltoe.Extensions.Logging.DynamicSerilogCore has been replaced in Steeltoe v4. Reference Steeltoe.Logging.DynamicSerilog instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>

--- a/src/Obsolete/Steeltoe.Extensions.Logging.DynamicSerilogCore/Build/Steeltoe.Extensions.Logging.DynamicSerilogCore.targets
+++ b/src/Obsolete/Steeltoe.Extensions.Logging.DynamicSerilogCore/Build/Steeltoe.Extensions.Logging.DynamicSerilogCore.targets
@@ -1,6 +1,10 @@
 <Project>
-  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
-    <Error
+  <Target Name="Warn_SteeltoeExtensionsLoggingDynamicSerilogCore" BeforeTargets="BeforeResolveReferences">
+    <Warning
       Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Logging.DynamicSerilog instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+
+  <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="One or more Steeltoe package dependencies need attention. See the build warnings for details." />
   </Target>
 </Project>

--- a/src/Obsolete/Steeltoe.Extensions.Logging.DynamicSerilogCore/Build/Steeltoe.Extensions.Logging.DynamicSerilogCore.targets
+++ b/src/Obsolete/Steeltoe.Extensions.Logging.DynamicSerilogCore/Build/Steeltoe.Extensions.Logging.DynamicSerilogCore.targets
@@ -1,0 +1,5 @@
+<Project>
+  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Logging.DynamicSerilog instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+</Project>

--- a/src/Obsolete/Steeltoe.Extensions.Logging.DynamicSerilogCore/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.Extensions.Logging.DynamicSerilogCore/PackageReadme.md
@@ -1,0 +1,17 @@
+# Steeltoe
+
+> [!IMPORTANT]
+> This package has been replaced in Steeltoe v4. Reference `Steeltoe.Logging.DynamicSerilog` instead.
+> See <https://steeltoe.io/docs/v3/obsolete> for details.
+
+[Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).
+
+Key features include:
+
+- External (optionally encrypted) configuration using [Spring Cloud Config Server](https://docs.spring.io/spring-cloud-config/docs/current/reference/html/)
+- Service discovery with [Netflix Eureka](https://spring.io/projects/spring-cloud-netflix) and [HashiCorp Consul](https://www.consul.io/)
+- Management endpoints (compatible with [actuators](https://docs.spring.io/spring-boot/docs/current/reference/html/actuator.html)), providing system info (such as versions, configuration, service container contents, mapped routes and HTTP traffic), heap/thread dumps, health checks, exporting metrics to [Prometheus](https://prometheus.io/), and changing log levels at runtime.
+- Connectivity to databases (such as [SQL Server](https://www.microsoft.com/sql-server)/[Azure SQL](https://azure.microsoft.com/products/azure-sql), [Cosmos DB](https://azure.microsoft.com/products/cosmos-db/), [MongoDB](https://www.mongodb.com/), [Redis](https://redis.io/), [RabbitMQ](https://www.rabbitmq.com/), [PostgreSQL](https://www.postgresql.org/), and [MySQL](https://www.mysql.com/)), including support for [Entity Framework Core](https://learn.microsoft.com/ef/core/)
+- Single sign-on, JWT and Certificate auth with [Cloud Foundry](https://www.cloudfoundry.org/)
+
+For more information and to get started, please visit [Steeltoe on GitHub](https://github.com/SteeltoeOSS/Steeltoe) or the [documentation](https://steeltoe.io/docs).

--- a/src/Obsolete/Steeltoe.Extensions.Logging.DynamicSerilogCore/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.Extensions.Logging.DynamicSerilogCore/PackageReadme.md
@@ -1,7 +1,7 @@
 # Steeltoe
 
 > [!IMPORTANT]
-> This package has been replaced in Steeltoe v4. Reference `Steeltoe.Logging.DynamicSerilog` instead.
+> This package has been superseded in Steeltoe v4. Reference `Steeltoe.Logging.DynamicSerilog` instead.
 > See <https://steeltoe.io/docs/v3/obsolete> for details.
 
 [Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).

--- a/src/Obsolete/Steeltoe.Extensions.Logging.DynamicSerilogCore/Steeltoe.Extensions.Logging.DynamicSerilogCore.csproj
+++ b/src/Obsolete/Steeltoe.Extensions.Logging.DynamicSerilogCore/Steeltoe.Extensions.Logging.DynamicSerilogCore.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net8.0</TargetFrameworks>
+    <Description>TODO: Fill package description.</Description>
+    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
+  <Import Project="..\..\..\shared.props" />
+
+  <ItemGroup>
+    <None Include="Build\*.props" Pack="True" PackagePath="build" />
+    <None Include="Build\*.targets" Pack="True" PackagePath="build" />
+  </ItemGroup>
+</Project>

--- a/src/Obsolete/Steeltoe.Extensions.Logging.DynamicSerilogCore/Steeltoe.Extensions.Logging.DynamicSerilogCore.csproj
+++ b/src/Obsolete/Steeltoe.Extensions.Logging.DynamicSerilogCore/Steeltoe.Extensions.Logging.DynamicSerilogCore.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
-    <Description>TODO: Fill package description.</Description>
-    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <Description>Steeltoe library for enabling dynamic management of Serilog in ASP.NET Core applications. Includes Console sink.</Description>
+    <PackageTags>logging;dynamic logging;serilog;aspnetcore;management;monitoring;Spring Cloud</PackageTags>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 

--- a/src/Obsolete/Steeltoe.Integration.Abstractions/Build/Steeltoe.Integration.Abstractions.targets
+++ b/src/Obsolete/Steeltoe.Integration.Abstractions/Build/Steeltoe.Integration.Abstractions.targets
@@ -1,5 +1,9 @@
 <Project>
-  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
-    <Error Text="This feature is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+  <Target Name="Warn_SteeltoeIntegrationAbstractions" BeforeTargets="BeforeResolveReferences">
+    <Warning Text="This feature is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+
+  <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="One or more Steeltoe package dependencies need attention. See the build warnings for details." />
   </Target>
 </Project>

--- a/src/Obsolete/Steeltoe.Integration.Abstractions/Build/Steeltoe.Integration.Abstractions.targets
+++ b/src/Obsolete/Steeltoe.Integration.Abstractions/Build/Steeltoe.Integration.Abstractions.targets
@@ -1,6 +1,7 @@
 <Project>
   <Target Name="Warn_SteeltoeIntegrationAbstractions" BeforeTargets="BeforeResolveReferences">
-    <Warning Text="This feature is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+    <Warning
+      Text="The NuGet package Steeltoe.Integration.Abstractions is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.Integration.Abstractions/Build/Steeltoe.Integration.Abstractions.targets
+++ b/src/Obsolete/Steeltoe.Integration.Abstractions/Build/Steeltoe.Integration.Abstractions.targets
@@ -1,0 +1,5 @@
+<Project>
+  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="This feature is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+</Project>

--- a/src/Obsolete/Steeltoe.Integration.Abstractions/Build/Steeltoe.Integration.Abstractions.targets
+++ b/src/Obsolete/Steeltoe.Integration.Abstractions/Build/Steeltoe.Integration.Abstractions.targets
@@ -1,5 +1,5 @@
 <Project>
-  <Target Name="Warn_SteeltoeIntegrationAbstractions" BeforeTargets="BeforeResolveReferences">
+  <Target Name="Warn_SteeltoeIntegrationAbstractions" AfterTargets="AfterResolveReferences">
     <Warning
       Text="The NuGet package Steeltoe.Integration.Abstractions is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>

--- a/src/Obsolete/Steeltoe.Integration.Abstractions/Build/Steeltoe.Integration.Abstractions.targets
+++ b/src/Obsolete/Steeltoe.Integration.Abstractions/Build/Steeltoe.Integration.Abstractions.targets
@@ -1,7 +1,7 @@
 <Project>
   <Target Name="Warn_SteeltoeIntegrationAbstractions" AfterTargets="AfterResolveReferences">
     <Warning
-      Text="The NuGet package Steeltoe.Integration.Abstractions is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+      Text="The NuGet package Steeltoe.Integration.Abstractions has been removed from Steeltoe in v4. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.Integration.Abstractions/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.Integration.Abstractions/PackageReadme.md
@@ -1,0 +1,17 @@
+# Steeltoe
+
+> [!IMPORTANT]
+> This feature is no longer available in Steeltoe v4.
+> See <https://steeltoe.io/docs/v3/obsolete> for details.
+
+[Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).
+
+Key features include:
+
+- External (optionally encrypted) configuration using [Spring Cloud Config Server](https://docs.spring.io/spring-cloud-config/docs/current/reference/html/)
+- Service discovery with [Netflix Eureka](https://spring.io/projects/spring-cloud-netflix) and [HashiCorp Consul](https://www.consul.io/)
+- Management endpoints (compatible with [actuators](https://docs.spring.io/spring-boot/docs/current/reference/html/actuator.html)), providing system info (such as versions, configuration, service container contents, mapped routes and HTTP traffic), heap/thread dumps, health checks, exporting metrics to [Prometheus](https://prometheus.io/), and changing log levels at runtime.
+- Connectivity to databases (such as [SQL Server](https://www.microsoft.com/sql-server)/[Azure SQL](https://azure.microsoft.com/products/azure-sql), [Cosmos DB](https://azure.microsoft.com/products/cosmos-db/), [MongoDB](https://www.mongodb.com/), [Redis](https://redis.io/), [RabbitMQ](https://www.rabbitmq.com/), [PostgreSQL](https://www.postgresql.org/), and [MySQL](https://www.mysql.com/)), including support for [Entity Framework Core](https://learn.microsoft.com/ef/core/)
+- Single sign-on, JWT and Certificate auth with [Cloud Foundry](https://www.cloudfoundry.org/)
+
+For more information and to get started, please visit [Steeltoe on GitHub](https://github.com/SteeltoeOSS/Steeltoe) or the [documentation](https://steeltoe.io/docs).

--- a/src/Obsolete/Steeltoe.Integration.Abstractions/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.Integration.Abstractions/PackageReadme.md
@@ -1,7 +1,7 @@
 # Steeltoe
 
 > [!IMPORTANT]
-> This feature is no longer available in Steeltoe v4.
+> This package has been removed from Steeltoe in v4.
 > See <https://steeltoe.io/docs/v3/obsolete> for details.
 
 [Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).

--- a/src/Obsolete/Steeltoe.Integration.Abstractions/Steeltoe.Integration.Abstractions.csproj
+++ b/src/Obsolete/Steeltoe.Integration.Abstractions/Steeltoe.Integration.Abstractions.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net8.0</TargetFrameworks>
+    <Description>TODO: Fill package description.</Description>
+    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
+  <Import Project="..\..\..\shared.props" />
+
+  <ItemGroup>
+    <None Include="Build\*.props" Pack="True" PackagePath="build" />
+    <None Include="Build\*.targets" Pack="True" PackagePath="build" />
+  </ItemGroup>
+</Project>

--- a/src/Obsolete/Steeltoe.Integration.Abstractions/Steeltoe.Integration.Abstractions.csproj
+++ b/src/Obsolete/Steeltoe.Integration.Abstractions/Steeltoe.Integration.Abstractions.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
     <Description>Abstractions for use with Steeltoe Integration libraries.</Description>
-    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <PackageTags>Integration, NET Core, Spring, Spring Cloud</PackageTags>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 

--- a/src/Obsolete/Steeltoe.Integration.Abstractions/Steeltoe.Integration.Abstractions.csproj
+++ b/src/Obsolete/Steeltoe.Integration.Abstractions/Steeltoe.Integration.Abstractions.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
     <Description>Abstractions for use with Steeltoe Integration libraries.</Description>
-    <PackageTags>Integration, NET Core, Spring, Spring Cloud</PackageTags>
+    <PackageTags>Integration;NET Core;Spring;Spring Cloud</PackageTags>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 

--- a/src/Obsolete/Steeltoe.Integration.Abstractions/Steeltoe.Integration.Abstractions.csproj
+++ b/src/Obsolete/Steeltoe.Integration.Abstractions/Steeltoe.Integration.Abstractions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
-    <Description>TODO: Fill package description.</Description>
+    <Description>Abstractions for use with Steeltoe Integration libraries.</Description>
     <PackageTags>TODO: Fill package tags.</PackageTags>
     <IsPackable>true</IsPackable>
   </PropertyGroup>

--- a/src/Obsolete/Steeltoe.Integration.IntegrationBase/Build/Steeltoe.Integration.IntegrationBase.targets
+++ b/src/Obsolete/Steeltoe.Integration.IntegrationBase/Build/Steeltoe.Integration.IntegrationBase.targets
@@ -1,5 +1,5 @@
 <Project>
-  <Target Name="Warn_SteeltoeIntegrationIntegrationBase" BeforeTargets="BeforeResolveReferences">
+  <Target Name="Warn_SteeltoeIntegrationIntegrationBase" AfterTargets="AfterResolveReferences">
     <Warning
       Text="The NuGet package Steeltoe.Integration.IntegrationBase is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>

--- a/src/Obsolete/Steeltoe.Integration.IntegrationBase/Build/Steeltoe.Integration.IntegrationBase.targets
+++ b/src/Obsolete/Steeltoe.Integration.IntegrationBase/Build/Steeltoe.Integration.IntegrationBase.targets
@@ -1,0 +1,5 @@
+<Project>
+  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="This feature is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+</Project>

--- a/src/Obsolete/Steeltoe.Integration.IntegrationBase/Build/Steeltoe.Integration.IntegrationBase.targets
+++ b/src/Obsolete/Steeltoe.Integration.IntegrationBase/Build/Steeltoe.Integration.IntegrationBase.targets
@@ -1,6 +1,7 @@
 <Project>
   <Target Name="Warn_SteeltoeIntegrationIntegrationBase" BeforeTargets="BeforeResolveReferences">
-    <Warning Text="This feature is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+    <Warning
+      Text="The NuGet package Steeltoe.Integration.IntegrationBase is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.Integration.IntegrationBase/Build/Steeltoe.Integration.IntegrationBase.targets
+++ b/src/Obsolete/Steeltoe.Integration.IntegrationBase/Build/Steeltoe.Integration.IntegrationBase.targets
@@ -1,5 +1,9 @@
 <Project>
-  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
-    <Error Text="This feature is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+  <Target Name="Warn_SteeltoeIntegrationIntegrationBase" BeforeTargets="BeforeResolveReferences">
+    <Warning Text="This feature is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+
+  <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="One or more Steeltoe package dependencies need attention. See the build warnings for details." />
   </Target>
 </Project>

--- a/src/Obsolete/Steeltoe.Integration.IntegrationBase/Build/Steeltoe.Integration.IntegrationBase.targets
+++ b/src/Obsolete/Steeltoe.Integration.IntegrationBase/Build/Steeltoe.Integration.IntegrationBase.targets
@@ -1,7 +1,7 @@
 <Project>
   <Target Name="Warn_SteeltoeIntegrationIntegrationBase" AfterTargets="AfterResolveReferences">
     <Warning
-      Text="The NuGet package Steeltoe.Integration.IntegrationBase is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+      Text="The NuGet package Steeltoe.Integration.IntegrationBase has been removed from Steeltoe in v4. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.Integration.IntegrationBase/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.Integration.IntegrationBase/PackageReadme.md
@@ -1,0 +1,17 @@
+# Steeltoe
+
+> [!IMPORTANT]
+> This feature is no longer available in Steeltoe v4.
+> See <https://steeltoe.io/docs/v3/obsolete> for details.
+
+[Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).
+
+Key features include:
+
+- External (optionally encrypted) configuration using [Spring Cloud Config Server](https://docs.spring.io/spring-cloud-config/docs/current/reference/html/)
+- Service discovery with [Netflix Eureka](https://spring.io/projects/spring-cloud-netflix) and [HashiCorp Consul](https://www.consul.io/)
+- Management endpoints (compatible with [actuators](https://docs.spring.io/spring-boot/docs/current/reference/html/actuator.html)), providing system info (such as versions, configuration, service container contents, mapped routes and HTTP traffic), heap/thread dumps, health checks, exporting metrics to [Prometheus](https://prometheus.io/), and changing log levels at runtime.
+- Connectivity to databases (such as [SQL Server](https://www.microsoft.com/sql-server)/[Azure SQL](https://azure.microsoft.com/products/azure-sql), [Cosmos DB](https://azure.microsoft.com/products/cosmos-db/), [MongoDB](https://www.mongodb.com/), [Redis](https://redis.io/), [RabbitMQ](https://www.rabbitmq.com/), [PostgreSQL](https://www.postgresql.org/), and [MySQL](https://www.mysql.com/)), including support for [Entity Framework Core](https://learn.microsoft.com/ef/core/)
+- Single sign-on, JWT and Certificate auth with [Cloud Foundry](https://www.cloudfoundry.org/)
+
+For more information and to get started, please visit [Steeltoe on GitHub](https://github.com/SteeltoeOSS/Steeltoe) or the [documentation](https://steeltoe.io/docs).

--- a/src/Obsolete/Steeltoe.Integration.IntegrationBase/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.Integration.IntegrationBase/PackageReadme.md
@@ -1,7 +1,7 @@
 # Steeltoe
 
 > [!IMPORTANT]
-> This feature is no longer available in Steeltoe v4.
+> This package has been removed from Steeltoe in v4.
 > See <https://steeltoe.io/docs/v3/obsolete> for details.
 
 [Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).

--- a/src/Obsolete/Steeltoe.Integration.IntegrationBase/Steeltoe.Integration.IntegrationBase.csproj
+++ b/src/Obsolete/Steeltoe.Integration.IntegrationBase/Steeltoe.Integration.IntegrationBase.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net8.0</TargetFrameworks>
+    <Description>TODO: Fill package description.</Description>
+    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
+  <Import Project="..\..\..\shared.props" />
+
+  <ItemGroup>
+    <None Include="Build\*.props" Pack="True" PackagePath="build" />
+    <None Include="Build\*.targets" Pack="True" PackagePath="build" />
+  </ItemGroup>
+</Project>

--- a/src/Obsolete/Steeltoe.Integration.IntegrationBase/Steeltoe.Integration.IntegrationBase.csproj
+++ b/src/Obsolete/Steeltoe.Integration.IntegrationBase/Steeltoe.Integration.IntegrationBase.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
     <Description>Steeltoe Integration Base.</Description>
-    <PackageTags>Integration, NET Core, Spring, Spring Cloud</PackageTags>
+    <PackageTags>Integration;NET Core;Spring;Spring Cloud</PackageTags>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 

--- a/src/Obsolete/Steeltoe.Integration.IntegrationBase/Steeltoe.Integration.IntegrationBase.csproj
+++ b/src/Obsolete/Steeltoe.Integration.IntegrationBase/Steeltoe.Integration.IntegrationBase.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
-    <Description>TODO: Fill package description.</Description>
-    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <Description>Steeltoe Integration Base.</Description>
+    <PackageTags>Integration, NET Core, Spring, Spring Cloud</PackageTags>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 

--- a/src/Obsolete/Steeltoe.Integration.RabbitMQ/Build/Steeltoe.Integration.RabbitMQ.targets
+++ b/src/Obsolete/Steeltoe.Integration.RabbitMQ/Build/Steeltoe.Integration.RabbitMQ.targets
@@ -1,6 +1,7 @@
 <Project>
   <Target Name="Warn_SteeltoeIntegrationRabbitMQ" BeforeTargets="BeforeResolveReferences">
-    <Warning Text="This feature is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+    <Warning
+      Text="The NuGet package Steeltoe.Integration.RabbitMQ is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.Integration.RabbitMQ/Build/Steeltoe.Integration.RabbitMQ.targets
+++ b/src/Obsolete/Steeltoe.Integration.RabbitMQ/Build/Steeltoe.Integration.RabbitMQ.targets
@@ -1,0 +1,5 @@
+<Project>
+  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="This feature is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+</Project>

--- a/src/Obsolete/Steeltoe.Integration.RabbitMQ/Build/Steeltoe.Integration.RabbitMQ.targets
+++ b/src/Obsolete/Steeltoe.Integration.RabbitMQ/Build/Steeltoe.Integration.RabbitMQ.targets
@@ -1,7 +1,6 @@
 <Project>
   <Target Name="Warn_SteeltoeIntegrationRabbitMQ" AfterTargets="AfterResolveReferences">
-    <Warning
-      Text="The NuGet package Steeltoe.Integration.RabbitMQ is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+    <Warning Text="The NuGet package Steeltoe.Integration.RabbitMQ has been removed from Steeltoe in v4. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.Integration.RabbitMQ/Build/Steeltoe.Integration.RabbitMQ.targets
+++ b/src/Obsolete/Steeltoe.Integration.RabbitMQ/Build/Steeltoe.Integration.RabbitMQ.targets
@@ -1,5 +1,9 @@
 <Project>
-  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
-    <Error Text="This feature is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+  <Target Name="Warn_SteeltoeIntegrationRabbitMQ" BeforeTargets="BeforeResolveReferences">
+    <Warning Text="This feature is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+
+  <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="One or more Steeltoe package dependencies need attention. See the build warnings for details." />
   </Target>
 </Project>

--- a/src/Obsolete/Steeltoe.Integration.RabbitMQ/Build/Steeltoe.Integration.RabbitMQ.targets
+++ b/src/Obsolete/Steeltoe.Integration.RabbitMQ/Build/Steeltoe.Integration.RabbitMQ.targets
@@ -1,5 +1,5 @@
 <Project>
-  <Target Name="Warn_SteeltoeIntegrationRabbitMQ" BeforeTargets="BeforeResolveReferences">
+  <Target Name="Warn_SteeltoeIntegrationRabbitMQ" AfterTargets="AfterResolveReferences">
     <Warning
       Text="The NuGet package Steeltoe.Integration.RabbitMQ is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>

--- a/src/Obsolete/Steeltoe.Integration.RabbitMQ/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.Integration.RabbitMQ/PackageReadme.md
@@ -1,0 +1,17 @@
+# Steeltoe
+
+> [!IMPORTANT]
+> This feature is no longer available in Steeltoe v4.
+> See <https://steeltoe.io/docs/v3/obsolete> for details.
+
+[Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).
+
+Key features include:
+
+- External (optionally encrypted) configuration using [Spring Cloud Config Server](https://docs.spring.io/spring-cloud-config/docs/current/reference/html/)
+- Service discovery with [Netflix Eureka](https://spring.io/projects/spring-cloud-netflix) and [HashiCorp Consul](https://www.consul.io/)
+- Management endpoints (compatible with [actuators](https://docs.spring.io/spring-boot/docs/current/reference/html/actuator.html)), providing system info (such as versions, configuration, service container contents, mapped routes and HTTP traffic), heap/thread dumps, health checks, exporting metrics to [Prometheus](https://prometheus.io/), and changing log levels at runtime.
+- Connectivity to databases (such as [SQL Server](https://www.microsoft.com/sql-server)/[Azure SQL](https://azure.microsoft.com/products/azure-sql), [Cosmos DB](https://azure.microsoft.com/products/cosmos-db/), [MongoDB](https://www.mongodb.com/), [Redis](https://redis.io/), [RabbitMQ](https://www.rabbitmq.com/), [PostgreSQL](https://www.postgresql.org/), and [MySQL](https://www.mysql.com/)), including support for [Entity Framework Core](https://learn.microsoft.com/ef/core/)
+- Single sign-on, JWT and Certificate auth with [Cloud Foundry](https://www.cloudfoundry.org/)
+
+For more information and to get started, please visit [Steeltoe on GitHub](https://github.com/SteeltoeOSS/Steeltoe) or the [documentation](https://steeltoe.io/docs).

--- a/src/Obsolete/Steeltoe.Integration.RabbitMQ/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.Integration.RabbitMQ/PackageReadme.md
@@ -1,7 +1,7 @@
 # Steeltoe
 
 > [!IMPORTANT]
-> This feature is no longer available in Steeltoe v4.
+> This package has been removed from Steeltoe in v4.
 > See <https://steeltoe.io/docs/v3/obsolete> for details.
 
 [Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).

--- a/src/Obsolete/Steeltoe.Integration.RabbitMQ/Steeltoe.Integration.RabbitMQ.csproj
+++ b/src/Obsolete/Steeltoe.Integration.RabbitMQ/Steeltoe.Integration.RabbitMQ.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
     <Description>Steeltoe Integration RabbitMQ.</Description>
-    <PackageTags>Integration, ASPNET Core, Spring, Spring Cloud, RabbitMQ</PackageTags>
+    <PackageTags>Integration;ASPNET Core;Spring;Spring Cloud;RabbitMQ</PackageTags>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 

--- a/src/Obsolete/Steeltoe.Integration.RabbitMQ/Steeltoe.Integration.RabbitMQ.csproj
+++ b/src/Obsolete/Steeltoe.Integration.RabbitMQ/Steeltoe.Integration.RabbitMQ.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net8.0</TargetFrameworks>
+    <Description>TODO: Fill package description.</Description>
+    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
+  <Import Project="..\..\..\shared.props" />
+
+  <ItemGroup>
+    <None Include="Build\*.props" Pack="True" PackagePath="build" />
+    <None Include="Build\*.targets" Pack="True" PackagePath="build" />
+  </ItemGroup>
+</Project>

--- a/src/Obsolete/Steeltoe.Integration.RabbitMQ/Steeltoe.Integration.RabbitMQ.csproj
+++ b/src/Obsolete/Steeltoe.Integration.RabbitMQ/Steeltoe.Integration.RabbitMQ.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
-    <Description>TODO: Fill package description.</Description>
-    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <Description>Steeltoe Integration RabbitMQ.</Description>
+    <PackageTags>Integration, ASPNET Core, Spring, Spring Cloud, RabbitMQ</PackageTags>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 

--- a/src/Obsolete/Steeltoe.Management.CloudFoundryCore/Build/Steeltoe.Management.CloudFoundryCore.targets
+++ b/src/Obsolete/Steeltoe.Management.CloudFoundryCore/Build/Steeltoe.Management.CloudFoundryCore.targets
@@ -1,6 +1,10 @@
 <Project>
-  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
-    <Error
+  <Target Name="Warn_SteeltoeManagementCloudFoundryCore" BeforeTargets="BeforeResolveReferences">
+    <Warning
       Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Management.Endpoint instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+
+  <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="One or more Steeltoe package dependencies need attention. See the build warnings for details." />
   </Target>
 </Project>

--- a/src/Obsolete/Steeltoe.Management.CloudFoundryCore/Build/Steeltoe.Management.CloudFoundryCore.targets
+++ b/src/Obsolete/Steeltoe.Management.CloudFoundryCore/Build/Steeltoe.Management.CloudFoundryCore.targets
@@ -1,5 +1,6 @@
 <Project>
   <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
-    <Error Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Management.Endpoint instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+    <Error
+      Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Management.Endpoint instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 </Project>

--- a/src/Obsolete/Steeltoe.Management.CloudFoundryCore/Build/Steeltoe.Management.CloudFoundryCore.targets
+++ b/src/Obsolete/Steeltoe.Management.CloudFoundryCore/Build/Steeltoe.Management.CloudFoundryCore.targets
@@ -1,5 +1,5 @@
 <Project>
-  <Target Name="Warn_SteeltoeManagementCloudFoundryCore" BeforeTargets="BeforeResolveReferences">
+  <Target Name="Warn_SteeltoeManagementCloudFoundryCore" AfterTargets="AfterResolveReferences">
     <Warning
       Text="The NuGet package Steeltoe.Management.CloudFoundryCore has been replaced in Steeltoe v4. Reference Steeltoe.Management.Endpoint instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>

--- a/src/Obsolete/Steeltoe.Management.CloudFoundryCore/Build/Steeltoe.Management.CloudFoundryCore.targets
+++ b/src/Obsolete/Steeltoe.Management.CloudFoundryCore/Build/Steeltoe.Management.CloudFoundryCore.targets
@@ -1,7 +1,7 @@
 <Project>
   <Target Name="Warn_SteeltoeManagementCloudFoundryCore" BeforeTargets="BeforeResolveReferences">
     <Warning
-      Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Management.Endpoint instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+      Text="The NuGet package Steeltoe.Management.CloudFoundryCore has been replaced in Steeltoe v4. Reference Steeltoe.Management.Endpoint instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.Management.CloudFoundryCore/Build/Steeltoe.Management.CloudFoundryCore.targets
+++ b/src/Obsolete/Steeltoe.Management.CloudFoundryCore/Build/Steeltoe.Management.CloudFoundryCore.targets
@@ -1,7 +1,7 @@
 <Project>
   <Target Name="Warn_SteeltoeManagementCloudFoundryCore" AfterTargets="AfterResolveReferences">
     <Warning
-      Text="The NuGet package Steeltoe.Management.CloudFoundryCore has been replaced in Steeltoe v4. Reference Steeltoe.Management.Endpoint instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+      Text="The NuGet package Steeltoe.Management.CloudFoundryCore has been superseded in Steeltoe v4. Reference Steeltoe.Management.Endpoint instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.Management.CloudFoundryCore/Build/Steeltoe.Management.CloudFoundryCore.targets
+++ b/src/Obsolete/Steeltoe.Management.CloudFoundryCore/Build/Steeltoe.Management.CloudFoundryCore.targets
@@ -1,0 +1,5 @@
+<Project>
+  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Management.Endpoint instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+</Project>

--- a/src/Obsolete/Steeltoe.Management.CloudFoundryCore/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.Management.CloudFoundryCore/PackageReadme.md
@@ -1,0 +1,17 @@
+# Steeltoe
+
+> [!IMPORTANT]
+> This package has been replaced in Steeltoe v4. Reference `Steeltoe.Management.Endpoint` instead.
+> See <https://steeltoe.io/docs/v3/obsolete> for details.
+
+[Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).
+
+Key features include:
+
+- External (optionally encrypted) configuration using [Spring Cloud Config Server](https://docs.spring.io/spring-cloud-config/docs/current/reference/html/)
+- Service discovery with [Netflix Eureka](https://spring.io/projects/spring-cloud-netflix) and [HashiCorp Consul](https://www.consul.io/)
+- Management endpoints (compatible with [actuators](https://docs.spring.io/spring-boot/docs/current/reference/html/actuator.html)), providing system info (such as versions, configuration, service container contents, mapped routes and HTTP traffic), heap/thread dumps, health checks, exporting metrics to [Prometheus](https://prometheus.io/), and changing log levels at runtime.
+- Connectivity to databases (such as [SQL Server](https://www.microsoft.com/sql-server)/[Azure SQL](https://azure.microsoft.com/products/azure-sql), [Cosmos DB](https://azure.microsoft.com/products/cosmos-db/), [MongoDB](https://www.mongodb.com/), [Redis](https://redis.io/), [RabbitMQ](https://www.rabbitmq.com/), [PostgreSQL](https://www.postgresql.org/), and [MySQL](https://www.mysql.com/)), including support for [Entity Framework Core](https://learn.microsoft.com/ef/core/)
+- Single sign-on, JWT and Certificate auth with [Cloud Foundry](https://www.cloudfoundry.org/)
+
+For more information and to get started, please visit [Steeltoe on GitHub](https://github.com/SteeltoeOSS/Steeltoe) or the [documentation](https://steeltoe.io/docs).

--- a/src/Obsolete/Steeltoe.Management.CloudFoundryCore/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.Management.CloudFoundryCore/PackageReadme.md
@@ -1,7 +1,7 @@
 # Steeltoe
 
 > [!IMPORTANT]
-> This package has been replaced in Steeltoe v4. Reference `Steeltoe.Management.Endpoint` instead.
+> This package has been superseded in Steeltoe v4. Reference `Steeltoe.Management.Endpoint` instead.
 > See <https://steeltoe.io/docs/v3/obsolete> for details.
 
 [Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).

--- a/src/Obsolete/Steeltoe.Management.CloudFoundryCore/Steeltoe.Management.CloudFoundryCore.csproj
+++ b/src/Obsolete/Steeltoe.Management.CloudFoundryCore/Steeltoe.Management.CloudFoundryCore.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net8.0</TargetFrameworks>
+    <Description>TODO: Fill package description.</Description>
+    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
+  <Import Project="..\..\..\shared.props" />
+
+  <ItemGroup>
+    <None Include="Build\*.props" Pack="True" PackagePath="build" />
+    <None Include="Build\*.targets" Pack="True" PackagePath="build" />
+  </ItemGroup>
+</Project>

--- a/src/Obsolete/Steeltoe.Management.CloudFoundryCore/Steeltoe.Management.CloudFoundryCore.csproj
+++ b/src/Obsolete/Steeltoe.Management.CloudFoundryCore/Steeltoe.Management.CloudFoundryCore.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
-    <Description>TODO: Fill package description.</Description>
-    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <Description>Package for using Steeltoe management endpoints with ASP.NET Core on Cloud Foundry.</Description>
+    <PackageTags>actuator;management;monitoring;aspnetcore;CloudFoundry;Spring Cloud</PackageTags>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 

--- a/src/Obsolete/Steeltoe.Management.Diagnostics/Build/Steeltoe.Management.Diagnostics.targets
+++ b/src/Obsolete/Steeltoe.Management.Diagnostics/Build/Steeltoe.Management.Diagnostics.targets
@@ -1,7 +1,7 @@
 <Project>
   <Target Name="Warn_SteeltoeManagementDiagnostics" BeforeTargets="BeforeResolveReferences">
     <Warning
-      Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Management.Endpoint instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+      Text="The NuGet package Steeltoe.Management.Diagnostics has been replaced in Steeltoe v4. Reference Steeltoe.Management.Endpoint instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.Management.Diagnostics/Build/Steeltoe.Management.Diagnostics.targets
+++ b/src/Obsolete/Steeltoe.Management.Diagnostics/Build/Steeltoe.Management.Diagnostics.targets
@@ -1,6 +1,10 @@
 <Project>
-  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
-    <Error
+  <Target Name="Warn_SteeltoeManagementDiagnostics" BeforeTargets="BeforeResolveReferences">
+    <Warning
       Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Management.Endpoint instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+
+  <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="One or more Steeltoe package dependencies need attention. See the build warnings for details." />
   </Target>
 </Project>

--- a/src/Obsolete/Steeltoe.Management.Diagnostics/Build/Steeltoe.Management.Diagnostics.targets
+++ b/src/Obsolete/Steeltoe.Management.Diagnostics/Build/Steeltoe.Management.Diagnostics.targets
@@ -1,5 +1,6 @@
 <Project>
   <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
-    <Error Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Management.Endpoint instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+    <Error
+      Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Management.Endpoint instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 </Project>

--- a/src/Obsolete/Steeltoe.Management.Diagnostics/Build/Steeltoe.Management.Diagnostics.targets
+++ b/src/Obsolete/Steeltoe.Management.Diagnostics/Build/Steeltoe.Management.Diagnostics.targets
@@ -1,5 +1,5 @@
 <Project>
-  <Target Name="Warn_SteeltoeManagementDiagnostics" BeforeTargets="BeforeResolveReferences">
+  <Target Name="Warn_SteeltoeManagementDiagnostics" AfterTargets="AfterResolveReferences">
     <Warning
       Text="The NuGet package Steeltoe.Management.Diagnostics has been replaced in Steeltoe v4. Reference Steeltoe.Management.Endpoint instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>

--- a/src/Obsolete/Steeltoe.Management.Diagnostics/Build/Steeltoe.Management.Diagnostics.targets
+++ b/src/Obsolete/Steeltoe.Management.Diagnostics/Build/Steeltoe.Management.Diagnostics.targets
@@ -1,7 +1,7 @@
 <Project>
   <Target Name="Warn_SteeltoeManagementDiagnostics" AfterTargets="AfterResolveReferences">
     <Warning
-      Text="The NuGet package Steeltoe.Management.Diagnostics has been replaced in Steeltoe v4. Reference Steeltoe.Management.Endpoint instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+      Text="The NuGet package Steeltoe.Management.Diagnostics has been superseded in Steeltoe v4. Reference Steeltoe.Management.Endpoint instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.Management.Diagnostics/Build/Steeltoe.Management.Diagnostics.targets
+++ b/src/Obsolete/Steeltoe.Management.Diagnostics/Build/Steeltoe.Management.Diagnostics.targets
@@ -1,0 +1,5 @@
+<Project>
+  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Management.Endpoint instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+</Project>

--- a/src/Obsolete/Steeltoe.Management.Diagnostics/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.Management.Diagnostics/PackageReadme.md
@@ -1,0 +1,17 @@
+# Steeltoe
+
+> [!IMPORTANT]
+> This package has been replaced in Steeltoe v4. Reference `Steeltoe.Management.Endpoint` instead.
+> See <https://steeltoe.io/docs/v3/obsolete> for details.
+
+[Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).
+
+Key features include:
+
+- External (optionally encrypted) configuration using [Spring Cloud Config Server](https://docs.spring.io/spring-cloud-config/docs/current/reference/html/)
+- Service discovery with [Netflix Eureka](https://spring.io/projects/spring-cloud-netflix) and [HashiCorp Consul](https://www.consul.io/)
+- Management endpoints (compatible with [actuators](https://docs.spring.io/spring-boot/docs/current/reference/html/actuator.html)), providing system info (such as versions, configuration, service container contents, mapped routes and HTTP traffic), heap/thread dumps, health checks, exporting metrics to [Prometheus](https://prometheus.io/), and changing log levels at runtime.
+- Connectivity to databases (such as [SQL Server](https://www.microsoft.com/sql-server)/[Azure SQL](https://azure.microsoft.com/products/azure-sql), [Cosmos DB](https://azure.microsoft.com/products/cosmos-db/), [MongoDB](https://www.mongodb.com/), [Redis](https://redis.io/), [RabbitMQ](https://www.rabbitmq.com/), [PostgreSQL](https://www.postgresql.org/), and [MySQL](https://www.mysql.com/)), including support for [Entity Framework Core](https://learn.microsoft.com/ef/core/)
+- Single sign-on, JWT and Certificate auth with [Cloud Foundry](https://www.cloudfoundry.org/)
+
+For more information and to get started, please visit [Steeltoe on GitHub](https://github.com/SteeltoeOSS/Steeltoe) or the [documentation](https://steeltoe.io/docs).

--- a/src/Obsolete/Steeltoe.Management.Diagnostics/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.Management.Diagnostics/PackageReadme.md
@@ -1,7 +1,7 @@
 # Steeltoe
 
 > [!IMPORTANT]
-> This package has been replaced in Steeltoe v4. Reference `Steeltoe.Management.Endpoint` instead.
+> This package has been superseded in Steeltoe v4. Reference `Steeltoe.Management.Endpoint` instead.
 > See <https://steeltoe.io/docs/v3/obsolete> for details.
 
 [Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).

--- a/src/Obsolete/Steeltoe.Management.Diagnostics/Steeltoe.Management.Diagnostics.csproj
+++ b/src/Obsolete/Steeltoe.Management.Diagnostics/Steeltoe.Management.Diagnostics.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net8.0</TargetFrameworks>
+    <Description>TODO: Fill package description.</Description>
+    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
+  <Import Project="..\..\..\shared.props" />
+
+  <ItemGroup>
+    <None Include="Build\*.props" Pack="True" PackagePath="build" />
+    <None Include="Build\*.targets" Pack="True" PackagePath="build" />
+  </ItemGroup>
+</Project>

--- a/src/Obsolete/Steeltoe.Management.Diagnostics/Steeltoe.Management.Diagnostics.csproj
+++ b/src/Obsolete/Steeltoe.Management.Diagnostics/Steeltoe.Management.Diagnostics.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
-    <Description>TODO: Fill package description.</Description>
-    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <Description>Steeltoe Management Runtime Diagnostics.</Description>
+    <PackageTags>actuator;management;monitoring;Spring Cloud</PackageTags>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 

--- a/src/Obsolete/Steeltoe.Management.EndpointBase/Build/Steeltoe.Management.EndpointBase.targets
+++ b/src/Obsolete/Steeltoe.Management.EndpointBase/Build/Steeltoe.Management.EndpointBase.targets
@@ -1,6 +1,10 @@
 <Project>
-  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
-    <Error
+  <Target Name="Warn_SteeltoeManagementEndpointBase" BeforeTargets="BeforeResolveReferences">
+    <Warning
       Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Management.Endpoint instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+
+  <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="One or more Steeltoe package dependencies need attention. See the build warnings for details." />
   </Target>
 </Project>

--- a/src/Obsolete/Steeltoe.Management.EndpointBase/Build/Steeltoe.Management.EndpointBase.targets
+++ b/src/Obsolete/Steeltoe.Management.EndpointBase/Build/Steeltoe.Management.EndpointBase.targets
@@ -1,7 +1,7 @@
 <Project>
   <Target Name="Warn_SteeltoeManagementEndpointBase" BeforeTargets="BeforeResolveReferences">
     <Warning
-      Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Management.Endpoint instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+      Text="The NuGet package Steeltoe.Management.EndpointBase has been replaced in Steeltoe v4. Reference Steeltoe.Management.Endpoint instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.Management.EndpointBase/Build/Steeltoe.Management.EndpointBase.targets
+++ b/src/Obsolete/Steeltoe.Management.EndpointBase/Build/Steeltoe.Management.EndpointBase.targets
@@ -1,5 +1,6 @@
 <Project>
   <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
-    <Error Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Management.Endpoint instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+    <Error
+      Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Management.Endpoint instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 </Project>

--- a/src/Obsolete/Steeltoe.Management.EndpointBase/Build/Steeltoe.Management.EndpointBase.targets
+++ b/src/Obsolete/Steeltoe.Management.EndpointBase/Build/Steeltoe.Management.EndpointBase.targets
@@ -1,7 +1,7 @@
 <Project>
   <Target Name="Warn_SteeltoeManagementEndpointBase" AfterTargets="AfterResolveReferences">
     <Warning
-      Text="The NuGet package Steeltoe.Management.EndpointBase has been replaced in Steeltoe v4. Reference Steeltoe.Management.Endpoint instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+      Text="The NuGet package Steeltoe.Management.EndpointBase has been superseded in Steeltoe v4. Reference Steeltoe.Management.Endpoint instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.Management.EndpointBase/Build/Steeltoe.Management.EndpointBase.targets
+++ b/src/Obsolete/Steeltoe.Management.EndpointBase/Build/Steeltoe.Management.EndpointBase.targets
@@ -1,5 +1,5 @@
 <Project>
-  <Target Name="Warn_SteeltoeManagementEndpointBase" BeforeTargets="BeforeResolveReferences">
+  <Target Name="Warn_SteeltoeManagementEndpointBase" AfterTargets="AfterResolveReferences">
     <Warning
       Text="The NuGet package Steeltoe.Management.EndpointBase has been replaced in Steeltoe v4. Reference Steeltoe.Management.Endpoint instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>

--- a/src/Obsolete/Steeltoe.Management.EndpointBase/Build/Steeltoe.Management.EndpointBase.targets
+++ b/src/Obsolete/Steeltoe.Management.EndpointBase/Build/Steeltoe.Management.EndpointBase.targets
@@ -1,0 +1,5 @@
+<Project>
+  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Management.Endpoint instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+</Project>

--- a/src/Obsolete/Steeltoe.Management.EndpointBase/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.Management.EndpointBase/PackageReadme.md
@@ -1,0 +1,17 @@
+# Steeltoe
+
+> [!IMPORTANT]
+> This package has been replaced in Steeltoe v4. Reference `Steeltoe.Management.Endpoint` instead.
+> See <https://steeltoe.io/docs/v3/obsolete> for details.
+
+[Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).
+
+Key features include:
+
+- External (optionally encrypted) configuration using [Spring Cloud Config Server](https://docs.spring.io/spring-cloud-config/docs/current/reference/html/)
+- Service discovery with [Netflix Eureka](https://spring.io/projects/spring-cloud-netflix) and [HashiCorp Consul](https://www.consul.io/)
+- Management endpoints (compatible with [actuators](https://docs.spring.io/spring-boot/docs/current/reference/html/actuator.html)), providing system info (such as versions, configuration, service container contents, mapped routes and HTTP traffic), heap/thread dumps, health checks, exporting metrics to [Prometheus](https://prometheus.io/), and changing log levels at runtime.
+- Connectivity to databases (such as [SQL Server](https://www.microsoft.com/sql-server)/[Azure SQL](https://azure.microsoft.com/products/azure-sql), [Cosmos DB](https://azure.microsoft.com/products/cosmos-db/), [MongoDB](https://www.mongodb.com/), [Redis](https://redis.io/), [RabbitMQ](https://www.rabbitmq.com/), [PostgreSQL](https://www.postgresql.org/), and [MySQL](https://www.mysql.com/)), including support for [Entity Framework Core](https://learn.microsoft.com/ef/core/)
+- Single sign-on, JWT and Certificate auth with [Cloud Foundry](https://www.cloudfoundry.org/)
+
+For more information and to get started, please visit [Steeltoe on GitHub](https://github.com/SteeltoeOSS/Steeltoe) or the [documentation](https://steeltoe.io/docs).

--- a/src/Obsolete/Steeltoe.Management.EndpointBase/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.Management.EndpointBase/PackageReadme.md
@@ -1,7 +1,7 @@
 # Steeltoe
 
 > [!IMPORTANT]
-> This package has been replaced in Steeltoe v4. Reference `Steeltoe.Management.Endpoint` instead.
+> This package has been superseded in Steeltoe v4. Reference `Steeltoe.Management.Endpoint` instead.
 > See <https://steeltoe.io/docs/v3/obsolete> for details.
 
 [Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).

--- a/src/Obsolete/Steeltoe.Management.EndpointBase/Steeltoe.Management.EndpointBase.csproj
+++ b/src/Obsolete/Steeltoe.Management.EndpointBase/Steeltoe.Management.EndpointBase.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net8.0</TargetFrameworks>
+    <Description>TODO: Fill package description.</Description>
+    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
+  <Import Project="..\..\..\shared.props" />
+
+  <ItemGroup>
+    <None Include="Build\*.props" Pack="True" PackagePath="build" />
+    <None Include="Build\*.targets" Pack="True" PackagePath="build" />
+  </ItemGroup>
+</Project>

--- a/src/Obsolete/Steeltoe.Management.EndpointBase/Steeltoe.Management.EndpointBase.csproj
+++ b/src/Obsolete/Steeltoe.Management.EndpointBase/Steeltoe.Management.EndpointBase.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
-    <Description>TODO: Fill package description.</Description>
-    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <Description>Steeltoe management endpoints.</Description>
+    <PackageTags>actuator;management;monitoring;Spring Cloud</PackageTags>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 

--- a/src/Obsolete/Steeltoe.Management.EndpointCore/Build/Steeltoe.Management.EndpointCore.targets
+++ b/src/Obsolete/Steeltoe.Management.EndpointCore/Build/Steeltoe.Management.EndpointCore.targets
@@ -1,5 +1,5 @@
 <Project>
-  <Target Name="Warn_SteeltoeManagementEndpointCore" BeforeTargets="BeforeResolveReferences">
+  <Target Name="Warn_SteeltoeManagementEndpointCore" AfterTargets="AfterResolveReferences">
     <Warning
       Text="The NuGet package Steeltoe.Management.EndpointCore has been replaced in Steeltoe v4. Reference Steeltoe.Management.Endpoint instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>

--- a/src/Obsolete/Steeltoe.Management.EndpointCore/Build/Steeltoe.Management.EndpointCore.targets
+++ b/src/Obsolete/Steeltoe.Management.EndpointCore/Build/Steeltoe.Management.EndpointCore.targets
@@ -1,7 +1,7 @@
 <Project>
   <Target Name="Warn_SteeltoeManagementEndpointCore" BeforeTargets="BeforeResolveReferences">
     <Warning
-      Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Management.Endpoint instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+      Text="The NuGet package Steeltoe.Management.EndpointCore has been replaced in Steeltoe v4. Reference Steeltoe.Management.Endpoint instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.Management.EndpointCore/Build/Steeltoe.Management.EndpointCore.targets
+++ b/src/Obsolete/Steeltoe.Management.EndpointCore/Build/Steeltoe.Management.EndpointCore.targets
@@ -1,5 +1,6 @@
 <Project>
   <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
-    <Error Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Management.Endpoint instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+    <Error
+      Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Management.Endpoint instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 </Project>

--- a/src/Obsolete/Steeltoe.Management.EndpointCore/Build/Steeltoe.Management.EndpointCore.targets
+++ b/src/Obsolete/Steeltoe.Management.EndpointCore/Build/Steeltoe.Management.EndpointCore.targets
@@ -1,6 +1,10 @@
 <Project>
-  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
-    <Error
+  <Target Name="Warn_SteeltoeManagementEndpointCore" BeforeTargets="BeforeResolveReferences">
+    <Warning
       Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Management.Endpoint instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+
+  <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="One or more Steeltoe package dependencies need attention. See the build warnings for details." />
   </Target>
 </Project>

--- a/src/Obsolete/Steeltoe.Management.EndpointCore/Build/Steeltoe.Management.EndpointCore.targets
+++ b/src/Obsolete/Steeltoe.Management.EndpointCore/Build/Steeltoe.Management.EndpointCore.targets
@@ -1,7 +1,7 @@
 <Project>
   <Target Name="Warn_SteeltoeManagementEndpointCore" AfterTargets="AfterResolveReferences">
     <Warning
-      Text="The NuGet package Steeltoe.Management.EndpointCore has been replaced in Steeltoe v4. Reference Steeltoe.Management.Endpoint instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+      Text="The NuGet package Steeltoe.Management.EndpointCore has been superseded in Steeltoe v4. Reference Steeltoe.Management.Endpoint instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.Management.EndpointCore/Build/Steeltoe.Management.EndpointCore.targets
+++ b/src/Obsolete/Steeltoe.Management.EndpointCore/Build/Steeltoe.Management.EndpointCore.targets
@@ -1,0 +1,5 @@
+<Project>
+  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Management.Endpoint instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+</Project>

--- a/src/Obsolete/Steeltoe.Management.EndpointCore/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.Management.EndpointCore/PackageReadme.md
@@ -1,0 +1,17 @@
+# Steeltoe
+
+> [!IMPORTANT]
+> This package has been replaced in Steeltoe v4. Reference `Steeltoe.Management.Endpoint` instead.
+> See <https://steeltoe.io/docs/v3/obsolete> for details.
+
+[Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).
+
+Key features include:
+
+- External (optionally encrypted) configuration using [Spring Cloud Config Server](https://docs.spring.io/spring-cloud-config/docs/current/reference/html/)
+- Service discovery with [Netflix Eureka](https://spring.io/projects/spring-cloud-netflix) and [HashiCorp Consul](https://www.consul.io/)
+- Management endpoints (compatible with [actuators](https://docs.spring.io/spring-boot/docs/current/reference/html/actuator.html)), providing system info (such as versions, configuration, service container contents, mapped routes and HTTP traffic), heap/thread dumps, health checks, exporting metrics to [Prometheus](https://prometheus.io/), and changing log levels at runtime.
+- Connectivity to databases (such as [SQL Server](https://www.microsoft.com/sql-server)/[Azure SQL](https://azure.microsoft.com/products/azure-sql), [Cosmos DB](https://azure.microsoft.com/products/cosmos-db/), [MongoDB](https://www.mongodb.com/), [Redis](https://redis.io/), [RabbitMQ](https://www.rabbitmq.com/), [PostgreSQL](https://www.postgresql.org/), and [MySQL](https://www.mysql.com/)), including support for [Entity Framework Core](https://learn.microsoft.com/ef/core/)
+- Single sign-on, JWT and Certificate auth with [Cloud Foundry](https://www.cloudfoundry.org/)
+
+For more information and to get started, please visit [Steeltoe on GitHub](https://github.com/SteeltoeOSS/Steeltoe) or the [documentation](https://steeltoe.io/docs).

--- a/src/Obsolete/Steeltoe.Management.EndpointCore/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.Management.EndpointCore/PackageReadme.md
@@ -1,7 +1,7 @@
 # Steeltoe
 
 > [!IMPORTANT]
-> This package has been replaced in Steeltoe v4. Reference `Steeltoe.Management.Endpoint` instead.
+> This package has been superseded in Steeltoe v4. Reference `Steeltoe.Management.Endpoint` instead.
 > See <https://steeltoe.io/docs/v3/obsolete> for details.
 
 [Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).

--- a/src/Obsolete/Steeltoe.Management.EndpointCore/Steeltoe.Management.EndpointCore.csproj
+++ b/src/Obsolete/Steeltoe.Management.EndpointCore/Steeltoe.Management.EndpointCore.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
-    <Description>TODO: Fill package description.</Description>
-    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <Description>Package for using Steeltoe management endpoints with ASP.NET Core.</Description>
+    <PackageTags>Spring Cloud;Actuator;Management;Monitoring</PackageTags>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 

--- a/src/Obsolete/Steeltoe.Management.EndpointCore/Steeltoe.Management.EndpointCore.csproj
+++ b/src/Obsolete/Steeltoe.Management.EndpointCore/Steeltoe.Management.EndpointCore.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net8.0</TargetFrameworks>
+    <Description>TODO: Fill package description.</Description>
+    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
+  <Import Project="..\..\..\shared.props" />
+
+  <ItemGroup>
+    <None Include="Build\*.props" Pack="True" PackagePath="build" />
+    <None Include="Build\*.targets" Pack="True" PackagePath="build" />
+  </ItemGroup>
+</Project>

--- a/src/Obsolete/Steeltoe.Management.KubernetesCore/Build/Steeltoe.Management.KubernetesCore.targets
+++ b/src/Obsolete/Steeltoe.Management.KubernetesCore/Build/Steeltoe.Management.KubernetesCore.targets
@@ -1,5 +1,9 @@
 <Project>
-  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
-    <Error Text="This feature is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+  <Target Name="Warn_SteeltoeManagementKubernetesCore" BeforeTargets="BeforeResolveReferences">
+    <Warning Text="This feature is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+
+  <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="One or more Steeltoe package dependencies need attention. See the build warnings for details." />
   </Target>
 </Project>

--- a/src/Obsolete/Steeltoe.Management.KubernetesCore/Build/Steeltoe.Management.KubernetesCore.targets
+++ b/src/Obsolete/Steeltoe.Management.KubernetesCore/Build/Steeltoe.Management.KubernetesCore.targets
@@ -1,6 +1,7 @@
 <Project>
   <Target Name="Warn_SteeltoeManagementKubernetesCore" BeforeTargets="BeforeResolveReferences">
-    <Warning Text="This feature is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+    <Warning
+      Text="The NuGet package Steeltoe.Management.KubernetesCore is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.Management.KubernetesCore/Build/Steeltoe.Management.KubernetesCore.targets
+++ b/src/Obsolete/Steeltoe.Management.KubernetesCore/Build/Steeltoe.Management.KubernetesCore.targets
@@ -1,0 +1,5 @@
+<Project>
+  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="This feature is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+</Project>

--- a/src/Obsolete/Steeltoe.Management.KubernetesCore/Build/Steeltoe.Management.KubernetesCore.targets
+++ b/src/Obsolete/Steeltoe.Management.KubernetesCore/Build/Steeltoe.Management.KubernetesCore.targets
@@ -1,7 +1,7 @@
 <Project>
   <Target Name="Warn_SteeltoeManagementKubernetesCore" AfterTargets="AfterResolveReferences">
     <Warning
-      Text="The NuGet package Steeltoe.Management.KubernetesCore is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+      Text="The NuGet package Steeltoe.Management.KubernetesCore has been removed from Steeltoe in v4. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.Management.KubernetesCore/Build/Steeltoe.Management.KubernetesCore.targets
+++ b/src/Obsolete/Steeltoe.Management.KubernetesCore/Build/Steeltoe.Management.KubernetesCore.targets
@@ -1,5 +1,5 @@
 <Project>
-  <Target Name="Warn_SteeltoeManagementKubernetesCore" BeforeTargets="BeforeResolveReferences">
+  <Target Name="Warn_SteeltoeManagementKubernetesCore" AfterTargets="AfterResolveReferences">
     <Warning
       Text="The NuGet package Steeltoe.Management.KubernetesCore is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>

--- a/src/Obsolete/Steeltoe.Management.KubernetesCore/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.Management.KubernetesCore/PackageReadme.md
@@ -1,0 +1,17 @@
+# Steeltoe
+
+> [!IMPORTANT]
+> This feature is no longer available in Steeltoe v4.
+> See <https://steeltoe.io/docs/v3/obsolete> for details.
+
+[Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).
+
+Key features include:
+
+- External (optionally encrypted) configuration using [Spring Cloud Config Server](https://docs.spring.io/spring-cloud-config/docs/current/reference/html/)
+- Service discovery with [Netflix Eureka](https://spring.io/projects/spring-cloud-netflix) and [HashiCorp Consul](https://www.consul.io/)
+- Management endpoints (compatible with [actuators](https://docs.spring.io/spring-boot/docs/current/reference/html/actuator.html)), providing system info (such as versions, configuration, service container contents, mapped routes and HTTP traffic), heap/thread dumps, health checks, exporting metrics to [Prometheus](https://prometheus.io/), and changing log levels at runtime.
+- Connectivity to databases (such as [SQL Server](https://www.microsoft.com/sql-server)/[Azure SQL](https://azure.microsoft.com/products/azure-sql), [Cosmos DB](https://azure.microsoft.com/products/cosmos-db/), [MongoDB](https://www.mongodb.com/), [Redis](https://redis.io/), [RabbitMQ](https://www.rabbitmq.com/), [PostgreSQL](https://www.postgresql.org/), and [MySQL](https://www.mysql.com/)), including support for [Entity Framework Core](https://learn.microsoft.com/ef/core/)
+- Single sign-on, JWT and Certificate auth with [Cloud Foundry](https://www.cloudfoundry.org/)
+
+For more information and to get started, please visit [Steeltoe on GitHub](https://github.com/SteeltoeOSS/Steeltoe) or the [documentation](https://steeltoe.io/docs).

--- a/src/Obsolete/Steeltoe.Management.KubernetesCore/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.Management.KubernetesCore/PackageReadme.md
@@ -1,7 +1,7 @@
 # Steeltoe
 
 > [!IMPORTANT]
-> This feature is no longer available in Steeltoe v4.
+> This package has been removed from Steeltoe in v4.
 > See <https://steeltoe.io/docs/v3/obsolete> for details.
 
 [Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).

--- a/src/Obsolete/Steeltoe.Management.KubernetesCore/Steeltoe.Management.KubernetesCore.csproj
+++ b/src/Obsolete/Steeltoe.Management.KubernetesCore/Steeltoe.Management.KubernetesCore.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net8.0</TargetFrameworks>
+    <Description>TODO: Fill package description.</Description>
+    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
+  <Import Project="..\..\..\shared.props" />
+
+  <ItemGroup>
+    <None Include="Build\*.props" Pack="True" PackagePath="build" />
+    <None Include="Build\*.targets" Pack="True" PackagePath="build" />
+  </ItemGroup>
+</Project>

--- a/src/Obsolete/Steeltoe.Management.KubernetesCore/Steeltoe.Management.KubernetesCore.csproj
+++ b/src/Obsolete/Steeltoe.Management.KubernetesCore/Steeltoe.Management.KubernetesCore.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
-    <Description>TODO: Fill package description.</Description>
-    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <Description>Package for using Steeltoe management endpoints with ASP.NET Core on Kubernetes.</Description>
+    <PackageTags>actuator;management;monitoring;aspnetcore;Kubernetes;Spring Cloud;k8s</PackageTags>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 

--- a/src/Obsolete/Steeltoe.Management.OpenTelemetryBase/Build/Steeltoe.Management.OpenTelemetryBase.targets
+++ b/src/Obsolete/Steeltoe.Management.OpenTelemetryBase/Build/Steeltoe.Management.OpenTelemetryBase.targets
@@ -1,0 +1,5 @@
+<Project>
+  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Management.Prometheus instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+</Project>

--- a/src/Obsolete/Steeltoe.Management.OpenTelemetryBase/Build/Steeltoe.Management.OpenTelemetryBase.targets
+++ b/src/Obsolete/Steeltoe.Management.OpenTelemetryBase/Build/Steeltoe.Management.OpenTelemetryBase.targets
@@ -1,6 +1,10 @@
 <Project>
-  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
-    <Error
+  <Target Name="Warn_SteeltoeManagementOpenTelemetryBase" BeforeTargets="BeforeResolveReferences">
+    <Warning
       Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Management.Prometheus instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+
+  <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="One or more Steeltoe package dependencies need attention. See the build warnings for details." />
   </Target>
 </Project>

--- a/src/Obsolete/Steeltoe.Management.OpenTelemetryBase/Build/Steeltoe.Management.OpenTelemetryBase.targets
+++ b/src/Obsolete/Steeltoe.Management.OpenTelemetryBase/Build/Steeltoe.Management.OpenTelemetryBase.targets
@@ -1,5 +1,6 @@
 <Project>
   <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
-    <Error Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Management.Prometheus instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+    <Error
+      Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Management.Prometheus instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 </Project>

--- a/src/Obsolete/Steeltoe.Management.OpenTelemetryBase/Build/Steeltoe.Management.OpenTelemetryBase.targets
+++ b/src/Obsolete/Steeltoe.Management.OpenTelemetryBase/Build/Steeltoe.Management.OpenTelemetryBase.targets
@@ -1,5 +1,5 @@
 <Project>
-  <Target Name="Warn_SteeltoeManagementOpenTelemetryBase" BeforeTargets="BeforeResolveReferences">
+  <Target Name="Warn_SteeltoeManagementOpenTelemetryBase" AfterTargets="AfterResolveReferences">
     <Warning
       Text="The NuGet package Steeltoe.Management.OpenTelemetryBase has been replaced in Steeltoe v4. Reference Steeltoe.Management.Prometheus instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>

--- a/src/Obsolete/Steeltoe.Management.OpenTelemetryBase/Build/Steeltoe.Management.OpenTelemetryBase.targets
+++ b/src/Obsolete/Steeltoe.Management.OpenTelemetryBase/Build/Steeltoe.Management.OpenTelemetryBase.targets
@@ -1,7 +1,7 @@
 <Project>
   <Target Name="Warn_SteeltoeManagementOpenTelemetryBase" BeforeTargets="BeforeResolveReferences">
     <Warning
-      Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Management.Prometheus instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+      Text="The NuGet package Steeltoe.Management.OpenTelemetryBase has been replaced in Steeltoe v4. Reference Steeltoe.Management.Prometheus instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.Management.OpenTelemetryBase/Build/Steeltoe.Management.OpenTelemetryBase.targets
+++ b/src/Obsolete/Steeltoe.Management.OpenTelemetryBase/Build/Steeltoe.Management.OpenTelemetryBase.targets
@@ -1,7 +1,7 @@
 <Project>
   <Target Name="Warn_SteeltoeManagementOpenTelemetryBase" AfterTargets="AfterResolveReferences">
     <Warning
-      Text="The NuGet package Steeltoe.Management.OpenTelemetryBase has been replaced in Steeltoe v4. Reference Steeltoe.Management.Prometheus instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+      Text="The NuGet package Steeltoe.Management.OpenTelemetryBase has been superseded in Steeltoe v4. Reference Steeltoe.Management.Prometheus instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.Management.OpenTelemetryBase/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.Management.OpenTelemetryBase/PackageReadme.md
@@ -1,0 +1,17 @@
+# Steeltoe
+
+> [!IMPORTANT]
+> This package has been replaced in Steeltoe v4. Reference `Steeltoe.Management.Prometheus` instead.
+> See <https://steeltoe.io/docs/v3/obsolete> for details.
+
+[Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).
+
+Key features include:
+
+- External (optionally encrypted) configuration using [Spring Cloud Config Server](https://docs.spring.io/spring-cloud-config/docs/current/reference/html/)
+- Service discovery with [Netflix Eureka](https://spring.io/projects/spring-cloud-netflix) and [HashiCorp Consul](https://www.consul.io/)
+- Management endpoints (compatible with [actuators](https://docs.spring.io/spring-boot/docs/current/reference/html/actuator.html)), providing system info (such as versions, configuration, service container contents, mapped routes and HTTP traffic), heap/thread dumps, health checks, exporting metrics to [Prometheus](https://prometheus.io/), and changing log levels at runtime.
+- Connectivity to databases (such as [SQL Server](https://www.microsoft.com/sql-server)/[Azure SQL](https://azure.microsoft.com/products/azure-sql), [Cosmos DB](https://azure.microsoft.com/products/cosmos-db/), [MongoDB](https://www.mongodb.com/), [Redis](https://redis.io/), [RabbitMQ](https://www.rabbitmq.com/), [PostgreSQL](https://www.postgresql.org/), and [MySQL](https://www.mysql.com/)), including support for [Entity Framework Core](https://learn.microsoft.com/ef/core/)
+- Single sign-on, JWT and Certificate auth with [Cloud Foundry](https://www.cloudfoundry.org/)
+
+For more information and to get started, please visit [Steeltoe on GitHub](https://github.com/SteeltoeOSS/Steeltoe) or the [documentation](https://steeltoe.io/docs).

--- a/src/Obsolete/Steeltoe.Management.OpenTelemetryBase/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.Management.OpenTelemetryBase/PackageReadme.md
@@ -1,7 +1,7 @@
 # Steeltoe
 
 > [!IMPORTANT]
-> This package has been replaced in Steeltoe v4. Reference `Steeltoe.Management.Prometheus` instead.
+> This package has been superseded in Steeltoe v4. Reference `Steeltoe.Management.Prometheus` instead.
 > See <https://steeltoe.io/docs/v3/obsolete> for details.
 
 [Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).

--- a/src/Obsolete/Steeltoe.Management.OpenTelemetryBase/Steeltoe.Management.OpenTelemetryBase.csproj
+++ b/src/Obsolete/Steeltoe.Management.OpenTelemetryBase/Steeltoe.Management.OpenTelemetryBase.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
-    <Description>TODO: Fill package description.</Description>
-    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <Description>Steeltoe Management OpenTelemetry.</Description>
+    <PackageTags>Tracing;OpenTelemetry;Management;Monitoring</PackageTags>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 

--- a/src/Obsolete/Steeltoe.Management.OpenTelemetryBase/Steeltoe.Management.OpenTelemetryBase.csproj
+++ b/src/Obsolete/Steeltoe.Management.OpenTelemetryBase/Steeltoe.Management.OpenTelemetryBase.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net8.0</TargetFrameworks>
+    <Description>TODO: Fill package description.</Description>
+    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
+  <Import Project="..\..\..\shared.props" />
+
+  <ItemGroup>
+    <None Include="Build\*.props" Pack="True" PackagePath="build" />
+    <None Include="Build\*.targets" Pack="True" PackagePath="build" />
+  </ItemGroup>
+</Project>

--- a/src/Obsolete/Steeltoe.Management.TaskCore/Build/Steeltoe.Management.TaskCore.targets
+++ b/src/Obsolete/Steeltoe.Management.TaskCore/Build/Steeltoe.Management.TaskCore.targets
@@ -1,5 +1,6 @@
 <Project>
   <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
-    <Error Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Management.Tasks instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+    <Error
+      Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Management.Tasks instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 </Project>

--- a/src/Obsolete/Steeltoe.Management.TaskCore/Build/Steeltoe.Management.TaskCore.targets
+++ b/src/Obsolete/Steeltoe.Management.TaskCore/Build/Steeltoe.Management.TaskCore.targets
@@ -1,0 +1,5 @@
+<Project>
+  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Management.Tasks instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+</Project>

--- a/src/Obsolete/Steeltoe.Management.TaskCore/Build/Steeltoe.Management.TaskCore.targets
+++ b/src/Obsolete/Steeltoe.Management.TaskCore/Build/Steeltoe.Management.TaskCore.targets
@@ -1,6 +1,10 @@
 <Project>
-  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
-    <Error
+  <Target Name="Warn_SteeltoeManagementTaskCore" BeforeTargets="BeforeResolveReferences">
+    <Warning
       Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Management.Tasks instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+
+  <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="One or more Steeltoe package dependencies need attention. See the build warnings for details." />
   </Target>
 </Project>

--- a/src/Obsolete/Steeltoe.Management.TaskCore/Build/Steeltoe.Management.TaskCore.targets
+++ b/src/Obsolete/Steeltoe.Management.TaskCore/Build/Steeltoe.Management.TaskCore.targets
@@ -1,5 +1,5 @@
 <Project>
-  <Target Name="Warn_SteeltoeManagementTaskCore" BeforeTargets="BeforeResolveReferences">
+  <Target Name="Warn_SteeltoeManagementTaskCore" AfterTargets="AfterResolveReferences">
     <Warning
       Text="The NuGet package Steeltoe.Management.TaskCore has been replaced in Steeltoe v4. Reference Steeltoe.Management.Tasks instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>

--- a/src/Obsolete/Steeltoe.Management.TaskCore/Build/Steeltoe.Management.TaskCore.targets
+++ b/src/Obsolete/Steeltoe.Management.TaskCore/Build/Steeltoe.Management.TaskCore.targets
@@ -1,7 +1,7 @@
 <Project>
   <Target Name="Warn_SteeltoeManagementTaskCore" BeforeTargets="BeforeResolveReferences">
     <Warning
-      Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Management.Tasks instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+      Text="The NuGet package Steeltoe.Management.TaskCore has been replaced in Steeltoe v4. Reference Steeltoe.Management.Tasks instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.Management.TaskCore/Build/Steeltoe.Management.TaskCore.targets
+++ b/src/Obsolete/Steeltoe.Management.TaskCore/Build/Steeltoe.Management.TaskCore.targets
@@ -1,7 +1,7 @@
 <Project>
   <Target Name="Warn_SteeltoeManagementTaskCore" AfterTargets="AfterResolveReferences">
     <Warning
-      Text="The NuGet package Steeltoe.Management.TaskCore has been replaced in Steeltoe v4. Reference Steeltoe.Management.Tasks instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+      Text="The NuGet package Steeltoe.Management.TaskCore has been superseded in Steeltoe v4. Reference Steeltoe.Management.Tasks instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.Management.TaskCore/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.Management.TaskCore/PackageReadme.md
@@ -1,0 +1,17 @@
+# Steeltoe
+
+> [!IMPORTANT]
+> This package has been replaced in Steeltoe v4. Reference `Steeltoe.Management.Tasks` instead.
+> See <https://steeltoe.io/docs/v3/obsolete> for details.
+
+[Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).
+
+Key features include:
+
+- External (optionally encrypted) configuration using [Spring Cloud Config Server](https://docs.spring.io/spring-cloud-config/docs/current/reference/html/)
+- Service discovery with [Netflix Eureka](https://spring.io/projects/spring-cloud-netflix) and [HashiCorp Consul](https://www.consul.io/)
+- Management endpoints (compatible with [actuators](https://docs.spring.io/spring-boot/docs/current/reference/html/actuator.html)), providing system info (such as versions, configuration, service container contents, mapped routes and HTTP traffic), heap/thread dumps, health checks, exporting metrics to [Prometheus](https://prometheus.io/), and changing log levels at runtime.
+- Connectivity to databases (such as [SQL Server](https://www.microsoft.com/sql-server)/[Azure SQL](https://azure.microsoft.com/products/azure-sql), [Cosmos DB](https://azure.microsoft.com/products/cosmos-db/), [MongoDB](https://www.mongodb.com/), [Redis](https://redis.io/), [RabbitMQ](https://www.rabbitmq.com/), [PostgreSQL](https://www.postgresql.org/), and [MySQL](https://www.mysql.com/)), including support for [Entity Framework Core](https://learn.microsoft.com/ef/core/)
+- Single sign-on, JWT and Certificate auth with [Cloud Foundry](https://www.cloudfoundry.org/)
+
+For more information and to get started, please visit [Steeltoe on GitHub](https://github.com/SteeltoeOSS/Steeltoe) or the [documentation](https://steeltoe.io/docs).

--- a/src/Obsolete/Steeltoe.Management.TaskCore/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.Management.TaskCore/PackageReadme.md
@@ -1,7 +1,7 @@
 # Steeltoe
 
 > [!IMPORTANT]
-> This package has been replaced in Steeltoe v4. Reference `Steeltoe.Management.Tasks` instead.
+> This package has been superseded in Steeltoe v4. Reference `Steeltoe.Management.Tasks` instead.
 > See <https://steeltoe.io/docs/v3/obsolete> for details.
 
 [Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).

--- a/src/Obsolete/Steeltoe.Management.TaskCore/Steeltoe.Management.TaskCore.csproj
+++ b/src/Obsolete/Steeltoe.Management.TaskCore/Steeltoe.Management.TaskCore.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net8.0</TargetFrameworks>
+    <Description>TODO: Fill package description.</Description>
+    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
+  <Import Project="..\..\..\shared.props" />
+
+  <ItemGroup>
+    <None Include="Build\*.props" Pack="True" PackagePath="build" />
+    <None Include="Build\*.targets" Pack="True" PackagePath="build" />
+  </ItemGroup>
+</Project>

--- a/src/Obsolete/Steeltoe.Management.TaskCore/Steeltoe.Management.TaskCore.csproj
+++ b/src/Obsolete/Steeltoe.Management.TaskCore/Steeltoe.Management.TaskCore.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
-    <Description>TODO: Fill package description.</Description>
-    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <Description>Extensions for running tasks embedded in your ASP.NET Core application. Ideal for cf run-task in Cloud Foundry.</Description>
+    <PackageTags>tasks;management;monitoring;aspnetcore;Spring Cloud;cf run-task</PackageTags>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 

--- a/src/Obsolete/Steeltoe.Management.TracingBase/Build/Steeltoe.Management.TracingBase.targets
+++ b/src/Obsolete/Steeltoe.Management.TracingBase/Build/Steeltoe.Management.TracingBase.targets
@@ -1,7 +1,7 @@
 <Project>
   <Target Name="Warn_SteeltoeManagementTracingBase" BeforeTargets="BeforeResolveReferences">
     <Warning
-      Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Management.Tracing instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+      Text="The NuGet package Steeltoe.Management.TracingBase has been replaced in Steeltoe v4. Reference Steeltoe.Management.Tracing instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.Management.TracingBase/Build/Steeltoe.Management.TracingBase.targets
+++ b/src/Obsolete/Steeltoe.Management.TracingBase/Build/Steeltoe.Management.TracingBase.targets
@@ -1,6 +1,10 @@
 <Project>
-  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
-    <Error
+  <Target Name="Warn_SteeltoeManagementTracingBase" BeforeTargets="BeforeResolveReferences">
+    <Warning
       Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Management.Tracing instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+
+  <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="One or more Steeltoe package dependencies need attention. See the build warnings for details." />
   </Target>
 </Project>

--- a/src/Obsolete/Steeltoe.Management.TracingBase/Build/Steeltoe.Management.TracingBase.targets
+++ b/src/Obsolete/Steeltoe.Management.TracingBase/Build/Steeltoe.Management.TracingBase.targets
@@ -1,5 +1,5 @@
 <Project>
-  <Target Name="Warn_SteeltoeManagementTracingBase" BeforeTargets="BeforeResolveReferences">
+  <Target Name="Warn_SteeltoeManagementTracingBase" AfterTargets="AfterResolveReferences">
     <Warning
       Text="The NuGet package Steeltoe.Management.TracingBase has been replaced in Steeltoe v4. Reference Steeltoe.Management.Tracing instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>

--- a/src/Obsolete/Steeltoe.Management.TracingBase/Build/Steeltoe.Management.TracingBase.targets
+++ b/src/Obsolete/Steeltoe.Management.TracingBase/Build/Steeltoe.Management.TracingBase.targets
@@ -1,0 +1,5 @@
+<Project>
+  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Management.Tracing instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+</Project>

--- a/src/Obsolete/Steeltoe.Management.TracingBase/Build/Steeltoe.Management.TracingBase.targets
+++ b/src/Obsolete/Steeltoe.Management.TracingBase/Build/Steeltoe.Management.TracingBase.targets
@@ -1,7 +1,7 @@
 <Project>
   <Target Name="Warn_SteeltoeManagementTracingBase" AfterTargets="AfterResolveReferences">
     <Warning
-      Text="The NuGet package Steeltoe.Management.TracingBase has been replaced in Steeltoe v4. Reference Steeltoe.Management.Tracing instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+      Text="The NuGet package Steeltoe.Management.TracingBase has been superseded in Steeltoe v4. Reference Steeltoe.Management.Tracing instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.Management.TracingBase/Build/Steeltoe.Management.TracingBase.targets
+++ b/src/Obsolete/Steeltoe.Management.TracingBase/Build/Steeltoe.Management.TracingBase.targets
@@ -1,5 +1,6 @@
 <Project>
   <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
-    <Error Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Management.Tracing instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+    <Error
+      Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Management.Tracing instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 </Project>

--- a/src/Obsolete/Steeltoe.Management.TracingBase/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.Management.TracingBase/PackageReadme.md
@@ -1,7 +1,7 @@
 # Steeltoe
 
 > [!IMPORTANT]
-> This package has been replaced in Steeltoe v4. Reference `Steeltoe.Management.Tracing` instead.
+> This package has been superseded in Steeltoe v4. Reference `Steeltoe.Management.Tracing` instead.
 > See <https://steeltoe.io/docs/v3/obsolete> for details.
 
 [Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).

--- a/src/Obsolete/Steeltoe.Management.TracingBase/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.Management.TracingBase/PackageReadme.md
@@ -1,0 +1,17 @@
+# Steeltoe
+
+> [!IMPORTANT]
+> This package has been replaced in Steeltoe v4. Reference `Steeltoe.Management.Tracing` instead.
+> See <https://steeltoe.io/docs/v3/obsolete> for details.
+
+[Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).
+
+Key features include:
+
+- External (optionally encrypted) configuration using [Spring Cloud Config Server](https://docs.spring.io/spring-cloud-config/docs/current/reference/html/)
+- Service discovery with [Netflix Eureka](https://spring.io/projects/spring-cloud-netflix) and [HashiCorp Consul](https://www.consul.io/)
+- Management endpoints (compatible with [actuators](https://docs.spring.io/spring-boot/docs/current/reference/html/actuator.html)), providing system info (such as versions, configuration, service container contents, mapped routes and HTTP traffic), heap/thread dumps, health checks, exporting metrics to [Prometheus](https://prometheus.io/), and changing log levels at runtime.
+- Connectivity to databases (such as [SQL Server](https://www.microsoft.com/sql-server)/[Azure SQL](https://azure.microsoft.com/products/azure-sql), [Cosmos DB](https://azure.microsoft.com/products/cosmos-db/), [MongoDB](https://www.mongodb.com/), [Redis](https://redis.io/), [RabbitMQ](https://www.rabbitmq.com/), [PostgreSQL](https://www.postgresql.org/), and [MySQL](https://www.mysql.com/)), including support for [Entity Framework Core](https://learn.microsoft.com/ef/core/)
+- Single sign-on, JWT and Certificate auth with [Cloud Foundry](https://www.cloudfoundry.org/)
+
+For more information and to get started, please visit [Steeltoe on GitHub](https://github.com/SteeltoeOSS/Steeltoe) or the [documentation](https://steeltoe.io/docs).

--- a/src/Obsolete/Steeltoe.Management.TracingBase/Steeltoe.Management.TracingBase.csproj
+++ b/src/Obsolete/Steeltoe.Management.TracingBase/Steeltoe.Management.TracingBase.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net8.0</TargetFrameworks>
+    <Description>TODO: Fill package description.</Description>
+    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
+  <Import Project="..\..\..\shared.props" />
+
+  <ItemGroup>
+    <None Include="Build\*.props" Pack="True" PackagePath="build" />
+    <None Include="Build\*.targets" Pack="True" PackagePath="build" />
+  </ItemGroup>
+</Project>

--- a/src/Obsolete/Steeltoe.Management.TracingBase/Steeltoe.Management.TracingBase.csproj
+++ b/src/Obsolete/Steeltoe.Management.TracingBase/Steeltoe.Management.TracingBase.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
-    <Description>TODO: Fill package description.</Description>
-    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <Description>Base package for enabling request tracing in distributed systems.</Description>
+    <PackageTags>management;monitoring;distributed trace</PackageTags>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 

--- a/src/Obsolete/Steeltoe.Management.TracingCore/Build/Steeltoe.Management.TracingCore.targets
+++ b/src/Obsolete/Steeltoe.Management.TracingCore/Build/Steeltoe.Management.TracingCore.targets
@@ -1,5 +1,5 @@
 <Project>
-  <Target Name="Warn_SteeltoeManagementTracingCore" BeforeTargets="BeforeResolveReferences">
+  <Target Name="Warn_SteeltoeManagementTracingCore" AfterTargets="AfterResolveReferences">
     <Warning
       Text="The NuGet package Steeltoe.Management.TracingCore has been replaced in Steeltoe v4. Reference Steeltoe.Management.Tracing instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>

--- a/src/Obsolete/Steeltoe.Management.TracingCore/Build/Steeltoe.Management.TracingCore.targets
+++ b/src/Obsolete/Steeltoe.Management.TracingCore/Build/Steeltoe.Management.TracingCore.targets
@@ -1,7 +1,7 @@
 <Project>
   <Target Name="Warn_SteeltoeManagementTracingCore" AfterTargets="AfterResolveReferences">
     <Warning
-      Text="The NuGet package Steeltoe.Management.TracingCore has been replaced in Steeltoe v4. Reference Steeltoe.Management.Tracing instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+      Text="The NuGet package Steeltoe.Management.TracingCore has been superseded in Steeltoe v4. Reference Steeltoe.Management.Tracing instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.Management.TracingCore/Build/Steeltoe.Management.TracingCore.targets
+++ b/src/Obsolete/Steeltoe.Management.TracingCore/Build/Steeltoe.Management.TracingCore.targets
@@ -1,7 +1,7 @@
 <Project>
   <Target Name="Warn_SteeltoeManagementTracingCore" BeforeTargets="BeforeResolveReferences">
     <Warning
-      Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Management.Tracing instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+      Text="The NuGet package Steeltoe.Management.TracingCore has been replaced in Steeltoe v4. Reference Steeltoe.Management.Tracing instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.Management.TracingCore/Build/Steeltoe.Management.TracingCore.targets
+++ b/src/Obsolete/Steeltoe.Management.TracingCore/Build/Steeltoe.Management.TracingCore.targets
@@ -1,0 +1,5 @@
+<Project>
+  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Management.Tracing instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+</Project>

--- a/src/Obsolete/Steeltoe.Management.TracingCore/Build/Steeltoe.Management.TracingCore.targets
+++ b/src/Obsolete/Steeltoe.Management.TracingCore/Build/Steeltoe.Management.TracingCore.targets
@@ -1,5 +1,6 @@
 <Project>
   <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
-    <Error Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Management.Tracing instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+    <Error
+      Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Management.Tracing instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 </Project>

--- a/src/Obsolete/Steeltoe.Management.TracingCore/Build/Steeltoe.Management.TracingCore.targets
+++ b/src/Obsolete/Steeltoe.Management.TracingCore/Build/Steeltoe.Management.TracingCore.targets
@@ -1,6 +1,10 @@
 <Project>
-  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
-    <Error
+  <Target Name="Warn_SteeltoeManagementTracingCore" BeforeTargets="BeforeResolveReferences">
+    <Warning
       Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Management.Tracing instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+
+  <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="One or more Steeltoe package dependencies need attention. See the build warnings for details." />
   </Target>
 </Project>

--- a/src/Obsolete/Steeltoe.Management.TracingCore/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.Management.TracingCore/PackageReadme.md
@@ -1,7 +1,7 @@
 # Steeltoe
 
 > [!IMPORTANT]
-> This package has been replaced in Steeltoe v4. Reference `Steeltoe.Management.Tracing` instead.
+> This package has been superseded in Steeltoe v4. Reference `Steeltoe.Management.Tracing` instead.
 > See <https://steeltoe.io/docs/v3/obsolete> for details.
 
 [Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).

--- a/src/Obsolete/Steeltoe.Management.TracingCore/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.Management.TracingCore/PackageReadme.md
@@ -1,0 +1,17 @@
+# Steeltoe
+
+> [!IMPORTANT]
+> This package has been replaced in Steeltoe v4. Reference `Steeltoe.Management.Tracing` instead.
+> See <https://steeltoe.io/docs/v3/obsolete> for details.
+
+[Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).
+
+Key features include:
+
+- External (optionally encrypted) configuration using [Spring Cloud Config Server](https://docs.spring.io/spring-cloud-config/docs/current/reference/html/)
+- Service discovery with [Netflix Eureka](https://spring.io/projects/spring-cloud-netflix) and [HashiCorp Consul](https://www.consul.io/)
+- Management endpoints (compatible with [actuators](https://docs.spring.io/spring-boot/docs/current/reference/html/actuator.html)), providing system info (such as versions, configuration, service container contents, mapped routes and HTTP traffic), heap/thread dumps, health checks, exporting metrics to [Prometheus](https://prometheus.io/), and changing log levels at runtime.
+- Connectivity to databases (such as [SQL Server](https://www.microsoft.com/sql-server)/[Azure SQL](https://azure.microsoft.com/products/azure-sql), [Cosmos DB](https://azure.microsoft.com/products/cosmos-db/), [MongoDB](https://www.mongodb.com/), [Redis](https://redis.io/), [RabbitMQ](https://www.rabbitmq.com/), [PostgreSQL](https://www.postgresql.org/), and [MySQL](https://www.mysql.com/)), including support for [Entity Framework Core](https://learn.microsoft.com/ef/core/)
+- Single sign-on, JWT and Certificate auth with [Cloud Foundry](https://www.cloudfoundry.org/)
+
+For more information and to get started, please visit [Steeltoe on GitHub](https://github.com/SteeltoeOSS/Steeltoe) or the [documentation](https://steeltoe.io/docs).

--- a/src/Obsolete/Steeltoe.Management.TracingCore/Steeltoe.Management.TracingCore.csproj
+++ b/src/Obsolete/Steeltoe.Management.TracingCore/Steeltoe.Management.TracingCore.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net8.0</TargetFrameworks>
+    <Description>TODO: Fill package description.</Description>
+    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
+  <Import Project="..\..\..\shared.props" />
+
+  <ItemGroup>
+    <None Include="Build\*.props" Pack="True" PackagePath="build" />
+    <None Include="Build\*.targets" Pack="True" PackagePath="build" />
+  </ItemGroup>
+</Project>

--- a/src/Obsolete/Steeltoe.Management.TracingCore/Steeltoe.Management.TracingCore.csproj
+++ b/src/Obsolete/Steeltoe.Management.TracingCore/Steeltoe.Management.TracingCore.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
-    <Description>TODO: Fill package description.</Description>
-    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <Description>Add distributed tracing to ASP.NET Core applications.</Description>
+    <PackageTags>aspnetcore;management;monitoring;metrics;Distributed Trace</PackageTags>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 

--- a/src/Obsolete/Steeltoe.Messaging.Abstractions/Build/Steeltoe.Messaging.Abstractions.targets
+++ b/src/Obsolete/Steeltoe.Messaging.Abstractions/Build/Steeltoe.Messaging.Abstractions.targets
@@ -1,0 +1,5 @@
+<Project>
+  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="This feature is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+</Project>

--- a/src/Obsolete/Steeltoe.Messaging.Abstractions/Build/Steeltoe.Messaging.Abstractions.targets
+++ b/src/Obsolete/Steeltoe.Messaging.Abstractions/Build/Steeltoe.Messaging.Abstractions.targets
@@ -1,7 +1,7 @@
 <Project>
   <Target Name="Warn_SteeltoeMessagingAbstractions" AfterTargets="AfterResolveReferences">
     <Warning
-      Text="The NuGet package Steeltoe.Messaging.Abstractions is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+      Text="The NuGet package Steeltoe.Messaging.Abstractions has been removed from Steeltoe in v4. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.Messaging.Abstractions/Build/Steeltoe.Messaging.Abstractions.targets
+++ b/src/Obsolete/Steeltoe.Messaging.Abstractions/Build/Steeltoe.Messaging.Abstractions.targets
@@ -1,6 +1,7 @@
 <Project>
   <Target Name="Warn_SteeltoeMessagingAbstractions" BeforeTargets="BeforeResolveReferences">
-    <Warning Text="This feature is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+    <Warning
+      Text="The NuGet package Steeltoe.Messaging.Abstractions is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.Messaging.Abstractions/Build/Steeltoe.Messaging.Abstractions.targets
+++ b/src/Obsolete/Steeltoe.Messaging.Abstractions/Build/Steeltoe.Messaging.Abstractions.targets
@@ -1,5 +1,9 @@
 <Project>
-  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
-    <Error Text="This feature is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+  <Target Name="Warn_SteeltoeMessagingAbstractions" BeforeTargets="BeforeResolveReferences">
+    <Warning Text="This feature is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+
+  <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="One or more Steeltoe package dependencies need attention. See the build warnings for details." />
   </Target>
 </Project>

--- a/src/Obsolete/Steeltoe.Messaging.Abstractions/Build/Steeltoe.Messaging.Abstractions.targets
+++ b/src/Obsolete/Steeltoe.Messaging.Abstractions/Build/Steeltoe.Messaging.Abstractions.targets
@@ -1,5 +1,5 @@
 <Project>
-  <Target Name="Warn_SteeltoeMessagingAbstractions" BeforeTargets="BeforeResolveReferences">
+  <Target Name="Warn_SteeltoeMessagingAbstractions" AfterTargets="AfterResolveReferences">
     <Warning
       Text="The NuGet package Steeltoe.Messaging.Abstractions is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>

--- a/src/Obsolete/Steeltoe.Messaging.Abstractions/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.Messaging.Abstractions/PackageReadme.md
@@ -1,0 +1,17 @@
+# Steeltoe
+
+> [!IMPORTANT]
+> This feature is no longer available in Steeltoe v4.
+> See <https://steeltoe.io/docs/v3/obsolete> for details.
+
+[Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).
+
+Key features include:
+
+- External (optionally encrypted) configuration using [Spring Cloud Config Server](https://docs.spring.io/spring-cloud-config/docs/current/reference/html/)
+- Service discovery with [Netflix Eureka](https://spring.io/projects/spring-cloud-netflix) and [HashiCorp Consul](https://www.consul.io/)
+- Management endpoints (compatible with [actuators](https://docs.spring.io/spring-boot/docs/current/reference/html/actuator.html)), providing system info (such as versions, configuration, service container contents, mapped routes and HTTP traffic), heap/thread dumps, health checks, exporting metrics to [Prometheus](https://prometheus.io/), and changing log levels at runtime.
+- Connectivity to databases (such as [SQL Server](https://www.microsoft.com/sql-server)/[Azure SQL](https://azure.microsoft.com/products/azure-sql), [Cosmos DB](https://azure.microsoft.com/products/cosmos-db/), [MongoDB](https://www.mongodb.com/), [Redis](https://redis.io/), [RabbitMQ](https://www.rabbitmq.com/), [PostgreSQL](https://www.postgresql.org/), and [MySQL](https://www.mysql.com/)), including support for [Entity Framework Core](https://learn.microsoft.com/ef/core/)
+- Single sign-on, JWT and Certificate auth with [Cloud Foundry](https://www.cloudfoundry.org/)
+
+For more information and to get started, please visit [Steeltoe on GitHub](https://github.com/SteeltoeOSS/Steeltoe) or the [documentation](https://steeltoe.io/docs).

--- a/src/Obsolete/Steeltoe.Messaging.Abstractions/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.Messaging.Abstractions/PackageReadme.md
@@ -1,7 +1,7 @@
 # Steeltoe
 
 > [!IMPORTANT]
-> This feature is no longer available in Steeltoe v4.
+> This package has been removed from Steeltoe in v4.
 > See <https://steeltoe.io/docs/v3/obsolete> for details.
 
 [Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).

--- a/src/Obsolete/Steeltoe.Messaging.Abstractions/Steeltoe.Messaging.Abstractions.csproj
+++ b/src/Obsolete/Steeltoe.Messaging.Abstractions/Steeltoe.Messaging.Abstractions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
-    <Description>TODO: Fill package description.</Description>
+    <Description>Abstractions for use with Steeltoe Messaging.</Description>
     <PackageTags>TODO: Fill package tags.</PackageTags>
     <IsPackable>true</IsPackable>
   </PropertyGroup>

--- a/src/Obsolete/Steeltoe.Messaging.Abstractions/Steeltoe.Messaging.Abstractions.csproj
+++ b/src/Obsolete/Steeltoe.Messaging.Abstractions/Steeltoe.Messaging.Abstractions.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
     <Description>Abstractions for use with Steeltoe Messaging.</Description>
-    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <PackageTags>Messaging, NET Core, Spring, Spring Cloud</PackageTags>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 

--- a/src/Obsolete/Steeltoe.Messaging.Abstractions/Steeltoe.Messaging.Abstractions.csproj
+++ b/src/Obsolete/Steeltoe.Messaging.Abstractions/Steeltoe.Messaging.Abstractions.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net8.0</TargetFrameworks>
+    <Description>TODO: Fill package description.</Description>
+    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
+  <Import Project="..\..\..\shared.props" />
+
+  <ItemGroup>
+    <None Include="Build\*.props" Pack="True" PackagePath="build" />
+    <None Include="Build\*.targets" Pack="True" PackagePath="build" />
+  </ItemGroup>
+</Project>

--- a/src/Obsolete/Steeltoe.Messaging.Abstractions/Steeltoe.Messaging.Abstractions.csproj
+++ b/src/Obsolete/Steeltoe.Messaging.Abstractions/Steeltoe.Messaging.Abstractions.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
     <Description>Abstractions for use with Steeltoe Messaging.</Description>
-    <PackageTags>Messaging, NET Core, Spring, Spring Cloud</PackageTags>
+    <PackageTags>Messaging;NET Core;Spring;Spring Cloud</PackageTags>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 

--- a/src/Obsolete/Steeltoe.Messaging.MessagingBase/Build/Steeltoe.Messaging.MessagingBase.targets
+++ b/src/Obsolete/Steeltoe.Messaging.MessagingBase/Build/Steeltoe.Messaging.MessagingBase.targets
@@ -1,5 +1,9 @@
 <Project>
-  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
-    <Error Text="This feature is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+  <Target Name="Warn_SteeltoeMessagingMessagingBase" BeforeTargets="BeforeResolveReferences">
+    <Warning Text="This feature is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+
+  <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="One or more Steeltoe package dependencies need attention. See the build warnings for details." />
   </Target>
 </Project>

--- a/src/Obsolete/Steeltoe.Messaging.MessagingBase/Build/Steeltoe.Messaging.MessagingBase.targets
+++ b/src/Obsolete/Steeltoe.Messaging.MessagingBase/Build/Steeltoe.Messaging.MessagingBase.targets
@@ -1,0 +1,5 @@
+<Project>
+  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="This feature is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+</Project>

--- a/src/Obsolete/Steeltoe.Messaging.MessagingBase/Build/Steeltoe.Messaging.MessagingBase.targets
+++ b/src/Obsolete/Steeltoe.Messaging.MessagingBase/Build/Steeltoe.Messaging.MessagingBase.targets
@@ -1,5 +1,5 @@
 <Project>
-  <Target Name="Warn_SteeltoeMessagingMessagingBase" BeforeTargets="BeforeResolveReferences">
+  <Target Name="Warn_SteeltoeMessagingMessagingBase" AfterTargets="AfterResolveReferences">
     <Warning
       Text="The NuGet package Steeltoe.Messaging.MessagingBase is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>

--- a/src/Obsolete/Steeltoe.Messaging.MessagingBase/Build/Steeltoe.Messaging.MessagingBase.targets
+++ b/src/Obsolete/Steeltoe.Messaging.MessagingBase/Build/Steeltoe.Messaging.MessagingBase.targets
@@ -1,7 +1,7 @@
 <Project>
   <Target Name="Warn_SteeltoeMessagingMessagingBase" AfterTargets="AfterResolveReferences">
     <Warning
-      Text="The NuGet package Steeltoe.Messaging.MessagingBase is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+      Text="The NuGet package Steeltoe.Messaging.MessagingBase has been removed from Steeltoe in v4. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.Messaging.MessagingBase/Build/Steeltoe.Messaging.MessagingBase.targets
+++ b/src/Obsolete/Steeltoe.Messaging.MessagingBase/Build/Steeltoe.Messaging.MessagingBase.targets
@@ -1,6 +1,7 @@
 <Project>
   <Target Name="Warn_SteeltoeMessagingMessagingBase" BeforeTargets="BeforeResolveReferences">
-    <Warning Text="This feature is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+    <Warning
+      Text="The NuGet package Steeltoe.Messaging.MessagingBase is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.Messaging.MessagingBase/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.Messaging.MessagingBase/PackageReadme.md
@@ -1,0 +1,17 @@
+# Steeltoe
+
+> [!IMPORTANT]
+> This feature is no longer available in Steeltoe v4.
+> See <https://steeltoe.io/docs/v3/obsolete> for details.
+
+[Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).
+
+Key features include:
+
+- External (optionally encrypted) configuration using [Spring Cloud Config Server](https://docs.spring.io/spring-cloud-config/docs/current/reference/html/)
+- Service discovery with [Netflix Eureka](https://spring.io/projects/spring-cloud-netflix) and [HashiCorp Consul](https://www.consul.io/)
+- Management endpoints (compatible with [actuators](https://docs.spring.io/spring-boot/docs/current/reference/html/actuator.html)), providing system info (such as versions, configuration, service container contents, mapped routes and HTTP traffic), heap/thread dumps, health checks, exporting metrics to [Prometheus](https://prometheus.io/), and changing log levels at runtime.
+- Connectivity to databases (such as [SQL Server](https://www.microsoft.com/sql-server)/[Azure SQL](https://azure.microsoft.com/products/azure-sql), [Cosmos DB](https://azure.microsoft.com/products/cosmos-db/), [MongoDB](https://www.mongodb.com/), [Redis](https://redis.io/), [RabbitMQ](https://www.rabbitmq.com/), [PostgreSQL](https://www.postgresql.org/), and [MySQL](https://www.mysql.com/)), including support for [Entity Framework Core](https://learn.microsoft.com/ef/core/)
+- Single sign-on, JWT and Certificate auth with [Cloud Foundry](https://www.cloudfoundry.org/)
+
+For more information and to get started, please visit [Steeltoe on GitHub](https://github.com/SteeltoeOSS/Steeltoe) or the [documentation](https://steeltoe.io/docs).

--- a/src/Obsolete/Steeltoe.Messaging.MessagingBase/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.Messaging.MessagingBase/PackageReadme.md
@@ -1,7 +1,7 @@
 # Steeltoe
 
 > [!IMPORTANT]
-> This feature is no longer available in Steeltoe v4.
+> This package has been removed from Steeltoe in v4.
 > See <https://steeltoe.io/docs/v3/obsolete> for details.
 
 [Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).

--- a/src/Obsolete/Steeltoe.Messaging.MessagingBase/Steeltoe.Messaging.MessagingBase.csproj
+++ b/src/Obsolete/Steeltoe.Messaging.MessagingBase/Steeltoe.Messaging.MessagingBase.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
-    <Description>TODO: Fill package description.</Description>
-    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <Description>Steeltoe Messaging Base.</Description>
+    <PackageTags>Messaging, NET Core, Spring, Spring Cloud</PackageTags>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 

--- a/src/Obsolete/Steeltoe.Messaging.MessagingBase/Steeltoe.Messaging.MessagingBase.csproj
+++ b/src/Obsolete/Steeltoe.Messaging.MessagingBase/Steeltoe.Messaging.MessagingBase.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net8.0</TargetFrameworks>
+    <Description>TODO: Fill package description.</Description>
+    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
+  <Import Project="..\..\..\shared.props" />
+
+  <ItemGroup>
+    <None Include="Build\*.props" Pack="True" PackagePath="build" />
+    <None Include="Build\*.targets" Pack="True" PackagePath="build" />
+  </ItemGroup>
+</Project>

--- a/src/Obsolete/Steeltoe.Messaging.MessagingBase/Steeltoe.Messaging.MessagingBase.csproj
+++ b/src/Obsolete/Steeltoe.Messaging.MessagingBase/Steeltoe.Messaging.MessagingBase.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
     <Description>Steeltoe Messaging Base.</Description>
-    <PackageTags>Messaging, NET Core, Spring, Spring Cloud</PackageTags>
+    <PackageTags>Messaging;NET Core;Spring;Spring Cloud</PackageTags>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 

--- a/src/Obsolete/Steeltoe.Messaging.RabbitMQ/Build/Steeltoe.Messaging.RabbitMQ.targets
+++ b/src/Obsolete/Steeltoe.Messaging.RabbitMQ/Build/Steeltoe.Messaging.RabbitMQ.targets
@@ -1,6 +1,6 @@
 <Project>
   <Target Name="Warn_SteeltoeMessagingRabbitMQ" AfterTargets="AfterResolveReferences">
-    <Warning Text="The NuGet package Steeltoe.Messaging.RabbitMQ is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+    <Warning Text="The NuGet package Steeltoe.Messaging.RabbitMQ has been removed from Steeltoe in v4. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.Messaging.RabbitMQ/Build/Steeltoe.Messaging.RabbitMQ.targets
+++ b/src/Obsolete/Steeltoe.Messaging.RabbitMQ/Build/Steeltoe.Messaging.RabbitMQ.targets
@@ -1,5 +1,9 @@
 <Project>
-  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
-    <Error Text="This feature is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+  <Target Name="Warn_SteeltoeMessagingRabbitMQ" BeforeTargets="BeforeResolveReferences">
+    <Warning Text="This feature is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+
+  <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="One or more Steeltoe package dependencies need attention. See the build warnings for details." />
   </Target>
 </Project>

--- a/src/Obsolete/Steeltoe.Messaging.RabbitMQ/Build/Steeltoe.Messaging.RabbitMQ.targets
+++ b/src/Obsolete/Steeltoe.Messaging.RabbitMQ/Build/Steeltoe.Messaging.RabbitMQ.targets
@@ -1,0 +1,5 @@
+<Project>
+  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="This feature is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+</Project>

--- a/src/Obsolete/Steeltoe.Messaging.RabbitMQ/Build/Steeltoe.Messaging.RabbitMQ.targets
+++ b/src/Obsolete/Steeltoe.Messaging.RabbitMQ/Build/Steeltoe.Messaging.RabbitMQ.targets
@@ -1,5 +1,5 @@
 <Project>
-  <Target Name="Warn_SteeltoeMessagingRabbitMQ" BeforeTargets="BeforeResolveReferences">
+  <Target Name="Warn_SteeltoeMessagingRabbitMQ" AfterTargets="AfterResolveReferences">
     <Warning Text="The NuGet package Steeltoe.Messaging.RabbitMQ is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 

--- a/src/Obsolete/Steeltoe.Messaging.RabbitMQ/Build/Steeltoe.Messaging.RabbitMQ.targets
+++ b/src/Obsolete/Steeltoe.Messaging.RabbitMQ/Build/Steeltoe.Messaging.RabbitMQ.targets
@@ -1,6 +1,6 @@
 <Project>
   <Target Name="Warn_SteeltoeMessagingRabbitMQ" BeforeTargets="BeforeResolveReferences">
-    <Warning Text="This feature is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+    <Warning Text="The NuGet package Steeltoe.Messaging.RabbitMQ is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.Messaging.RabbitMQ/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.Messaging.RabbitMQ/PackageReadme.md
@@ -1,0 +1,17 @@
+# Steeltoe
+
+> [!IMPORTANT]
+> This feature is no longer available in Steeltoe v4.
+> See <https://steeltoe.io/docs/v3/obsolete> for details.
+
+[Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).
+
+Key features include:
+
+- External (optionally encrypted) configuration using [Spring Cloud Config Server](https://docs.spring.io/spring-cloud-config/docs/current/reference/html/)
+- Service discovery with [Netflix Eureka](https://spring.io/projects/spring-cloud-netflix) and [HashiCorp Consul](https://www.consul.io/)
+- Management endpoints (compatible with [actuators](https://docs.spring.io/spring-boot/docs/current/reference/html/actuator.html)), providing system info (such as versions, configuration, service container contents, mapped routes and HTTP traffic), heap/thread dumps, health checks, exporting metrics to [Prometheus](https://prometheus.io/), and changing log levels at runtime.
+- Connectivity to databases (such as [SQL Server](https://www.microsoft.com/sql-server)/[Azure SQL](https://azure.microsoft.com/products/azure-sql), [Cosmos DB](https://azure.microsoft.com/products/cosmos-db/), [MongoDB](https://www.mongodb.com/), [Redis](https://redis.io/), [RabbitMQ](https://www.rabbitmq.com/), [PostgreSQL](https://www.postgresql.org/), and [MySQL](https://www.mysql.com/)), including support for [Entity Framework Core](https://learn.microsoft.com/ef/core/)
+- Single sign-on, JWT and Certificate auth with [Cloud Foundry](https://www.cloudfoundry.org/)
+
+For more information and to get started, please visit [Steeltoe on GitHub](https://github.com/SteeltoeOSS/Steeltoe) or the [documentation](https://steeltoe.io/docs).

--- a/src/Obsolete/Steeltoe.Messaging.RabbitMQ/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.Messaging.RabbitMQ/PackageReadme.md
@@ -1,7 +1,7 @@
 # Steeltoe
 
 > [!IMPORTANT]
-> This feature is no longer available in Steeltoe v4.
+> This package has been removed from Steeltoe in v4.
 > See <https://steeltoe.io/docs/v3/obsolete> for details.
 
 [Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).

--- a/src/Obsolete/Steeltoe.Messaging.RabbitMQ/Steeltoe.Messaging.RabbitMQ.csproj
+++ b/src/Obsolete/Steeltoe.Messaging.RabbitMQ/Steeltoe.Messaging.RabbitMQ.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net8.0</TargetFrameworks>
+    <Description>TODO: Fill package description.</Description>
+    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
+  <Import Project="..\..\..\shared.props" />
+
+  <ItemGroup>
+    <None Include="Build\*.props" Pack="True" PackagePath="build" />
+    <None Include="Build\*.targets" Pack="True" PackagePath="build" />
+  </ItemGroup>
+</Project>

--- a/src/Obsolete/Steeltoe.Messaging.RabbitMQ/Steeltoe.Messaging.RabbitMQ.csproj
+++ b/src/Obsolete/Steeltoe.Messaging.RabbitMQ/Steeltoe.Messaging.RabbitMQ.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
-    <Description>TODO: Fill package description.</Description>
-    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <Description>Steeltoe Messaging RabbitMQ.</Description>
+    <PackageTags>Messaging, ASPNET Core, Spring, Spring Cloud</PackageTags>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 

--- a/src/Obsolete/Steeltoe.Messaging.RabbitMQ/Steeltoe.Messaging.RabbitMQ.csproj
+++ b/src/Obsolete/Steeltoe.Messaging.RabbitMQ/Steeltoe.Messaging.RabbitMQ.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
     <Description>Steeltoe Messaging RabbitMQ.</Description>
-    <PackageTags>Messaging, ASPNET Core, Spring, Spring Cloud</PackageTags>
+    <PackageTags>Messaging;ASPNET Core;Spring;Spring Cloud</PackageTags>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 

--- a/src/Obsolete/Steeltoe.Security.Authentication.CloudFoundryBase/Build/Steeltoe.Security.Authentication.CloudFoundryBase.targets
+++ b/src/Obsolete/Steeltoe.Security.Authentication.CloudFoundryBase/Build/Steeltoe.Security.Authentication.CloudFoundryBase.targets
@@ -1,0 +1,5 @@
+<Project>
+  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Security.Authentication.JwtBearer / Steeltoe.Security.Authentication.OpenIdConnect / Steeltoe.Security.Authorization.Certificate instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+</Project>

--- a/src/Obsolete/Steeltoe.Security.Authentication.CloudFoundryBase/Build/Steeltoe.Security.Authentication.CloudFoundryBase.targets
+++ b/src/Obsolete/Steeltoe.Security.Authentication.CloudFoundryBase/Build/Steeltoe.Security.Authentication.CloudFoundryBase.targets
@@ -1,5 +1,6 @@
 <Project>
   <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
-    <Error Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Security.Authentication.JwtBearer / Steeltoe.Security.Authentication.OpenIdConnect / Steeltoe.Security.Authorization.Certificate instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+    <Error
+      Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Security.Authentication.JwtBearer / Steeltoe.Security.Authentication.OpenIdConnect / Steeltoe.Security.Authorization.Certificate instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 </Project>

--- a/src/Obsolete/Steeltoe.Security.Authentication.CloudFoundryBase/Build/Steeltoe.Security.Authentication.CloudFoundryBase.targets
+++ b/src/Obsolete/Steeltoe.Security.Authentication.CloudFoundryBase/Build/Steeltoe.Security.Authentication.CloudFoundryBase.targets
@@ -1,6 +1,10 @@
 <Project>
-  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
-    <Error
+  <Target Name="Warn_SteeltoeSecurityAuthenticationCloudFoundryBase" BeforeTargets="BeforeResolveReferences">
+    <Warning
       Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Security.Authentication.JwtBearer / Steeltoe.Security.Authentication.OpenIdConnect / Steeltoe.Security.Authorization.Certificate instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+
+  <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="One or more Steeltoe package dependencies need attention. See the build warnings for details." />
   </Target>
 </Project>

--- a/src/Obsolete/Steeltoe.Security.Authentication.CloudFoundryBase/Build/Steeltoe.Security.Authentication.CloudFoundryBase.targets
+++ b/src/Obsolete/Steeltoe.Security.Authentication.CloudFoundryBase/Build/Steeltoe.Security.Authentication.CloudFoundryBase.targets
@@ -1,7 +1,7 @@
 <Project>
   <Target Name="Warn_SteeltoeSecurityAuthenticationCloudFoundryBase" BeforeTargets="BeforeResolveReferences">
     <Warning
-      Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Security.Authentication.JwtBearer / Steeltoe.Security.Authentication.OpenIdConnect / Steeltoe.Security.Authorization.Certificate instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+      Text="The NuGet package Steeltoe.Security.Authentication.CloudFoundryBase has been replaced in Steeltoe v4. Reference Steeltoe.Security.Authentication.JwtBearer / Steeltoe.Security.Authentication.OpenIdConnect / Steeltoe.Security.Authorization.Certificate instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.Security.Authentication.CloudFoundryBase/Build/Steeltoe.Security.Authentication.CloudFoundryBase.targets
+++ b/src/Obsolete/Steeltoe.Security.Authentication.CloudFoundryBase/Build/Steeltoe.Security.Authentication.CloudFoundryBase.targets
@@ -1,7 +1,7 @@
 <Project>
   <Target Name="Warn_SteeltoeSecurityAuthenticationCloudFoundryBase" AfterTargets="AfterResolveReferences">
     <Warning
-      Text="The NuGet package Steeltoe.Security.Authentication.CloudFoundryBase has been replaced in Steeltoe v4. Reference Steeltoe.Security.Authentication.JwtBearer / Steeltoe.Security.Authentication.OpenIdConnect / Steeltoe.Security.Authorization.Certificate instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+      Text="The NuGet package Steeltoe.Security.Authentication.CloudFoundryBase has been superseded in Steeltoe v4. Reference Steeltoe.Security.Authentication.JwtBearer / Steeltoe.Security.Authentication.OpenIdConnect / Steeltoe.Security.Authorization.Certificate instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.Security.Authentication.CloudFoundryBase/Build/Steeltoe.Security.Authentication.CloudFoundryBase.targets
+++ b/src/Obsolete/Steeltoe.Security.Authentication.CloudFoundryBase/Build/Steeltoe.Security.Authentication.CloudFoundryBase.targets
@@ -1,5 +1,5 @@
 <Project>
-  <Target Name="Warn_SteeltoeSecurityAuthenticationCloudFoundryBase" BeforeTargets="BeforeResolveReferences">
+  <Target Name="Warn_SteeltoeSecurityAuthenticationCloudFoundryBase" AfterTargets="AfterResolveReferences">
     <Warning
       Text="The NuGet package Steeltoe.Security.Authentication.CloudFoundryBase has been replaced in Steeltoe v4. Reference Steeltoe.Security.Authentication.JwtBearer / Steeltoe.Security.Authentication.OpenIdConnect / Steeltoe.Security.Authorization.Certificate instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>

--- a/src/Obsolete/Steeltoe.Security.Authentication.CloudFoundryBase/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.Security.Authentication.CloudFoundryBase/PackageReadme.md
@@ -1,7 +1,7 @@
 # Steeltoe
 
 > [!IMPORTANT]
-> This package has been replaced in Steeltoe v4. Reference `Steeltoe.Security.Authentication.JwtBearer` / `Steeltoe.Security.Authentication.OpenIdConnect` / `Steeltoe.Security.Authorization.Certificate` instead.
+> This package has been superseded in Steeltoe v4. Reference `Steeltoe.Security.Authentication.JwtBearer` / `Steeltoe.Security.Authentication.OpenIdConnect` / `Steeltoe.Security.Authorization.Certificate` instead.
 > See <https://steeltoe.io/docs/v3/obsolete> for details.
 
 [Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).

--- a/src/Obsolete/Steeltoe.Security.Authentication.CloudFoundryBase/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.Security.Authentication.CloudFoundryBase/PackageReadme.md
@@ -1,0 +1,17 @@
+# Steeltoe
+
+> [!IMPORTANT]
+> This package has been replaced in Steeltoe v4. Reference `Steeltoe.Security.Authentication.JwtBearer` / `Steeltoe.Security.Authentication.OpenIdConnect` / `Steeltoe.Security.Authorization.Certificate` instead.
+> See <https://steeltoe.io/docs/v3/obsolete> for details.
+
+[Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).
+
+Key features include:
+
+- External (optionally encrypted) configuration using [Spring Cloud Config Server](https://docs.spring.io/spring-cloud-config/docs/current/reference/html/)
+- Service discovery with [Netflix Eureka](https://spring.io/projects/spring-cloud-netflix) and [HashiCorp Consul](https://www.consul.io/)
+- Management endpoints (compatible with [actuators](https://docs.spring.io/spring-boot/docs/current/reference/html/actuator.html)), providing system info (such as versions, configuration, service container contents, mapped routes and HTTP traffic), heap/thread dumps, health checks, exporting metrics to [Prometheus](https://prometheus.io/), and changing log levels at runtime.
+- Connectivity to databases (such as [SQL Server](https://www.microsoft.com/sql-server)/[Azure SQL](https://azure.microsoft.com/products/azure-sql), [Cosmos DB](https://azure.microsoft.com/products/cosmos-db/), [MongoDB](https://www.mongodb.com/), [Redis](https://redis.io/), [RabbitMQ](https://www.rabbitmq.com/), [PostgreSQL](https://www.postgresql.org/), and [MySQL](https://www.mysql.com/)), including support for [Entity Framework Core](https://learn.microsoft.com/ef/core/)
+- Single sign-on, JWT and Certificate auth with [Cloud Foundry](https://www.cloudfoundry.org/)
+
+For more information and to get started, please visit [Steeltoe on GitHub](https://github.com/SteeltoeOSS/Steeltoe) or the [documentation](https://steeltoe.io/docs).

--- a/src/Obsolete/Steeltoe.Security.Authentication.CloudFoundryBase/Steeltoe.Security.Authentication.CloudFoundryBase.csproj
+++ b/src/Obsolete/Steeltoe.Security.Authentication.CloudFoundryBase/Steeltoe.Security.Authentication.CloudFoundryBase.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net8.0</TargetFrameworks>
+    <Description>TODO: Fill package description.</Description>
+    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
+  <Import Project="..\..\..\shared.props" />
+
+  <ItemGroup>
+    <None Include="Build\*.props" Pack="True" PackagePath="build" />
+    <None Include="Build\*.targets" Pack="True" PackagePath="build" />
+  </ItemGroup>
+</Project>

--- a/src/Obsolete/Steeltoe.Security.Authentication.CloudFoundryBase/Steeltoe.Security.Authentication.CloudFoundryBase.csproj
+++ b/src/Obsolete/Steeltoe.Security.Authentication.CloudFoundryBase/Steeltoe.Security.Authentication.CloudFoundryBase.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
-    <Description>TODO: Fill package description.</Description>
-    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <Description>Base Security Provider for CloudFoundry.</Description>
+    <PackageTags>CloudFoundry;security;oauth2;sso;openid</PackageTags>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 

--- a/src/Obsolete/Steeltoe.Security.Authentication.CloudFoundryCore/Build/Steeltoe.Security.Authentication.CloudFoundryCore.targets
+++ b/src/Obsolete/Steeltoe.Security.Authentication.CloudFoundryCore/Build/Steeltoe.Security.Authentication.CloudFoundryCore.targets
@@ -1,0 +1,5 @@
+<Project>
+  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Security.Authentication.JwtBearer / Steeltoe.Security.Authentication.OpenIdConnect / Steeltoe.Security.Authorization.Certificate instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+</Project>

--- a/src/Obsolete/Steeltoe.Security.Authentication.CloudFoundryCore/Build/Steeltoe.Security.Authentication.CloudFoundryCore.targets
+++ b/src/Obsolete/Steeltoe.Security.Authentication.CloudFoundryCore/Build/Steeltoe.Security.Authentication.CloudFoundryCore.targets
@@ -1,7 +1,7 @@
 <Project>
   <Target Name="Warn_SteeltoeSecurityAuthenticationCloudFoundryCore" BeforeTargets="BeforeResolveReferences">
     <Warning
-      Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Security.Authentication.JwtBearer / Steeltoe.Security.Authentication.OpenIdConnect / Steeltoe.Security.Authorization.Certificate instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+      Text="The NuGet package Steeltoe.Security.Authentication.CloudFoundryCore has been replaced in Steeltoe v4. Reference Steeltoe.Security.Authentication.JwtBearer / Steeltoe.Security.Authentication.OpenIdConnect / Steeltoe.Security.Authorization.Certificate instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.Security.Authentication.CloudFoundryCore/Build/Steeltoe.Security.Authentication.CloudFoundryCore.targets
+++ b/src/Obsolete/Steeltoe.Security.Authentication.CloudFoundryCore/Build/Steeltoe.Security.Authentication.CloudFoundryCore.targets
@@ -1,5 +1,6 @@
 <Project>
   <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
-    <Error Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Security.Authentication.JwtBearer / Steeltoe.Security.Authentication.OpenIdConnect / Steeltoe.Security.Authorization.Certificate instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+    <Error
+      Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Security.Authentication.JwtBearer / Steeltoe.Security.Authentication.OpenIdConnect / Steeltoe.Security.Authorization.Certificate instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 </Project>

--- a/src/Obsolete/Steeltoe.Security.Authentication.CloudFoundryCore/Build/Steeltoe.Security.Authentication.CloudFoundryCore.targets
+++ b/src/Obsolete/Steeltoe.Security.Authentication.CloudFoundryCore/Build/Steeltoe.Security.Authentication.CloudFoundryCore.targets
@@ -1,7 +1,7 @@
 <Project>
   <Target Name="Warn_SteeltoeSecurityAuthenticationCloudFoundryCore" AfterTargets="AfterResolveReferences">
     <Warning
-      Text="The NuGet package Steeltoe.Security.Authentication.CloudFoundryCore has been replaced in Steeltoe v4. Reference Steeltoe.Security.Authentication.JwtBearer / Steeltoe.Security.Authentication.OpenIdConnect / Steeltoe.Security.Authorization.Certificate instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+      Text="The NuGet package Steeltoe.Security.Authentication.CloudFoundryCore has been superseded in Steeltoe v4. Reference Steeltoe.Security.Authentication.JwtBearer / Steeltoe.Security.Authentication.OpenIdConnect / Steeltoe.Security.Authorization.Certificate instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.Security.Authentication.CloudFoundryCore/Build/Steeltoe.Security.Authentication.CloudFoundryCore.targets
+++ b/src/Obsolete/Steeltoe.Security.Authentication.CloudFoundryCore/Build/Steeltoe.Security.Authentication.CloudFoundryCore.targets
@@ -1,5 +1,5 @@
 <Project>
-  <Target Name="Warn_SteeltoeSecurityAuthenticationCloudFoundryCore" BeforeTargets="BeforeResolveReferences">
+  <Target Name="Warn_SteeltoeSecurityAuthenticationCloudFoundryCore" AfterTargets="AfterResolveReferences">
     <Warning
       Text="The NuGet package Steeltoe.Security.Authentication.CloudFoundryCore has been replaced in Steeltoe v4. Reference Steeltoe.Security.Authentication.JwtBearer / Steeltoe.Security.Authentication.OpenIdConnect / Steeltoe.Security.Authorization.Certificate instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>

--- a/src/Obsolete/Steeltoe.Security.Authentication.CloudFoundryCore/Build/Steeltoe.Security.Authentication.CloudFoundryCore.targets
+++ b/src/Obsolete/Steeltoe.Security.Authentication.CloudFoundryCore/Build/Steeltoe.Security.Authentication.CloudFoundryCore.targets
@@ -1,6 +1,10 @@
 <Project>
-  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
-    <Error
+  <Target Name="Warn_SteeltoeSecurityAuthenticationCloudFoundryCore" BeforeTargets="BeforeResolveReferences">
+    <Warning
       Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Security.Authentication.JwtBearer / Steeltoe.Security.Authentication.OpenIdConnect / Steeltoe.Security.Authorization.Certificate instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+
+  <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="One or more Steeltoe package dependencies need attention. See the build warnings for details." />
   </Target>
 </Project>

--- a/src/Obsolete/Steeltoe.Security.Authentication.CloudFoundryCore/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.Security.Authentication.CloudFoundryCore/PackageReadme.md
@@ -1,7 +1,7 @@
 # Steeltoe
 
 > [!IMPORTANT]
-> This package has been replaced in Steeltoe v4. Reference `Steeltoe.Security.Authentication.JwtBearer` / `Steeltoe.Security.Authentication.OpenIdConnect` / `Steeltoe.Security.Authorization.Certificate` instead.
+> This package has been superseded in Steeltoe v4. Reference `Steeltoe.Security.Authentication.JwtBearer` / `Steeltoe.Security.Authentication.OpenIdConnect` / `Steeltoe.Security.Authorization.Certificate` instead.
 > See <https://steeltoe.io/docs/v3/obsolete> for details.
 
 [Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).

--- a/src/Obsolete/Steeltoe.Security.Authentication.CloudFoundryCore/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.Security.Authentication.CloudFoundryCore/PackageReadme.md
@@ -1,0 +1,17 @@
+# Steeltoe
+
+> [!IMPORTANT]
+> This package has been replaced in Steeltoe v4. Reference `Steeltoe.Security.Authentication.JwtBearer` / `Steeltoe.Security.Authentication.OpenIdConnect` / `Steeltoe.Security.Authorization.Certificate` instead.
+> See <https://steeltoe.io/docs/v3/obsolete> for details.
+
+[Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).
+
+Key features include:
+
+- External (optionally encrypted) configuration using [Spring Cloud Config Server](https://docs.spring.io/spring-cloud-config/docs/current/reference/html/)
+- Service discovery with [Netflix Eureka](https://spring.io/projects/spring-cloud-netflix) and [HashiCorp Consul](https://www.consul.io/)
+- Management endpoints (compatible with [actuators](https://docs.spring.io/spring-boot/docs/current/reference/html/actuator.html)), providing system info (such as versions, configuration, service container contents, mapped routes and HTTP traffic), heap/thread dumps, health checks, exporting metrics to [Prometheus](https://prometheus.io/), and changing log levels at runtime.
+- Connectivity to databases (such as [SQL Server](https://www.microsoft.com/sql-server)/[Azure SQL](https://azure.microsoft.com/products/azure-sql), [Cosmos DB](https://azure.microsoft.com/products/cosmos-db/), [MongoDB](https://www.mongodb.com/), [Redis](https://redis.io/), [RabbitMQ](https://www.rabbitmq.com/), [PostgreSQL](https://www.postgresql.org/), and [MySQL](https://www.mysql.com/)), including support for [Entity Framework Core](https://learn.microsoft.com/ef/core/)
+- Single sign-on, JWT and Certificate auth with [Cloud Foundry](https://www.cloudfoundry.org/)
+
+For more information and to get started, please visit [Steeltoe on GitHub](https://github.com/SteeltoeOSS/Steeltoe) or the [documentation](https://steeltoe.io/docs).

--- a/src/Obsolete/Steeltoe.Security.Authentication.CloudFoundryCore/Steeltoe.Security.Authentication.CloudFoundryCore.csproj
+++ b/src/Obsolete/Steeltoe.Security.Authentication.CloudFoundryCore/Steeltoe.Security.Authentication.CloudFoundryCore.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net8.0</TargetFrameworks>
+    <Description>TODO: Fill package description.</Description>
+    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
+  <Import Project="..\..\..\shared.props" />
+
+  <ItemGroup>
+    <None Include="Build\*.props" Pack="True" PackagePath="build" />
+    <None Include="Build\*.targets" Pack="True" PackagePath="build" />
+  </ItemGroup>
+</Project>

--- a/src/Obsolete/Steeltoe.Security.Authentication.CloudFoundryCore/Steeltoe.Security.Authentication.CloudFoundryCore.csproj
+++ b/src/Obsolete/Steeltoe.Security.Authentication.CloudFoundryCore/Steeltoe.Security.Authentication.CloudFoundryCore.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
-    <Description>TODO: Fill package description.</Description>
-    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <Description>ASP.NET Core External Security Provider for CloudFoundry.</Description>
+    <PackageTags>CloudFoundry;ASPNET Core;Security;OAuth2;SSO;OpenIDConnect</PackageTags>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 

--- a/src/Obsolete/Steeltoe.Security.Authentication.MtlsCore/Build/Steeltoe.Security.Authentication.MtlsCore.targets
+++ b/src/Obsolete/Steeltoe.Security.Authentication.MtlsCore/Build/Steeltoe.Security.Authentication.MtlsCore.targets
@@ -1,6 +1,10 @@
 <Project>
-  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
-    <Error
+  <Target Name="Warn_SteeltoeSecurityAuthenticationMtlsCore" BeforeTargets="BeforeResolveReferences">
+    <Warning
       Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Security.Authorization.Certificate instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+
+  <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="One or more Steeltoe package dependencies need attention. See the build warnings for details." />
   </Target>
 </Project>

--- a/src/Obsolete/Steeltoe.Security.Authentication.MtlsCore/Build/Steeltoe.Security.Authentication.MtlsCore.targets
+++ b/src/Obsolete/Steeltoe.Security.Authentication.MtlsCore/Build/Steeltoe.Security.Authentication.MtlsCore.targets
@@ -1,0 +1,5 @@
+<Project>
+  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Security.Authorization.Certificate instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+</Project>

--- a/src/Obsolete/Steeltoe.Security.Authentication.MtlsCore/Build/Steeltoe.Security.Authentication.MtlsCore.targets
+++ b/src/Obsolete/Steeltoe.Security.Authentication.MtlsCore/Build/Steeltoe.Security.Authentication.MtlsCore.targets
@@ -1,7 +1,7 @@
 <Project>
   <Target Name="Warn_SteeltoeSecurityAuthenticationMtlsCore" AfterTargets="AfterResolveReferences">
     <Warning
-      Text="The NuGet package Steeltoe.Security.Authentication.MtlsCore has been replaced in Steeltoe v4. Reference Steeltoe.Security.Authorization.Certificate instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+      Text="The NuGet package Steeltoe.Security.Authentication.MtlsCore has been superseded in Steeltoe v4. Reference Steeltoe.Security.Authorization.Certificate instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.Security.Authentication.MtlsCore/Build/Steeltoe.Security.Authentication.MtlsCore.targets
+++ b/src/Obsolete/Steeltoe.Security.Authentication.MtlsCore/Build/Steeltoe.Security.Authentication.MtlsCore.targets
@@ -1,5 +1,5 @@
 <Project>
-  <Target Name="Warn_SteeltoeSecurityAuthenticationMtlsCore" BeforeTargets="BeforeResolveReferences">
+  <Target Name="Warn_SteeltoeSecurityAuthenticationMtlsCore" AfterTargets="AfterResolveReferences">
     <Warning
       Text="The NuGet package Steeltoe.Security.Authentication.MtlsCore has been replaced in Steeltoe v4. Reference Steeltoe.Security.Authorization.Certificate instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>

--- a/src/Obsolete/Steeltoe.Security.Authentication.MtlsCore/Build/Steeltoe.Security.Authentication.MtlsCore.targets
+++ b/src/Obsolete/Steeltoe.Security.Authentication.MtlsCore/Build/Steeltoe.Security.Authentication.MtlsCore.targets
@@ -1,5 +1,6 @@
 <Project>
   <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
-    <Error Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Security.Authorization.Certificate instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+    <Error
+      Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Security.Authorization.Certificate instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 </Project>

--- a/src/Obsolete/Steeltoe.Security.Authentication.MtlsCore/Build/Steeltoe.Security.Authentication.MtlsCore.targets
+++ b/src/Obsolete/Steeltoe.Security.Authentication.MtlsCore/Build/Steeltoe.Security.Authentication.MtlsCore.targets
@@ -1,7 +1,7 @@
 <Project>
   <Target Name="Warn_SteeltoeSecurityAuthenticationMtlsCore" BeforeTargets="BeforeResolveReferences">
     <Warning
-      Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Security.Authorization.Certificate instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+      Text="The NuGet package Steeltoe.Security.Authentication.MtlsCore has been replaced in Steeltoe v4. Reference Steeltoe.Security.Authorization.Certificate instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.Security.Authentication.MtlsCore/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.Security.Authentication.MtlsCore/PackageReadme.md
@@ -1,7 +1,7 @@
 # Steeltoe
 
 > [!IMPORTANT]
-> This package has been replaced in Steeltoe v4. Reference `Steeltoe.Security.Authorization.Certificate` instead.
+> This package has been superseded in Steeltoe v4. Reference `Steeltoe.Security.Authorization.Certificate` instead.
 > See <https://steeltoe.io/docs/v3/obsolete> for details.
 
 [Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).

--- a/src/Obsolete/Steeltoe.Security.Authentication.MtlsCore/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.Security.Authentication.MtlsCore/PackageReadme.md
@@ -1,0 +1,17 @@
+# Steeltoe
+
+> [!IMPORTANT]
+> This package has been replaced in Steeltoe v4. Reference `Steeltoe.Security.Authorization.Certificate` instead.
+> See <https://steeltoe.io/docs/v3/obsolete> for details.
+
+[Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).
+
+Key features include:
+
+- External (optionally encrypted) configuration using [Spring Cloud Config Server](https://docs.spring.io/spring-cloud-config/docs/current/reference/html/)
+- Service discovery with [Netflix Eureka](https://spring.io/projects/spring-cloud-netflix) and [HashiCorp Consul](https://www.consul.io/)
+- Management endpoints (compatible with [actuators](https://docs.spring.io/spring-boot/docs/current/reference/html/actuator.html)), providing system info (such as versions, configuration, service container contents, mapped routes and HTTP traffic), heap/thread dumps, health checks, exporting metrics to [Prometheus](https://prometheus.io/), and changing log levels at runtime.
+- Connectivity to databases (such as [SQL Server](https://www.microsoft.com/sql-server)/[Azure SQL](https://azure.microsoft.com/products/azure-sql), [Cosmos DB](https://azure.microsoft.com/products/cosmos-db/), [MongoDB](https://www.mongodb.com/), [Redis](https://redis.io/), [RabbitMQ](https://www.rabbitmq.com/), [PostgreSQL](https://www.postgresql.org/), and [MySQL](https://www.mysql.com/)), including support for [Entity Framework Core](https://learn.microsoft.com/ef/core/)
+- Single sign-on, JWT and Certificate auth with [Cloud Foundry](https://www.cloudfoundry.org/)
+
+For more information and to get started, please visit [Steeltoe on GitHub](https://github.com/SteeltoeOSS/Steeltoe) or the [documentation](https://steeltoe.io/docs).

--- a/src/Obsolete/Steeltoe.Security.Authentication.MtlsCore/Steeltoe.Security.Authentication.MtlsCore.csproj
+++ b/src/Obsolete/Steeltoe.Security.Authentication.MtlsCore/Steeltoe.Security.Authentication.MtlsCore.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net8.0</TargetFrameworks>
+    <Description>TODO: Fill package description.</Description>
+    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
+  <Import Project="..\..\..\shared.props" />
+
+  <ItemGroup>
+    <None Include="Build\*.props" Pack="True" PackagePath="build" />
+    <None Include="Build\*.targets" Pack="True" PackagePath="build" />
+  </ItemGroup>
+</Project>

--- a/src/Obsolete/Steeltoe.Security.Authentication.MtlsCore/Steeltoe.Security.Authentication.MtlsCore.csproj
+++ b/src/Obsolete/Steeltoe.Security.Authentication.MtlsCore/Steeltoe.Security.Authentication.MtlsCore.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
-    <Description>TODO: Fill package description.</Description>
-    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <Description>ASP.NET Core middleware that enables an application to support certificate authentication.</Description>
+    <PackageTags>aspnetcore;authentication;security;x509;certificate;mtls</PackageTags>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 

--- a/src/Obsolete/Steeltoe.Security.DataProtection.CredHubBase/Build/Steeltoe.Security.DataProtection.CredHubBase.targets
+++ b/src/Obsolete/Steeltoe.Security.DataProtection.CredHubBase/Build/Steeltoe.Security.DataProtection.CredHubBase.targets
@@ -1,0 +1,5 @@
+<Project>
+  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="This feature is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+</Project>

--- a/src/Obsolete/Steeltoe.Security.DataProtection.CredHubBase/Build/Steeltoe.Security.DataProtection.CredHubBase.targets
+++ b/src/Obsolete/Steeltoe.Security.DataProtection.CredHubBase/Build/Steeltoe.Security.DataProtection.CredHubBase.targets
@@ -1,7 +1,7 @@
 <Project>
   <Target Name="Warn_SteeltoeSecurityDataProtectionCredHubBase" AfterTargets="AfterResolveReferences">
     <Warning
-      Text="The NuGet package Steeltoe.Security.DataProtection.CredHubBase is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+      Text="The NuGet package Steeltoe.Security.DataProtection.CredHubBase has been removed from Steeltoe in v4. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.Security.DataProtection.CredHubBase/Build/Steeltoe.Security.DataProtection.CredHubBase.targets
+++ b/src/Obsolete/Steeltoe.Security.DataProtection.CredHubBase/Build/Steeltoe.Security.DataProtection.CredHubBase.targets
@@ -1,5 +1,9 @@
 <Project>
-  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
-    <Error Text="This feature is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+  <Target Name="Warn_SteeltoeSecurityDataProtectionCredHubBase" BeforeTargets="BeforeResolveReferences">
+    <Warning Text="This feature is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+
+  <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="One or more Steeltoe package dependencies need attention. See the build warnings for details." />
   </Target>
 </Project>

--- a/src/Obsolete/Steeltoe.Security.DataProtection.CredHubBase/Build/Steeltoe.Security.DataProtection.CredHubBase.targets
+++ b/src/Obsolete/Steeltoe.Security.DataProtection.CredHubBase/Build/Steeltoe.Security.DataProtection.CredHubBase.targets
@@ -1,6 +1,7 @@
 <Project>
   <Target Name="Warn_SteeltoeSecurityDataProtectionCredHubBase" BeforeTargets="BeforeResolveReferences">
-    <Warning Text="This feature is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+    <Warning
+      Text="The NuGet package Steeltoe.Security.DataProtection.CredHubBase is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.Security.DataProtection.CredHubBase/Build/Steeltoe.Security.DataProtection.CredHubBase.targets
+++ b/src/Obsolete/Steeltoe.Security.DataProtection.CredHubBase/Build/Steeltoe.Security.DataProtection.CredHubBase.targets
@@ -1,5 +1,5 @@
 <Project>
-  <Target Name="Warn_SteeltoeSecurityDataProtectionCredHubBase" BeforeTargets="BeforeResolveReferences">
+  <Target Name="Warn_SteeltoeSecurityDataProtectionCredHubBase" AfterTargets="AfterResolveReferences">
     <Warning
       Text="The NuGet package Steeltoe.Security.DataProtection.CredHubBase is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>

--- a/src/Obsolete/Steeltoe.Security.DataProtection.CredHubBase/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.Security.DataProtection.CredHubBase/PackageReadme.md
@@ -1,0 +1,17 @@
+# Steeltoe
+
+> [!IMPORTANT]
+> This feature is no longer available in Steeltoe v4.
+> See <https://steeltoe.io/docs/v3/obsolete> for details.
+
+[Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).
+
+Key features include:
+
+- External (optionally encrypted) configuration using [Spring Cloud Config Server](https://docs.spring.io/spring-cloud-config/docs/current/reference/html/)
+- Service discovery with [Netflix Eureka](https://spring.io/projects/spring-cloud-netflix) and [HashiCorp Consul](https://www.consul.io/)
+- Management endpoints (compatible with [actuators](https://docs.spring.io/spring-boot/docs/current/reference/html/actuator.html)), providing system info (such as versions, configuration, service container contents, mapped routes and HTTP traffic), heap/thread dumps, health checks, exporting metrics to [Prometheus](https://prometheus.io/), and changing log levels at runtime.
+- Connectivity to databases (such as [SQL Server](https://www.microsoft.com/sql-server)/[Azure SQL](https://azure.microsoft.com/products/azure-sql), [Cosmos DB](https://azure.microsoft.com/products/cosmos-db/), [MongoDB](https://www.mongodb.com/), [Redis](https://redis.io/), [RabbitMQ](https://www.rabbitmq.com/), [PostgreSQL](https://www.postgresql.org/), and [MySQL](https://www.mysql.com/)), including support for [Entity Framework Core](https://learn.microsoft.com/ef/core/)
+- Single sign-on, JWT and Certificate auth with [Cloud Foundry](https://www.cloudfoundry.org/)
+
+For more information and to get started, please visit [Steeltoe on GitHub](https://github.com/SteeltoeOSS/Steeltoe) or the [documentation](https://steeltoe.io/docs).

--- a/src/Obsolete/Steeltoe.Security.DataProtection.CredHubBase/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.Security.DataProtection.CredHubBase/PackageReadme.md
@@ -1,7 +1,7 @@
 # Steeltoe
 
 > [!IMPORTANT]
-> This feature is no longer available in Steeltoe v4.
+> This package has been removed from Steeltoe in v4.
 > See <https://steeltoe.io/docs/v3/obsolete> for details.
 
 [Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).

--- a/src/Obsolete/Steeltoe.Security.DataProtection.CredHubBase/Steeltoe.Security.DataProtection.CredHubBase.csproj
+++ b/src/Obsolete/Steeltoe.Security.DataProtection.CredHubBase/Steeltoe.Security.DataProtection.CredHubBase.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net8.0</TargetFrameworks>
+    <Description>TODO: Fill package description.</Description>
+    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
+  <Import Project="..\..\..\shared.props" />
+
+  <ItemGroup>
+    <None Include="Build\*.props" Pack="True" PackagePath="build" />
+    <None Include="Build\*.targets" Pack="True" PackagePath="build" />
+  </ItemGroup>
+</Project>

--- a/src/Obsolete/Steeltoe.Security.DataProtection.CredHubBase/Steeltoe.Security.DataProtection.CredHubBase.csproj
+++ b/src/Obsolete/Steeltoe.Security.DataProtection.CredHubBase/Steeltoe.Security.DataProtection.CredHubBase.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
-    <Description>TODO: Fill package description.</Description>
-    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <Description>NET Client for CredHub - Base Package.</Description>
+    <PackageTags>CloudFoundry;NET Core;Security;DataProtection;CredHub</PackageTags>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 

--- a/src/Obsolete/Steeltoe.Security.DataProtection.CredHubCore/Build/Steeltoe.Security.DataProtection.CredHubCore.targets
+++ b/src/Obsolete/Steeltoe.Security.DataProtection.CredHubCore/Build/Steeltoe.Security.DataProtection.CredHubCore.targets
@@ -1,5 +1,5 @@
 <Project>
-  <Target Name="Warn_SteeltoeSecurityDataProtectionCredHubCore" BeforeTargets="BeforeResolveReferences">
+  <Target Name="Warn_SteeltoeSecurityDataProtectionCredHubCore" AfterTargets="AfterResolveReferences">
     <Warning
       Text="The NuGet package Steeltoe.Security.DataProtection.CredHubCore is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>

--- a/src/Obsolete/Steeltoe.Security.DataProtection.CredHubCore/Build/Steeltoe.Security.DataProtection.CredHubCore.targets
+++ b/src/Obsolete/Steeltoe.Security.DataProtection.CredHubCore/Build/Steeltoe.Security.DataProtection.CredHubCore.targets
@@ -1,0 +1,5 @@
+<Project>
+  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="This feature is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+</Project>

--- a/src/Obsolete/Steeltoe.Security.DataProtection.CredHubCore/Build/Steeltoe.Security.DataProtection.CredHubCore.targets
+++ b/src/Obsolete/Steeltoe.Security.DataProtection.CredHubCore/Build/Steeltoe.Security.DataProtection.CredHubCore.targets
@@ -1,5 +1,9 @@
 <Project>
-  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
-    <Error Text="This feature is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+  <Target Name="Warn_SteeltoeSecurityDataProtectionCredHubCore" BeforeTargets="BeforeResolveReferences">
+    <Warning Text="This feature is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+
+  <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="One or more Steeltoe package dependencies need attention. See the build warnings for details." />
   </Target>
 </Project>

--- a/src/Obsolete/Steeltoe.Security.DataProtection.CredHubCore/Build/Steeltoe.Security.DataProtection.CredHubCore.targets
+++ b/src/Obsolete/Steeltoe.Security.DataProtection.CredHubCore/Build/Steeltoe.Security.DataProtection.CredHubCore.targets
@@ -1,6 +1,7 @@
 <Project>
   <Target Name="Warn_SteeltoeSecurityDataProtectionCredHubCore" BeforeTargets="BeforeResolveReferences">
-    <Warning Text="This feature is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+    <Warning
+      Text="The NuGet package Steeltoe.Security.DataProtection.CredHubCore is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.Security.DataProtection.CredHubCore/Build/Steeltoe.Security.DataProtection.CredHubCore.targets
+++ b/src/Obsolete/Steeltoe.Security.DataProtection.CredHubCore/Build/Steeltoe.Security.DataProtection.CredHubCore.targets
@@ -1,7 +1,7 @@
 <Project>
   <Target Name="Warn_SteeltoeSecurityDataProtectionCredHubCore" AfterTargets="AfterResolveReferences">
     <Warning
-      Text="The NuGet package Steeltoe.Security.DataProtection.CredHubCore is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+      Text="The NuGet package Steeltoe.Security.DataProtection.CredHubCore has been removed from Steeltoe in v4. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.Security.DataProtection.CredHubCore/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.Security.DataProtection.CredHubCore/PackageReadme.md
@@ -1,0 +1,17 @@
+# Steeltoe
+
+> [!IMPORTANT]
+> This feature is no longer available in Steeltoe v4.
+> See <https://steeltoe.io/docs/v3/obsolete> for details.
+
+[Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).
+
+Key features include:
+
+- External (optionally encrypted) configuration using [Spring Cloud Config Server](https://docs.spring.io/spring-cloud-config/docs/current/reference/html/)
+- Service discovery with [Netflix Eureka](https://spring.io/projects/spring-cloud-netflix) and [HashiCorp Consul](https://www.consul.io/)
+- Management endpoints (compatible with [actuators](https://docs.spring.io/spring-boot/docs/current/reference/html/actuator.html)), providing system info (such as versions, configuration, service container contents, mapped routes and HTTP traffic), heap/thread dumps, health checks, exporting metrics to [Prometheus](https://prometheus.io/), and changing log levels at runtime.
+- Connectivity to databases (such as [SQL Server](https://www.microsoft.com/sql-server)/[Azure SQL](https://azure.microsoft.com/products/azure-sql), [Cosmos DB](https://azure.microsoft.com/products/cosmos-db/), [MongoDB](https://www.mongodb.com/), [Redis](https://redis.io/), [RabbitMQ](https://www.rabbitmq.com/), [PostgreSQL](https://www.postgresql.org/), and [MySQL](https://www.mysql.com/)), including support for [Entity Framework Core](https://learn.microsoft.com/ef/core/)
+- Single sign-on, JWT and Certificate auth with [Cloud Foundry](https://www.cloudfoundry.org/)
+
+For more information and to get started, please visit [Steeltoe on GitHub](https://github.com/SteeltoeOSS/Steeltoe) or the [documentation](https://steeltoe.io/docs).

--- a/src/Obsolete/Steeltoe.Security.DataProtection.CredHubCore/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.Security.DataProtection.CredHubCore/PackageReadme.md
@@ -1,7 +1,7 @@
 # Steeltoe
 
 > [!IMPORTANT]
-> This feature is no longer available in Steeltoe v4.
+> This package has been removed from Steeltoe in v4.
 > See <https://steeltoe.io/docs/v3/obsolete> for details.
 
 [Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).

--- a/src/Obsolete/Steeltoe.Security.DataProtection.CredHubCore/Steeltoe.Security.DataProtection.CredHubCore.csproj
+++ b/src/Obsolete/Steeltoe.Security.DataProtection.CredHubCore/Steeltoe.Security.DataProtection.CredHubCore.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net8.0</TargetFrameworks>
+    <Description>TODO: Fill package description.</Description>
+    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
+  <Import Project="..\..\..\shared.props" />
+
+  <ItemGroup>
+    <None Include="Build\*.props" Pack="True" PackagePath="build" />
+    <None Include="Build\*.targets" Pack="True" PackagePath="build" />
+  </ItemGroup>
+</Project>

--- a/src/Obsolete/Steeltoe.Security.DataProtection.CredHubCore/Steeltoe.Security.DataProtection.CredHubCore.csproj
+++ b/src/Obsolete/Steeltoe.Security.DataProtection.CredHubCore/Steeltoe.Security.DataProtection.CredHubCore.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
-    <Description>TODO: Fill package description.</Description>
-    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <Description>ASP.NET Core Extensions for CredHub Client.</Description>
+    <PackageTags>CloudFoundry;aspnetcore;Security;DataProtection;CredHub</PackageTags>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 

--- a/src/Obsolete/Steeltoe.Security.DataProtection.RedisCore/Build/Steeltoe.Security.DataProtection.RedisCore.targets
+++ b/src/Obsolete/Steeltoe.Security.DataProtection.RedisCore/Build/Steeltoe.Security.DataProtection.RedisCore.targets
@@ -1,7 +1,7 @@
 <Project>
   <Target Name="Warn_SteeltoeSecurityDataProtectionRedisCore" BeforeTargets="BeforeResolveReferences">
     <Warning
-      Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Security.DataProtection.Redis instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+      Text="The NuGet package Steeltoe.Security.DataProtection.RedisCore has been replaced in Steeltoe v4. Reference Steeltoe.Security.DataProtection.Redis instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.Security.DataProtection.RedisCore/Build/Steeltoe.Security.DataProtection.RedisCore.targets
+++ b/src/Obsolete/Steeltoe.Security.DataProtection.RedisCore/Build/Steeltoe.Security.DataProtection.RedisCore.targets
@@ -1,5 +1,6 @@
 <Project>
   <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
-    <Error Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Security.DataProtection.Redis instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+    <Error
+      Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Security.DataProtection.Redis instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 </Project>

--- a/src/Obsolete/Steeltoe.Security.DataProtection.RedisCore/Build/Steeltoe.Security.DataProtection.RedisCore.targets
+++ b/src/Obsolete/Steeltoe.Security.DataProtection.RedisCore/Build/Steeltoe.Security.DataProtection.RedisCore.targets
@@ -1,5 +1,5 @@
 <Project>
-  <Target Name="Warn_SteeltoeSecurityDataProtectionRedisCore" BeforeTargets="BeforeResolveReferences">
+  <Target Name="Warn_SteeltoeSecurityDataProtectionRedisCore" AfterTargets="AfterResolveReferences">
     <Warning
       Text="The NuGet package Steeltoe.Security.DataProtection.RedisCore has been replaced in Steeltoe v4. Reference Steeltoe.Security.DataProtection.Redis instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>

--- a/src/Obsolete/Steeltoe.Security.DataProtection.RedisCore/Build/Steeltoe.Security.DataProtection.RedisCore.targets
+++ b/src/Obsolete/Steeltoe.Security.DataProtection.RedisCore/Build/Steeltoe.Security.DataProtection.RedisCore.targets
@@ -1,0 +1,5 @@
+<Project>
+  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Security.DataProtection.Redis instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+</Project>

--- a/src/Obsolete/Steeltoe.Security.DataProtection.RedisCore/Build/Steeltoe.Security.DataProtection.RedisCore.targets
+++ b/src/Obsolete/Steeltoe.Security.DataProtection.RedisCore/Build/Steeltoe.Security.DataProtection.RedisCore.targets
@@ -1,6 +1,10 @@
 <Project>
-  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
-    <Error
+  <Target Name="Warn_SteeltoeSecurityDataProtectionRedisCore" BeforeTargets="BeforeResolveReferences">
+    <Warning
       Text="This package has been replaced in Steeltoe v4. Reference Steeltoe.Security.DataProtection.Redis instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+
+  <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="One or more Steeltoe package dependencies need attention. See the build warnings for details." />
   </Target>
 </Project>

--- a/src/Obsolete/Steeltoe.Security.DataProtection.RedisCore/Build/Steeltoe.Security.DataProtection.RedisCore.targets
+++ b/src/Obsolete/Steeltoe.Security.DataProtection.RedisCore/Build/Steeltoe.Security.DataProtection.RedisCore.targets
@@ -1,7 +1,7 @@
 <Project>
   <Target Name="Warn_SteeltoeSecurityDataProtectionRedisCore" AfterTargets="AfterResolveReferences">
     <Warning
-      Text="The NuGet package Steeltoe.Security.DataProtection.RedisCore has been replaced in Steeltoe v4. Reference Steeltoe.Security.DataProtection.Redis instead. See https://steeltoe.io/docs/v3/obsolete for details." />
+      Text="The NuGet package Steeltoe.Security.DataProtection.RedisCore has been superseded in Steeltoe v4. Reference Steeltoe.Security.DataProtection.Redis instead. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.Security.DataProtection.RedisCore/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.Security.DataProtection.RedisCore/PackageReadme.md
@@ -1,7 +1,7 @@
 # Steeltoe
 
 > [!IMPORTANT]
-> This package has been replaced in Steeltoe v4. Reference `Steeltoe.Security.DataProtection.Redis` instead.
+> This package has been superseded in Steeltoe v4. Reference `Steeltoe.Security.DataProtection.Redis` instead.
 > See <https://steeltoe.io/docs/v3/obsolete> for details.
 
 [Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).

--- a/src/Obsolete/Steeltoe.Security.DataProtection.RedisCore/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.Security.DataProtection.RedisCore/PackageReadme.md
@@ -1,0 +1,17 @@
+# Steeltoe
+
+> [!IMPORTANT]
+> This package has been replaced in Steeltoe v4. Reference `Steeltoe.Security.DataProtection.Redis` instead.
+> See <https://steeltoe.io/docs/v3/obsolete> for details.
+
+[Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).
+
+Key features include:
+
+- External (optionally encrypted) configuration using [Spring Cloud Config Server](https://docs.spring.io/spring-cloud-config/docs/current/reference/html/)
+- Service discovery with [Netflix Eureka](https://spring.io/projects/spring-cloud-netflix) and [HashiCorp Consul](https://www.consul.io/)
+- Management endpoints (compatible with [actuators](https://docs.spring.io/spring-boot/docs/current/reference/html/actuator.html)), providing system info (such as versions, configuration, service container contents, mapped routes and HTTP traffic), heap/thread dumps, health checks, exporting metrics to [Prometheus](https://prometheus.io/), and changing log levels at runtime.
+- Connectivity to databases (such as [SQL Server](https://www.microsoft.com/sql-server)/[Azure SQL](https://azure.microsoft.com/products/azure-sql), [Cosmos DB](https://azure.microsoft.com/products/cosmos-db/), [MongoDB](https://www.mongodb.com/), [Redis](https://redis.io/), [RabbitMQ](https://www.rabbitmq.com/), [PostgreSQL](https://www.postgresql.org/), and [MySQL](https://www.mysql.com/)), including support for [Entity Framework Core](https://learn.microsoft.com/ef/core/)
+- Single sign-on, JWT and Certificate auth with [Cloud Foundry](https://www.cloudfoundry.org/)
+
+For more information and to get started, please visit [Steeltoe on GitHub](https://github.com/SteeltoeOSS/Steeltoe) or the [documentation](https://steeltoe.io/docs).

--- a/src/Obsolete/Steeltoe.Security.DataProtection.RedisCore/Steeltoe.Security.DataProtection.RedisCore.csproj
+++ b/src/Obsolete/Steeltoe.Security.DataProtection.RedisCore/Steeltoe.Security.DataProtection.RedisCore.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net8.0</TargetFrameworks>
+    <Description>TODO: Fill package description.</Description>
+    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
+  <Import Project="..\..\..\shared.props" />
+
+  <ItemGroup>
+    <None Include="Build\*.props" Pack="True" PackagePath="build" />
+    <None Include="Build\*.targets" Pack="True" PackagePath="build" />
+  </ItemGroup>
+</Project>

--- a/src/Obsolete/Steeltoe.Security.DataProtection.RedisCore/Steeltoe.Security.DataProtection.RedisCore.csproj
+++ b/src/Obsolete/Steeltoe.Security.DataProtection.RedisCore/Steeltoe.Security.DataProtection.RedisCore.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
-    <Description>TODO: Fill package description.</Description>
-    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <Description>Support for storing data protection keys in Redis.</Description>
+    <PackageTags>CloudFoundry;aspnetcore;security;dataprotection;redis</PackageTags>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 

--- a/src/Obsolete/Steeltoe.Stream.Abstractions/Build/Steeltoe.Stream.Abstractions.targets
+++ b/src/Obsolete/Steeltoe.Stream.Abstractions/Build/Steeltoe.Stream.Abstractions.targets
@@ -1,6 +1,6 @@
 <Project>
   <Target Name="Warn_SteeltoeStreamAbstractions" AfterTargets="AfterResolveReferences">
-    <Warning Text="The NuGet package Steeltoe.Stream.Abstractions is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+    <Warning Text="The NuGet package Steeltoe.Stream.Abstractions has been removed from Steeltoe in v4. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.Stream.Abstractions/Build/Steeltoe.Stream.Abstractions.targets
+++ b/src/Obsolete/Steeltoe.Stream.Abstractions/Build/Steeltoe.Stream.Abstractions.targets
@@ -1,0 +1,5 @@
+<Project>
+  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="This feature is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+</Project>

--- a/src/Obsolete/Steeltoe.Stream.Abstractions/Build/Steeltoe.Stream.Abstractions.targets
+++ b/src/Obsolete/Steeltoe.Stream.Abstractions/Build/Steeltoe.Stream.Abstractions.targets
@@ -1,6 +1,6 @@
 <Project>
   <Target Name="Warn_SteeltoeStreamAbstractions" BeforeTargets="BeforeResolveReferences">
-    <Warning Text="This feature is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+    <Warning Text="The NuGet package Steeltoe.Stream.Abstractions is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.Stream.Abstractions/Build/Steeltoe.Stream.Abstractions.targets
+++ b/src/Obsolete/Steeltoe.Stream.Abstractions/Build/Steeltoe.Stream.Abstractions.targets
@@ -1,5 +1,9 @@
 <Project>
-  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
-    <Error Text="This feature is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+  <Target Name="Warn_SteeltoeStreamAbstractions" BeforeTargets="BeforeResolveReferences">
+    <Warning Text="This feature is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+
+  <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="One or more Steeltoe package dependencies need attention. See the build warnings for details." />
   </Target>
 </Project>

--- a/src/Obsolete/Steeltoe.Stream.Abstractions/Build/Steeltoe.Stream.Abstractions.targets
+++ b/src/Obsolete/Steeltoe.Stream.Abstractions/Build/Steeltoe.Stream.Abstractions.targets
@@ -1,5 +1,5 @@
 <Project>
-  <Target Name="Warn_SteeltoeStreamAbstractions" BeforeTargets="BeforeResolveReferences">
+  <Target Name="Warn_SteeltoeStreamAbstractions" AfterTargets="AfterResolveReferences">
     <Warning Text="The NuGet package Steeltoe.Stream.Abstractions is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 

--- a/src/Obsolete/Steeltoe.Stream.Abstractions/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.Stream.Abstractions/PackageReadme.md
@@ -1,0 +1,17 @@
+# Steeltoe
+
+> [!IMPORTANT]
+> This feature is no longer available in Steeltoe v4.
+> See <https://steeltoe.io/docs/v3/obsolete> for details.
+
+[Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).
+
+Key features include:
+
+- External (optionally encrypted) configuration using [Spring Cloud Config Server](https://docs.spring.io/spring-cloud-config/docs/current/reference/html/)
+- Service discovery with [Netflix Eureka](https://spring.io/projects/spring-cloud-netflix) and [HashiCorp Consul](https://www.consul.io/)
+- Management endpoints (compatible with [actuators](https://docs.spring.io/spring-boot/docs/current/reference/html/actuator.html)), providing system info (such as versions, configuration, service container contents, mapped routes and HTTP traffic), heap/thread dumps, health checks, exporting metrics to [Prometheus](https://prometheus.io/), and changing log levels at runtime.
+- Connectivity to databases (such as [SQL Server](https://www.microsoft.com/sql-server)/[Azure SQL](https://azure.microsoft.com/products/azure-sql), [Cosmos DB](https://azure.microsoft.com/products/cosmos-db/), [MongoDB](https://www.mongodb.com/), [Redis](https://redis.io/), [RabbitMQ](https://www.rabbitmq.com/), [PostgreSQL](https://www.postgresql.org/), and [MySQL](https://www.mysql.com/)), including support for [Entity Framework Core](https://learn.microsoft.com/ef/core/)
+- Single sign-on, JWT and Certificate auth with [Cloud Foundry](https://www.cloudfoundry.org/)
+
+For more information and to get started, please visit [Steeltoe on GitHub](https://github.com/SteeltoeOSS/Steeltoe) or the [documentation](https://steeltoe.io/docs).

--- a/src/Obsolete/Steeltoe.Stream.Abstractions/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.Stream.Abstractions/PackageReadme.md
@@ -1,7 +1,7 @@
 # Steeltoe
 
 > [!IMPORTANT]
-> This feature is no longer available in Steeltoe v4.
+> This package has been removed from Steeltoe in v4.
 > See <https://steeltoe.io/docs/v3/obsolete> for details.
 
 [Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).

--- a/src/Obsolete/Steeltoe.Stream.Abstractions/Steeltoe.Stream.Abstractions.csproj
+++ b/src/Obsolete/Steeltoe.Stream.Abstractions/Steeltoe.Stream.Abstractions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
-    <Description>TODO: Fill package description.</Description>
+    <Description>Abstractions for use with Steeltoe Stream.</Description>
     <PackageTags>TODO: Fill package tags.</PackageTags>
     <IsPackable>true</IsPackable>
   </PropertyGroup>

--- a/src/Obsolete/Steeltoe.Stream.Abstractions/Steeltoe.Stream.Abstractions.csproj
+++ b/src/Obsolete/Steeltoe.Stream.Abstractions/Steeltoe.Stream.Abstractions.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net8.0</TargetFrameworks>
+    <Description>TODO: Fill package description.</Description>
+    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
+  <Import Project="..\..\..\shared.props" />
+
+  <ItemGroup>
+    <None Include="Build\*.props" Pack="True" PackagePath="build" />
+    <None Include="Build\*.targets" Pack="True" PackagePath="build" />
+  </ItemGroup>
+</Project>

--- a/src/Obsolete/Steeltoe.Stream.Abstractions/Steeltoe.Stream.Abstractions.csproj
+++ b/src/Obsolete/Steeltoe.Stream.Abstractions/Steeltoe.Stream.Abstractions.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
     <Description>Abstractions for use with Steeltoe Stream.</Description>
-    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <PackageTags>Streams, NET Core, Spring, Spring Cloud</PackageTags>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 

--- a/src/Obsolete/Steeltoe.Stream.Abstractions/Steeltoe.Stream.Abstractions.csproj
+++ b/src/Obsolete/Steeltoe.Stream.Abstractions/Steeltoe.Stream.Abstractions.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
     <Description>Abstractions for use with Steeltoe Stream.</Description>
-    <PackageTags>Streams, NET Core, Spring, Spring Cloud</PackageTags>
+    <PackageTags>Streams;NET Core;Spring;Spring Cloud</PackageTags>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 

--- a/src/Obsolete/Steeltoe.Stream.Binder.RabbitMQ/Build/Steeltoe.Stream.Binder.RabbitMQ.targets
+++ b/src/Obsolete/Steeltoe.Stream.Binder.RabbitMQ/Build/Steeltoe.Stream.Binder.RabbitMQ.targets
@@ -1,5 +1,9 @@
 <Project>
-  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
-    <Error Text="This feature is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+  <Target Name="Warn_SteeltoeStreamBinderRabbitMQ" BeforeTargets="BeforeResolveReferences">
+    <Warning Text="This feature is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+
+  <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="One or more Steeltoe package dependencies need attention. See the build warnings for details." />
   </Target>
 </Project>

--- a/src/Obsolete/Steeltoe.Stream.Binder.RabbitMQ/Build/Steeltoe.Stream.Binder.RabbitMQ.targets
+++ b/src/Obsolete/Steeltoe.Stream.Binder.RabbitMQ/Build/Steeltoe.Stream.Binder.RabbitMQ.targets
@@ -1,6 +1,7 @@
 <Project>
   <Target Name="Warn_SteeltoeStreamBinderRabbitMQ" BeforeTargets="BeforeResolveReferences">
-    <Warning Text="This feature is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+    <Warning
+      Text="The NuGet package Steeltoe.Stream.Binder.RabbitMQ is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.Stream.Binder.RabbitMQ/Build/Steeltoe.Stream.Binder.RabbitMQ.targets
+++ b/src/Obsolete/Steeltoe.Stream.Binder.RabbitMQ/Build/Steeltoe.Stream.Binder.RabbitMQ.targets
@@ -1,7 +1,7 @@
 <Project>
   <Target Name="Warn_SteeltoeStreamBinderRabbitMQ" AfterTargets="AfterResolveReferences">
     <Warning
-      Text="The NuGet package Steeltoe.Stream.Binder.RabbitMQ is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+      Text="The NuGet package Steeltoe.Stream.Binder.RabbitMQ has been removed from Steeltoe in v4. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.Stream.Binder.RabbitMQ/Build/Steeltoe.Stream.Binder.RabbitMQ.targets
+++ b/src/Obsolete/Steeltoe.Stream.Binder.RabbitMQ/Build/Steeltoe.Stream.Binder.RabbitMQ.targets
@@ -1,0 +1,5 @@
+<Project>
+  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="This feature is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+</Project>

--- a/src/Obsolete/Steeltoe.Stream.Binder.RabbitMQ/Build/Steeltoe.Stream.Binder.RabbitMQ.targets
+++ b/src/Obsolete/Steeltoe.Stream.Binder.RabbitMQ/Build/Steeltoe.Stream.Binder.RabbitMQ.targets
@@ -1,5 +1,5 @@
 <Project>
-  <Target Name="Warn_SteeltoeStreamBinderRabbitMQ" BeforeTargets="BeforeResolveReferences">
+  <Target Name="Warn_SteeltoeStreamBinderRabbitMQ" AfterTargets="AfterResolveReferences">
     <Warning
       Text="The NuGet package Steeltoe.Stream.Binder.RabbitMQ is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>

--- a/src/Obsolete/Steeltoe.Stream.Binder.RabbitMQ/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.Stream.Binder.RabbitMQ/PackageReadme.md
@@ -1,0 +1,17 @@
+# Steeltoe
+
+> [!IMPORTANT]
+> This feature is no longer available in Steeltoe v4.
+> See <https://steeltoe.io/docs/v3/obsolete> for details.
+
+[Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).
+
+Key features include:
+
+- External (optionally encrypted) configuration using [Spring Cloud Config Server](https://docs.spring.io/spring-cloud-config/docs/current/reference/html/)
+- Service discovery with [Netflix Eureka](https://spring.io/projects/spring-cloud-netflix) and [HashiCorp Consul](https://www.consul.io/)
+- Management endpoints (compatible with [actuators](https://docs.spring.io/spring-boot/docs/current/reference/html/actuator.html)), providing system info (such as versions, configuration, service container contents, mapped routes and HTTP traffic), heap/thread dumps, health checks, exporting metrics to [Prometheus](https://prometheus.io/), and changing log levels at runtime.
+- Connectivity to databases (such as [SQL Server](https://www.microsoft.com/sql-server)/[Azure SQL](https://azure.microsoft.com/products/azure-sql), [Cosmos DB](https://azure.microsoft.com/products/cosmos-db/), [MongoDB](https://www.mongodb.com/), [Redis](https://redis.io/), [RabbitMQ](https://www.rabbitmq.com/), [PostgreSQL](https://www.postgresql.org/), and [MySQL](https://www.mysql.com/)), including support for [Entity Framework Core](https://learn.microsoft.com/ef/core/)
+- Single sign-on, JWT and Certificate auth with [Cloud Foundry](https://www.cloudfoundry.org/)
+
+For more information and to get started, please visit [Steeltoe on GitHub](https://github.com/SteeltoeOSS/Steeltoe) or the [documentation](https://steeltoe.io/docs).

--- a/src/Obsolete/Steeltoe.Stream.Binder.RabbitMQ/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.Stream.Binder.RabbitMQ/PackageReadme.md
@@ -1,7 +1,7 @@
 # Steeltoe
 
 > [!IMPORTANT]
-> This feature is no longer available in Steeltoe v4.
+> This package has been removed from Steeltoe in v4.
 > See <https://steeltoe.io/docs/v3/obsolete> for details.
 
 [Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).

--- a/src/Obsolete/Steeltoe.Stream.Binder.RabbitMQ/Steeltoe.Stream.Binder.RabbitMQ.csproj
+++ b/src/Obsolete/Steeltoe.Stream.Binder.RabbitMQ/Steeltoe.Stream.Binder.RabbitMQ.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
     <Description>Steeltoe Stream RabbitMQ Binder.</Description>
-    <PackageTags>Streams, ASPNET Core, Spring, Spring Cloud, RabbitMQ, Binder</PackageTags>
+    <PackageTags>Streams;ASPNET Core;Spring;Spring Cloud;RabbitMQ;Binder</PackageTags>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 

--- a/src/Obsolete/Steeltoe.Stream.Binder.RabbitMQ/Steeltoe.Stream.Binder.RabbitMQ.csproj
+++ b/src/Obsolete/Steeltoe.Stream.Binder.RabbitMQ/Steeltoe.Stream.Binder.RabbitMQ.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
-    <Description>TODO: Fill package description.</Description>
-    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <Description>Steeltoe Stream RabbitMQ Binder.</Description>
+    <PackageTags>Streams, ASPNET Core, Spring, Spring Cloud, RabbitMQ, Binder</PackageTags>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 

--- a/src/Obsolete/Steeltoe.Stream.Binder.RabbitMQ/Steeltoe.Stream.Binder.RabbitMQ.csproj
+++ b/src/Obsolete/Steeltoe.Stream.Binder.RabbitMQ/Steeltoe.Stream.Binder.RabbitMQ.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net8.0</TargetFrameworks>
+    <Description>TODO: Fill package description.</Description>
+    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
+  <Import Project="..\..\..\shared.props" />
+
+  <ItemGroup>
+    <None Include="Build\*.props" Pack="True" PackagePath="build" />
+    <None Include="Build\*.targets" Pack="True" PackagePath="build" />
+  </ItemGroup>
+</Project>

--- a/src/Obsolete/Steeltoe.Stream.StreamBase/Build/Steeltoe.Stream.StreamBase.targets
+++ b/src/Obsolete/Steeltoe.Stream.StreamBase/Build/Steeltoe.Stream.StreamBase.targets
@@ -1,6 +1,6 @@
 <Project>
   <Target Name="Warn_SteeltoeStreamStreamBase" BeforeTargets="BeforeResolveReferences">
-    <Warning Text="This feature is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+    <Warning Text="The NuGet package Steeltoe.Stream.StreamBase is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.Stream.StreamBase/Build/Steeltoe.Stream.StreamBase.targets
+++ b/src/Obsolete/Steeltoe.Stream.StreamBase/Build/Steeltoe.Stream.StreamBase.targets
@@ -1,0 +1,5 @@
+<Project>
+  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="This feature is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+</Project>

--- a/src/Obsolete/Steeltoe.Stream.StreamBase/Build/Steeltoe.Stream.StreamBase.targets
+++ b/src/Obsolete/Steeltoe.Stream.StreamBase/Build/Steeltoe.Stream.StreamBase.targets
@@ -1,6 +1,6 @@
 <Project>
   <Target Name="Warn_SteeltoeStreamStreamBase" AfterTargets="AfterResolveReferences">
-    <Warning Text="The NuGet package Steeltoe.Stream.StreamBase is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+    <Warning Text="The NuGet package Steeltoe.Stream.StreamBase has been removed from Steeltoe in v4. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 
   <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">

--- a/src/Obsolete/Steeltoe.Stream.StreamBase/Build/Steeltoe.Stream.StreamBase.targets
+++ b/src/Obsolete/Steeltoe.Stream.StreamBase/Build/Steeltoe.Stream.StreamBase.targets
@@ -1,5 +1,5 @@
 <Project>
-  <Target Name="Warn_SteeltoeStreamStreamBase" BeforeTargets="BeforeResolveReferences">
+  <Target Name="Warn_SteeltoeStreamStreamBase" AfterTargets="AfterResolveReferences">
     <Warning Text="The NuGet package Steeltoe.Stream.StreamBase is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
   </Target>
 

--- a/src/Obsolete/Steeltoe.Stream.StreamBase/Build/Steeltoe.Stream.StreamBase.targets
+++ b/src/Obsolete/Steeltoe.Stream.StreamBase/Build/Steeltoe.Stream.StreamBase.targets
@@ -1,5 +1,9 @@
 <Project>
-  <Target Name="FailTheBuild" BeforeTargets="BeforeCompile;CoreCompile">
-    <Error Text="This feature is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+  <Target Name="Warn_SteeltoeStreamStreamBase" BeforeTargets="BeforeResolveReferences">
+    <Warning Text="This feature is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details." />
+  </Target>
+
+  <Target Name="Fail_Steeltoe" BeforeTargets="BeforeCompile;CoreCompile">
+    <Error Text="One or more Steeltoe package dependencies need attention. See the build warnings for details." />
   </Target>
 </Project>

--- a/src/Obsolete/Steeltoe.Stream.StreamBase/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.Stream.StreamBase/PackageReadme.md
@@ -1,0 +1,17 @@
+# Steeltoe
+
+> [!IMPORTANT]
+> This feature is no longer available in Steeltoe v4.
+> See <https://steeltoe.io/docs/v3/obsolete> for details.
+
+[Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).
+
+Key features include:
+
+- External (optionally encrypted) configuration using [Spring Cloud Config Server](https://docs.spring.io/spring-cloud-config/docs/current/reference/html/)
+- Service discovery with [Netflix Eureka](https://spring.io/projects/spring-cloud-netflix) and [HashiCorp Consul](https://www.consul.io/)
+- Management endpoints (compatible with [actuators](https://docs.spring.io/spring-boot/docs/current/reference/html/actuator.html)), providing system info (such as versions, configuration, service container contents, mapped routes and HTTP traffic), heap/thread dumps, health checks, exporting metrics to [Prometheus](https://prometheus.io/), and changing log levels at runtime.
+- Connectivity to databases (such as [SQL Server](https://www.microsoft.com/sql-server)/[Azure SQL](https://azure.microsoft.com/products/azure-sql), [Cosmos DB](https://azure.microsoft.com/products/cosmos-db/), [MongoDB](https://www.mongodb.com/), [Redis](https://redis.io/), [RabbitMQ](https://www.rabbitmq.com/), [PostgreSQL](https://www.postgresql.org/), and [MySQL](https://www.mysql.com/)), including support for [Entity Framework Core](https://learn.microsoft.com/ef/core/)
+- Single sign-on, JWT and Certificate auth with [Cloud Foundry](https://www.cloudfoundry.org/)
+
+For more information and to get started, please visit [Steeltoe on GitHub](https://github.com/SteeltoeOSS/Steeltoe) or the [documentation](https://steeltoe.io/docs).

--- a/src/Obsolete/Steeltoe.Stream.StreamBase/PackageReadme.md
+++ b/src/Obsolete/Steeltoe.Stream.StreamBase/PackageReadme.md
@@ -1,7 +1,7 @@
 # Steeltoe
 
 > [!IMPORTANT]
-> This feature is no longer available in Steeltoe v4.
+> This package has been removed from Steeltoe in v4.
 > See <https://steeltoe.io/docs/v3/obsolete> for details.
 
 [Steeltoe](https://steeltoe.io/) provides building blocks for development of .NET applications that integrate with [Spring](https://spring.io/) and [Spring Boot](https://spring.io/projects/spring-boot) environments, as well as [Cloud Foundry](https://www.cloudfoundry.org/) and [Kubernetes](https://kubernetes.io/) with first-party support for [Tanzu](https://tanzu.vmware.com/tanzu).

--- a/src/Obsolete/Steeltoe.Stream.StreamBase/Steeltoe.Stream.StreamBase.csproj
+++ b/src/Obsolete/Steeltoe.Stream.StreamBase/Steeltoe.Stream.StreamBase.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net8.0</TargetFrameworks>
+    <Description>TODO: Fill package description.</Description>
+    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
+  <Import Project="..\..\..\shared.props" />
+
+  <ItemGroup>
+    <None Include="Build\*.props" Pack="True" PackagePath="build" />
+    <None Include="Build\*.targets" Pack="True" PackagePath="build" />
+  </ItemGroup>
+</Project>

--- a/src/Obsolete/Steeltoe.Stream.StreamBase/Steeltoe.Stream.StreamBase.csproj
+++ b/src/Obsolete/Steeltoe.Stream.StreamBase/Steeltoe.Stream.StreamBase.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
     <Description>Steeltoe Stream Base.</Description>
-    <PackageTags>Streams, NET Core, Spring, Spring Cloud</PackageTags>
+    <PackageTags>Streams;NET Core;Spring;Spring Cloud</PackageTags>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 

--- a/src/Obsolete/Steeltoe.Stream.StreamBase/Steeltoe.Stream.StreamBase.csproj
+++ b/src/Obsolete/Steeltoe.Stream.StreamBase/Steeltoe.Stream.StreamBase.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
-    <Description>TODO: Fill package description.</Description>
-    <PackageTags>TODO: Fill package tags.</PackageTags>
+    <Description>Steeltoe Stream Base.</Description>
+    <PackageTags>Streams, NET Core, Spring, Spring Cloud</PackageTags>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 

--- a/src/Security/src/Authentication.JwtBearer/Steeltoe.Security.Authentication.JwtBearer.csproj
+++ b/src/Security/src/Authentication.JwtBearer/Steeltoe.Security.Authentication.JwtBearer.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
     <Description>Library for using JWT Bearer tokens with UAA-based systems, including Cloud Foundry.</Description>
-    <PackageTags>CloudFoundry;uaa;security;jwt;bearer;tanzu;aspnetcore;</PackageTags>
+    <PackageTags>CloudFoundry;uaa;security;jwt;bearer;tanzu;aspnetcore</PackageTags>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 

--- a/src/Security/src/Authentication.OpenIdConnect/Steeltoe.Security.Authentication.OpenIdConnect.csproj
+++ b/src/Security/src/Authentication.OpenIdConnect/Steeltoe.Security.Authentication.OpenIdConnect.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
     <Description>Library for using OpenID Connect with UAA-based systems, including Cloud Foundry.</Description>
-    <PackageTags>CloudFoundry;uaa;security;sso;openid;oidc;tanzu;aspnetcore;</PackageTags>
+    <PackageTags>CloudFoundry;uaa;security;sso;openid;oidc;tanzu;aspnetcore</PackageTags>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 

--- a/src/Security/src/Authorization.Certificate/Steeltoe.Security.Authorization.Certificate.csproj
+++ b/src/Security/src/Authorization.Certificate/Steeltoe.Security.Authorization.Certificate.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
     <Description>Provides support for authorization with client certificates.</Description>
-    <PackageTags>authorization;security;x509;certificate;mutualtls;CloudFoundry;tanzu;aspnetcore;</PackageTags>
+    <PackageTags>authorization;security;x509;certificate;mutualtls;CloudFoundry;tanzu;aspnetcore</PackageTags>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 

--- a/src/Security/src/DataProtection.Redis/Steeltoe.Security.DataProtection.Redis.csproj
+++ b/src/Security/src/DataProtection.Redis/Steeltoe.Security.DataProtection.Redis.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
     <Description>Support for storing data protection keys in Redis.</Description>
-    <PackageTags>CloudFoundry;security;dataprotection;redis;aspnetcore;</PackageTags>
+    <PackageTags>CloudFoundry;security;dataprotection;redis;aspnetcore</PackageTags>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 

--- a/src/Steeltoe.All.sln
+++ b/src/Steeltoe.All.sln
@@ -204,6 +204,134 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Steeltoe.Common.Logging.Tes
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Steeltoe.Management.Endpoint.RazorPagesTestWebApp", "Management\test\RazorPagesTestWebApp\Steeltoe.Management.Endpoint.RazorPagesTestWebApp.csproj", "{51DD3135-1EAA-4640-82F1-9FBECA421708}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Obsolete", "Obsolete", "{02EA681E-C7D8-13C7-8484-4AC65E1B71E8}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Steeltoe.Bootstrap.Autoconfig", "Obsolete\Steeltoe.Bootstrap.Autoconfig\Steeltoe.Bootstrap.Autoconfig.csproj", "{6607EBEE-8668-E1D3-C1CB-ED11A91DC100}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Steeltoe.CircuitBreaker.Abstractions", "Obsolete\Steeltoe.CircuitBreaker.Abstractions\Steeltoe.CircuitBreaker.Abstractions.csproj", "{5D16D6CC-2BBF-3E53-A932-7E6FCD64E123}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Steeltoe.CircuitBreaker.Hystrix.MetricsEventsCore", "Obsolete\Steeltoe.CircuitBreaker.Hystrix.MetricsEventsCore\Steeltoe.CircuitBreaker.Hystrix.MetricsEventsCore.csproj", "{77459A1A-63B4-F7CE-5B20-79091A4BC6C8}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Steeltoe.CircuitBreaker.Hystrix.MetricsStreamCore", "Obsolete\Steeltoe.CircuitBreaker.Hystrix.MetricsStreamCore\Steeltoe.CircuitBreaker.Hystrix.MetricsStreamCore.csproj", "{7A06889E-2503-38D9-FE44-36527A9FD0C9}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Steeltoe.CircuitBreaker.HystrixBase", "Obsolete\Steeltoe.CircuitBreaker.HystrixBase\Steeltoe.CircuitBreaker.HystrixBase.csproj", "{5159B5AC-6354-B394-93DD-2621DB302EDF}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Steeltoe.CircuitBreaker.HystrixCore", "Obsolete\Steeltoe.CircuitBreaker.HystrixCore\Steeltoe.CircuitBreaker.HystrixCore.csproj", "{44D3B2AE-DA53-A134-182B-E4301BB856A3}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Steeltoe.Common.Abstractions", "Obsolete\Steeltoe.Common.Abstractions\Steeltoe.Common.Abstractions.csproj", "{55DDF80C-42C8-A046-883C-954049FCB811}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Steeltoe.Common.Expression", "Obsolete\Steeltoe.Common.Expression\Steeltoe.Common.Expression.csproj", "{98E31A4F-30D0-0F7B-2E9D-D8F1AEB53DA5}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Steeltoe.Common.Kubernetes", "Obsolete\Steeltoe.Common.Kubernetes\Steeltoe.Common.Kubernetes.csproj", "{3F841B6E-2AEA-23B1-C141-CC67A8FB33E0}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Steeltoe.Common.Retry", "Obsolete\Steeltoe.Common.Retry\Steeltoe.Common.Retry.csproj", "{8057DA4A-FF84-72D3-54BE-A17B47760608}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Steeltoe.Common.Security", "Obsolete\Steeltoe.Common.Security\Steeltoe.Common.Security.csproj", "{5A179D89-95C6-F103-DA7D-6FD33FDF151B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Steeltoe.Common.Utils", "Obsolete\Steeltoe.Common.Utils\Steeltoe.Common.Utils.csproj", "{A4F19C30-3624-86C4-F533-D88C9DC2A972}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Steeltoe.Connector.Abstractions", "Obsolete\Steeltoe.Connector.Abstractions\Steeltoe.Connector.Abstractions.csproj", "{3E41717A-789B-D213-A4A8-56BFED2E8D17}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Steeltoe.Connector.CloudFoundry", "Obsolete\Steeltoe.Connector.CloudFoundry\Steeltoe.Connector.CloudFoundry.csproj", "{63CAD818-CAFA-41ED-E389-C7553AD813FD}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Steeltoe.Connector.ConnectorBase", "Obsolete\Steeltoe.Connector.ConnectorBase\Steeltoe.Connector.ConnectorBase.csproj", "{C6277231-D388-0D78-CC9F-973172F92585}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Steeltoe.Connector.ConnectorCore", "Obsolete\Steeltoe.Connector.ConnectorCore\Steeltoe.Connector.ConnectorCore.csproj", "{981F5916-AB63-4E99-7762-1BC03CDD8D00}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Steeltoe.Connector.EF6Core", "Obsolete\Steeltoe.Connector.EF6Core\Steeltoe.Connector.EF6Core.csproj", "{3105ADCB-D81E-25F2-8390-986E50E3A88B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Steeltoe.Connector.EFCore", "Obsolete\Steeltoe.Connector.EFCore\Steeltoe.Connector.EFCore.csproj", "{2F785E38-6E2A-834A-0C9A-CBE3B307DE01}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Steeltoe.Discovery.Abstractions", "Obsolete\Steeltoe.Discovery.Abstractions\Steeltoe.Discovery.Abstractions.csproj", "{4C3111B7-D8EC-0538-2C30-952EA4D9FC94}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Steeltoe.Discovery.ClientBase", "Obsolete\Steeltoe.Discovery.ClientBase\Steeltoe.Discovery.ClientBase.csproj", "{2388CA32-2573-C097-0B04-B67C58BDB7CA}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Steeltoe.Discovery.ClientCore", "Obsolete\Steeltoe.Discovery.ClientCore\Steeltoe.Discovery.ClientCore.csproj", "{C5824CE4-D590-20E7-0565-6BDE1D809A19}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Steeltoe.Discovery.Kubernetes", "Obsolete\Steeltoe.Discovery.Kubernetes\Steeltoe.Discovery.Kubernetes.csproj", "{14E1A30B-2E8A-794C-CF13-F47FDEF4ACD3}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Steeltoe.Extensions.Configuration.Abstractions", "Obsolete\Steeltoe.Extensions.Configuration.Abstractions\Steeltoe.Extensions.Configuration.Abstractions.csproj", "{644C6F28-AEC7-AD30-1D65-F459E0F21DC6}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Steeltoe.Extensions.Configuration.CloudFoundryBase", "Obsolete\Steeltoe.Extensions.Configuration.CloudFoundryBase\Steeltoe.Extensions.Configuration.CloudFoundryBase.csproj", "{18B7AC0F-16B9-B612-A6AA-E092EE68DA1D}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Steeltoe.Extensions.Configuration.CloudFoundryCore", "Obsolete\Steeltoe.Extensions.Configuration.CloudFoundryCore\Steeltoe.Extensions.Configuration.CloudFoundryCore.csproj", "{5B7C359B-81DB-8BF9-D806-6DCEAC1A51D5}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Steeltoe.Extensions.Configuration.ConfigServerBase", "Obsolete\Steeltoe.Extensions.Configuration.ConfigServerBase\Steeltoe.Extensions.Configuration.ConfigServerBase.csproj", "{EEDC48F4-14C6-4017-0CB4-1A7E2315C685}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Steeltoe.Extensions.Configuration.ConfigServerCore", "Obsolete\Steeltoe.Extensions.Configuration.ConfigServerCore\Steeltoe.Extensions.Configuration.ConfigServerCore.csproj", "{B1965821-5021-E09B-0107-9BF12D674AB1}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Steeltoe.Extensions.Configuration.Kubernetes.ServiceBinding", "Obsolete\Steeltoe.Extensions.Configuration.Kubernetes.ServiceBinding\Steeltoe.Extensions.Configuration.Kubernetes.ServiceBinding.csproj", "{C11055B8-9185-2BF4-35E7-65C977DD5DEC}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Steeltoe.Extensions.Configuration.KubernetesBase", "Obsolete\Steeltoe.Extensions.Configuration.KubernetesBase\Steeltoe.Extensions.Configuration.KubernetesBase.csproj", "{F44A6978-521A-1E7B-8841-C1BF15F80CCB}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Steeltoe.Extensions.Configuration.KubernetesCore", "Obsolete\Steeltoe.Extensions.Configuration.KubernetesCore\Steeltoe.Extensions.Configuration.KubernetesCore.csproj", "{CD01D081-2759-DBD2-A98F-BE5ECE04A403}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Steeltoe.Extensions.Configuration.PlaceholderBase", "Obsolete\Steeltoe.Extensions.Configuration.PlaceholderBase\Steeltoe.Extensions.Configuration.PlaceholderBase.csproj", "{F7A34F42-9092-1D8D-BEA7-146968B3EE3A}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Steeltoe.Extensions.Configuration.PlaceholderCore", "Obsolete\Steeltoe.Extensions.Configuration.PlaceholderCore\Steeltoe.Extensions.Configuration.PlaceholderCore.csproj", "{73DB7209-1957-2295-FB91-3FBC82442B01}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Steeltoe.Extensions.Configuration.RandomValueBase", "Obsolete\Steeltoe.Extensions.Configuration.RandomValueBase\Steeltoe.Extensions.Configuration.RandomValueBase.csproj", "{135C853D-B3A2-8F7C-4926-B52E9392002F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Steeltoe.Extensions.Configuration.SpringBootBase", "Obsolete\Steeltoe.Extensions.Configuration.SpringBootBase\Steeltoe.Extensions.Configuration.SpringBootBase.csproj", "{E87C0BA6-E772-68FA-34C6-64227DD9F3EE}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Steeltoe.Extensions.Configuration.SpringBootCore", "Obsolete\Steeltoe.Extensions.Configuration.SpringBootCore\Steeltoe.Extensions.Configuration.SpringBootCore.csproj", "{5FFC2953-2430-8AC9-0096-3FDBC1CA5140}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Steeltoe.Extensions.Logging.Abstractions", "Obsolete\Steeltoe.Extensions.Logging.Abstractions\Steeltoe.Extensions.Logging.Abstractions.csproj", "{192D3A1C-8554-3D05-DA6E-A57030ECA124}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Steeltoe.Extensions.Logging.DynamicLogger", "Obsolete\Steeltoe.Extensions.Logging.DynamicLogger\Steeltoe.Extensions.Logging.DynamicLogger.csproj", "{31EC11DD-755D-FECE-4678-D88E17BFDBB6}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Steeltoe.Extensions.Logging.DynamicSerilogBase", "Obsolete\Steeltoe.Extensions.Logging.DynamicSerilogBase\Steeltoe.Extensions.Logging.DynamicSerilogBase.csproj", "{CB988CB6-A9A2-0365-354E-1464906386FF}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Steeltoe.Extensions.Logging.DynamicSerilogCore", "Obsolete\Steeltoe.Extensions.Logging.DynamicSerilogCore\Steeltoe.Extensions.Logging.DynamicSerilogCore.csproj", "{5064A781-B3B0-585F-B856-E294556180F1}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Steeltoe.Integration.Abstractions", "Obsolete\Steeltoe.Integration.Abstractions\Steeltoe.Integration.Abstractions.csproj", "{97D530C8-97AC-CEBE-9657-CE02557D6ED9}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Steeltoe.Integration.IntegrationBase", "Obsolete\Steeltoe.Integration.IntegrationBase\Steeltoe.Integration.IntegrationBase.csproj", "{942F9B69-02CD-469B-C00C-3454E93BA2AE}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Steeltoe.Integration.RabbitMQ", "Obsolete\Steeltoe.Integration.RabbitMQ\Steeltoe.Integration.RabbitMQ.csproj", "{48145FD7-B653-CFE3-B30A-7EF2E0120B21}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Steeltoe.Management.CloudFoundryCore", "Obsolete\Steeltoe.Management.CloudFoundryCore\Steeltoe.Management.CloudFoundryCore.csproj", "{05B5D7F9-FE77-1519-2023-61CD1FAD90B1}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Steeltoe.Management.Diagnostics", "Obsolete\Steeltoe.Management.Diagnostics\Steeltoe.Management.Diagnostics.csproj", "{1BB203B2-65E0-3834-3EB4-0BEC2F75FEBC}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Steeltoe.Management.EndpointBase", "Obsolete\Steeltoe.Management.EndpointBase\Steeltoe.Management.EndpointBase.csproj", "{E974FA60-F02F-FA1F-BA84-C25972F8DD4F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Steeltoe.Management.EndpointCore", "Obsolete\Steeltoe.Management.EndpointCore\Steeltoe.Management.EndpointCore.csproj", "{A857F14B-45A2-8244-554B-C3205FC38F08}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Steeltoe.Management.KubernetesCore", "Obsolete\Steeltoe.Management.KubernetesCore\Steeltoe.Management.KubernetesCore.csproj", "{A12F0AE9-DCB4-9D54-E586-FBBF10CA93F6}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Steeltoe.Management.OpenTelemetryBase", "Obsolete\Steeltoe.Management.OpenTelemetryBase\Steeltoe.Management.OpenTelemetryBase.csproj", "{56589499-4FA9-EC26-7F7E-D187D035D4DA}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Steeltoe.Management.TaskCore", "Obsolete\Steeltoe.Management.TaskCore\Steeltoe.Management.TaskCore.csproj", "{0F613620-3071-DF98-3506-F37F016C07E1}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Steeltoe.Management.TracingBase", "Obsolete\Steeltoe.Management.TracingBase\Steeltoe.Management.TracingBase.csproj", "{C45ED108-A68D-B447-00D1-BCB45EEC0D15}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Steeltoe.Management.TracingCore", "Obsolete\Steeltoe.Management.TracingCore\Steeltoe.Management.TracingCore.csproj", "{1AFEBB7F-BFB8-2C11-28BF-68AA6376479B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Steeltoe.Messaging.Abstractions", "Obsolete\Steeltoe.Messaging.Abstractions\Steeltoe.Messaging.Abstractions.csproj", "{63AA9B32-84B1-BE5F-4507-8E7DF73880F2}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Steeltoe.Messaging.MessagingBase", "Obsolete\Steeltoe.Messaging.MessagingBase\Steeltoe.Messaging.MessagingBase.csproj", "{83653A8C-7946-338C-F42C-AB714F49991D}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Steeltoe.Messaging.RabbitMQ", "Obsolete\Steeltoe.Messaging.RabbitMQ\Steeltoe.Messaging.RabbitMQ.csproj", "{32481813-3CE4-F4C8-086F-15FED097835F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Steeltoe.Security.Authentication.CloudFoundryBase", "Obsolete\Steeltoe.Security.Authentication.CloudFoundryBase\Steeltoe.Security.Authentication.CloudFoundryBase.csproj", "{4F6C59C7-0311-8ADF-017D-E64F46510A70}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Steeltoe.Security.Authentication.CloudFoundryCore", "Obsolete\Steeltoe.Security.Authentication.CloudFoundryCore\Steeltoe.Security.Authentication.CloudFoundryCore.csproj", "{FF8B81BD-63BA-BEE6-2466-B1A3EE553494}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Steeltoe.Security.Authentication.MtlsCore", "Obsolete\Steeltoe.Security.Authentication.MtlsCore\Steeltoe.Security.Authentication.MtlsCore.csproj", "{9D7D20F4-F986-4194-9D18-4F28654EDE7D}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Steeltoe.Security.DataProtection.CredHubBase", "Obsolete\Steeltoe.Security.DataProtection.CredHubBase\Steeltoe.Security.DataProtection.CredHubBase.csproj", "{A90ADACF-3BC4-3C34-F6D6-D02D99C799D5}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Steeltoe.Security.DataProtection.CredHubCore", "Obsolete\Steeltoe.Security.DataProtection.CredHubCore\Steeltoe.Security.DataProtection.CredHubCore.csproj", "{75087953-E456-EA40-857F-B38A2BF4DD1D}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Steeltoe.Security.DataProtection.RedisCore", "Obsolete\Steeltoe.Security.DataProtection.RedisCore\Steeltoe.Security.DataProtection.RedisCore.csproj", "{CF879664-186D-AE54-434E-F0FC3B5D27DC}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Steeltoe.Stream.Abstractions", "Obsolete\Steeltoe.Stream.Abstractions\Steeltoe.Stream.Abstractions.csproj", "{D377B3DB-B229-DC7A-D651-320B5904BC29}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Steeltoe.Stream.Binder.RabbitMQ", "Obsolete\Steeltoe.Stream.Binder.RabbitMQ\Steeltoe.Stream.Binder.RabbitMQ.csproj", "{F42A9BC5-DA3E-A1CE-B48E-7EBF59D8D161}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Steeltoe.Stream.StreamBase", "Obsolete\Steeltoe.Stream.StreamBase\Steeltoe.Stream.StreamBase.csproj", "{51FBF981-91B2-407E-7A10-D28E5FB717F4}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -490,6 +618,195 @@ Global
 		{51DD3135-1EAA-4640-82F1-9FBECA421708}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{51DD3135-1EAA-4640-82F1-9FBECA421708}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{51DD3135-1EAA-4640-82F1-9FBECA421708}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6607EBEE-8668-E1D3-C1CB-ED11A91DC100}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6607EBEE-8668-E1D3-C1CB-ED11A91DC100}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6607EBEE-8668-E1D3-C1CB-ED11A91DC100}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5D16D6CC-2BBF-3E53-A932-7E6FCD64E123}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5D16D6CC-2BBF-3E53-A932-7E6FCD64E123}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5D16D6CC-2BBF-3E53-A932-7E6FCD64E123}.Release|Any CPU.Build.0 = Release|Any CPU
+		{77459A1A-63B4-F7CE-5B20-79091A4BC6C8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{77459A1A-63B4-F7CE-5B20-79091A4BC6C8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{77459A1A-63B4-F7CE-5B20-79091A4BC6C8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7A06889E-2503-38D9-FE44-36527A9FD0C9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7A06889E-2503-38D9-FE44-36527A9FD0C9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7A06889E-2503-38D9-FE44-36527A9FD0C9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5159B5AC-6354-B394-93DD-2621DB302EDF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5159B5AC-6354-B394-93DD-2621DB302EDF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5159B5AC-6354-B394-93DD-2621DB302EDF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{44D3B2AE-DA53-A134-182B-E4301BB856A3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{44D3B2AE-DA53-A134-182B-E4301BB856A3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{44D3B2AE-DA53-A134-182B-E4301BB856A3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{55DDF80C-42C8-A046-883C-954049FCB811}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{55DDF80C-42C8-A046-883C-954049FCB811}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{55DDF80C-42C8-A046-883C-954049FCB811}.Release|Any CPU.Build.0 = Release|Any CPU
+		{98E31A4F-30D0-0F7B-2E9D-D8F1AEB53DA5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{98E31A4F-30D0-0F7B-2E9D-D8F1AEB53DA5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{98E31A4F-30D0-0F7B-2E9D-D8F1AEB53DA5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3F841B6E-2AEA-23B1-C141-CC67A8FB33E0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3F841B6E-2AEA-23B1-C141-CC67A8FB33E0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3F841B6E-2AEA-23B1-C141-CC67A8FB33E0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8057DA4A-FF84-72D3-54BE-A17B47760608}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8057DA4A-FF84-72D3-54BE-A17B47760608}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8057DA4A-FF84-72D3-54BE-A17B47760608}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5A179D89-95C6-F103-DA7D-6FD33FDF151B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5A179D89-95C6-F103-DA7D-6FD33FDF151B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5A179D89-95C6-F103-DA7D-6FD33FDF151B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A4F19C30-3624-86C4-F533-D88C9DC2A972}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A4F19C30-3624-86C4-F533-D88C9DC2A972}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A4F19C30-3624-86C4-F533-D88C9DC2A972}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3E41717A-789B-D213-A4A8-56BFED2E8D17}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3E41717A-789B-D213-A4A8-56BFED2E8D17}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3E41717A-789B-D213-A4A8-56BFED2E8D17}.Release|Any CPU.Build.0 = Release|Any CPU
+		{63CAD818-CAFA-41ED-E389-C7553AD813FD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{63CAD818-CAFA-41ED-E389-C7553AD813FD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{63CAD818-CAFA-41ED-E389-C7553AD813FD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C6277231-D388-0D78-CC9F-973172F92585}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C6277231-D388-0D78-CC9F-973172F92585}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C6277231-D388-0D78-CC9F-973172F92585}.Release|Any CPU.Build.0 = Release|Any CPU
+		{981F5916-AB63-4E99-7762-1BC03CDD8D00}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{981F5916-AB63-4E99-7762-1BC03CDD8D00}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{981F5916-AB63-4E99-7762-1BC03CDD8D00}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3105ADCB-D81E-25F2-8390-986E50E3A88B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3105ADCB-D81E-25F2-8390-986E50E3A88B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3105ADCB-D81E-25F2-8390-986E50E3A88B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2F785E38-6E2A-834A-0C9A-CBE3B307DE01}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2F785E38-6E2A-834A-0C9A-CBE3B307DE01}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2F785E38-6E2A-834A-0C9A-CBE3B307DE01}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4C3111B7-D8EC-0538-2C30-952EA4D9FC94}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4C3111B7-D8EC-0538-2C30-952EA4D9FC94}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4C3111B7-D8EC-0538-2C30-952EA4D9FC94}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2388CA32-2573-C097-0B04-B67C58BDB7CA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2388CA32-2573-C097-0B04-B67C58BDB7CA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2388CA32-2573-C097-0B04-B67C58BDB7CA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C5824CE4-D590-20E7-0565-6BDE1D809A19}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C5824CE4-D590-20E7-0565-6BDE1D809A19}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C5824CE4-D590-20E7-0565-6BDE1D809A19}.Release|Any CPU.Build.0 = Release|Any CPU
+		{14E1A30B-2E8A-794C-CF13-F47FDEF4ACD3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{14E1A30B-2E8A-794C-CF13-F47FDEF4ACD3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{14E1A30B-2E8A-794C-CF13-F47FDEF4ACD3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{644C6F28-AEC7-AD30-1D65-F459E0F21DC6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{644C6F28-AEC7-AD30-1D65-F459E0F21DC6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{644C6F28-AEC7-AD30-1D65-F459E0F21DC6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{18B7AC0F-16B9-B612-A6AA-E092EE68DA1D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{18B7AC0F-16B9-B612-A6AA-E092EE68DA1D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{18B7AC0F-16B9-B612-A6AA-E092EE68DA1D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5B7C359B-81DB-8BF9-D806-6DCEAC1A51D5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5B7C359B-81DB-8BF9-D806-6DCEAC1A51D5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5B7C359B-81DB-8BF9-D806-6DCEAC1A51D5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EEDC48F4-14C6-4017-0CB4-1A7E2315C685}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EEDC48F4-14C6-4017-0CB4-1A7E2315C685}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EEDC48F4-14C6-4017-0CB4-1A7E2315C685}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B1965821-5021-E09B-0107-9BF12D674AB1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B1965821-5021-E09B-0107-9BF12D674AB1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B1965821-5021-E09B-0107-9BF12D674AB1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C11055B8-9185-2BF4-35E7-65C977DD5DEC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C11055B8-9185-2BF4-35E7-65C977DD5DEC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C11055B8-9185-2BF4-35E7-65C977DD5DEC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F44A6978-521A-1E7B-8841-C1BF15F80CCB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F44A6978-521A-1E7B-8841-C1BF15F80CCB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F44A6978-521A-1E7B-8841-C1BF15F80CCB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CD01D081-2759-DBD2-A98F-BE5ECE04A403}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CD01D081-2759-DBD2-A98F-BE5ECE04A403}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CD01D081-2759-DBD2-A98F-BE5ECE04A403}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F7A34F42-9092-1D8D-BEA7-146968B3EE3A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F7A34F42-9092-1D8D-BEA7-146968B3EE3A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F7A34F42-9092-1D8D-BEA7-146968B3EE3A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{73DB7209-1957-2295-FB91-3FBC82442B01}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{73DB7209-1957-2295-FB91-3FBC82442B01}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{73DB7209-1957-2295-FB91-3FBC82442B01}.Release|Any CPU.Build.0 = Release|Any CPU
+		{135C853D-B3A2-8F7C-4926-B52E9392002F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{135C853D-B3A2-8F7C-4926-B52E9392002F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{135C853D-B3A2-8F7C-4926-B52E9392002F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E87C0BA6-E772-68FA-34C6-64227DD9F3EE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E87C0BA6-E772-68FA-34C6-64227DD9F3EE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E87C0BA6-E772-68FA-34C6-64227DD9F3EE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5FFC2953-2430-8AC9-0096-3FDBC1CA5140}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5FFC2953-2430-8AC9-0096-3FDBC1CA5140}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5FFC2953-2430-8AC9-0096-3FDBC1CA5140}.Release|Any CPU.Build.0 = Release|Any CPU
+		{192D3A1C-8554-3D05-DA6E-A57030ECA124}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{192D3A1C-8554-3D05-DA6E-A57030ECA124}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{192D3A1C-8554-3D05-DA6E-A57030ECA124}.Release|Any CPU.Build.0 = Release|Any CPU
+		{31EC11DD-755D-FECE-4678-D88E17BFDBB6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{31EC11DD-755D-FECE-4678-D88E17BFDBB6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{31EC11DD-755D-FECE-4678-D88E17BFDBB6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CB988CB6-A9A2-0365-354E-1464906386FF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CB988CB6-A9A2-0365-354E-1464906386FF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CB988CB6-A9A2-0365-354E-1464906386FF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5064A781-B3B0-585F-B856-E294556180F1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5064A781-B3B0-585F-B856-E294556180F1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5064A781-B3B0-585F-B856-E294556180F1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{97D530C8-97AC-CEBE-9657-CE02557D6ED9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{97D530C8-97AC-CEBE-9657-CE02557D6ED9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{97D530C8-97AC-CEBE-9657-CE02557D6ED9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{942F9B69-02CD-469B-C00C-3454E93BA2AE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{942F9B69-02CD-469B-C00C-3454E93BA2AE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{942F9B69-02CD-469B-C00C-3454E93BA2AE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{48145FD7-B653-CFE3-B30A-7EF2E0120B21}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{48145FD7-B653-CFE3-B30A-7EF2E0120B21}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{48145FD7-B653-CFE3-B30A-7EF2E0120B21}.Release|Any CPU.Build.0 = Release|Any CPU
+		{05B5D7F9-FE77-1519-2023-61CD1FAD90B1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{05B5D7F9-FE77-1519-2023-61CD1FAD90B1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{05B5D7F9-FE77-1519-2023-61CD1FAD90B1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1BB203B2-65E0-3834-3EB4-0BEC2F75FEBC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1BB203B2-65E0-3834-3EB4-0BEC2F75FEBC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1BB203B2-65E0-3834-3EB4-0BEC2F75FEBC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E974FA60-F02F-FA1F-BA84-C25972F8DD4F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E974FA60-F02F-FA1F-BA84-C25972F8DD4F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E974FA60-F02F-FA1F-BA84-C25972F8DD4F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A857F14B-45A2-8244-554B-C3205FC38F08}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A857F14B-45A2-8244-554B-C3205FC38F08}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A857F14B-45A2-8244-554B-C3205FC38F08}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A12F0AE9-DCB4-9D54-E586-FBBF10CA93F6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A12F0AE9-DCB4-9D54-E586-FBBF10CA93F6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A12F0AE9-DCB4-9D54-E586-FBBF10CA93F6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{56589499-4FA9-EC26-7F7E-D187D035D4DA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{56589499-4FA9-EC26-7F7E-D187D035D4DA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{56589499-4FA9-EC26-7F7E-D187D035D4DA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0F613620-3071-DF98-3506-F37F016C07E1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0F613620-3071-DF98-3506-F37F016C07E1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0F613620-3071-DF98-3506-F37F016C07E1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C45ED108-A68D-B447-00D1-BCB45EEC0D15}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C45ED108-A68D-B447-00D1-BCB45EEC0D15}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C45ED108-A68D-B447-00D1-BCB45EEC0D15}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1AFEBB7F-BFB8-2C11-28BF-68AA6376479B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1AFEBB7F-BFB8-2C11-28BF-68AA6376479B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1AFEBB7F-BFB8-2C11-28BF-68AA6376479B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{63AA9B32-84B1-BE5F-4507-8E7DF73880F2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{63AA9B32-84B1-BE5F-4507-8E7DF73880F2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{63AA9B32-84B1-BE5F-4507-8E7DF73880F2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{83653A8C-7946-338C-F42C-AB714F49991D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{83653A8C-7946-338C-F42C-AB714F49991D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{83653A8C-7946-338C-F42C-AB714F49991D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{32481813-3CE4-F4C8-086F-15FED097835F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{32481813-3CE4-F4C8-086F-15FED097835F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{32481813-3CE4-F4C8-086F-15FED097835F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4F6C59C7-0311-8ADF-017D-E64F46510A70}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4F6C59C7-0311-8ADF-017D-E64F46510A70}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4F6C59C7-0311-8ADF-017D-E64F46510A70}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FF8B81BD-63BA-BEE6-2466-B1A3EE553494}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FF8B81BD-63BA-BEE6-2466-B1A3EE553494}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FF8B81BD-63BA-BEE6-2466-B1A3EE553494}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9D7D20F4-F986-4194-9D18-4F28654EDE7D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9D7D20F4-F986-4194-9D18-4F28654EDE7D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9D7D20F4-F986-4194-9D18-4F28654EDE7D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A90ADACF-3BC4-3C34-F6D6-D02D99C799D5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A90ADACF-3BC4-3C34-F6D6-D02D99C799D5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A90ADACF-3BC4-3C34-F6D6-D02D99C799D5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{75087953-E456-EA40-857F-B38A2BF4DD1D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{75087953-E456-EA40-857F-B38A2BF4DD1D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{75087953-E456-EA40-857F-B38A2BF4DD1D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CF879664-186D-AE54-434E-F0FC3B5D27DC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CF879664-186D-AE54-434E-F0FC3B5D27DC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CF879664-186D-AE54-434E-F0FC3B5D27DC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D377B3DB-B229-DC7A-D651-320B5904BC29}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D377B3DB-B229-DC7A-D651-320B5904BC29}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D377B3DB-B229-DC7A-D651-320B5904BC29}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F42A9BC5-DA3E-A1CE-B48E-7EBF59D8D161}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F42A9BC5-DA3E-A1CE-B48E-7EBF59D8D161}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F42A9BC5-DA3E-A1CE-B48E-7EBF59D8D161}.Release|Any CPU.Build.0 = Release|Any CPU
+		{51FBF981-91B2-407E-7A10-D28E5FB717F4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{51FBF981-91B2-407E-7A10-D28E5FB717F4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{51FBF981-91B2-407E-7A10-D28E5FB717F4}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -565,6 +882,69 @@ Global
 		{738AFF97-B4C4-4EAC-B9C5-C405D481C92B} = {59874241-E276-4035-B31D-14924889A1C9}
 		{A9CCC214-212A-4296-98F5-65ADDB2BB8B4} = {59874241-E276-4035-B31D-14924889A1C9}
 		{51DD3135-1EAA-4640-82F1-9FBECA421708} = {8BD7D5E5-D887-4BD7-9F42-725A8714F7BC}
+		{6607EBEE-8668-E1D3-C1CB-ED11A91DC100} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
+		{5D16D6CC-2BBF-3E53-A932-7E6FCD64E123} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
+		{77459A1A-63B4-F7CE-5B20-79091A4BC6C8} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
+		{7A06889E-2503-38D9-FE44-36527A9FD0C9} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
+		{5159B5AC-6354-B394-93DD-2621DB302EDF} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
+		{44D3B2AE-DA53-A134-182B-E4301BB856A3} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
+		{55DDF80C-42C8-A046-883C-954049FCB811} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
+		{98E31A4F-30D0-0F7B-2E9D-D8F1AEB53DA5} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
+		{3F841B6E-2AEA-23B1-C141-CC67A8FB33E0} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
+		{8057DA4A-FF84-72D3-54BE-A17B47760608} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
+		{5A179D89-95C6-F103-DA7D-6FD33FDF151B} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
+		{A4F19C30-3624-86C4-F533-D88C9DC2A972} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
+		{3E41717A-789B-D213-A4A8-56BFED2E8D17} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
+		{63CAD818-CAFA-41ED-E389-C7553AD813FD} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
+		{C6277231-D388-0D78-CC9F-973172F92585} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
+		{981F5916-AB63-4E99-7762-1BC03CDD8D00} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
+		{3105ADCB-D81E-25F2-8390-986E50E3A88B} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
+		{2F785E38-6E2A-834A-0C9A-CBE3B307DE01} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
+		{4C3111B7-D8EC-0538-2C30-952EA4D9FC94} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
+		{2388CA32-2573-C097-0B04-B67C58BDB7CA} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
+		{C5824CE4-D590-20E7-0565-6BDE1D809A19} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
+		{14E1A30B-2E8A-794C-CF13-F47FDEF4ACD3} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
+		{644C6F28-AEC7-AD30-1D65-F459E0F21DC6} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
+		{18B7AC0F-16B9-B612-A6AA-E092EE68DA1D} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
+		{5B7C359B-81DB-8BF9-D806-6DCEAC1A51D5} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
+		{EEDC48F4-14C6-4017-0CB4-1A7E2315C685} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
+		{B1965821-5021-E09B-0107-9BF12D674AB1} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
+		{C11055B8-9185-2BF4-35E7-65C977DD5DEC} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
+		{F44A6978-521A-1E7B-8841-C1BF15F80CCB} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
+		{CD01D081-2759-DBD2-A98F-BE5ECE04A403} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
+		{F7A34F42-9092-1D8D-BEA7-146968B3EE3A} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
+		{73DB7209-1957-2295-FB91-3FBC82442B01} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
+		{135C853D-B3A2-8F7C-4926-B52E9392002F} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
+		{E87C0BA6-E772-68FA-34C6-64227DD9F3EE} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
+		{5FFC2953-2430-8AC9-0096-3FDBC1CA5140} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
+		{192D3A1C-8554-3D05-DA6E-A57030ECA124} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
+		{31EC11DD-755D-FECE-4678-D88E17BFDBB6} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
+		{CB988CB6-A9A2-0365-354E-1464906386FF} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
+		{5064A781-B3B0-585F-B856-E294556180F1} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
+		{97D530C8-97AC-CEBE-9657-CE02557D6ED9} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
+		{942F9B69-02CD-469B-C00C-3454E93BA2AE} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
+		{48145FD7-B653-CFE3-B30A-7EF2E0120B21} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
+		{05B5D7F9-FE77-1519-2023-61CD1FAD90B1} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
+		{1BB203B2-65E0-3834-3EB4-0BEC2F75FEBC} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
+		{E974FA60-F02F-FA1F-BA84-C25972F8DD4F} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
+		{A857F14B-45A2-8244-554B-C3205FC38F08} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
+		{A12F0AE9-DCB4-9D54-E586-FBBF10CA93F6} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
+		{56589499-4FA9-EC26-7F7E-D187D035D4DA} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
+		{0F613620-3071-DF98-3506-F37F016C07E1} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
+		{C45ED108-A68D-B447-00D1-BCB45EEC0D15} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
+		{1AFEBB7F-BFB8-2C11-28BF-68AA6376479B} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
+		{63AA9B32-84B1-BE5F-4507-8E7DF73880F2} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
+		{83653A8C-7946-338C-F42C-AB714F49991D} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
+		{32481813-3CE4-F4C8-086F-15FED097835F} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
+		{4F6C59C7-0311-8ADF-017D-E64F46510A70} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
+		{FF8B81BD-63BA-BEE6-2466-B1A3EE553494} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
+		{9D7D20F4-F986-4194-9D18-4F28654EDE7D} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
+		{A90ADACF-3BC4-3C34-F6D6-D02D99C799D5} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
+		{75087953-E456-EA40-857F-B38A2BF4DD1D} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
+		{CF879664-186D-AE54-434E-F0FC3B5D27DC} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
+		{D377B3DB-B229-DC7A-D651-320B5904BC29} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
+		{F42A9BC5-DA3E-A1CE-B48E-7EBF59D8D161} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
+		{51FBF981-91B2-407E-7A10-D28E5FB717F4} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {AB0245B9-2464-47F8-BE15-D80A7A2FA965}


### PR DESCRIPTION
## Description

This PR adds projects for packages that don't exist in Steeltoe v4 anymore, so that we can push 4.0.0 versions that fail to compile. The error message points to the replacement package, if applicable, and links to https://steeltoe.io/docs/v3/obsolete. A `readme.md` for nuget.org is included with the same information.

The obsolete packages only build in Release configuration, to keep local builds efficient.

<details>
<summary>Output from Discovery 3x sample, after updating Steeltoe version</summary>

### Visual Studio (requires a Rebuild)

<img width="1789" height="220" alt="image" src="https://github.com/user-attachments/assets/4ccc059c-ae92-49a0-b9a5-2a45b5e97e70" />

### CLI

```text
> dotnet restore
Restore complete (0.7s)

Build succeeded in 0.7s
> dotnet build
Restore complete (0.4s)
  Fortune-Teller-UI failed with 1 error(s) and 5 warning(s) (0.0s)
    C:\Users\***\.nuget\packages\steeltoe.management.endpointcore\4.0.0\build\Steeltoe.Management.EndpointCore.targets(3,5): warning : The NuGet package Steeltoe.Management.EndpointCore has been replaced in Steeltoe v4. Reference Steeltoe.Management.Endpoint instead. See https://steeltoe.io/docs/v3/obsolete for details.
    C:\Users\***\.nuget\packages\steeltoe.extensions.configuration.cloudfoundrycore\4.0.0\build\Steeltoe.Extensions.Configuration.CloudFoundryCore.targets(3,5): warning : The NuGet package Steeltoe.Extensions.Configuration.CloudFoundryCore has been replaced in Steeltoe v4. Reference Steeltoe.Configuration.CloudFoundry instead. See https://steeltoe.io/docs/v3/obsolete for details.
    C:\Users\***\.nuget\packages\steeltoe.discovery.kubernetes\4.0.0\build\Steeltoe.Discovery.Kubernetes.targets(3,5): warning : The NuGet package Steeltoe.Discovery.Kubernetes is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details.
    C:\Users\***\.nuget\packages\steeltoe.discovery.clientcore\4.0.0\build\Steeltoe.Discovery.ClientCore.targets(3,5): warning : The NuGet package Steeltoe.Discovery.ClientCore has been replaced in Steeltoe v4. Reference Steeltoe.Discovery.Configuration instead. See https://steeltoe.io/docs/v3/obsolete for details.
    C:\Users\***\.nuget\packages\steeltoe.connector.cloudfoundry\4.0.0\build\Steeltoe.Connector.CloudFoundry.targets(3,5): warning : The NuGet package Steeltoe.Connector.CloudFoundry has been replaced in Steeltoe v4. Reference Steeltoe.Connectors instead. See https://steeltoe.io/docs/v3/obsolete for details.
    C:\Users\***\.nuget\packages\steeltoe.connector.cloudfoundry\4.0.0\build\Steeltoe.Connector.CloudFoundry.targets(8,5): error : One or more Steeltoe package dependencies need attention. See the build warnings for details.
  Fortune-Teller-Service failed with 1 error(s) and 6 warning(s) (0.2s)
    C:\Users\***\.nuget\packages\steeltoe.management.endpointcore\4.0.0\build\Steeltoe.Management.EndpointCore.targets(3,5): warning : The NuGet package Steeltoe.Management.EndpointCore has been replaced in Steeltoe v4. Reference Steeltoe.Management.Endpoint instead. See https://steeltoe.io/docs/v3/obsolete for details.
    C:\Users\***\.nuget\packages\steeltoe.extensions.configuration.placeholdercore\4.0.0\build\Steeltoe.Extensions.Configuration.PlaceholderCore.targets(3,5): warning : The NuGet package Steeltoe.Extensions.Configuration.PlaceholderCore has been replaced in Steeltoe v4. Reference Steeltoe.Configuration.Placeholder instead. See https://steeltoe.io/docs/v3/obsolete for details.
    C:\Users\***\.nuget\packages\steeltoe.extensions.configuration.cloudfoundrycore\4.0.0\build\Steeltoe.Extensions.Configuration.CloudFoundryCore.targets(3,5): warning : The NuGet package Steeltoe.Extensions.Configuration.CloudFoundryCore has been replaced in Steeltoe v4. Reference Steeltoe.Configuration.CloudFoundry instead. See https://steeltoe.io/docs/v3/obsolete for details.
    C:\Users\***\.nuget\packages\steeltoe.discovery.kubernetes\4.0.0\build\Steeltoe.Discovery.Kubernetes.targets(3,5): warning : The NuGet package Steeltoe.Discovery.Kubernetes is no longer available in Steeltoe v4. See https://steeltoe.io/docs/v3/obsolete for details.
    C:\Users\***\.nuget\packages\steeltoe.discovery.clientcore\4.0.0\build\Steeltoe.Discovery.ClientCore.targets(3,5): warning : The NuGet package Steeltoe.Discovery.ClientCore has been replaced in Steeltoe v4. Reference Steeltoe.Discovery.Configuration instead. See https://steeltoe.io/docs/v3/obsolete for details.
    C:\Users\***\.nuget\packages\steeltoe.connector.cloudfoundry\4.0.0\build\Steeltoe.Connector.CloudFoundry.targets(3,5): warning : The NuGet package Steeltoe.Connector.CloudFoundry has been replaced in Steeltoe v4. Reference Steeltoe.Connectors instead. See https://steeltoe.io/docs/v3/obsolete for details.
    C:\Users\***\.nuget\packages\steeltoe.connector.cloudfoundry\4.0.0\build\Steeltoe.Connector.CloudFoundry.targets(8,5): error : One or more Steeltoe package dependencies need attention. See the build warnings for details.

Build failed with 2 error(s) and 11 warning(s) in 0.9s
```
</details>

<details>
<summary>Source used for code generation</summary>

```text
Steeltoe.Bootstrap.Autoconfig -> Steeltoe.Bootstrap.AutoConfiguration
Steeltoe.CircuitBreaker.Abstractions
Steeltoe.CircuitBreaker.Hystrix.MetricsEventsCore
Steeltoe.CircuitBreaker.Hystrix.MetricsStreamCore
Steeltoe.CircuitBreaker.HystrixBase
Steeltoe.CircuitBreaker.HystrixCore
Steeltoe.Common.Abstractions -> Steeltoe.Common
Steeltoe.Common.Expression
Steeltoe.Common.Kubernetes
Steeltoe.Common.Retry
Steeltoe.Common.Security -> Steeltoe.Common.Certificates
Steeltoe.Common.Utils
Steeltoe.Connector.Abstractions -> Steeltoe.Connectors
Steeltoe.Connector.CloudFoundry -> Steeltoe.Connectors
Steeltoe.Connector.ConnectorBase -> Steeltoe.Connectors
Steeltoe.Connector.ConnectorCore -> Steeltoe.Connectors
Steeltoe.Connector.EF6Core
Steeltoe.Connector.EFCore -> Steeltoe.Connectors.EntityFrameworkCore
Steeltoe.Discovery.Abstractions -> Steeltoe.Common
Steeltoe.Discovery.ClientBase -> Steeltoe.Discovery.Configuration
Steeltoe.Discovery.ClientCore -> Steeltoe.Discovery.Configuration
Steeltoe.Discovery.Kubernetes
Steeltoe.Extensions.Configuration.Abstractions -> Steeltoe.Configuration.Abstractions
Steeltoe.Extensions.Configuration.CloudFoundryBase -> Steeltoe.Configuration.CloudFoundry
Steeltoe.Extensions.Configuration.CloudFoundryCore -> Steeltoe.Configuration.CloudFoundry
Steeltoe.Extensions.Configuration.ConfigServerBase -> Steeltoe.Configuration.ConfigServer
Steeltoe.Extensions.Configuration.ConfigServerCore -> Steeltoe.Configuration.ConfigServer
Steeltoe.Extensions.Configuration.Kubernetes.ServiceBinding -> Steeltoe.Configuration.Kubernetes.ServiceBindings
Steeltoe.Extensions.Configuration.KubernetesBase
Steeltoe.Extensions.Configuration.KubernetesCore
Steeltoe.Extensions.Configuration.PlaceholderBase -> Steeltoe.Configuration.Placeholder
Steeltoe.Extensions.Configuration.PlaceholderCore -> Steeltoe.Configuration.Placeholder
Steeltoe.Extensions.Configuration.RandomValueBase -> Steeltoe.Configuration.RandomValue
Steeltoe.Extensions.Configuration.SpringBootBase -> Steeltoe.Configuration.SpringBoot
Steeltoe.Extensions.Configuration.SpringBootCore -> Steeltoe.Configuration.SpringBoot
Steeltoe.Extensions.Logging.Abstractions -> Steeltoe.Logging.Abstractions
Steeltoe.Extensions.Logging.DynamicLogger -> Steeltoe.Logging.DynamicConsole
Steeltoe.Extensions.Logging.DynamicSerilogBase -> Steeltoe.Logging.DynamicSerilog
Steeltoe.Extensions.Logging.DynamicSerilogCore -> Steeltoe.Logging.DynamicSerilog
Steeltoe.Integration.Abstractions
Steeltoe.Integration.IntegrationBase
Steeltoe.Integration.RabbitMQ
Steeltoe.Management.CloudFoundryCore -> Steeltoe.Management.Endpoint
Steeltoe.Management.Diagnostics -> Steeltoe.Management.Endpoint
Steeltoe.Management.EndpointBase -> Steeltoe.Management.Endpoint
Steeltoe.Management.EndpointCore -> Steeltoe.Management.Endpoint
Steeltoe.Management.KubernetesCore
Steeltoe.Management.OpenTelemetryBase -> Steeltoe.Management.Prometheus
Steeltoe.Management.TaskCore -> Steeltoe.Management.Tasks
Steeltoe.Management.TracingBase -> Steeltoe.Management.Tracing
Steeltoe.Management.TracingCore -> Steeltoe.Management.Tracing
Steeltoe.Messaging.Abstractions
Steeltoe.Messaging.MessagingBase
Steeltoe.Messaging.RabbitMQ
Steeltoe.Security.Authentication.CloudFoundryBase -> Steeltoe.Security.Authentication.JwtBearer / Steeltoe.Security.Authentication.OpenIdConnect / Steeltoe.Security.Authorization.Certificate
Steeltoe.Security.Authentication.CloudFoundryCore -> Steeltoe.Security.Authentication.JwtBearer / Steeltoe.Security.Authentication.OpenIdConnect / Steeltoe.Security.Authorization.Certificate
Steeltoe.Security.Authentication.MtlsCore -> Steeltoe.Security.Authorization.Certificate
Steeltoe.Security.DataProtection.CredHubBase
Steeltoe.Security.DataProtection.CredHubCore
Steeltoe.Security.DataProtection.RedisCore -> Steeltoe.Security.DataProtection.Redis
Steeltoe.Stream.Abstractions
Steeltoe.Stream.Binder.RabbitMQ
Steeltoe.Stream.StreamBase
```
</details>

Closes #1242.

## Quality checklist

- [x] Your code complies with our [Coding Style](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-code-style.md).
- [ ] You've updated unit and/or integration tests for your change, where applicable.
- [ ] You've updated documentation for your change, where applicable.
      If your change affects other repositories, such as [Documentation](https://github.com/SteeltoeOSS/Documentation), [Samples](https://github.com/SteeltoeOSS/Samples) and/or [MainSite](https://github.com/SteeltoeOSS/MainSite), add linked PRs here.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
- [ ] You've added required license files and/or file headers (explaining where the code came from with proper attribution), where code is copied from StackOverflow, a blog, or OSS.
