### PR TITLE
Fixed crash in RabbitMQ connector

### DIFF
--- a/src/Connectors/src/Connectors/RabbitMQ/RabbitMQServiceCollectionExtensions.cs
+++ b/src/Connectors/src/Connectors/RabbitMQ/RabbitMQServiceCollectionExtensions.cs
@@ -63,7 +63,7 @@ public static class RabbitMQServiceCollectionExtensions
         if (!ConnectorFactoryShim<RabbitMQOptions>.IsRegistered(packageResolver.ConnectionInterface.Type, services))
         {
             var optionsBuilder = new ConnectorAddOptionsBuilder(
-                (serviceProvider, serviceBindingName) => CreateConnectionAsync(serviceProvider, serviceBindingName, packageResolver, CancellationToken.None),
+                (serviceProvider, serviceBindingName) => CreateConnection(serviceProvider, serviceBindingName, packageResolver, CancellationToken.None),
                 (serviceProvider, serviceBindingName) => CreateHealthContributor(serviceProvider, serviceBindingName, packageResolver))
             {
                 // From https://www.rabbitmq.com/dotnet-api-guide.html#connection-and-channel-lifespan:
@@ -120,8 +120,8 @@ public static class RabbitMQServiceCollectionExtensions
         return (string?)builder["host"] ?? "localhost";
     }
 
-    private static async Task<IDisposable> CreateConnectionAsync(IServiceProvider serviceProvider, string serviceBindingName,
-        RabbitMQPackageResolver packageResolver, CancellationToken cancellationToken)
+    private static IDisposable CreateConnection(IServiceProvider serviceProvider, string serviceBindingName, RabbitMQPackageResolver packageResolver,
+        CancellationToken cancellationToken)
     {
         var optionsMonitor = serviceProvider.GetRequiredService<IOptionsMonitor<RabbitMQOptions>>();
         RabbitMQOptions options = optionsMonitor.Get(serviceBindingName);
@@ -134,7 +134,7 @@ public static class RabbitMQServiceCollectionExtensions
         }
 
         ConnectionFactoryInterfaceShim connectionFactoryInterfaceShim = connectionFactoryShim.AsInterface();
-        ConnectionInterfaceShim connectionInterfaceShim = await connectionFactoryInterfaceShim.CreateConnectionAsync(cancellationToken);
+        ConnectionInterfaceShim connectionInterfaceShim = connectionFactoryInterfaceShim.CreateConnection(cancellationToken);
         return connectionInterfaceShim.Instance;
     }
 }

--- a/src/Connectors/test/Connectors.Test/RabbitMQ/RabbitMQConnectorTest.cs
+++ b/src/Connectors/test/Connectors.Test/RabbitMQ/RabbitMQConnectorTest.cs
@@ -347,6 +347,26 @@ public sealed class RabbitMQConnectorTest
         rabbitMQHealthContributors[1].Host.Should().Be("host2");
     }
 
+    [Fact(Skip = "Integration test - Requires local RabbitMQ server")]
+    public async Task Can_connect_to_running_server()
+    {
+        var appSettings = new Dictionary<string, string?>
+        {
+            ["Steeltoe:Client:RabbitMQ:Default:ConnectionString"] = "amqp://localhost:5672"
+        };
+
+        WebApplicationBuilder builder = TestWebApplicationBuilderFactory.Create();
+        builder.Configuration.AddInMemoryCollection(appSettings);
+        builder.AddRabbitMQ();
+
+        await using WebApplication app = builder.Build();
+
+        var connectorFactory = app.Services.GetRequiredService<ConnectorFactory<RabbitMQOptions, IConnection>>();
+        IConnection connection = connectorFactory.Get().GetConnection();
+
+        connection.IsOpen.Should().BeTrue();
+    }
+
     [Fact]
     public async Task Registers_default_connection_string_when_only_single_server_binding_found()
     {


### PR DESCRIPTION
## Description

Fixed crash during RabbitMQ connect:

> System.InvalidCastException: 'Unable to cast object of type 'AsyncStateMachineBox`1[System.IDisposable,Steeltoe.Connectors.RabbitMQ.RabbitMQServiceCollectionExtensions+<CreateConnectionAsync>d__5]' to type 'RabbitMQ.Client.IConnection'.'

This happened because the connect callback returned a `Task<IConnection>`, whereas the connector is registered in the service container with `IConnection`. There are two solutions:

1. Change the service registration from `ConnectorFactory<RabbitMQOptions, IConnection>` to `ConnectorFactory<RabbitMQOptions, Task<IConnection>>`, such that the call to `connectorFactory.Get().GetConnection()` needs to be awaited.
2. Stick with the current API and synchronously wait for the task to complete before returning it.

This PR implements solution 2, because that doesn't require breaking the public API. I'm also unsure whether it's safe when the task is awaited concurrently.

## Quality checklist

- [x] Your code complies with our [Coding Style](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-code-style.md).
- [x] You've updated unit and/or integration tests for your change, where applicable.
- [ ] You've updated documentation for your change, where applicable.
      If your change affects other repositories, such as [Documentation](https://github.com/SteeltoeOSS/Documentation), [Samples](https://github.com/SteeltoeOSS/Samples) and/or [MainSite](https://github.com/SteeltoeOSS/MainSite), add linked PRs here.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
- [ ] You've added required license files and/or file headers (explaining where the code came from with proper attribution), where code is copied from StackOverflow, a blog, or OSS.
