### PR TITLE
Fix broken build netsdk 10.0.200, fix green builds on failure

### DIFF
--- a/.github/workflows/Steeltoe.All.yml
+++ b/.github/workflows/Steeltoe.All.yml
@@ -113,7 +113,7 @@ jobs:
       with:
         name: ${{ matrix.os }} test results
         reporter: dotnet-trx
-        path: '**/*.trx'
+        path: '**/*.notfound'
         fail-on-empty: 'true'
         fail-on-error: 'false'
 

--- a/.github/workflows/Steeltoe.All.yml
+++ b/.github/workflows/Steeltoe.All.yml
@@ -41,7 +41,6 @@ jobs:
         - os: macos-latest
           skipIntegrationTests: true
     runs-on: ${{ matrix.os }}
-    continue-on-error: true
 
     services:
       eurekaServer:
@@ -91,13 +90,15 @@ jobs:
       run: dotnet build ${{ env.SOLUTION_FILE }} --no-restore --configuration Release --verbosity minimal
 
     - name: Test
+      id: test
       run: dotnet test ${{ env.SOLUTION_FILE }} --filter "${{ matrix.skipIntegrationTests == true && 'Category!=MemoryDumps&Category!=Integration' || 'Category!=MemoryDumps' }}" ${{ env.COMMON_TEST_ARGS }}
 
     - name: Test (memory dumps)
+      id: test-memory-dumps
       run: dotnet test src/Management/test/Endpoint.Test --filter "Category=MemoryDumps" ${{ env.COMMON_TEST_ARGS }}
 
     - name: Upload crash/hang dumps (on failure)
-      if: ${{ failure() }}
+      if: ${{ !cancelled() && (steps.test.outcome == 'failure' || steps.test-memory-dumps.outcome == 'failure') }}
       uses: actions/upload-artifact@v5
       with:
         name: FailedTestOutput-${{ matrix.os }}
@@ -107,7 +108,7 @@ jobs:
         if-no-files-found: ignore
 
     - name: Report test results
-      if: ${{ !cancelled() }}
+      if: ${{ !cancelled() && (steps.test.outcome != 'skipped' || steps.test-memory-dumps.outcome != 'skipped') }}
       uses: dorny/test-reporter@v2
       with:
         name: ${{ matrix.os }} test results

--- a/.github/workflows/Steeltoe.All.yml
+++ b/.github/workflows/Steeltoe.All.yml
@@ -113,7 +113,7 @@ jobs:
       with:
         name: ${{ matrix.os }} test results
         reporter: dotnet-trx
-        path: '**/*.notfound'
+        path: '**/*.trx'
         fail-on-empty: 'true'
         fail-on-error: 'false'
 

--- a/.github/workflows/component-shared-workflow.yml
+++ b/.github/workflows/component-shared-workflow.yml
@@ -105,6 +105,6 @@ jobs:
       with:
         name: ${{ inputs.OS }}-latest test results
         reporter: dotnet-trx
-        path: '**/*.notfound'
+        path: '**/*.trx'
         fail-on-empty: 'true'
         fail-on-error: 'false'

--- a/.github/workflows/component-shared-workflow.yml
+++ b/.github/workflows/component-shared-workflow.yml
@@ -105,6 +105,6 @@ jobs:
       with:
         name: ${{ inputs.OS }}-latest test results
         reporter: dotnet-trx
-        path: '**/*.trx'
+        path: '**/*.notfound'
         fail-on-empty: 'true'
         fail-on-error: 'false'

--- a/.github/workflows/component-shared-workflow.yml
+++ b/.github/workflows/component-shared-workflow.yml
@@ -81,14 +81,16 @@ jobs:
       run: dotnet build ${{ env.SOLUTION_FILE }} --no-restore --configuration Release --verbosity minimal
 
     - name: Test
+      id: test
       run: dotnet test ${{ env.SOLUTION_FILE }} --filter "Category!=MemoryDumps" ${{ env.COMMON_TEST_ARGS }}
 
     - name: Test (memory dumps)
+      id: test-memory-dumps
       if: ${{ inputs.component == 'Management' }}
       run: dotnet test src/Management/test/Endpoint.Test --filter "Category=MemoryDumps" ${{ env.COMMON_TEST_ARGS }}
 
     - name: Upload crash/hang dumps (on failure)
-      if: ${{ failure() }}
+      if: ${{ !cancelled() && (steps.test.outcome == 'failure' || steps.test-memory-dumps.outcome == 'failure') }}
       uses: actions/upload-artifact@v5
       with:
         name: FailedTestOutput-${{ inputs.OS }}-latest
@@ -98,7 +100,7 @@ jobs:
         if-no-files-found: ignore
 
     - name: Report test results
-      if: ${{ !cancelled() }}
+      if: ${{ !cancelled() && (steps.test.outcome != 'skipped' || steps.test-memory-dumps.outcome != 'skipped') }}
       uses: dorny/test-reporter@v2
       with:
         name: ${{ inputs.OS }}-latest test results

--- a/src/Connectors/test/Connectors.Test/CosmosDb/CosmosDbHealthContributorTest.cs
+++ b/src/Connectors/test/Connectors.Test/CosmosDb/CosmosDbHealthContributorTest.cs
@@ -105,7 +105,7 @@ public sealed class CosmosDbHealthContributorTest
         cosmosClientMock.Setup(client => client.ReadAccountAsync()).Returns(async () =>
         {
             await Task.Delay(3.Seconds(), TestContext.Current.CancellationToken);
-            return null!;
+            return null;
         });
 
         await using ServiceProvider serviceProvider = CreateServiceProvider(serviceName, connectionString, cosmosClientMock.Object);

