### PR TITLE
Crashfix config server

### DIFF
--- a/src/Configuration/src/ConfigServer/ConfigServerClientOptions.cs
+++ b/src/Configuration/src/ConfigServer/ConfigServerClientOptions.cs
@@ -32,7 +32,7 @@ public sealed class ConfigServerClientOptions : IValidateCertificatesOptions
     public bool FailFast { get; set; }
 
     /// <summary>
-    /// Gets or sets the environment used when accessing configuration data. Default value: "Production".
+    /// Gets or sets a comma-separated list of environments used when accessing configuration data. Default value: "Production".
     /// </summary>
     [ConfigurationKeyName("Env")]
     public string? Environment { get; set; } = "Production";

--- a/src/Configuration/src/ConfigServer/ConfigServerConfigurationProvider.cs
+++ b/src/Configuration/src/ConfigServer/ConfigServerConfigurationProvider.cs
@@ -630,15 +630,15 @@ internal sealed class ConfigServerConfigurationProvider : ConfigurationProvider,
 
         if (!string.IsNullOrEmpty(ClientOptions.Username))
         {
-            uriBuilder.UserName = ClientOptions.Username;
+            uriBuilder.UserName = WebUtility.UrlEncode(ClientOptions.Username);
         }
 
         if (!string.IsNullOrEmpty(ClientOptions.Password))
         {
-            uriBuilder.Password = ClientOptions.Password;
+            uriBuilder.Password = WebUtility.UrlEncode(ClientOptions.Password);
         }
 
-        string pathSuffix = $"{ClientOptions.Name}/{WebUtility.UrlEncode(ClientOptions.Environment)}";
+        string pathSuffix = $"{WebUtility.UrlEncode(ClientOptions.Name)}/{WebUtility.UrlEncode(ClientOptions.Environment)}";
 
         if (!string.IsNullOrWhiteSpace(label))
         {
@@ -648,7 +648,7 @@ internal sealed class ConfigServerConfigurationProvider : ConfigurationProvider,
                 label = label.Replace("/", "(_)", StringComparison.Ordinal);
             }
 
-            pathSuffix = $"{pathSuffix}/{label.Trim()}";
+            pathSuffix = $"{pathSuffix}/{WebUtility.UrlEncode(label)}";
         }
 
         if (!uriBuilder.Path.EndsWith('/'))

--- a/src/Configuration/src/ConfigServer/ConfigServerConfigurationProvider.cs
+++ b/src/Configuration/src/ConfigServer/ConfigServerConfigurationProvider.cs
@@ -638,7 +638,7 @@ internal sealed class ConfigServerConfigurationProvider : ConfigurationProvider,
             uriBuilder.Password = ClientOptions.Password;
         }
 
-        string pathSuffix = $"{ClientOptions.Name}/{ClientOptions.Environment}";
+        string pathSuffix = $"{ClientOptions.Name}/{WebUtility.UrlEncode(ClientOptions.Environment)}";
 
         if (!string.IsNullOrWhiteSpace(label))
         {

--- a/src/Configuration/src/ConfigServer/ConfigurationSchema.json
+++ b/src/Configuration/src/ConfigServer/ConfigurationSchema.json
@@ -90,7 +90,7 @@
                 },
                 "Env": {
                   "type": "string",
-                  "description": "Gets or sets the environment used when accessing configuration data. Default value: \"Production\"."
+                  "description": "Gets or sets a comma-separated list of environments used when accessing configuration data. Default value: \"Production\"."
                 },
                 "FailFast": {
                   "type": "boolean",

--- a/src/Configuration/test/ConfigServer.Test/ConfigServerConfigurationProviderTest.Settings.cs
+++ b/src/Configuration/test/ConfigServer.Test/ConfigServerConfigurationProviderTest.Settings.cs
@@ -79,9 +79,9 @@ public sealed partial class ConfigServerConfigurationProviderTest
         };
 
         using var provider = new ConfigServerConfigurationProvider(options, null, null, NullLoggerFactory.Instance);
-        string path = provider.BuildConfigServerUri(options.Uri!, null).ToString();
+        string uri = provider.BuildConfigServerUri(options.Uri!, null).ToString();
 
-        path.Should().Be($"{options.Uri}/{options.Name}/{options.Environment}");
+        uri.Should().Be($"{options.Uri}/{options.Name}/{options.Environment}");
     }
 
     [Fact]
