### PR TITLE
Guard usages of BindConfiguration 

### DIFF
--- a/src/Configuration/test/CloudFoundry.Test/CloudFoundryHostBuilderExtensionsTest.cs
+++ b/src/Configuration/test/CloudFoundry.Test/CloudFoundryHostBuilderExtensionsTest.cs
@@ -63,4 +63,18 @@ public sealed class CloudFoundryHostBuilderExtensionsTest
 
         configurationRoot.EnumerateProviders<CloudFoundryConfigurationProvider>().Should().ContainSingle();
     }
+
+    [Fact]
+    public void Does_not_register_multiple_times()
+    {
+        WebApplicationBuilder hostBuilder = TestWebApplicationBuilderFactory.Create();
+        hostBuilder.AddCloudFoundryConfiguration();
+        int beforeSourceCount = hostBuilder.Configuration.EnumerateSources().Count();
+        int beforeServiceCount = hostBuilder.Services.Count;
+
+        hostBuilder.AddCloudFoundryConfiguration();
+
+        hostBuilder.Configuration.EnumerateSources().Count().Should().Be(beforeSourceCount);
+        hostBuilder.Services.Count.Should().Be(beforeServiceCount);
+    }
 }

--- a/src/Discovery/src/Configuration/ConfigurationServiceCollectionExtensions.cs
+++ b/src/Discovery/src/Configuration/ConfigurationServiceCollectionExtensions.cs
@@ -4,6 +4,7 @@
 
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Steeltoe.Common;
 using Steeltoe.Common.Discovery;
 
 namespace Steeltoe.Discovery.Configuration;
@@ -49,11 +50,19 @@ public static class ConfigurationServiceCollectionExtensions
     {
         ArgumentNullException.ThrowIfNull(services);
 
-        services.AddOptions<ConfigurationDiscoveryOptions>().BindConfiguration(ConfigurationDiscoveryOptions.ConfigurationPrefix);
+        if (!IsRegistered(services))
+        {
+            services.AddOptions<ConfigurationDiscoveryOptions>().BindConfiguration(ConfigurationDiscoveryOptions.ConfigurationPrefix);
 
-        services.TryAddEnumerable(ServiceDescriptor.Singleton<IDiscoveryClient, ConfigurationDiscoveryClient>());
-        services.AddHostedService<DiscoveryClientHostedService>();
+            services.TryAddEnumerable(ServiceDescriptor.Singleton<IDiscoveryClient, ConfigurationDiscoveryClient>());
+            services.AddHostedService<DiscoveryClientHostedService>();
+        }
 
         return services;
+    }
+
+    private static bool IsRegistered(IServiceCollection services)
+    {
+        return services.Any(descriptor => descriptor.SafeGetImplementationType() == typeof(ConfigurationDiscoveryClient));
     }
 }

--- a/src/Discovery/src/Consul/ConsulServiceCollectionExtensions.cs
+++ b/src/Discovery/src/Consul/ConsulServiceCollectionExtensions.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
+using Steeltoe.Common;
 using Steeltoe.Common.Discovery;
 using Steeltoe.Common.Extensions;
 using Steeltoe.Common.HealthChecks;
@@ -32,10 +33,18 @@ public static class ConsulServiceCollectionExtensions
     {
         ArgumentNullException.ThrowIfNull(services);
 
-        ConfigureConsulServices(services);
-        AddConsulServices(services);
+        if (!IsRegistered(services))
+        {
+            ConfigureConsulServices(services);
+            AddConsulServices(services);
+        }
 
         return services;
+    }
+
+    private static bool IsRegistered(IServiceCollection services)
+    {
+        return services.Any(descriptor => descriptor.SafeGetImplementationType() == typeof(PostConfigureConsulDiscoveryOptions));
     }
 
     private static void ConfigureConsulServices(IServiceCollection services)
@@ -96,6 +105,6 @@ public static class ConsulServiceCollectionExtensions
         services.AddSingleton<ConsulServiceRegistrar>();
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IDiscoveryClient, ConsulDiscoveryClient>());
         services.AddHostedService<DiscoveryClientHostedService>();
-        services.TryAddEnumerable(ServiceDescriptor.Singleton<IHealthContributor, ConsulHealthContributor>());
+        services.AddSingleton<IHealthContributor, ConsulHealthContributor>();
     }
 }

--- a/src/Discovery/src/Eureka/EurekaServiceCollectionExtensions.cs
+++ b/src/Discovery/src/Eureka/EurekaServiceCollectionExtensions.cs
@@ -35,13 +35,18 @@ public static class EurekaServiceCollectionExtensions
     {
         ArgumentNullException.ThrowIfNull(services);
 
-        if (services.All(descriptor => descriptor.SafeGetImplementationType() != typeof(EurekaDiscoveryClient)))
+        if (!IsRegistered(services))
         {
             ConfigureEurekaServices(services);
             AddEurekaServices(services);
         }
 
         return services;
+    }
+
+    private static bool IsRegistered(IServiceCollection services)
+    {
+        return services.Any(descriptor => descriptor.SafeGetImplementationType() == typeof(EurekaDiscoveryClient));
     }
 
     private static void ConfigureEurekaServices(IServiceCollection services)