--- a/src/Discovery/test/Eureka.Test/PostConfigureEurekaInstanceOptionsTest.cs
+++ b/src/Discovery/test/Eureka.Test/PostConfigureEurekaInstanceOptionsTest.cs
@@ -329,7 +329,7 @@ public sealed class PostConfigureEurekaInstanceOptionsTest
         EurekaInstanceOptions instanceOptions = optionsMonitor.CurrentValue;
 
         instanceOptions.InstanceId.Should().NotBeNull();
-        string[] parts = instanceOptions.InstanceId.Split(':');
+        string[] parts = instanceOptions.InstanceId!.Split(':');
         parts.Should().HaveCount(3);
 
         int.TryParse(parts[2], CultureInfo.InvariantCulture, out int number).Should().BeTrue();

--- a/src/Discovery/test/Eureka.Test/PostConfigureEurekaInstanceOptionsTest.cs
+++ b/src/Discovery/test/Eureka.Test/PostConfigureEurekaInstanceOptionsTest.cs
@@ -329,7 +329,7 @@ public sealed class PostConfigureEurekaInstanceOptionsTest
         EurekaInstanceOptions instanceOptions = optionsMonitor.CurrentValue;
 
         instanceOptions.InstanceId.Should().NotBeNull();
-        string[] parts = instanceOptions.InstanceId!.Split(':');
+        string[] parts = instanceOptions.InstanceId.Split(':');
         parts.Should().HaveCount(3);
 
         int.TryParse(parts[2], CultureInfo.InvariantCulture, out int number).Should().BeTrue();

--- a/src/Discovery/test/Eureka.Test/PostConfigureEurekaInstanceOptionsTest.cs
+++ b/src/Discovery/test/Eureka.Test/PostConfigureEurekaInstanceOptionsTest.cs
@@ -61,8 +61,6 @@ public sealed class PostConfigureEurekaInstanceOptionsTest
         instanceOptions.AutoScalingGroupName.Should().BeNull();
         instanceOptions.DataCenterInfo.Name.Should().Be(DataCenterName.MyOwn);
         instanceOptions.UseNetworkInterfaces.Should().BeFalse();
-
-        true.Should().BeFalse();
     }
 
     [Fact]

--- a/src/Discovery/test/Eureka.Test/PostConfigureEurekaInstanceOptionsTest.cs
+++ b/src/Discovery/test/Eureka.Test/PostConfigureEurekaInstanceOptionsTest.cs
@@ -61,6 +61,8 @@ public sealed class PostConfigureEurekaInstanceOptionsTest
         instanceOptions.AutoScalingGroupName.Should().BeNull();
         instanceOptions.DataCenterInfo.Name.Should().Be(DataCenterName.MyOwn);
         instanceOptions.UseNetworkInterfaces.Should().BeFalse();
+
+        true.Should().BeFalse();
     }
 
     [Fact]


### PR DESCRIPTION
## Description

- Fix broken build on .NET SDK v10.0.200: Fixes occurrences of the following error:
  - error IDE0370: Suppression is unnecessary (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0370)
- Fix GHA workflows: Overall build was reported Green if jobs have failures (see details below)

### Problem

The `Steeltoe.All.yml` workflow had `continue-on-error: true` at the job level, which told GitHub Actions to treat every job as successful regardless of outcome. This made the workflow appear green even when all jobs failed.

### Fix

Removed `continue-on-error: true` from the job level. Test steps now fail naturally, showing a red X in the UI and putting the job in a failure state. Post-test steps use `if` conditions with `!cancelled()` (a status check function that prevents GitHub from prepending the implicit `success()` check) to control whether they run after a failure.

### Changes

- **`Steeltoe.All.yml`**: Removed job-level `continue-on-error: true`. Added `id` to test steps and `!cancelled()`-based conditions on post-test steps.
- **`component-shared-workflow.yml`**: Added `id` to test steps and `!cancelled()`-based conditions on post-test steps (this file never had job-level `continue-on-error`, but previously used `if: ${{ failure() }}` and `if: ${{ !cancelled() }}` which didn't account for all scenarios).

### Scenarios

| Scenario | Upload dumps | Report results | Coverage | **Job result** |
|---|---|---|---|---|
| **Build fails** | skip | skip | skip | **red** |
| **Tests pass** | skip | run | run | **green** |
| **Tests fail** | run | run | skip | **red** |
| **Tests pass, reporter fails** | skip | run (fails) | skip | **red** |
| **Tests pass, coverage fails** | skip | run | run (fails) | **red** |
| **Cancelled** | skip | skip | skip | **cancelled** |

### Manually verified (see commit history)

- Test: build failure must abort the job and report outcome Red
- Test: test failure must upload results and report outcome Red
- Test: report failure must abort the job and report outcome Red
- Test: cancel during build skips all subsequent steps
- Test: cancel during test skips all subsequent steps

## Quality checklist

- [x] Your code complies with our [Coding Style](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-code-style.md).
- [ ] You've updated unit and/or integration tests for your change, where applicable.
- [ ] You've updated documentation for your change, where applicable.
      If your change affects other repositories, such as [Documentation](https://github.com/SteeltoeOSS/Documentation), [Samples](https://github.com/SteeltoeOSS/Samples) and/or [MainSite](https://github.com/SteeltoeOSS/MainSite), add linked PRs here.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
- [ ] You've added required license files and/or file headers (explaining where the code came from with proper attribution), where code is copied from StackOverflow, a blog, or OSS.
