### PR TITLE
Consul: fix invalid port number in app registration

### DIFF
--- a/src/Discovery/src/Consul/Configuration/ConsulDiscoveryOptions.cs
+++ b/src/Discovery/src/Consul/Configuration/ConsulDiscoveryOptions.cs
@@ -15,6 +15,7 @@ public sealed class ConsulDiscoveryOptions
 
     internal bool IsHeartbeatEnabled => Heartbeat is { Enabled: true };
     internal bool IsRetryEnabled => Retry is { Enabled: true };
+    internal string EffectiveScheme => Scheme ?? "http";
 
     /// <summary>
     /// Gets or sets a value indicating whether to enable the Consul client. Default value: true.
@@ -58,9 +59,9 @@ public sealed class ConsulDiscoveryOptions
     public bool QueryPassing { get; set; } = true;
 
     /// <summary>
-    /// Gets or sets the scheme to register the running app with ("http" or "https"). Default value: http.
+    /// Gets or sets the scheme to register the running app with ("http" or "https").
     /// </summary>
-    public string? Scheme { get; set; } = "http";
+    public string? Scheme { get; set; }
 
     /// <summary>
     /// Gets or sets a value indicating whether to enable periodic health checking for the running app. Default value: true.

--- a/src/Discovery/src/Consul/ConfigurationSchema.json
+++ b/src/Discovery/src/Consul/ConfigurationSchema.json
@@ -173,7 +173,7 @@
             },
             "Scheme": {
               "type": "string",
-              "description": "Gets or sets the scheme to register the running app with (\"http\" or \"https\"). Default value: http."
+              "description": "Gets or sets the scheme to register the running app with (\"http\" or \"https\")."
             },
             "ServiceName": {
               "type": "string",

--- a/src/Discovery/src/Consul/Registry/ConsulRegistration.cs
+++ b/src/Discovery/src/Consul/Registry/ConsulRegistration.cs
@@ -34,10 +34,10 @@ internal sealed class ConsulRegistration : IServiceInstance
     public int Port { get; }
 
     /// <inheritdoc />
-    public bool IsSecure => _optionsMonitor.CurrentValue.Scheme == "https";
+    public bool IsSecure => _optionsMonitor.CurrentValue.EffectiveScheme == "https";
 
     /// <inheritdoc />
-    public Uri Uri => new($"{_optionsMonitor.CurrentValue.Scheme}://{Host}:{Port}");
+    public Uri Uri => new($"{_optionsMonitor.CurrentValue.EffectiveScheme}://{Host}:{Port}");
 
     public IReadOnlyList<string> Tags { get; }
 
@@ -114,7 +114,7 @@ internal sealed class ConsulRegistration : IServiceInstance
         }
 
         // store the secure flag in the metadata so that clients will be able to figure out whether to use http or https automatically
-        metadata.TryAdd("secure", options.Scheme == "https" ? "true" : "false");
+        metadata.TryAdd("secure", options.EffectiveScheme == "https" ? "true" : "false");
 
         return metadata;
     }
@@ -145,7 +145,7 @@ internal sealed class ConsulRegistration : IServiceInstance
         }
         else
         {
-            var uri = new Uri($"{options.Scheme}://{options.HostName}:{port}{options.HealthCheckPath}");
+            var uri = new Uri($"{options.EffectiveScheme}://{options.HostName}:{port}{options.HealthCheckPath}");
             check.HTTP = uri.ToString();
         }
 

--- a/src/Discovery/test/Consul.Test/Discovery/PostConfigureConsulDiscoveryOptionsTest.cs
+++ b/src/Discovery/test/Consul.Test/Discovery/PostConfigureConsulDiscoveryOptionsTest.cs
@@ -41,7 +41,8 @@ public sealed class PostConfigureConsulDiscoveryOptionsTest
         options.InstanceZone.Should().BeNull();
         options.PreferIPAddress.Should().BeFalse();
         options.QueryPassing.Should().BeTrue();
-        options.Scheme.Should().Be("http");
+        options.Scheme.Should().BeNull();
+        options.EffectiveScheme.Should().Be("http");
         options.ServiceName.Should().BeNull();
         options.Tags.Should().BeEmpty();
         options.Metadata.Should().BeEmpty();

--- a/src/Discovery/test/Consul.Test/Registry/ConsulRegistrationTest.cs
+++ b/src/Discovery/test/Consul.Test/Registry/ConsulRegistrationTest.cs
@@ -161,7 +161,7 @@ public sealed class ConsulRegistrationTest
         options.Heartbeat = null;
         const int port = 1234;
         result = ConsulRegistration.CreateCheck(port, options);
-        var uri = new Uri($"{options.Scheme}://{options.HostName}:{port}{options.HealthCheckPath}");
+        var uri = new Uri($"{options.EffectiveScheme}://{options.HostName}:{port}{options.HealthCheckPath}");
 
         result.HTTP.Should().Be(uri.ToString());
         result.Interval.Should().Be(DateTimeConversions.ToTimeSpan(options.HealthCheckInterval!));


### PR DESCRIPTION
## Description

Fixed: Without any configuration, an app listening on both https and http would be registered as non-secure (but with the https port number) in Consul.

The default value of `Scheme` at https://steeltoe.io/docs/v4/discovery/hashicorp-consul.html#configuration-settings should be changed to `computed`.

When no explicit scheme or port is configured, and the app listens on both schemes, we now prefer https over http (similar to Eureka).

## Quality checklist

- [x] Your code complies with our [Coding Style](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-code-style.md).
- [x] You've updated unit and/or integration tests for your change, where applicable.
- [ ] You've updated documentation for your change, where applicable.
      If your change affects other repositories, such as [Documentation](https://github.com/SteeltoeOSS/Documentation), [Samples](https://github.com/SteeltoeOSS/Samples) and/or [MainSite](https://github.com/SteeltoeOSS/MainSite), add linked PRs here.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
- [ ] You've added required license files and/or file headers (explaining where the code came from with proper attribution), where code is copied from StackOverflow, a blog, or OSS.
