### PR TITLE
Update non-exposed dependencies

### DIFF
--- a/src/Configuration/src/Abstractions/CompositeConfigurationProvider.cs
+++ b/src/Configuration/src/Abstractions/CompositeConfigurationProvider.cs
@@ -96,11 +96,7 @@ internal abstract partial class CompositeConfigurationProvider : IConfigurationP
         ArgumentNullException.ThrowIfNull(key);
 
         LogSet(GetType().Name, key, value);
-
-#pragma warning disable S1121 // Assignments should not be made from within sub-expressions
-        // Justification: Workaround for Sonar bug https://github.com/SonarSource/sonar-dotnet/issues/9761.
         ConfigurationRoot?[key] = value;
-#pragma warning restore S1121 // Assignments should not be made from within sub-expressions
     }
 
     public void Dispose()

--- a/src/Connectors/src/Connectors/PublicAPI.Unshipped.txt
+++ b/src/Connectors/src/Connectors/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+*REMOVED*virtual Steeltoe.Connectors.ConnectorCreateConnection.Invoke(System.IServiceProvider! serviceProvider, string! serviceBindingName) -> object!
+*REMOVED*virtual Steeltoe.Connectors.ConnectorCreateHealthContributor.Invoke(System.IServiceProvider! serviceProvider, string! serviceBindingName) -> Steeltoe.Common.HealthChecks.IHealthContributor!

--- a/src/Connectors/test/EntityFrameworkCore.Test/Steeltoe.Connectors.EntityFrameworkCore.Test.csproj
+++ b/src/Connectors/test/EntityFrameworkCore.Test/Steeltoe.Connectors.EntityFrameworkCore.Test.csproj
@@ -8,9 +8,7 @@
   <PropertyGroup>
     <NoWarn>
       <!--
-        Temporary workaround: Stable EF Core 10 packages for Npgsql.EntityFrameworkCore.PostgreSQL and
-        Pomelo.EntityFrameworkCore.MySql are not available yet.
-
+        Temporary workaround: Unstable EF Core 10 package for Pomelo.EntityFrameworkCore.MySql is not available yet.
         NU1608: Detected package version outside of dependency constraint
       -->
       $(NoWarn);NU1608

--- a/src/Logging/src/Abstractions/PublicAPI.Unshipped.txt
+++ b/src/Logging/src/Abstractions/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 #nullable enable
+*REMOVED*virtual Steeltoe.Logging.LoggerFilter.Invoke(Microsoft.Extensions.Logging.LogLevel level) -> bool

--- a/versions.props
+++ b/versions.props
@@ -8,23 +8,23 @@
     <AspNetCoreHealthChecksVersion>9.0.*</AspNetCoreHealthChecksVersion>
     <CoverletVersion>6.0.*</CoverletVersion>
     <FluentAssertionsVersion>7.2.*</FluentAssertionsVersion>
-    <MicrosoftAzureCosmosVersion>3.54.*</MicrosoftAzureCosmosVersion>
-    <MicrosoftCodeAnalysisVersion>4.14.*</MicrosoftCodeAnalysisVersion>
+    <MicrosoftAzureCosmosVersion>3.57.*</MicrosoftAzureCosmosVersion>
+    <MicrosoftCodeAnalysisVersion>5.0.*</MicrosoftCodeAnalysisVersion>
     <MicrosoftSqlClientVersion>6.1.*</MicrosoftSqlClientVersion>
     <MockHttpVersion>7.0.*</MockHttpVersion>
-    <MongoDbDriverVersion>3.5.*</MongoDbDriverVersion>
+    <MongoDbDriverVersion>3.6.*</MongoDbDriverVersion>
     <MoqVersion>4.20.69</MoqVersion>
     <MySqlConnectorVersion>2.5.*</MySqlConnectorVersion>
-    <MySqlDataVersion>9.5.*</MySqlDataVersion>
+    <MySqlDataVersion>9.6.*</MySqlDataVersion>
     <NewtonsoftJsonVersion>13.0.*</NewtonsoftJsonVersion>
-    <PublicApiAnalyzersVersion>4.14.*</PublicApiAnalyzersVersion>
+    <PublicApiAnalyzersVersion>3.3.*</PublicApiAnalyzersVersion>
     <RabbitClientTestVersion>7.2.*</RabbitClientTestVersion>
     <SerilogEnrichersThreadVersion>4.0.*</SerilogEnrichersThreadVersion>
     <SerilogExceptionsVersion>8.4.*</SerilogExceptionsVersion>
-    <SonarAnalyzerVersion>10.15.0.120848</SonarAnalyzerVersion>
+    <SonarAnalyzerVersion>10.18.0.131500</SonarAnalyzerVersion>
     <StyleCopVersion>1.2.0-beta.556</StyleCopVersion>
     <SystemCommandLineVersion>2.0.*</SystemCommandLineVersion>
-    <SystemIdentityModelVersion>8.14.*</SystemIdentityModelVersion>
+    <SystemIdentityModelVersion>8.15.*</SystemIdentityModelVersion>
     <SystemSqlClientVersion>4.9.*</SystemSqlClientVersion>
     <TestSdkVersion>18.0.*</TestSdkVersion>
     <XunitVersion>3.2.*</XunitVersion>
@@ -42,7 +42,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'net10.0'">
-    <EntityFrameworkCoreTestVersion>10.0.*-*</EntityFrameworkCoreTestVersion>
+    <EntityFrameworkCoreTestVersion>10.0.*</EntityFrameworkCoreTestVersion>
     <PomeloEntityFrameworkCoreTestVersion>
       <!-- Temporary workaround: Unstable EF Core 10 package for Pomelo.EntityFrameworkCore.MySql is not available yet. -->
       9.0.*


### PR DESCRIPTION
## Description

Update versions of dependent packages that are not publicly exposed.

Interestingly, all 4.x versions of `Microsoft.CodeAnalysis.PublicApiAnalyzers` were unlisted from nuget.org, and there is no stable 5.x version yet. So I switched back to the 3.x line. The changes to PublicAPI text files in this PR are solely to satisfy the analyzer.

Manually verified that skipped integration tests are still green.

## Quality checklist

- [x] Your code complies with our [Coding Style](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-code-style.md).
- [x] You've updated unit and/or integration tests for your change, where applicable.
- [ ] You've updated documentation for your change, where applicable.
      If your change affects other repositories, such as [Documentation](https://github.com/SteeltoeOSS/Documentation), [Samples](https://github.com/SteeltoeOSS/Samples) and/or [MainSite](https://github.com/SteeltoeOSS/MainSite), add linked PRs here.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
- [ ] You've added required license files and/or file headers (explaining where the code came from with proper attribution), where code is copied from StackOverflow, a blog, or OSS.
