### PR TITLE
Capture memory dump diagnostics on test failure

### DIFF
--- a/src/Management/test/Endpoint.Test/Actuators/ThreadDump/EventPipeThreadDumperTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/ThreadDump/EventPipeThreadDumperTest.cs
@@ -35,7 +35,12 @@ public sealed class EventPipeThreadDumperTest
         StackTraceElement? backgroundThreadFrame = threads.SelectMany(thread => thread.StackTrace)
             .FirstOrDefault(frame => frame.MethodName == "BackgroundThreadCallback(class System.Object)");
 
-        backgroundThreadFrame.Should().NotBeNull();
+        if (backgroundThreadFrame == null)
+        {
+            string logs = loggerProvider.GetAsText();
+            throw new InvalidOperationException($"Failed to find expected stack frame. Captured log:{System.Environment.NewLine}{logs}");
+        }
+
         backgroundThreadFrame.IsNativeMethod.Should().BeFalse();
         backgroundThreadFrame.ModuleName.Should().Be(GetType().Assembly.GetName().Name);
         backgroundThreadFrame.ClassName.Should().Be(typeof(NestedType).FullName);


### PR DESCRIPTION
## Description

This PR adds code to capture more diagnostics when a memory dump test fails. It syncs Steeltoe logs with CLR dump logs.
Hopefully, this will give us better insights into the sporadic test failures.

## Quality checklist

- [x] Your code complies with our [Coding Style](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-code-style.md).
- [x] You've updated unit and/or integration tests for your change, where applicable.
- [ ] You've updated documentation for your change, where applicable.
      If your change affects other repositories, such as [Documentation](https://github.com/SteeltoeOSS/Documentation), [Samples](https://github.com/SteeltoeOSS/Samples) and/or [MainSite](https://github.com/SteeltoeOSS/MainSite), add linked PRs here.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
- [ ] You've added required license files and/or file headers (explaining where the code came from with proper attribution), where code is copied from StackOverflow, a blog, or OSS.