@@ -86,9 +91,9 @@ public static class EurekaServiceCollectionExtensions
     private static void AddEurekaServices(IServiceCollection services)
     {
         services.TryAddSingleton(TimeProvider.System);
-        services.AddSingleton<HealthCheckHandlerProvider>();
-        services.TryAddEnumerable(ServiceDescriptor.Singleton<IHealthContributor, EurekaServerHealthContributor>());
-        services.AddSingleton<EurekaApplicationInfoManager>();
+        services.TryAddSingleton<HealthCheckHandlerProvider>();
+        services.AddSingleton<IHealthContributor, EurekaServerHealthContributor>();
+        services.TryAddSingleton<EurekaApplicationInfoManager>();
 
         services.TryAddSingleton<EurekaDiscoveryClient>();
         services.AddSingleton<IDiscoveryClient>(serviceProvider => serviceProvider.GetRequiredService<EurekaDiscoveryClient>());
@@ -103,9 +108,9 @@ public static class EurekaServiceCollectionExtensions
     private static void AddEurekaClient(IServiceCollection services)
     {
         services.TryAddSingleton<HttpClientHandlerFactory>();
-        services.TryAddSingleton<ValidateCertificatesHttpClientHandlerConfigurer<EurekaClientOptions>>();
+        services.AddSingleton<ValidateCertificatesHttpClientHandlerConfigurer<EurekaClientOptions>>();
         services.TryAddSingleton<ClientCertificateHttpClientHandlerConfigurer>();
-        services.TryAddSingleton<EurekaHttpClientHandlerConfigurer>();
+        services.AddSingleton<EurekaHttpClientHandlerConfigurer>();
         services.ConfigureCertificateOptions("Eureka");
 
         IHttpClientBuilder eurekaHttpClientBuilder = services.AddHttpClient("Eureka");

--- a/src/Discovery/test/Configuration.Test/ConfigurationDiscoveryClientTest.cs
+++ b/src/Discovery/test/Configuration.Test/ConfigurationDiscoveryClientTest.cs
@@ -179,4 +179,16 @@ public sealed class ConfigurationDiscoveryClientTest
 
         serviceProvider.GetServices<IHostedService>().OfType<DiscoveryClientHostedService>().Should().ContainSingle();
     }
+
+    [Fact]
+    public void Does_not_register_multiple_times()
+    {
+        var services = new ServiceCollection();
+        services.AddConfigurationDiscoveryClient();
+        int beforeServiceCount = services.Count;
+
+        services.AddConfigurationDiscoveryClient();
+
+        services.Count.Should().Be(beforeServiceCount);
+    }
 }

--- a/src/Discovery/test/HttpClients.Test/RegisterMultipleDiscoveryClientsTest.cs
+++ b/src/Discovery/test/HttpClients.Test/RegisterMultipleDiscoveryClientsTest.cs
@@ -873,4 +873,20 @@ public sealed class RegisterMultipleDiscoveryClientsTest
         serviceProvider.GetServices<IHealthContributor>().OfType<EurekaServerHealthContributor>().Should().ContainSingle();
         serviceProvider.GetServices<IHealthContributor>().OfType<EurekaApplicationsHealthContributor>().Should().BeEmpty();
     }
+
+    [Fact]
+    public void WithMultipleClients_DotNotRegisterMultipleTimes()
+    {
+        var services = new ServiceCollection();
+        services.AddConfigurationDiscoveryClient();
+        services.AddConsulDiscoveryClient();
+        services.AddEurekaDiscoveryClient();
+        int beforeServiceCount = services.Count;
+
+        services.AddConfigurationDiscoveryClient();
+        services.AddConsulDiscoveryClient();
+        services.AddEurekaDiscoveryClient();
+
+        services.Count.Should().Be(beforeServiceCount);
+    }
 }

--- a/src/Logging/src/DynamicSerilog/SerilogLoggingBuilderExtensions.cs
+++ b/src/Logging/src/DynamicSerilog/SerilogLoggingBuilderExtensions.cs
@@ -104,7 +104,7 @@ public static class SerilogLoggingBuilderExtensions
     private static bool IsSerilogDynamicLoggerProviderAlreadyRegistered(ILoggingBuilder builder)
     {
         return builder.Services.Any(descriptor =>
-            descriptor.ServiceType == typeof(ILoggerProvider) && descriptor.SafeGetImplementationType() == typeof(DynamicSerilogLoggerProvider));
+            descriptor.SafeGetImplementationType() == typeof(DynamicSerilogLoggerProvider) && descriptor.ServiceType == typeof(ILoggerProvider));
     }
 
     private static void AssertNoDynamicLoggerProviderRegistered(ILoggingBuilder builder)


### PR DESCRIPTION
## Description

Update places where [`BindConfiguration`](https://learn.microsoft.com/en-us/dotnet/api/microsoft.extensions.dependencyinjection.optionsbuilderconfigurationextensions.bindconfiguration?view=net-9.0-pp) is called, which registers anonymous delegates, and is thus not safe to be called multiple times.

With a pre-check in place, several Try* methods behind it can be replaced for efficiency, but only if:
- The implementation is an internal type and does not implement a public interface
- The implementation type is not shared between Steeltoe components

## Quality checklist

- [x] Your code complies with our [Coding Style](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-code-style.md).
- [x] You've updated unit and/or integration tests for your change, where applicable.
- [ ] You've updated documentation for your change, where applicable.
      If your change affects other repositories, such as [Documentation](https://github.com/SteeltoeOSS/Documentation), [Samples](https://github.com/SteeltoeOSS/Samples) and/or [MainSite](https://github.com/SteeltoeOSS/MainSite), add linked PRs here.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
- [ ] You've added required license files and/or file headers (explaining where the code came from with proper attribution), where code is copied from StackOverflow, a blog, or OSS.
