### PR TITLE
Exclude Aspire resolver from Eureka internal HttpClient

### DIFF
--- a/src/Discovery/src/Eureka/EurekaServiceCollectionExtensions.cs
+++ b/src/Discovery/src/Eureka/EurekaServiceCollectionExtensions.cs
@@ -20,6 +20,7 @@ namespace Steeltoe.Discovery.Eureka;
 public static class EurekaServiceCollectionExtensions
 {
     private const string SpringDiscoveryEnabled = "spring:cloud:discovery:enabled";
+    private const string ResolvingHttpDelegatingHandlerName = "Microsoft.Extensions.ServiceDiscovery.Http.ResolvingHttpDelegatingHandler";
 
     /// <summary>
     /// Configures to use <see cref="EurekaDiscoveryClient" /> for service discovery.
@@ -108,7 +109,7 @@ public static class EurekaServiceCollectionExtensions
         services.ConfigureCertificateOptions("Eureka");
 
         IHttpClientBuilder eurekaHttpClientBuilder = services.AddHttpClient("Eureka");
-        eurekaHttpClientBuilder.ConfigureAdditionalHttpMessageHandlers((defaultHandlers, _) => RemoveDiscoveryHttpDelegatingHandler(defaultHandlers));
+        eurekaHttpClientBuilder.ConfigureAdditionalHttpMessageHandlers((defaultHandlers, _) => RemoveDiscoveryHttpHandlers(defaultHandlers));
 
         eurekaHttpClientBuilder.ConfigurePrimaryHttpMessageHandler(serviceProvider =>
         {
@@ -122,7 +123,7 @@ public static class EurekaServiceCollectionExtensions
         });
 
         IHttpClientBuilder eurekaTokenHttpClientBuilder = services.AddHttpClient("AccessTokenForEureka");
-        eurekaTokenHttpClientBuilder.ConfigureAdditionalHttpMessageHandlers((defaultHandlers, _) => RemoveDiscoveryHttpDelegatingHandler(defaultHandlers));
+        eurekaTokenHttpClientBuilder.ConfigureAdditionalHttpMessageHandlers((defaultHandlers, _) => RemoveDiscoveryHttpHandlers(defaultHandlers));
 
         eurekaTokenHttpClientBuilder.ConfigurePrimaryHttpMessageHandler(serviceProvider =>
         {
@@ -139,11 +140,18 @@ public static class EurekaServiceCollectionExtensions
         services.AddSingleton<EurekaClient>();
     }
 
-    private static void RemoveDiscoveryHttpDelegatingHandler(ICollection<DelegatingHandler> defaultHandlers)
+    private static void RemoveDiscoveryHttpHandlers(ICollection<DelegatingHandler> defaultHandlers)
     {
+        // Prevent infinite recursion: The inner HttClient used by EurekaDiscoveryClient must not use service discovery.
+
         DelegatingHandler[] discoveryHandlers = defaultHandlers.Where(handler =>
         {
             Type handlerType = handler.GetType();
+
+            if (handlerType.FullName == ResolvingHttpDelegatingHandlerName)
+            {
+                return true;
+            }
 
             if (handlerType.IsConstructedGenericType)
             {
@@ -160,7 +168,6 @@ public static class EurekaServiceCollectionExtensions
 
         foreach (DelegatingHandler discoveryHandler in discoveryHandlers)
         {
-            // Prevent infinite recursion: DiscoveryHttpDelegatingHandler depends on EurekaDiscoveryClient.
             defaultHandlers.Remove(discoveryHandler);
         }
     }

--- a/src/Discovery/test/HttpClients.Test/ResolvingHttpDelegatingHandler.cs
+++ b/src/Discovery/test/HttpClients.Test/ResolvingHttpDelegatingHandler.cs
@@ -1,0 +1,16 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+#pragma warning disable IDE0130 // Namespace does not match folder structure
+// ReSharper disable once CheckNamespace
+namespace Microsoft.Extensions.ServiceDiscovery.Http;
+#pragma warning restore IDE0130 // Namespace does not match folder structure
+
+internal sealed class ResolvingHttpDelegatingHandler : DelegatingHandler
+{
+    protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        throw new InvalidOperationException("This handler should have been removed from the HttpClient pipeline.");
+    }
+}


### PR DESCRIPTION
## Description

Exclude Aspire service discovery resolver from internal HttpClient used by Eureka.

## Quality checklist

<!-- Please run through the checklist below to ensure a smooth review and merge process for your PR. -->

- [x] Your code complies with our [Coding Style](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-code-style.md).
- [x] You've updated unit and/or integration tests for your change, where applicable.
- [ ] You've updated documentation for your change, where applicable.
      If your change affects other repositories, such as [Documentation](https://github.com/SteeltoeOSS/Documentation), [Samples](https://github.com/SteeltoeOSS/Samples) and/or [MainSite](https://github.com/SteeltoeOSS/MainSite), add linked PRs here.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
- [ ] You've added required license files and/or file headers (explaining where the code came from with proper attribution), where code is copied from StackOverflow, a blog, or OSS.
