### PR TITLE
Constrain the maximum RabbitMQ version for Hystrix and Messaging/Stream

### DIFF
--- a/src/CircuitBreaker/src/Hystrix.MetricsStreamCore/Steeltoe.CircuitBreaker.Hystrix.MetricsStreamCore.csproj
+++ b/src/CircuitBreaker/src/Hystrix.MetricsStreamCore/Steeltoe.CircuitBreaker.Hystrix.MetricsStreamCore.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <Description>Netflix Hystrix metrics event stream for ASP.NET Core over RabbitMQ</Description>
@@ -19,7 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="RabbitMQ.Client" Version="$(RabbitClientVersion)" PrivateAssets="All" />
+    <PackageReference Include="RabbitMQ.Client" Version="[$(RabbitClientVersion),$(RabbitClientMaxVersion))" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>

--- a/src/Messaging/src/RabbitMQ/Steeltoe.Messaging.RabbitMQ.csproj
+++ b/src/Messaging/src/RabbitMQ/Steeltoe.Messaging.RabbitMQ.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   
   <PropertyGroup>
     <Description>Steeltoe Messaging RabbitMQ</Description>
@@ -23,7 +23,7 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="$(JsonNetVersion)" />
-    <PackageReference Include="RabbitMQ.Client" Version="$(RabbitClientVersion)" />
+    <PackageReference Include="RabbitMQ.Client" Version="[$(RabbitClientVersion),$(RabbitClientMaxVersion))" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="$(ExtensionsVersion)" />
   </ItemGroup>
   

--- a/versions.props
+++ b/versions.props
@@ -25,6 +25,7 @@
     <OpenTelemetryVersion>1.8.1</OpenTelemetryVersion>
     <WavefrontSdkVersion>1.8.0-beta</WavefrontSdkVersion>
     <RabbitClientVersion>5.1.2</RabbitClientVersion>
+    <RabbitClientMaxVersion>6.0.0</RabbitClientMaxVersion>
     <ReactiveVersion>4.1.5</ReactiveVersion>
     <PollyVersion>7.1.1</PollyVersion>
     <PollyContribVersion>1.0.0</PollyContribVersion>


### PR DESCRIPTION
## Description

Constrain the maximum RabbitMQ version for Hystrix and Messaging/Stream, because RabbitMQ.Client v6 and higher are known to be incompatible with Steeltoe 3.x.

## Quality checklist

- [x] Your code complies with our [Coding Style](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-code-style.md).
- [ ] You've updated unit and/or integration tests for your change, where applicable.
- [ ] You've updated documentation for your change, where applicable.
      If your change affects other repositories, such as [Documentation](https://github.com/SteeltoeOSS/Documentation), [Samples](https://github.com/SteeltoeOSS/Samples) and/or [MainSite](https://github.com/SteeltoeOSS/MainSite), add linked PRs here.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
- [ ] You've added required license files and/or file headers (explaining where the code came from with proper attribution), where code is copied from StackOverflow, a blog, or OSS.
