### PR TITLE
Add public method to convert InstanceInfo to EurekaServiceInstance

### DIFF
--- a/src/Discovery/src/Eureka/AppInfo/InstanceInfo.cs
+++ b/src/Discovery/src/Eureka/AppInfo/InstanceInfo.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.ObjectModel;
 using System.Text.Json;
+using Steeltoe.Common.Discovery;
 using Steeltoe.Discovery.Eureka.Configuration;
 using Steeltoe.Discovery.Eureka.Transport;
 using Steeltoe.Discovery.Eureka.Util;
@@ -572,6 +573,11 @@ public sealed class InstanceInfo
         // The same applies to changes in the ordering of metadata entries.
 
         return ReferenceEquals(left, right) || left.SequenceEqual(right, KeyValuePairEqualityComparer<string, string?>.Instance);
+    }
+
+    public IServiceInstance ToServiceInstance()
+    {
+        return new EurekaServiceInstance(this);
     }
 
     private sealed class KeyValuePairEqualityComparer<TKey, TValue> : IEqualityComparer<KeyValuePair<TKey, TValue>>

--- a/src/Discovery/src/Eureka/PublicAPI.Unshipped.txt
+++ b/src/Discovery/src/Eureka/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 #nullable enable
+Steeltoe.Discovery.Eureka.AppInfo.InstanceInfo.ToServiceInstance() -> Steeltoe.Common.Discovery.IServiceInstance!


### PR DESCRIPTION
## Description

This PR adds a public method to `InstanceInfo` to convert it to a `EurekaServiceInstance` object. This method is added to make it easier for consuming apps to track changes.

## Quality checklist

- [x] Your code complies with our [Coding Style](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-code-style.md).
- [ ] You've updated unit and/or integration tests for your change, where applicable.
- [ ] You've updated documentation for your change, where applicable.
      If your change affects other repositories, such as [Documentation](https://github.com/SteeltoeOSS/Documentation), [Samples](https://github.com/SteeltoeOSS/Samples) and/or [MainSite](https://github.com/SteeltoeOSS/MainSite), add linked PRs here.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
- [ ] You've added required license files and/or file headers (explaining where the code came from with proper attribution), where code is copied from StackOverflow, a blog, or OSS.
