### PR TITLE
Exposed RelationalDatabaseHealthContributor

### DIFF
--- a/src/Connectors/src/Connectors/PublicAPI.Shipped.txt
+++ b/src/Connectors/src/Connectors/PublicAPI.Shipped.txt
@@ -112,3 +112,8 @@ Steeltoe.Connectors.SqlServer.SqlServerOptions.SqlServerOptions() -> void
 Steeltoe.Connectors.SqlServer.SqlServerServiceCollectionExtensions
 virtual Steeltoe.Connectors.ConnectorCreateConnection.Invoke(System.IServiceProvider! serviceProvider, string! serviceBindingName) -> object!
 virtual Steeltoe.Connectors.ConnectorCreateHealthContributor.Invoke(System.IServiceProvider! serviceProvider, string! serviceBindingName) -> Steeltoe.Common.HealthChecks.IHealthContributor!
+Steeltoe.Connectors.RelationalDatabaseHealthContributor
+Steeltoe.Connectors.RelationalDatabaseHealthContributor.RelationalDatabaseHealthContributor(System.Data.Common.DbConnection! connection, string? id, string? host, string? commandText, Microsoft.Extensions.Logging.ILogger<Steeltoe.Connectors.RelationalDatabaseHealthContributor!>! logger) -> void
+Steeltoe.Connectors.RelationalDatabaseHealthContributor.RelationalDatabaseHealthContributor(System.Data.Common.DbConnection! connection, string? host, Microsoft.Extensions.Logging.ILogger<Steeltoe.Connectors.RelationalDatabaseHealthContributor!>! logger) -> void
+Steeltoe.Connectors.RelationalDatabaseHealthContributor.CheckHealthAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Steeltoe.Common.HealthChecks.HealthCheckResult?>!
+Steeltoe.Connectors.RelationalDatabaseHealthContributor.Dispose() -> void


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->

<!-- If this is your first PR in this repo, please read our [Contributing Guidelines (https://github.com/SteeltoeOSS/.github/blob/master/CONTRIBUTING.md) and remember to sign the [Contributor License Agreement](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-license.md). Our bot will notify you shortly after the PR has been created. -->

## Description

Makes `Steeltoe.Connectors.RelationalDatabaseHealthContributor` public and adds a way to override the `Id` property and  `CommandText` used to check the DB (default is "SELECT 1;")

The goal of this is to make it easier to implement custom health checks for non-supported databases (like Oracle).

Fixes #1594

## Quality checklist

<!-- Please run through the checklist below to ensure a smooth review and merge process for your PR. -->

- [x] Your code complies with our [Coding Style](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-code-style.md).
- [x] You've updated unit and/or integration tests for your change, where applicable.
- [ ] You've updated documentation for your change, where applicable.
      If your change affects other repositories, such as [Documentation](https://github.com/SteeltoeOSS/Documentation), [Samples](https://github.com/SteeltoeOSS/Samples) and/or [MainSite](https://github.com/SteeltoeOSS/MainSite), add linked PRs here.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
- [ ] You've added required license files and/or file headers (explaining where the code came from with proper attribution), where code is copied from StackOverflow, a blog, or OSS.