@@ -95,9 +95,9 @@ public sealed partial class ConfigServerConfigurationProviderTest
         };
 
         using var provider = new ConfigServerConfigurationProvider(options, null, null, NullLoggerFactory.Instance);
-        string path = provider.BuildConfigServerUri(options.Uri!, options.Label).ToString();
+        string uri = provider.BuildConfigServerUri(options.Uri!, options.Label).ToString();
 
-        path.Should().Be($"{options.Uri}/{options.Name}/{options.Environment}/{options.Label}");
+        uri.Should().Be($"{options.Uri}/{options.Name}/{options.Environment}/{options.Label}");
     }
 
     [Fact]
@@ -111,9 +111,9 @@ public sealed partial class ConfigServerConfigurationProviderTest
         };
 
         using var provider = new ConfigServerConfigurationProvider(options, null, null, NullLoggerFactory.Instance);
-        string path = provider.BuildConfigServerUri(options.Uri!, options.Label).ToString();
+        string uri = provider.BuildConfigServerUri(options.Uri!, options.Label).ToString();
 
-        path.Should().Be($"{options.Uri}/{options.Name}/{options.Environment}/myLabel(_)version");
+        uri.Should().Be($"{options.Uri}/{options.Name}/{options.Environment}/myLabel(_)version");
     }
 
     [Fact]
@@ -127,9 +127,9 @@ public sealed partial class ConfigServerConfigurationProviderTest
         };
 
         using var provider = new ConfigServerConfigurationProvider(options, null, null, NullLoggerFactory.Instance);
-        string path = provider.BuildConfigServerUri(options.Uri, null).ToString();
+        string uri = provider.BuildConfigServerUri(options.Uri, null).ToString();
 
-        path.Should().Be($"http://localhost:9999/myPath/path/{options.Name}/{options.Environment}");
+        uri.Should().Be($"http://localhost:9999/myPath/path/{options.Name}/{options.Environment}");
     }
 
     [Fact]
@@ -143,9 +143,9 @@ public sealed partial class ConfigServerConfigurationProviderTest
         };
 
         using var provider = new ConfigServerConfigurationProvider(options, null, null, NullLoggerFactory.Instance);
-        string path = provider.BuildConfigServerUri(options.Uri, null).ToString();
+        string uri = provider.BuildConfigServerUri(options.Uri, null).ToString();
 
-        path.Should().Be($"http://localhost:9999/myPath/path/{options.Name}/{options.Environment}");
+        uri.Should().Be($"http://localhost:9999/myPath/path/{options.Name}/{options.Environment}");
     }
 
     [Fact]
@@ -159,9 +159,9 @@ public sealed partial class ConfigServerConfigurationProviderTest
         };
 
         using var provider = new ConfigServerConfigurationProvider(options, null, null, NullLoggerFactory.Instance);
-        string path = provider.BuildConfigServerUri(options.Uri, null).ToString();
+        string uri = provider.BuildConfigServerUri(options.Uri, null).ToString();
 
-        path.Should().Be($"http://localhost:9999/{options.Name}/{options.Environment}");
+        uri.Should().Be($"http://localhost:9999/{options.Name}/{options.Environment}");
     }
 
     [Fact]
@@ -175,9 +175,9 @@ public sealed partial class ConfigServerConfigurationProviderTest
         };
 
         using var provider = new ConfigServerConfigurationProvider(options, null, null, NullLoggerFactory.Instance);
-        string path = provider.BuildConfigServerUri(options.Uri, null).ToString();
+        string uri = provider.BuildConfigServerUri(options.Uri, null).ToString();
 
-        path.Should().Be($"http://localhost:9999/{options.Name}/{options.Environment}");
+        uri.Should().Be($"http://localhost:9999/{options.Name}/{options.Environment}");
     }
 
     [Fact]
@@ -191,8 +191,27 @@ public sealed partial class ConfigServerConfigurationProviderTest
         };
 
         using var provider = new ConfigServerConfigurationProvider(options, null, null, NullLoggerFactory.Instance);
-        string path = provider.BuildConfigServerUri(options.Uri!, options.Label).ToString();
+        string uri = provider.BuildConfigServerUri(options.Uri!, options.Label).ToString();
 
