### PR TITLE
Enable skipping ASP.NET health checks at actuator endpoint

### DIFF
--- a/src/Common/src/Common/HealthChecks/HealthAggregator.cs
+++ b/src/Common/src/Common/HealthChecks/HealthAggregator.cs
@@ -69,7 +69,7 @@ internal sealed class HealthAggregator : IHealthAggregator
         ICollection<HealthCheckRegistration> healthCheckRegistrations, IServiceProvider serviceProvider, CancellationToken cancellationToken)
     {
         HealthCheckRegistration[] activeHealthCheckRegistrations =
-            healthCheckRegistrations.Where(registration => !registration.Tags.Contains("SkipFromHealthActuator")).ToArray();
+            healthCheckRegistrations.Where(registration => !registration.Tags.Contains("ExcludeFromHealthActuator")).ToArray();
 
         if (activeHealthCheckRegistrations.Length == 0)
         {

--- a/src/Management/test/Endpoint.Test/Actuators/Health/HealthAggregationTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/Health/HealthAggregationTest.cs
@@ -525,7 +525,7 @@ public sealed class HealthAggregationTest
         builder.Services.AddHealthActuator();
 
         IHealthChecksBuilder checksBuilder = builder.Services.AddHealthChecks();
-        checksBuilder.AddCheck<AspNetUnhealthyCheck>("aspnet-unhealthy-check", tags: ["SkipFromHealthActuator"]);
+        checksBuilder.AddCheck<AspNetUnhealthyCheck>("aspnet-unhealthy-check", tags: ["ExcludeFromHealthActuator"]);
         checksBuilder.AddCheck<AspNetHealthyCheck>("aspnet-healthy-check");
 
         await using WebApplication host = builder.Build();


### PR DESCRIPTION
## Description

Adds detection of the "SkipFromHealthActuator" tag in ASP.NET health checks to enable skipping them from the `actuator/health` endpoint.

This enables adding a health check to verify that an app is registered as healthy in Spring Boot Admin. Because SBA queries the health actuator to determine whether the app is healthy, we'd otherwise end up in a chicken-and-egg problem: SBA observes an unhealthy app because the app hasn't been registered as healthy in SBA yet.

## Quality checklist

- [x] Your code complies with our [Coding Style](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-code-style.md).
- [x] You've updated unit and/or integration tests for your change, where applicable.
- [ ] You've updated documentation for your change, where applicable.
      If your change affects other repositories, such as [Documentation](https://github.com/SteeltoeOSS/Documentation), [Samples](https://github.com/SteeltoeOSS/Samples) and/or [MainSite](https://github.com/SteeltoeOSS/MainSite), add linked PRs here.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
- [ ] You've added required license files and/or file headers (explaining where the code came from with proper attribution), where code is copied from StackOverflow, a blog, or OSS.
