### PR TITLE
Set OutputType=Exe for test projects (required by xUnit3)

### DIFF
--- a/shared-test.props
+++ b/shared-test.props
@@ -1,5 +1,6 @@
 <Project>
   <PropertyGroup>
+    <OutputType>Exe</OutputType>
     <NoWarn>$(NoWarn);S2094;S3717;SA1602;CA1062;CA1707;NU5104</NoWarn>
   </PropertyGroup>
 


### PR DESCRIPTION
## Description

The build error that `apphost.exe` is not found keeps popping up at corner cases, such as when running in WSL, and using .NET 10 previews. According to the xUnit documentation, setting `OutputType` is required. We haven't done so because it seemed redundant, but according to [this comment](https://github.com/xunit/xunit/issues/3139#issuecomment-2603594598), we should:

> Executable output type is a requirement. We have been trying to set it for you via the NuGet package but the time at which it's set isn't appropriate

## Quality checklist

- [x] Your code complies with our [Coding Style](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-code-style.md).
- [ ] You've updated unit and/or integration tests for your change, where applicable.
- [ ] You've updated documentation for your change, where applicable.
      If your change affects other repositories, such as [Documentation](https://github.com/SteeltoeOSS/Documentation), [Samples](https://github.com/SteeltoeOSS/Samples) and/or [MainSite](https://github.com/SteeltoeOSS/MainSite), add linked PRs here.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
- [ ] You've added required license files and/or file headers (explaining where the code came from with proper attribution), where code is copied from StackOverflow, a blog, or OSS.
