### PR TITLE
Fix DynamicSerilog registration conflict when using AddSteeltoe

### DIFF
--- a/src/Bootstrap/src/AutoConfiguration/BootstrapScanner.cs
+++ b/src/Bootstrap/src/AutoConfiguration/BootstrapScanner.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Steeltoe.Common;
 using Steeltoe.Common.DynamicTypeAccess;
@@ -44,6 +45,7 @@ internal sealed partial class BootstrapScanner
     private readonly AssemblyLoader _loader;
     private readonly ILoggerFactory _loggerFactory;
     private readonly ILogger _logger;
+    private bool _isSerilogLoaded;
 
     public BootstrapScanner(HostBuilderWrapper wrapper, IReadOnlySet<string> assemblyNamesToExclude, ILoggerFactory loggerFactory)
     {
@@ -76,7 +78,9 @@ internal sealed partial class BootstrapScanner
         WireIfLoaded(WirePlaceholderResolver, SteeltoeAssemblyNames.ConfigurationPlaceholder);
         WireIfLoaded(WireConnectors, SteeltoeAssemblyNames.Connectors);
 
-        if (!WireIfLoaded(WireDynamicSerilog, SteeltoeAssemblyNames.LoggingDynamicSerilog))
+        _isSerilogLoaded = WireIfLoaded(WireDynamicSerilog, SteeltoeAssemblyNames.LoggingDynamicSerilog);
+
+        if (!_isSerilogLoaded)
         {
             WireIfLoaded(WireDynamicConsole, SteeltoeAssemblyNames.LoggingDynamicConsole);
         }
@@ -244,7 +248,20 @@ internal sealed partial class BootstrapScanner
 
     private void WireAllActuators()
     {
-        _wrapper.ConfigureServices(services => services.AddAllActuators());
+        if (_isSerilogLoaded)
+        {
+            _wrapper.ConfigureServices(services =>
+            {
+#pragma warning disable S4792 // Configuring loggers is security-sensitive
+                services.AddLogging(loggingBuilder => loggingBuilder.AddDynamicSerilog());
+#pragma warning restore S4792 // Configuring loggers is security-sensitive
+                services.AddAllActuators();
+            });
+        }
+        else
+        {
+            _wrapper.ConfigureServices(services => services.AddAllActuators());
+        }
 
         LogActuatorsConfigured();
     }
@@ -258,7 +275,20 @@ internal sealed partial class BootstrapScanner
 
     private void WireDistributedTracingLogProcessor()
     {
-        _wrapper.ConfigureServices(services => services.AddTracingLogProcessor());
+        if (_isSerilogLoaded)
+        {
+            _wrapper.ConfigureServices(services =>
+            {
+#pragma warning disable S4792 // Configuring loggers is security-sensitive
+                services.AddLogging(loggingBuilder => loggingBuilder.AddDynamicSerilog());
+#pragma warning restore S4792 // Configuring loggers is security-sensitive
+                services.AddTracingLogProcessor();
+            });
+        }
+        else
+        {
+            _wrapper.ConfigureServices(services => services.AddTracingLogProcessor());
+        }
 
         LogDistributedTracingConfigured();
     }

--- a/src/Bootstrap/test/AutoConfiguration.Test/HostBuilderExtensionsTest.cs
+++ b/src/Bootstrap/test/AutoConfiguration.Test/HostBuilderExtensionsTest.cs
@@ -169,6 +169,25 @@ public sealed class HostBuilderExtensionsTest
     [InlineData(HostBuilderType.WebHost)]
     [InlineData(HostBuilderType.WebApplication)]
     [InlineData(HostBuilderType.HostApplication)]
+    public async Task DynamicSerilog_WinsOverActuatorFallback(HostBuilderType hostBuilderType)
+    {
+        var assembliesToInclude = new HashSet<string>
+        {
+            SteeltoeAssemblyNames.LoggingDynamicSerilog,
+            SteeltoeAssemblyNames.ManagementEndpoint
+        };
+
+        await using HostWrapper hostWrapper =
+            HostWrapperFactory.GetExcluding(SteeltoeAssemblyNames.All.Except(assembliesToInclude).ToHashSet(), hostBuilderType);
+
+        AssertDynamicSerilogIsAutowired(hostWrapper);
+    }
+
+    [Theory]
+    [InlineData(HostBuilderType.Host)]
+    [InlineData(HostBuilderType.WebHost)]
+    [InlineData(HostBuilderType.WebApplication)]
+    [InlineData(HostBuilderType.HostApplication)]
     public async Task DynamicConsoleLogger_IsAutowired(HostBuilderType hostBuilderType)
     {
         await using HostWrapper hostWrapper = HostWrapperFactory.GetForOnly(SteeltoeAssemblyNames.LoggingDynamicConsole, hostBuilderType);


### PR DESCRIPTION
## Description

When both DynamicSerilog and Management.Endpoint assemblies are loaded, BootstrapScanner's WireAllActuators and WireDistributedTracingLogProcessor internally call AddDynamicConsole, which can register before the user's AddDynamicSerilog due to IHostBuilder callback ordering. This causes AddDynamicSerilog to throw because it finds an existing IDynamicLoggerProvider.

Fix by pre-registering DynamicSerilog within the same deferred callback as the actuator/tracing registration when the Serilog assembly is loaded. This ensures Serilog's IDynamicLoggerProvider is always present before AddDynamicConsole runs, which then gracefully skips.

Fixes #1658 

## Quality checklist

<!-- Please run through the checklist below to ensure a smooth review and merge process for your PR. -->

- [ ] Your code complies with our [Coding Style](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-code-style.md).
- [ ] You've updated unit and/or integration tests for your change, where applicable.
- [ ] You've updated documentation for your change, where applicable.
      If your change affects other repositories, such as [Documentation](https://github.com/SteeltoeOSS/Documentation), [Samples](https://github.com/SteeltoeOSS/Samples) and/or [MainSite](https://github.com/SteeltoeOSS/MainSite), add linked PRs here.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
- [ ] You've added required license files and/or file headers (explaining where the code came from with proper attribution), where code is copied from StackOverflow, a blog, or OSS.