-        path.Should().Be("http://localhost:8888/myName/one%2Ctwo/demo");
+        uri.Should().Be("http://localhost:8888/myName/one%2Ctwo/demo");
+    }
+
+    [Fact]
+    public void GetConfigServerUri_EncodesSpecialCharacters()
+    {
+        var options = new ConfigServerClientOptions
+        {
+            Name = "my$<>:,\"'Name",
+            Environment = "@/&?:\"'",
+            Label = "^&$@#*<>+",
+            Username = "a\":?'*,b/\\&",
+            Password = "#&:$<>'/so,\"me"
+        };
+
+        using var provider = new ConfigServerConfigurationProvider(options, null, null, NullLoggerFactory.Instance);
+        string uri = provider.BuildConfigServerUri(options.Uri!, options.Label).ToString();
+
+        uri.Should().Be(
+            "http://a%22%3A%3F%27*%2Cb%2F%5C%26:%23%26%3A%24%3C%3E%27%2Fso%2C%22me@localhost:8888/my%24<>%3A%2C\"%27Name/%40%2F%26%3F%3A\"%27/^%26%24%40%23*<>%2B");
     }
 }

--- a/src/Configuration/test/ConfigServer.Test/ConfigServerConfigurationProviderTest.Settings.cs
+++ b/src/Configuration/test/ConfigServer.Test/ConfigServerConfigurationProviderTest.Settings.cs
@@ -179,4 +179,20 @@ public sealed partial class ConfigServerConfigurationProviderTest
 
         path.Should().Be($"http://localhost:9999/{options.Name}/{options.Environment}");
     }
+
+    [Fact]
+    public void GetConfigServerUri_MultipleEnvironments_EncodesComma()
+    {
+        var options = new ConfigServerClientOptions
+        {
+            Name = "myName",
+            Environment = "one,two",
+            Label = "demo"
+        };
+
+        using var provider = new ConfigServerConfigurationProvider(options, null, null, NullLoggerFactory.Instance);
+        string path = provider.BuildConfigServerUri(options.Uri!, options.Label).ToString();
+
+        path.Should().Be("http://localhost:8888/myName/one%2Ctwo/demo");
+    }
 }

--- a/src/Discovery/test/HttpClients.Test/RegisterMultipleDiscoveryClientsTest.cs
+++ b/src/Discovery/test/HttpClients.Test/RegisterMultipleDiscoveryClientsTest.cs
@@ -602,8 +602,8 @@ public sealed class RegisterMultipleDiscoveryClientsTest
             }
             """;
 
-        string username = WebUtility.UrlEncode("u$er?N@me");
-        string password = WebUtility.UrlEncode(":p@ssw0rd=");
+        string username = WebUtility.UrlEncode("u$er?,N@me");
+        string password = WebUtility.UrlEncode(":p@ss,w0rd=");
 
         var appSettings = new Dictionary<string, string?>
         {
@@ -619,7 +619,7 @@ public sealed class RegisterMultipleDiscoveryClientsTest
 
         var handler = new DelegateToMockHttpClientHandler();
 
-        handler.Mock.Expect(HttpMethod.Get, "https://api.eureka-server.com/eureka/apps").WithHeaders("Authorization", "Basic dSRlcj9OQG1lOjpwQHNzdzByZD0=")
+        handler.Mock.Expect(HttpMethod.Get, "https://api.eureka-server.com/eureka/apps").WithHeaders("Authorization", "Basic dSRlcj8sTkBtZTo6cEBzcyx3MHJkPQ==")
             .WithHeaders("X-Discovery-AllowRedirect", "false").Respond("application/json", applicationsResponse);
 
         await using WebApplication webApplication = builder.Build();


### PR DESCRIPTION
## Description

Allow a comma-separated list of environments in Config Server settings.
Harden against special characters to prevent URL masking from crashing.

Fixes #1566.

## Quality checklist

<!-- Please run through the checklist below to ensure a smooth review and merge process for your PR. -->

- [ ] Your code complies with our [Coding Style](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-code-style.md).
- [ ] You've updated unit and/or integration tests for your change, where applicable.
- [ ] You've updated documentation for your change, where applicable.
      If your change affects other repositories, such as [Documentation](https://github.com/SteeltoeOSS/Documentation), [Samples](https://github.com/SteeltoeOSS/Samples) and/or [MainSite](https://github.com/SteeltoeOSS/MainSite), add linked PRs here.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
- [ ] You've added required license files and/or file headers (explaining where the code came from with proper attribution), where code is copied from StackOverflow, a blog, or OSS.
