### PR TITLE
Configuration Schema Generator: Port changes from Aspire

### DIFF
--- a/src/Tools/src/ConfigurationSchemaGenerator/ConfigSchemaEmitter.cs
+++ b/src/Tools/src/ConfigurationSchemaGenerator/ConfigSchemaEmitter.cs
@@ -721,17 +721,12 @@ internal sealed partial class ConfigSchemaEmitter(SchemaGenerationSpec spec, Com
 
     private static void ReplaceNodeWithKeyCasingChange(JsonObject jsonObject, string key, JsonNode value)
     {
-        // In System.Text.Json v9, the casing of the new key is not adapted. See https://github.com/dotnet/runtime/issues/108790.
-        // So instead, remove the existing node and insert a new one with the updated key.
-        var index = jsonObject.IndexOf(key);
-        if (index != -1)
+        if (!jsonObject.TryAdd(key, value, out var index))
         {
+            // Starting from System.Text.Json v9, the casing of the new key is not adapted. See https://github.com/dotnet/runtime/issues/108790.
+            // So instead, remove the existing node and insert a new one with the updated key.
             jsonObject.RemoveAt(index);
             jsonObject.Insert(index, key, value);
-        }
-        else
-        {
-            jsonObject[key] = value;
         }
     }
 


### PR DESCRIPTION
## Description

Configuration Schema Generator: Port changes from https://github.com/dotnet/aspire/pull/13529.

## Quality checklist

- [x] Your code complies with our [Coding Style](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-code-style.md).
- [ ] You've updated unit and/or integration tests for your change, where applicable.
- [ ] You've updated documentation for your change, where applicable.
      If your change affects other repositories, such as [Documentation](https://github.com/SteeltoeOSS/Documentation), [Samples](https://github.com/SteeltoeOSS/Samples) and/or [MainSite](https://github.com/SteeltoeOSS/MainSite), add linked PRs here.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
- [ ] You've added required license files and/or file headers (explaining where the code came from with proper attribution), where code is copied from StackOverflow, a blog, or OSS.
