### PR TITLE
Remove middleware warning, it's not reliable

### DIFF
--- a/src/Management/src/Endpoint/ConfigureActuatorsMiddlewareStartupFilter.cs
+++ b/src/Management/src/Endpoint/ConfigureActuatorsMiddlewareStartupFilter.cs
@@ -2,27 +2,15 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-using System.Reflection;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
 using Steeltoe.Management.Endpoint.Actuators.CloudFoundry;
 
 namespace Steeltoe.Management.Endpoint;
 
 internal sealed class ConfigureActuatorsMiddlewareStartupFilter : IStartupFilter
 {
-    private readonly ILogger<ConfigureActuatorsMiddlewareStartupFilter> _logger;
-
-    public ConfigureActuatorsMiddlewareStartupFilter(ILogger<ConfigureActuatorsMiddlewareStartupFilter> logger)
-    {
-        ArgumentNullException.ThrowIfNull(logger);
-
-        _logger = logger;
-    }
-
     public Action<IApplicationBuilder> Configure(Action<IApplicationBuilder> next)
     {
         ArgumentNullException.ThrowIfNull(next);
@@ -45,30 +33,9 @@ internal sealed class ConfigureActuatorsMiddlewareStartupFilter : IStartupFilter
                 app.UseCloudFoundrySecurity();
             }
 
-            int? beforeMiddlewareCount = GetMiddlewareCount(app);
             next.Invoke(app);
-            int? afterMiddlewareCount = GetMiddlewareCount(app);
-
-            if (beforeMiddlewareCount != afterMiddlewareCount)
-            {
-                _logger.LogWarning(
-                    "Actuators were registered with automatic middleware setup, and at least one additional middleware was registered afterward. This combination is usually undesired. " +
-                    "To remove this warning, either remove the additional middleware registration or set configureMiddleware to false when registering actuators.");
-            }
 
             app.UseActuatorEndpoints();
         };
-    }
-
-    private static int? GetMiddlewareCount(IApplicationBuilder app)
-    {
-        FieldInfo? componentsField = app.GetType().GetField("_components", BindingFlags.NonPublic | BindingFlags.Instance);
-        return componentsField?.GetValue(app) is List<Func<RequestDelegate, RequestDelegate>> components ? components.Count(IsMiddleware) : null;
-    }
-
-    private static bool IsMiddleware(Func<RequestDelegate, RequestDelegate> component)
-    {
-        // This type exists so that ASP.NET Core can identify where to inject UseRouting. It is not a real middleware.
-        return component.Target == null || component.Target.ToString() != "Microsoft.AspNetCore.Builder.WebApplicationBuilder+WireSourcePipeline";
     }
 }

--- a/src/Management/test/Endpoint.Test/Actuators/All/AllActuatorsTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/All/AllActuatorsTest.cs
@@ -2,12 +2,10 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Cors.Infrastructure;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Steeltoe.Common.TestResources;
 using Steeltoe.Management.Endpoint.Actuators.All;
@@ -133,25 +131,5 @@ public sealed class AllActuatorsTest
         host.Services.GetServices<IInfoEndpointHandler>().OfType<InfoEndpointHandler>().Should().ContainSingle();
         host.Services.GetServices<InfoEndpointMiddleware>().Should().ContainSingle();
         host.Services.GetServices<IEndpointMiddleware>().OfType<InfoEndpointMiddleware>().Should().ContainSingle();
-    }
-
-    [Fact]
-    public async Task Logs_warning_when_custom_middleware_is_registered_without_configureMiddleware_false()
-    {
-        using var capturingLoggerProvider = new CapturingLoggerProvider((_, logLevel) => logLevel >= LogLevel.Warning);
-
-        WebApplicationBuilder builder = TestWebApplicationBuilderFactory.Create();
-        builder.Logging.AddProvider(capturingLoggerProvider);
-        builder.Services.AddAllActuators();
-        await using WebApplication host = builder.Build();
-
-        host.UseRouting();
-        host.UseActuatorEndpoints();
-
-        await host.StartAsync(TestContext.Current.CancellationToken);
-
-        capturingLoggerProvider.GetAll().Should().Contain($"WARN {typeof(ConfigureActuatorsMiddlewareStartupFilter)}: " +
-            "Actuators were registered with automatic middleware setup, and at least one additional middleware was registered afterward. This combination is usually undesired. " +
-            "To remove this warning, either remove the additional middleware registration or set configureMiddleware to false when registering actuators.");
     }
 }


### PR DESCRIPTION
## Description

The detection added in #1618 only works in corner cases. Removing it, because it's not possible to reliably detect whether additional middleware is used.

## Quality checklist

- [x] Your code complies with our [Coding Style](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-code-style.md).
- [x] You've updated unit and/or integration tests for your change, where applicable.
- [ ] You've updated documentation for your change, where applicable.
      If your change affects other repositories, such as [Documentation](https://github.com/SteeltoeOSS/Documentation), [Samples](https://github.com/SteeltoeOSS/Samples) and/or [MainSite](https://github.com/SteeltoeOSS/MainSite), add linked PRs here.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
- [ ] You've added required license files and/or file headers (explaining where the code came from with proper attribution), where code is copied from StackOverflow, a blog, or OSS.
