### PR TITLE
GHA: Explicitly set git credential persistence (true by default)

### DIFF
--- a/.github/workflows/Steeltoe.All.yml
+++ b/.github/workflows/Steeltoe.All.yml
@@ -79,6 +79,8 @@ jobs:
 
     - name: Git checkout
       uses: actions/checkout@v4
+      with:
+        persist-credentials: false
 
     - name: Restore packages
       run: dotnet restore ${{ env.SOLUTION_FILE }} /p:Configuration=Release --verbosity minimal

--- a/.github/workflows/component-shared-workflow.yml
+++ b/.github/workflows/component-shared-workflow.yml
@@ -76,6 +76,8 @@ jobs:
 
     - name: Git checkout
       uses: actions/checkout@v4
+      with:
+        persist-credentials: false
 
     - name: Restore packages
       run: dotnet restore ${{ env.SOLUTION_FILE }} /p:Configuration=Release --verbosity minimal

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -40,6 +40,8 @@ jobs:
 
     - name: Git checkout
       uses: actions/checkout@v4
+      with:
+        persist-credentials: false
 
     - name: Restore packages
       run: dotnet restore ${{ env.SOLUTION_FILE }} /p:Configuration=Release --verbosity minimal
@@ -261,6 +263,8 @@ jobs:
     steps:
     - name: Git checkout
       uses: actions/checkout@v4
+      with:
+        persist-credentials: true
 
     - name: Calculate next package version
       shell: pwsh

--- a/.github/workflows/scan-vulnerable-dependencies.yml
+++ b/.github/workflows/scan-vulnerable-dependencies.yml
@@ -36,6 +36,8 @@ jobs:
 
     - name: Git checkout
       uses: actions/checkout@v4
+      with:
+        persist-credentials: false
 
     - name: Report vulnerable dependencies
       run: dotnet restore ${{ env.SOLUTION_FILE }} --verbosity minimal /p:NuGetAudit=true /p:NuGetAuditMode=all /p:NuGetAuditLevel=low /p:TreatWarningsAsErrors=True

--- a/.github/workflows/sonarcube.yml
+++ b/.github/workflows/sonarcube.yml
@@ -60,6 +60,7 @@ jobs:
     - name: Git checkout
       uses: actions/checkout@v4
       with:
+        persist-credentials: false
         # Sonar: Shallow clones should be disabled for a better relevancy of analysis.
         fetch-depth: 0
 

--- a/.github/workflows/verify-code-style.yml
+++ b/.github/workflows/verify-code-style.yml
@@ -36,6 +36,7 @@ jobs:
     - name: Git checkout
       uses: actions/checkout@v4
       with:
+        persist-credentials: false
         fetch-depth: 2
 
     - name: Restore tools


### PR DESCRIPTION
## Description

Picks one commit from #1578, after concluding this tool is way too aggressive regarding potential code injection via template expansion (reporting many false positives), and the lack of flexibility in suppressing reported alerts.

## Quality checklist

- [x] Your code complies with our [Coding Style](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-code-style.md).
- [ ] You've updated unit and/or integration tests for your change, where applicable.
- [ ] You've updated documentation for your change, where applicable.
      If your change affects other repositories, such as [Documentation](https://github.com/SteeltoeOSS/Documentation), [Samples](https://github.com/SteeltoeOSS/Samples) and/or [MainSite](https://github.com/SteeltoeOSS/MainSite), add linked PRs here.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
- [ ] You've added required license files and/or file headers (explaining where the code came from with proper attribution), where code is copied from StackOverflow, a blog, or OSS.
