### PR TITLE
Accept null tags/meta in Consul responses

### DIFF
--- a/src/Discovery/src/Consul/ConsulServiceInstance.cs
+++ b/src/Discovery/src/Consul/ConsulServiceInstance.cs
@@ -13,6 +13,9 @@ namespace Steeltoe.Discovery.Consul;
 /// </summary>
 internal sealed class ConsulServiceInstance : IServiceInstance
 {
+    private static readonly IReadOnlyList<string> EmptyStringList = Array.Empty<string>();
+    private static readonly IReadOnlyDictionary<string, string?> EmptyStringDictionary = new Dictionary<string, string?>().AsReadOnly();
+
     /// <inheritdoc />
     public string ServiceId { get; }
 
@@ -53,9 +56,9 @@ internal sealed class ConsulServiceInstance : IServiceInstance
         ArgumentNullException.ThrowIfNull(serviceEntry);
 
         Host = ConsulServerUtils.FindHost(serviceEntry);
-        Tags = serviceEntry.Service.Tags;
-        Metadata = serviceEntry.Service.Meta.AsReadOnly();
-        IsSecure = serviceEntry.Service.Meta != null && serviceEntry.Service.Meta.TryGetValue("secure", out string? secureString) && bool.Parse(secureString);
+        Tags = serviceEntry.Service.Tags ?? EmptyStringList;
+        Metadata = serviceEntry.Service.Meta?.AsReadOnly() ?? EmptyStringDictionary;
+        IsSecure = Metadata.TryGetValue("secure", out string? secureString) && secureString != null && bool.Parse(secureString);
         ServiceId = serviceEntry.Service.Service;
         InstanceId = serviceEntry.Service.ID;
         Port = serviceEntry.Service.Port;

--- a/src/Discovery/test/Consul.Test/Discovery/ConsulServiceInstanceTest.cs
+++ b/src/Discovery/test/Consul.Test/Discovery/ConsulServiceInstanceTest.cs
@@ -49,4 +49,24 @@ public sealed class ConsulServiceInstanceTest
         serviceInstance.NonSecureUri.Should().BeNull();
         serviceInstance.SecureUri.Should().Be(serviceInstance.Uri);
     }
+
+    [Fact]
+    public void Constructor_accepts_null_tags_and_meta()
+    {
+        var healthService = new ServiceEntry
+        {
+            Service = new AgentService
+            {
+                Service = "ServiceId",
+                ID = "Instance1",
+                Address = "foo.bar.com",
+                Port = 1234
+            }
+        };
+
+        var serviceInstance = new ConsulServiceInstance(healthService);
+
+        serviceInstance.Tags.Should().BeEmpty();
+        serviceInstance.Metadata.Should().BeEmpty();
+    }
 }


### PR DESCRIPTION
## Description

Fixes a crash when a Consul response contains `null` for tags or meta.

Fixes #1629

## Quality checklist

- [x] Your code complies with our [Coding Style](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-code-style.md).
- [x] You've updated unit and/or integration tests for your change, where applicable.
- [ ] You've updated documentation for your change, where applicable.
      If your change affects other repositories, such as [Documentation](https://github.com/SteeltoeOSS/Documentation), [Samples](https://github.com/SteeltoeOSS/Samples) and/or [MainSite](https://github.com/SteeltoeOSS/MainSite), add linked PRs here.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
- [ ] You've added required license files and/or file headers (explaining where the code came from with proper attribution), where code is copied from StackOverflow, a blog, or OSS.
