### PR TITLE
Fix binding options against null values

### DIFF
--- a/src/Configuration/src/Abstractions/CompositeConfigurationProvider.cs
+++ b/src/Configuration/src/Abstractions/CompositeConfigurationProvider.cs
@@ -84,8 +84,13 @@ internal abstract partial class CompositeConfigurationProvider : IConfigurationP
 
         LogTryGet(GetType().Name, key);
 
-        value = ConfigurationRoot?.GetValue<string>(key);
-        bool found = value != null;
+        if (ConfigurationRoot == null)
+        {
+            value = null;
+            return false;
+        }
+
+        bool found = InnerTryGet(ConfigurationRoot, key, out value);
 
         if (found)
         {
@@ -93,6 +98,31 @@ internal abstract partial class CompositeConfigurationProvider : IConfigurationP
         }
 
         return found;
+    }
+
+    private static bool InnerTryGet(IConfigurationRoot root, string key, out string? value)
+    {
+        IList<IConfigurationProvider> providers = root.Providers as IList<IConfigurationProvider> ?? root.Providers.ToList();
+
+        for (int index = providers.Count - 1; index >= 0; index--)
+        {
+            IConfigurationProvider provider = providers[index];
+
+            try
+            {
+                if (provider.TryGet(key, out value))
+                {
+                    return true;
+                }
+            }
+            catch (ObjectDisposedException)
+            {
+                // Skip disposed providers to avoid exceptions during access.
+            }
+        }
+
+        value = null;
+        return false;
     }
 
     public void Set(string key, string? value)

--- a/src/Configuration/src/Encryption/DecryptionConfigurationProvider.cs
+++ b/src/Configuration/src/Encryption/DecryptionConfigurationProvider.cs
@@ -46,7 +46,7 @@ internal sealed partial class DecryptionConfigurationProvider(
             }
         }
 
-        return value != null;
+        return found;
     }
 
     private ITextDecryptor EnsureDecryptor(IConfigurationRoot configurationRoot)

--- a/src/Configuration/src/Placeholder/PlaceholderConfigurationProvider.cs
+++ b/src/Configuration/src/Placeholder/PlaceholderConfigurationProvider.cs
@@ -36,7 +36,7 @@ internal sealed partial class PlaceholderConfigurationProvider : CompositeConfig
             }
         }
 
-        return value != null;
+        return found;
     }
 
     [LoggerMessage(Level = LogLevel.Trace, Message = "Replaced value '{OriginalValue}' at key '{Key}' with '{ReplacementValue}'.")]

--- a/src/Configuration/test/Placeholder.Test/PlaceholderConfigurationTest.cs
+++ b/src/Configuration/test/Placeholder.Test/PlaceholderConfigurationTest.cs
@@ -431,6 +431,26 @@ public sealed class PlaceholderConfigurationTest : IDisposable
         options.Value.Should().BeNull();
     }
 
+    [Fact]
+    public void Binding_property_against_empty_string_overwrites_default_value()
+    {
+        var appSettings = new Dictionary<string, string?>
+        {
+            ["Root:TestOptions:Value"] = string.Empty
+        };
+
+        var builder = new ConfigurationBuilder();
+        builder.AddInMemoryCollection(appSettings);
+        builder.AddPlaceholderResolver();
+        IConfigurationRoot configuration = builder.Build();
+
+        IConfigurationSection section = configuration.GetSection("Root:TestOptions");
+        var options = section.Get<TestOptions>();
+
+        options.Should().NotBeNull();
+        options.Value.Should().BeEmpty();
+    }
+
     public void Dispose()
     {
         _loggerFactory.Dispose();

--- a/src/Configuration/test/Placeholder.Test/PlaceholderConfigurationTest.cs
+++ b/src/Configuration/test/Placeholder.Test/PlaceholderConfigurationTest.cs
@@ -205,7 +205,8 @@ public sealed class PlaceholderConfigurationTest : IDisposable
             ["key2"] = "${key1?not-found}",
             ["key3"] = "${no-key?not-found}",
             ["key4"] = "${no-key}",
-            ["key5"] = string.Empty
+            ["key5"] = string.Empty,
+            ["key6"] = null
         };
 
         var builder = new ConfigurationBuilder();
@@ -219,6 +220,8 @@ public sealed class PlaceholderConfigurationTest : IDisposable
         configuration["key3"].Should().Be("not-found");
         configuration["key4"].Should().Be("${no-key}");
         configuration["key5"].Should().BeEmpty();
+        configuration["key6"].Should().BeNull();
+        configuration["key7"].Should().BeNull();
 
         configuration["no-key"] = "new-key-value";
 
@@ -406,6 +409,26 @@ public sealed class PlaceholderConfigurationTest : IDisposable
                 }
             }
         }
+    }
+
+    [Fact]
+    public void Binding_property_against_null_overwrites_default_value()
+    {
+        var appSettings = new Dictionary<string, string?>
+        {
+            ["Root:TestOptions:Value"] = null
+        };
+
+        var builder = new ConfigurationBuilder();
+        builder.AddInMemoryCollection(appSettings);
+        builder.AddPlaceholderResolver();
+        IConfigurationRoot configuration = builder.Build();
+
+        IConfigurationSection section = configuration.GetSection("Root:TestOptions");
+        var options = section.Get<TestOptions>();
+
+        options.Should().NotBeNull();
+        options.Value.Should().BeNull();
     }
 
     public void Dispose()

--- a/src/Configuration/test/Placeholder.Test/TestOptions.cs
+++ b/src/Configuration/test/Placeholder.Test/TestOptions.cs
@@ -6,5 +6,5 @@ namespace Steeltoe.Configuration.Placeholder.Test;
 
 internal sealed class TestOptions
 {
-    public string? Value { get; set; }
+    public string? Value { get; set; } = "DefaultValue";
 }


### PR DESCRIPTION
## Description

This PR fixes `CompositeConfigurationProvider` (a shared building block for the placeholder and decryption configuration providers) to properly handle `null` entries in configuration.

Fixes #1659.

## Quality checklist

- [x] Your code complies with our [Coding Style](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-code-style.md).
- [x] You've updated unit and/or integration tests for your change, where applicable.
- [ ] You've updated documentation for your change, where applicable.
      If your change affects other repositories, such as [Documentation](https://github.com/SteeltoeOSS/Documentation), [Samples](https://github.com/SteeltoeOSS/Samples) and/or [MainSite](https://github.com/SteeltoeOSS/MainSite), add linked PRs here.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
- [ ] You've added required license files and/or file headers (explaining where the code came from with proper attribution), where code is copied from StackOverflow, a blog, or OSS.
