### PR TITLE
Fix Eureka Dynamic Port Assignment overriding user-configured ports

### DIFF
--- a/src/Discovery/src/Consul/Configuration/ConsulDiscoveryOptions.cs
+++ b/src/Discovery/src/Consul/Configuration/ConsulDiscoveryOptions.cs
@@ -176,5 +176,9 @@ public sealed class ConsulDiscoveryOptions
     /// <summary>
     /// Gets or sets a value indicating whether to register with the port number ASP.NET Core is listening on. Default value: true.
     /// </summary>
+    /// <remarks>
+    /// This property is ignored when <see cref="Port" /> or <see cref="Scheme" /> is explicitly configured, or when <see cref="UseNetworkInterfaces" /> is
+    /// <c>true</c>.
+    /// </remarks>
     public bool UseAspNetCoreUrls { get; set; } = true;
 }

--- a/src/Discovery/src/Consul/Configuration/ConsulDiscoveryOptions.cs
+++ b/src/Discovery/src/Consul/Configuration/ConsulDiscoveryOptions.cs
@@ -175,10 +175,9 @@ public sealed class ConsulDiscoveryOptions
 
     /// <summary>
     /// Gets or sets a value indicating whether to register with the port number ASP.NET Core is listening on. Default value: true.
-    /// </summary>
-    /// <remarks>
+    /// <para />
     /// This property is ignored when <see cref="Port" /> or <see cref="Scheme" /> is explicitly configured, or when <see cref="UseNetworkInterfaces" /> is
     /// <c>true</c>.
-    /// </remarks>
+    /// </summary>
     public bool UseAspNetCoreUrls { get; set; } = true;
 }

--- a/src/Discovery/src/Consul/ConfigurationSchema.json
+++ b/src/Discovery/src/Consul/ConfigurationSchema.json
@@ -188,7 +188,7 @@
             },
             "UseAspNetCoreUrls": {
               "type": "boolean",
-              "description": "Gets or sets a value indicating whether to register with the port number ASP.NET Core is listening on. Default value: true."
+              "description": "Gets or sets a value indicating whether to register with the port number ASP.NET Core is listening on. Default value: true.\n\nThis property is ignored when 'Steeltoe.Discovery.Consul.Configuration.ConsulDiscoveryOptions.Port' or 'Steeltoe.Discovery.Consul.Configuration.ConsulDiscoveryOptions.Scheme' is explicitly configured, or when 'Steeltoe.Discovery.Consul.Configuration.ConsulDiscoveryOptions.UseNetworkInterfaces' is true."
             },
             "UseNetworkInterfaces": {
               "type": "boolean",

--- a/src/Discovery/src/Consul/PostConfigureConsulDiscoveryOptions.cs
+++ b/src/Discovery/src/Consul/PostConfigureConsulDiscoveryOptions.cs
@@ -62,7 +62,7 @@ internal sealed class PostConfigureConsulDiscoveryOptions : IPostConfigureOption
             options.HostName = options.IPAddress;
         }
 
-        if (options.Port == 0)
+        if (options is { UseAspNetCoreUrls: true, Port: 0, Scheme: null, UseNetworkInterfaces: false })
         {
             ICollection<string> addresses = _configuration.GetListenAddresses();
             SetSchemeWithPortFromListenAddresses(options, addresses);
@@ -79,37 +79,32 @@ internal sealed class PostConfigureConsulDiscoveryOptions : IPostConfigureOption
 
     private void SetSchemeWithPortFromListenAddresses(ConsulDiscoveryOptions options, IEnumerable<string> listenOnAddresses)
     {
-        // Try to pull some values out of server configuration to override defaults, but only if not using NetUtils.
-        // If NetUtils are configured, the user probably wants to define their own behavior.
-        if (options is { UseAspNetCoreUrls: true, Port: 0, Scheme: null })
+        int? listenHttpPort = null;
+        int? listenHttpsPort = null;
+
+        foreach (string address in listenOnAddresses)
         {
-            int? listenHttpPort = null;
-            int? listenHttpsPort = null;
+            BindingAddress bindingAddress = BindingAddress.Parse(address);
 
-            foreach (string address in listenOnAddresses)
+            if (bindingAddress is { Scheme: "http", Port: > 0 } && listenHttpPort == null)
             {
-                BindingAddress bindingAddress = BindingAddress.Parse(address);
+                listenHttpPort = bindingAddress.Port;
+            }
+            else if (bindingAddress is { Scheme: "https", Port: > 0 } && listenHttpsPort == null)
+            {
+                listenHttpsPort = bindingAddress.Port;
+            }
+        }
 
-                if (bindingAddress is { Scheme: "http", Port: > 0 } && listenHttpPort == null)
-                {
-                    listenHttpPort = bindingAddress.Port;
-                }
-                else if (bindingAddress is { Scheme: "https", Port: > 0 } && listenHttpsPort == null)
-                {
-                    listenHttpsPort = bindingAddress.Port;
-                }
-            }
-
-            if (listenHttpsPort != null)
-            {
-                options.Port = listenHttpsPort.Value;
-                options.Scheme = "https";
-            }
-            else if (listenHttpPort != null)
-            {
-                options.Port = listenHttpPort.Value;
-                options.Scheme = "http";
-            }
+        if (listenHttpsPort != null)
+        {
+            options.Port = listenHttpsPort.Value;
+            options.Scheme = "https";
+        }
+        else if (listenHttpPort != null)
+        {
+            options.Port = listenHttpPort.Value;
+            options.Scheme = "http";
         }
     }
 

--- a/src/Discovery/src/Eureka/Configuration/EurekaInstanceOptions.cs
+++ b/src/Discovery/src/Eureka/Configuration/EurekaInstanceOptions.cs
@@ -20,14 +20,13 @@ public sealed partial class EurekaInstanceOptions
     internal const string DefaultStatusPageUrlPath = "/info";
     internal const string DefaultHealthCheckUrlPath = "/health";
 
-#pragma warning disable S1067 // Expressions should not be too complex
-    internal bool ShouldSetPortsFromListenAddresses =>
-        UseAspNetCoreUrls && (!Platform.IsCloudFoundry || IsContainerToContainerMethod() || IsForceHostNameMethod()) &&
-        (!IsNonSecurePortEnabled || NonSecurePort == null) && (!IsSecurePortEnabled || SecurePort == null);
-#pragma warning restore S1067 // Expressions should not be too complex
+    private bool IsSuitableRegistrationMethod => !Platform.IsCloudFoundry || IsContainerToContainerMethod() || IsForceHostNameMethod();
+    internal bool ShouldSetPortsFromListenAddresses => UseAspNetCoreUrls && IsSuitableRegistrationMethod && !IsPortConfigured;
 
     internal TimeSpan LeaseRenewalInterval => TimeSpan.FromSeconds(LeaseRenewalIntervalInSeconds);
     internal TimeSpan LeaseExpirationDuration => TimeSpan.FromSeconds(LeaseExpirationDurationInSeconds);
+
+    internal bool IsPortConfigured { get; set; }
 
     /// <summary>
     /// Gets or sets the unique ID (within the scope of the app name) of the instance to be registered with Eureka.
@@ -211,10 +210,9 @@ public sealed partial class EurekaInstanceOptions
 
     /// <summary>
     /// Gets or sets a value indicating whether to register with the port number(s) ASP.NET Core is listening on. Default value: true.
-    /// </summary>
-    /// <remarks>
+    /// <para />
     /// This property is ignored when <see cref="NonSecurePort" /> or <see cref="SecurePort" /> is explicitly configured.
-    /// </remarks>
+    /// </summary>
     public bool UseAspNetCoreUrls { get; set; } = true;
 
     /// <summary>
@@ -243,72 +241,69 @@ public sealed partial class EurekaInstanceOptions
 
     internal void SetPortsFromListenAddresses(IEnumerable<string> listenOnAddresses, string source, ILogger<EurekaInstanceOptions> logger)
     {
-        if (ShouldSetPortsFromListenAddresses)
+        int? listenHttpPort = null;
+        int? listenHttpsPort = null;
+
+        foreach (string address in listenOnAddresses)
         {
-            int? listenHttpPort = null;
-            int? listenHttpsPort = null;
+            BindingAddress bindingAddress = BindingAddress.Parse(address);
 
-            foreach (string address in listenOnAddresses)
+            if (bindingAddress is { Scheme: "http", Port: > 0 } && listenHttpPort == null)
             {
-                BindingAddress bindingAddress = BindingAddress.Parse(address);
-
-                if (bindingAddress is { Scheme: "http", Port: > 0 } && listenHttpPort == null)
-                {
-                    listenHttpPort = bindingAddress.Port;
-                }
-                else if (bindingAddress is { Scheme: "https", Port: > 0 } && listenHttpsPort == null)
-                {
-                    listenHttpsPort = bindingAddress.Port;
-                }
+                listenHttpPort = bindingAddress.Port;
             }
-
-            int? nonSecurePort = IsNonSecurePortEnabled ? NonSecurePort : null;
-            int? securePort = IsSecurePortEnabled ? SecurePort : null;
-
-            if (nonSecurePort != listenHttpPort)
+            else if (bindingAddress is { Scheme: "https", Port: > 0 } && listenHttpsPort == null)
             {
-                if (listenHttpPort != null)
-                {
-                    if (nonSecurePort == null)
-                    {
-                        LogActivatingNonSecurePort(logger, listenHttpPort, source);
-                    }
-                    else
-                    {
-                        LogChangingNonSecurePort(logger, listenHttpPort, source);
-                    }
-
-                    NonSecurePort = listenHttpPort.Value;
-                    IsNonSecurePortEnabled = true;
-                }
-                else if (nonSecurePort != null)
-                {
-                    LogDeactivatingNonSecurePort(logger, source);
-                    IsNonSecurePortEnabled = false;
-                }
+                listenHttpsPort = bindingAddress.Port;
             }
+        }
 
-            if (securePort != listenHttpsPort)
+        int? nonSecurePort = IsNonSecurePortEnabled ? NonSecurePort : null;
+        int? securePort = IsSecurePortEnabled ? SecurePort : null;
+
+        if (nonSecurePort != listenHttpPort)
+        {
+            if (listenHttpPort != null)
             {
-                if (listenHttpsPort != null)
+                if (nonSecurePort == null)
                 {
-                    if (securePort == null)
-                    {
-                        LogActivatingSecurePort(logger, listenHttpsPort, source);
-                    }
-                    else
-                    {
-                        LogChangingSecurePort(logger, listenHttpsPort, source);
-                    }
+                    LogActivatingNonSecurePort(logger, listenHttpPort, source);
+                }
+                else
+                {
+                    LogChangingNonSecurePort(logger, listenHttpPort, source);
+                }
 
-                    SecurePort = listenHttpsPort.Value;
-                    IsSecurePortEnabled = true;
-                }
-                else if (securePort != null)
+                NonSecurePort = listenHttpPort.Value;
+                IsNonSecurePortEnabled = true;
+            }
+            else if (nonSecurePort != null)
+            {
+                LogDeactivatingNonSecurePort(logger, source);
+                IsNonSecurePortEnabled = false;
+            }
+        }
+
+        if (securePort != listenHttpsPort)
+        {
+            if (listenHttpsPort != null)
+            {
+                if (securePort == null)
                 {
-                    LogDeactivatingSecurePort(logger, source);
-                    IsSecurePortEnabled = false;
+                    LogActivatingSecurePort(logger, listenHttpsPort, source);
                 }
+                else
+                {
+                    LogChangingSecurePort(logger, listenHttpsPort, source);
+                }
+
+                SecurePort = listenHttpsPort.Value;
+                IsSecurePortEnabled = true;
+            }
+            else if (securePort != null)
+            {
+                LogDeactivatingSecurePort(logger, source);
+                IsSecurePortEnabled = false;
             }
         }
     }

--- a/src/Discovery/src/Eureka/Configuration/EurekaInstanceOptions.cs
+++ b/src/Discovery/src/Eureka/Configuration/EurekaInstanceOptions.cs
@@ -25,9 +25,7 @@ public sealed partial class EurekaInstanceOptions
     internal TimeSpan LeaseRenewalInterval => TimeSpan.FromSeconds(LeaseRenewalIntervalInSeconds);
     internal TimeSpan LeaseExpirationDuration => TimeSpan.FromSeconds(LeaseExpirationDurationInSeconds);
 
-    internal bool IsNonSecurePortConfigured { get; set; }
-
-    internal bool IsSecurePortConfigured { get; set; }
+    internal bool IsPortConfigured { get; set; }
 
     /// <summary>
     /// Gets or sets the unique ID (within the scope of the app name) of the instance to be registered with Eureka.
@@ -210,7 +208,7 @@ public sealed partial class EurekaInstanceOptions
     };
 
     /// <summary>
-    /// Gets or sets a value indicating whether to register with the port number ASP.NET Core is listening on. Default value: true.
+    /// Gets or sets a value indicating whether to register with the port number(s) ASP.NET Core is listening on. Default value: true.
     /// </summary>
     public bool UseAspNetCoreUrls { get; set; } = true;
 
@@ -240,7 +238,7 @@ public sealed partial class EurekaInstanceOptions
 
     internal void SetPortsFromListenAddresses(IEnumerable<string> listenOnAddresses, string source, ILogger<EurekaInstanceOptions> logger)
     {
-        if (ShouldUseAspNetCoreUrls)
+        if (ShouldUseAspNetCoreUrls && !IsPortConfigured)
         {
             int? listenHttpPort = null;
             int? listenHttpsPort = null;
@@ -259,59 +257,52 @@ public sealed partial class EurekaInstanceOptions
                 }
             }
 
-            if (!IsNonSecurePortConfigured)
+            int? nonSecurePort = IsNonSecurePortEnabled ? NonSecurePort : null;
+            int? securePort = IsSecurePortEnabled ? SecurePort : null;
+
+            if (nonSecurePort != listenHttpPort)
             {
-                int? nonSecurePort = IsNonSecurePortEnabled ? NonSecurePort : null;
-
-                if (nonSecurePort != listenHttpPort)
+                if (listenHttpPort != null)
                 {
-                    if (listenHttpPort != null)
+                    if (nonSecurePort == null)
                     {
-                        if (nonSecurePort == null)
-                        {
-                            LogActivatingNonSecurePort(logger, listenHttpPort, source);
-                        }
-                        else
-                        {
-                            LogChangingNonSecurePort(logger, listenHttpPort, source);
-                        }
+                        LogActivatingNonSecurePort(logger, listenHttpPort, source);
+                    }
+                    else
+                    {
+                        LogChangingNonSecurePort(logger, listenHttpPort, source);
+                    }
 
-                        NonSecurePort = listenHttpPort.Value;
-                        IsNonSecurePortEnabled = true;
-                    }
-                    else if (nonSecurePort != null)
-                    {
-                        LogDeactivatingNonSecurePort(logger, source);
-                        IsNonSecurePortEnabled = false;
-                    }
+                    NonSecurePort = listenHttpPort.Value;
+                    IsNonSecurePortEnabled = true;
+                }
+                else if (nonSecurePort != null)
+                {
+                    LogDeactivatingNonSecurePort(logger, source);
+                    IsNonSecurePortEnabled = false;
                 }
             }
 
-            if (!IsSecurePortConfigured)
+            if (securePort != listenHttpsPort)
             {
-                int? securePort = IsSecurePortEnabled ? SecurePort : null;
-
-                if (securePort != listenHttpsPort)
+                if (listenHttpsPort != null)
                 {
-                    if (listenHttpsPort != null)
+                    if (securePort == null)
                     {
-                        if (securePort == null)
-                        {
-                            LogActivatingSecurePort(logger, listenHttpsPort, source);
-                        }
-                        else
-                        {
-                            LogChangingSecurePort(logger, listenHttpsPort, source);
-                        }
+                        LogActivatingSecurePort(logger, listenHttpsPort, source);
+                    }
+                    else
+                    {
+                        LogChangingSecurePort(logger, listenHttpsPort, source);
+                    }
 
-                        SecurePort = listenHttpsPort.Value;
-                        IsSecurePortEnabled = true;
-                    }
-                    else if (securePort != null)
-                    {
-                        LogDeactivatingSecurePort(logger, source);
-                        IsSecurePortEnabled = false;
-                    }
+                    SecurePort = listenHttpsPort.Value;
+                    IsSecurePortEnabled = true;
+                }
+                else if (securePort != null)
+                {
+                    LogDeactivatingSecurePort(logger, source);
+                    IsSecurePortEnabled = false;
                 }
             }
         }

--- a/src/Discovery/src/Eureka/Configuration/EurekaInstanceOptions.cs
+++ b/src/Discovery/src/Eureka/Configuration/EurekaInstanceOptions.cs
@@ -245,16 +245,17 @@ public sealed partial class EurekaInstanceOptions
         int? listenHttpPort = null;
         int? listenHttpsPort = null;
 
-        foreach (BindingAddress bindingAddress in listenOnAddresses.Select(BindingAddress.Parse))
+        foreach (string address in listenOnAddresses)
         {
-            switch (bindingAddress)
+            BindingAddress bindingAddress = BindingAddress.Parse(address);
+
+            if (bindingAddress is { Scheme: "http", Port: > 0 } && listenHttpPort == null)
             {
-                case { Scheme: "http", Port: > 0 } when listenHttpPort == null:
-                    listenHttpPort = bindingAddress.Port;
-                    break;
-                case { Scheme: "https", Port: > 0 } when listenHttpsPort == null:
-                    listenHttpsPort = bindingAddress.Port;
-                    break;
+                listenHttpPort = bindingAddress.Port;
+            }
+            else if (bindingAddress is { Scheme: "https", Port: > 0 } && listenHttpsPort == null)
+            {
+                listenHttpsPort = bindingAddress.Port;
             }
         }
 
@@ -284,29 +285,27 @@ public sealed partial class EurekaInstanceOptions
             }
         }
 
-        if (securePort == listenHttpsPort)
+        if (securePort != listenHttpsPort)
         {
-            return;
-        }
-
-        if (listenHttpsPort != null)
-        {
-            if (securePort == null)
+            if (listenHttpsPort != null)
             {
-                LogActivatingSecurePort(logger, listenHttpsPort, source);
-            }
-            else
-            {
-                LogChangingSecurePort(logger, listenHttpsPort, source);
-            }
+                if (securePort == null)
+                {
+                    LogActivatingSecurePort(logger, listenHttpsPort, source);
+                }
+                else
+                {
+                    LogChangingSecurePort(logger, listenHttpsPort, source);
+                }
 
-            SecurePort = listenHttpsPort.Value;
-            IsSecurePortEnabled = true;
-        }
-        else if (securePort != null)
-        {
-            LogDeactivatingSecurePort(logger, source);
-            IsSecurePortEnabled = false;
+                SecurePort = listenHttpsPort.Value;
+                IsSecurePortEnabled = true;
+            }
+            else if (securePort != null)
+            {
+                LogDeactivatingSecurePort(logger, source);
+                IsSecurePortEnabled = false;
+            }
         }
     }
 

--- a/src/Discovery/src/Eureka/Configuration/EurekaInstanceOptions.cs
+++ b/src/Discovery/src/Eureka/Configuration/EurekaInstanceOptions.cs
@@ -20,10 +20,14 @@ public sealed partial class EurekaInstanceOptions
     internal const string DefaultStatusPageUrlPath = "/info";
     internal const string DefaultHealthCheckUrlPath = "/health";
 
-    private bool UseAspNetCoreUrls => !Platform.IsCloudFoundry || IsContainerToContainerMethod() || IsForceHostNameMethod();
+    private bool ShouldUseAspNetCoreUrls => UseAspNetCoreUrls && (!Platform.IsCloudFoundry || IsContainerToContainerMethod() || IsForceHostNameMethod());
 
     internal TimeSpan LeaseRenewalInterval => TimeSpan.FromSeconds(LeaseRenewalIntervalInSeconds);
     internal TimeSpan LeaseExpirationDuration => TimeSpan.FromSeconds(LeaseExpirationDurationInSeconds);
+
+    internal bool IsNonSecurePortConfigured { get; set; }
+
+    internal bool IsSecurePortConfigured { get; set; }
 
     /// <summary>
     /// Gets or sets the unique ID (within the scope of the app name) of the instance to be registered with Eureka.
@@ -206,6 +210,11 @@ public sealed partial class EurekaInstanceOptions
     };
 
     /// <summary>
+    /// Gets or sets a value indicating whether to register with the port number ASP.NET Core is listening on. Default value: true.
+    /// </summary>
+    public bool UseAspNetCoreUrls { get; set; } = true;
+
+    /// <summary>
     /// Gets or sets a value indicating whether <see cref="NetworkInterface.GetAllNetworkInterfaces" /> is used to determine <see cref="IPAddress" /> and
     /// <see cref="HostName" />. Default value: false.
     /// </summary>
@@ -231,7 +240,7 @@ public sealed partial class EurekaInstanceOptions
 
     internal void SetPortsFromListenAddresses(IEnumerable<string> listenOnAddresses, string source, ILogger<EurekaInstanceOptions> logger)
     {
-        if (UseAspNetCoreUrls)
+        if (ShouldUseAspNetCoreUrls)
         {
             int? listenHttpPort = null;
             int? listenHttpsPort = null;
@@ -250,52 +259,59 @@ public sealed partial class EurekaInstanceOptions
                 }
             }
 
-            int? nonSecurePort = IsNonSecurePortEnabled ? NonSecurePort : null;
-            int? securePort = IsSecurePortEnabled ? SecurePort : null;
-
-            if (nonSecurePort != listenHttpPort)
+            if (!IsNonSecurePortConfigured)
             {
-                if (listenHttpPort != null)
-                {
-                    if (nonSecurePort == null)
-                    {
-                        LogActivatingNonSecurePort(logger, listenHttpPort, source);
-                    }
-                    else
-                    {
-                        LogChangingNonSecurePort(logger, listenHttpPort, source);
-                    }
+                int? nonSecurePort = IsNonSecurePortEnabled ? NonSecurePort : null;
 
-                    NonSecurePort = listenHttpPort.Value;
-                    IsNonSecurePortEnabled = true;
-                }
-                else if (nonSecurePort != null)
+                if (nonSecurePort != listenHttpPort)
                 {
-                    LogDeactivatingNonSecurePort(logger, source);
-                    IsNonSecurePortEnabled = false;
+                    if (listenHttpPort != null)
+                    {
+                        if (nonSecurePort == null)
+                        {
+                            LogActivatingNonSecurePort(logger, listenHttpPort, source);
+                        }
+                        else
+                        {
+                            LogChangingNonSecurePort(logger, listenHttpPort, source);
+                        }
+
+                        NonSecurePort = listenHttpPort.Value;
+                        IsNonSecurePortEnabled = true;
+                    }
+                    else if (nonSecurePort != null)
+                    {
+                        LogDeactivatingNonSecurePort(logger, source);
+                        IsNonSecurePortEnabled = false;
+                    }
                 }
             }
 
-            if (securePort != listenHttpsPort)
+            if (!IsSecurePortConfigured)
             {
-                if (listenHttpsPort != null)
-                {
-                    if (securePort == null)
-                    {
-                        LogActivatingSecurePort(logger, listenHttpsPort, source);
-                    }
-                    else
-                    {
-                        LogChangingSecurePort(logger, listenHttpsPort, source);
-                    }
+                int? securePort = IsSecurePortEnabled ? SecurePort : null;
 
-                    SecurePort = listenHttpsPort.Value;
-                    IsSecurePortEnabled = true;
-                }
-                else if (securePort != null)
+                if (securePort != listenHttpsPort)
                 {
-                    LogDeactivatingSecurePort(logger, source);
-                    IsSecurePortEnabled = false;
+                    if (listenHttpsPort != null)
+                    {
+                        if (securePort == null)
+                        {
+                            LogActivatingSecurePort(logger, listenHttpsPort, source);
+                        }
+                        else
+                        {
+                            LogChangingSecurePort(logger, listenHttpsPort, source);
+                        }
+
+                        SecurePort = listenHttpsPort.Value;
+                        IsSecurePortEnabled = true;
+                    }
+                    else if (securePort != null)
+                    {
+                        LogDeactivatingSecurePort(logger, source);
+                        IsSecurePortEnabled = false;
+                    }
                 }
             }
         }

--- a/src/Discovery/src/Eureka/Configuration/EurekaInstanceOptions.cs
+++ b/src/Discovery/src/Eureka/Configuration/EurekaInstanceOptions.cs
@@ -20,13 +20,14 @@ public sealed partial class EurekaInstanceOptions
     internal const string DefaultStatusPageUrlPath = "/info";
     internal const string DefaultHealthCheckUrlPath = "/health";
 
+    private bool IsAnyPortConfigured =>
+        this is { IsNonSecurePortEnabled: true, NonSecurePort: not null } or { IsSecurePortEnabled: true, SecurePort: not null };
+
     private bool IsSuitableRegistrationMethod => !Platform.IsCloudFoundry || IsContainerToContainerMethod() || IsForceHostNameMethod();
-    internal bool ShouldSetPortsFromListenAddresses => UseAspNetCoreUrls && IsSuitableRegistrationMethod && !IsPortConfigured;
+    internal bool ShouldSetPortsFromListenAddresses => UseAspNetCoreUrls && IsSuitableRegistrationMethod && !IsAnyPortConfigured;
 
     internal TimeSpan LeaseRenewalInterval => TimeSpan.FromSeconds(LeaseRenewalIntervalInSeconds);
     internal TimeSpan LeaseExpirationDuration => TimeSpan.FromSeconds(LeaseExpirationDurationInSeconds);
-
-    internal bool IsPortConfigured { get; set; }
 
     /// <summary>
     /// Gets or sets the unique ID (within the scope of the app name) of the instance to be registered with Eureka.
@@ -244,17 +245,16 @@ public sealed partial class EurekaInstanceOptions
         int? listenHttpPort = null;
         int? listenHttpsPort = null;
 
-        foreach (string address in listenOnAddresses)
+        foreach (BindingAddress bindingAddress in listenOnAddresses.Select(BindingAddress.Parse))
         {
-            BindingAddress bindingAddress = BindingAddress.Parse(address);
-
-            if (bindingAddress is { Scheme: "http", Port: > 0 } && listenHttpPort == null)
+            switch (bindingAddress)
             {
-                listenHttpPort = bindingAddress.Port;
-            }
-            else if (bindingAddress is { Scheme: "https", Port: > 0 } && listenHttpsPort == null)
-            {
-                listenHttpsPort = bindingAddress.Port;
+                case { Scheme: "http", Port: > 0 } when listenHttpPort == null:
+                    listenHttpPort = bindingAddress.Port;
+                    break;
+                case { Scheme: "https", Port: > 0 } when listenHttpsPort == null:
+                    listenHttpsPort = bindingAddress.Port;
+                    break;
             }
         }
 
@@ -284,27 +284,29 @@ public sealed partial class EurekaInstanceOptions
             }
         }
 
-        if (securePort != listenHttpsPort)
+        if (securePort == listenHttpsPort)
         {
-            if (listenHttpsPort != null)
-            {
-                if (securePort == null)
-                {
-                    LogActivatingSecurePort(logger, listenHttpsPort, source);
-                }
-                else
-                {
-                    LogChangingSecurePort(logger, listenHttpsPort, source);
-                }
+            return;
+        }
 
-                SecurePort = listenHttpsPort.Value;
-                IsSecurePortEnabled = true;
-            }
-            else if (securePort != null)
+        if (listenHttpsPort != null)
+        {
+            if (securePort == null)
             {
-                LogDeactivatingSecurePort(logger, source);
-                IsSecurePortEnabled = false;
+                LogActivatingSecurePort(logger, listenHttpsPort, source);
             }
+            else
+            {
+                LogChangingSecurePort(logger, listenHttpsPort, source);
+            }
+
+            SecurePort = listenHttpsPort.Value;
+            IsSecurePortEnabled = true;
+        }
+        else if (securePort != null)
+        {
+            LogDeactivatingSecurePort(logger, source);
+            IsSecurePortEnabled = false;
         }
     }
 

--- a/src/Discovery/src/Eureka/Configuration/EurekaInstanceOptions.cs
+++ b/src/Discovery/src/Eureka/Configuration/EurekaInstanceOptions.cs
@@ -20,12 +20,14 @@ public sealed partial class EurekaInstanceOptions
     internal const string DefaultStatusPageUrlPath = "/info";
     internal const string DefaultHealthCheckUrlPath = "/health";
 
-    private bool ShouldUseAspNetCoreUrls => UseAspNetCoreUrls && (!Platform.IsCloudFoundry || IsContainerToContainerMethod() || IsForceHostNameMethod());
+#pragma warning disable S1067 // Expressions should not be too complex
+    internal bool ShouldSetPortsFromListenAddresses =>
+        UseAspNetCoreUrls && (!Platform.IsCloudFoundry || IsContainerToContainerMethod() || IsForceHostNameMethod()) &&
+        (!IsNonSecurePortEnabled || NonSecurePort == null) && (!IsSecurePortEnabled || SecurePort == null);
+#pragma warning restore S1067 // Expressions should not be too complex
 
     internal TimeSpan LeaseRenewalInterval => TimeSpan.FromSeconds(LeaseRenewalIntervalInSeconds);
     internal TimeSpan LeaseExpirationDuration => TimeSpan.FromSeconds(LeaseExpirationDurationInSeconds);
-
-    internal bool IsPortConfigured { get; set; }
 
     /// <summary>
     /// Gets or sets the unique ID (within the scope of the app name) of the instance to be registered with Eureka.
@@ -210,6 +212,9 @@ public sealed partial class EurekaInstanceOptions
     /// <summary>
     /// Gets or sets a value indicating whether to register with the port number(s) ASP.NET Core is listening on. Default value: true.
     /// </summary>
+    /// <remarks>
+    /// This property is ignored when <see cref="NonSecurePort" /> or <see cref="SecurePort" /> is explicitly configured.
+    /// </remarks>
     public bool UseAspNetCoreUrls { get; set; } = true;
 
     /// <summary>
@@ -238,7 +243,7 @@ public sealed partial class EurekaInstanceOptions
 
     internal void SetPortsFromListenAddresses(IEnumerable<string> listenOnAddresses, string source, ILogger<EurekaInstanceOptions> logger)
     {
-        if (ShouldUseAspNetCoreUrls && !IsPortConfigured)
+        if (ShouldSetPortsFromListenAddresses)
         {
             int? listenHttpPort = null;
             int? listenHttpsPort = null;

--- a/src/Discovery/src/Eureka/ConfigurationSchema.json
+++ b/src/Discovery/src/Eureka/ConfigurationSchema.json
@@ -260,7 +260,7 @@
             },
             "UseAspNetCoreUrls": {
               "type": "boolean",
-              "description": "Gets or sets a value indicating whether to register with the port number(s) ASP.NET Core is listening on. Default value: true."
+              "description": "Gets or sets a value indicating whether to register with the port number(s) ASP.NET Core is listening on. Default value: true.\n\nThis property is ignored when 'Steeltoe.Discovery.Eureka.Configuration.EurekaInstanceOptions.NonSecurePort' or 'Steeltoe.Discovery.Eureka.Configuration.EurekaInstanceOptions.SecurePort' is explicitly configured."
             },
             "UseNetworkInterfaces": {
               "type": "boolean",

--- a/src/Discovery/src/Eureka/ConfigurationSchema.json
+++ b/src/Discovery/src/Eureka/ConfigurationSchema.json
@@ -258,6 +258,10 @@
               "type": "string",
               "description": "Gets or sets the relative path to the status page for the instance. The status page URL is then constructed out of the 'Steeltoe.Discovery.Eureka.Configuration.EurekaInstanceOptions.HostName' and the type of communication - secure or non-secure, as specified in 'Steeltoe.Discovery.Eureka.Configuration.EurekaInstanceOptions.SecurePort' and 'Steeltoe.Discovery.Eureka.Configuration.EurekaInstanceOptions.NonSecurePort'. It is normally used for informational purposes for other services to find out about the status of the instance. Users can provide a simple HTML page indicating what the current status of the instance is. Default value: /info."
             },
+            "UseAspNetCoreUrls": {
+              "type": "boolean",
+              "description": "Gets or sets a value indicating whether to register with the port number ASP.NET Core is listening on. Default value: true."
+            },
             "UseNetworkInterfaces": {
               "type": "boolean",
               "description": "Gets or sets a value indicating whether 'System.Net.NetworkInformation.NetworkInterface.GetAllNetworkInterfaces' is used to determine 'Steeltoe.Discovery.Eureka.Configuration.EurekaInstanceOptions.IPAddress' and 'Steeltoe.Discovery.Eureka.Configuration.EurekaInstanceOptions.HostName'. Default value: false."

--- a/src/Discovery/src/Eureka/ConfigurationSchema.json
+++ b/src/Discovery/src/Eureka/ConfigurationSchema.json
@@ -260,7 +260,7 @@
             },
             "UseAspNetCoreUrls": {
               "type": "boolean",
-              "description": "Gets or sets a value indicating whether to register with the port number ASP.NET Core is listening on. Default value: true."
+              "description": "Gets or sets a value indicating whether to register with the port number(s) ASP.NET Core is listening on. Default value: true."
             },
             "UseNetworkInterfaces": {
               "type": "boolean",

--- a/src/Discovery/src/Eureka/DynamicPortAssignmentHostedService.cs
+++ b/src/Discovery/src/Eureka/DynamicPortAssignmentHostedService.cs
@@ -136,7 +136,7 @@ internal sealed class DynamicPortAssignmentHostedService : IHostedLifecycleServi
         {
             ArgumentNullException.ThrowIfNull(options);
 
-            if (_listenState.ListenOnAddresses != null)
+            if (_listenState.ListenOnAddresses != null && options.ShouldSetPortsFromListenAddresses)
             {
                 options.SetPortsFromListenAddresses(_listenState.ListenOnAddresses, "address features", _optionsLogger);
             }

--- a/src/Discovery/src/Eureka/EurekaServiceCollectionExtensions.cs
+++ b/src/Discovery/src/Eureka/EurekaServiceCollectionExtensions.cs
@@ -81,24 +81,7 @@ public static class EurekaServiceCollectionExtensions
 
     private static void ConfigureEurekaInstanceOptions(IServiceCollection services)
     {
-        OptionsBuilder<EurekaInstanceOptions> optionsBuilder = services.AddOptions<EurekaInstanceOptions>();
-        optionsBuilder.BindConfiguration(EurekaInstanceOptions.ConfigurationPrefix);
-
-        optionsBuilder.Configure<IConfiguration>((options, configuration) =>
-        {
-            IConfigurationSection instanceSection = configuration.GetSection(EurekaInstanceOptions.ConfigurationPrefix);
-
-            if (instanceSection.GetSection("Port").Exists())
-            {
-                options.IsNonSecurePortConfigured = true;
-            }
-
-            if (instanceSection.GetSection("SecurePort").Exists())
-            {
-                options.IsSecurePortConfigured = true;
-            }
-        });
-
+        services.AddOptions<EurekaInstanceOptions>().BindConfiguration(EurekaInstanceOptions.ConfigurationPrefix);
         services.AddOptions<InetOptions>().BindConfiguration(InetOptions.ConfigurationPrefix);
         services.AddSingleton<IPostConfigureOptions<EurekaInstanceOptions>, PostConfigureEurekaInstanceOptions>();
 

--- a/src/Discovery/src/Eureka/EurekaServiceCollectionExtensions.cs
+++ b/src/Discovery/src/Eureka/EurekaServiceCollectionExtensions.cs
@@ -81,11 +81,11 @@ public static class EurekaServiceCollectionExtensions
 
     private static void ConfigureEurekaInstanceOptions(IServiceCollection services)
     {
+        DynamicPortAssignmentHostedService.Wire(services);
+
         services.AddOptions<EurekaInstanceOptions>().BindConfiguration(EurekaInstanceOptions.ConfigurationPrefix);
         services.AddOptions<InetOptions>().BindConfiguration(InetOptions.ConfigurationPrefix);
         services.AddSingleton<IPostConfigureOptions<EurekaInstanceOptions>, PostConfigureEurekaInstanceOptions>();
-
-        DynamicPortAssignmentHostedService.Wire(services);
     }
 
     private static void AddEurekaServices(IServiceCollection services)

--- a/src/Discovery/src/Eureka/EurekaServiceCollectionExtensions.cs
+++ b/src/Discovery/src/Eureka/EurekaServiceCollectionExtensions.cs
@@ -81,7 +81,24 @@ public static class EurekaServiceCollectionExtensions
 
     private static void ConfigureEurekaInstanceOptions(IServiceCollection services)
     {
-        services.AddOptions<EurekaInstanceOptions>().BindConfiguration(EurekaInstanceOptions.ConfigurationPrefix);
+        OptionsBuilder<EurekaInstanceOptions> optionsBuilder = services.AddOptions<EurekaInstanceOptions>();
+        optionsBuilder.BindConfiguration(EurekaInstanceOptions.ConfigurationPrefix);
+
+        optionsBuilder.Configure<IConfiguration>((options, configuration) =>
+        {
+            IConfigurationSection instanceSection = configuration.GetSection(EurekaInstanceOptions.ConfigurationPrefix);
+
+            if (instanceSection.GetSection("Port").Exists())
+            {
+                options.IsNonSecurePortConfigured = true;
+            }
+
+            if (instanceSection.GetSection("SecurePort").Exists())
+            {
+                options.IsSecurePortConfigured = true;
+            }
+        });
+
         services.AddOptions<InetOptions>().BindConfiguration(InetOptions.ConfigurationPrefix);
         services.AddSingleton<IPostConfigureOptions<EurekaInstanceOptions>, PostConfigureEurekaInstanceOptions>();
 

--- a/src/Discovery/src/Eureka/PostConfigureEurekaInstanceOptions.cs
+++ b/src/Discovery/src/Eureka/PostConfigureEurekaInstanceOptions.cs
@@ -140,6 +140,11 @@ internal sealed class PostConfigureEurekaInstanceOptions : IPostConfigureOptions
             options.IsSecurePortEnabled = true;
         }
 
+        if (options is { IsNonSecurePortEnabled: true, NonSecurePort: not null } or { IsSecurePortEnabled: true, SecurePort: not null })
+        {
+            options.IsPortConfigured = true;
+        }
+
         if (options.ShouldSetPortsFromListenAddresses)
         {
             var optionsLogger = _serviceProvider.GetRequiredService<ILogger<EurekaInstanceOptions>>();

--- a/src/Discovery/src/Eureka/PostConfigureEurekaInstanceOptions.cs
+++ b/src/Discovery/src/Eureka/PostConfigureEurekaInstanceOptions.cs
@@ -140,12 +140,7 @@ internal sealed class PostConfigureEurekaInstanceOptions : IPostConfigureOptions
             options.IsSecurePortEnabled = true;
         }
 
-        if (options.NonSecurePort != null || options.SecurePort != null)
-        {
-            options.IsPortConfigured = true;
-        }
-
-        if (!options.IsPortConfigured)
+        if (options.ShouldSetPortsFromListenAddresses)
         {
             var optionsLogger = _serviceProvider.GetRequiredService<ILogger<EurekaInstanceOptions>>();
             ICollection<string> addresses = _configuration.GetListenAddresses();

--- a/src/Discovery/src/Eureka/PostConfigureEurekaInstanceOptions.cs
+++ b/src/Discovery/src/Eureka/PostConfigureEurekaInstanceOptions.cs
@@ -140,11 +140,6 @@ internal sealed class PostConfigureEurekaInstanceOptions : IPostConfigureOptions
             options.IsSecurePortEnabled = true;
         }
 
-        if (options is { IsNonSecurePortEnabled: true, NonSecurePort: not null } or { IsSecurePortEnabled: true, SecurePort: not null })
-        {
-            options.IsPortConfigured = true;
-        }
-
         if (options.ShouldSetPortsFromListenAddresses)
         {
             var optionsLogger = _serviceProvider.GetRequiredService<ILogger<EurekaInstanceOptions>>();

--- a/src/Discovery/src/Eureka/PostConfigureEurekaInstanceOptions.cs
+++ b/src/Discovery/src/Eureka/PostConfigureEurekaInstanceOptions.cs
@@ -140,7 +140,12 @@ internal sealed class PostConfigureEurekaInstanceOptions : IPostConfigureOptions
             options.IsSecurePortEnabled = true;
         }
 
-        if (options.NonSecurePort == null && options.SecurePort == null)
+        if (options.NonSecurePort != null || options.SecurePort != null)
+        {
+            options.IsPortConfigured = true;
+        }
+
+        if (!options.IsPortConfigured)
         {
             var optionsLogger = _serviceProvider.GetRequiredService<ILogger<EurekaInstanceOptions>>();
             ICollection<string> addresses = _configuration.GetListenAddresses();

--- a/src/Discovery/src/Eureka/PublicAPI.Unshipped.txt
+++ b/src/Discovery/src/Eureka/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+Steeltoe.Discovery.Eureka.Configuration.EurekaInstanceOptions.UseAspNetCoreUrls.get -> bool
+Steeltoe.Discovery.Eureka.Configuration.EurekaInstanceOptions.UseAspNetCoreUrls.set -> void

--- a/src/Discovery/test/Eureka.Test/DynamicPortAssignmentTest.cs
+++ b/src/Discovery/test/Eureka.Test/DynamicPortAssignmentTest.cs
@@ -69,6 +69,8 @@ public sealed class DynamicPortAssignmentTest
         infoManager.Instance.IsNonSecurePortEnabled.Should().BeTrue();
         infoManager.Instance.NonSecurePort.Should().NotBe(5000);
         infoManager.Instance.NonSecurePort.Should().BePositive();
+        infoManager.Instance.IsSecurePortEnabled.Should().BeFalse();
+        infoManager.Instance.SecurePort.Should().Be(0);
     }
 
     [Fact]

--- a/src/Discovery/test/Eureka.Test/DynamicPortAssignmentTest.cs
+++ b/src/Discovery/test/Eureka.Test/DynamicPortAssignmentTest.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Steeltoe.Common.TestResources;
+using Steeltoe.Discovery.Eureka.Configuration;
 
 namespace Steeltoe.Discovery.Eureka.Test;
 
@@ -87,6 +88,35 @@ public sealed class DynamicPortAssignmentTest
 
         infoManager.Instance.IsNonSecurePortEnabled.Should().BeTrue();
         infoManager.Instance.NonSecurePort.Should().Be(80);
+    }
+
+    [Fact]
+    public async Task Does_not_override_ports_configured_via_code()
+    {
+        var appSettings = new Dictionary<string, string?>
+        {
+            ["Eureka:Client:ShouldFetchRegistry"] = "false",
+            ["Eureka:Client:ShouldRegisterWithEureka"] = "false"
+        };
+
+        WebApplicationBuilder builder = TestWebApplicationBuilderFactory.CreateDefault(false);
+        builder.WebHost.UseSetting("urls", "http://*:0");
+        builder.Configuration.AddInMemoryCollection(appSettings);
+        builder.Services.AddEurekaDiscoveryClient();
+
+        builder.Services.Configure<EurekaInstanceOptions>(options =>
+        {
+            options.SecurePort = 8443;
+            options.IsSecurePortEnabled = true;
+        });
+
+        await using WebApplication app = builder.Build();
+        await app.StartAsync(TestContext.Current.CancellationToken);
+
+        var infoManager = app.Services.GetRequiredService<EurekaApplicationInfoManager>();
+
+        infoManager.Instance.IsSecurePortEnabled.Should().BeTrue();
+        infoManager.Instance.SecurePort.Should().Be(8443);
     }
 
     [Fact]

--- a/src/Discovery/test/Eureka.Test/DynamicPortAssignmentTest.cs
+++ b/src/Discovery/test/Eureka.Test/DynamicPortAssignmentTest.cs
@@ -4,6 +4,7 @@
 
 using System.Runtime.InteropServices;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Steeltoe.Common.TestResources;
@@ -41,6 +42,36 @@ public sealed class DynamicPortAssignmentTest
     }
 
     [Fact]
+    public async Task Applies_dynamically_assigned_ports_when_kestrel_overrides_urls_config()
+    {
+        var appSettings = new Dictionary<string, string?>
+        {
+            ["Eureka:Client:ShouldFetchRegistry"] = "false",
+            ["Eureka:Client:ShouldRegisterWithEureka"] = "false",
+            ["urls"] = "http://*:5000"
+        };
+
+        WebApplicationBuilder builder = TestWebApplicationBuilderFactory.CreateDefault(false);
+        builder.Configuration.AddInMemoryCollection(appSettings);
+
+        builder.WebHost.ConfigureKestrel(options =>
+        {
+            options.ListenAnyIP(0);
+        });
+
+        builder.Services.AddEurekaDiscoveryClient();
+
+        await using WebApplication app = builder.Build();
+        await app.StartAsync(TestContext.Current.CancellationToken);
+
+        var infoManager = app.Services.GetRequiredService<EurekaApplicationInfoManager>();
+
+        infoManager.Instance.IsNonSecurePortEnabled.Should().BeTrue();
+        infoManager.Instance.NonSecurePort.Should().NotBe(5000);
+        infoManager.Instance.NonSecurePort.Should().BePositive();
+    }
+
+    [Fact]
     public async Task Does_not_override_explicitly_configured_secure_port()
     {
         var appSettings = new Dictionary<string, string?>
@@ -64,6 +95,7 @@ public sealed class DynamicPortAssignmentTest
         infoManager.Instance.IsSecurePortEnabled.Should().BeTrue();
         infoManager.Instance.SecurePort.Should().Be(443);
         infoManager.Instance.IsNonSecurePortEnabled.Should().BeFalse();
+        infoManager.Instance.NonSecurePort.Should().Be(0);
     }
 
     [Fact]
@@ -90,6 +122,7 @@ public sealed class DynamicPortAssignmentTest
         infoManager.Instance.IsNonSecurePortEnabled.Should().BeTrue();
         infoManager.Instance.NonSecurePort.Should().Be(80);
         infoManager.Instance.IsSecurePortEnabled.Should().BeFalse();
+        infoManager.Instance.SecurePort.Should().Be(0);
     }
 
     [Fact]
@@ -120,6 +153,7 @@ public sealed class DynamicPortAssignmentTest
         infoManager.Instance.IsSecurePortEnabled.Should().BeTrue();
         infoManager.Instance.SecurePort.Should().Be(8443);
         infoManager.Instance.IsNonSecurePortEnabled.Should().BeFalse();
+        infoManager.Instance.NonSecurePort.Should().Be(0);
     }
 
     [Fact]

--- a/src/Discovery/test/Eureka.Test/DynamicPortAssignmentTest.cs
+++ b/src/Discovery/test/Eureka.Test/DynamicPortAssignmentTest.cs
@@ -63,6 +63,7 @@ public sealed class DynamicPortAssignmentTest
 
         infoManager.Instance.IsSecurePortEnabled.Should().BeTrue();
         infoManager.Instance.SecurePort.Should().Be(443);
+        infoManager.Instance.IsNonSecurePortEnabled.Should().BeFalse();
     }
 
     [Fact]
@@ -88,6 +89,7 @@ public sealed class DynamicPortAssignmentTest
 
         infoManager.Instance.IsNonSecurePortEnabled.Should().BeTrue();
         infoManager.Instance.NonSecurePort.Should().Be(80);
+        infoManager.Instance.IsSecurePortEnabled.Should().BeFalse();
     }
 
     [Fact]
@@ -117,6 +119,7 @@ public sealed class DynamicPortAssignmentTest
 
         infoManager.Instance.IsSecurePortEnabled.Should().BeTrue();
         infoManager.Instance.SecurePort.Should().Be(8443);
+        infoManager.Instance.IsNonSecurePortEnabled.Should().BeFalse();
     }
 
     [Fact]

--- a/src/Discovery/test/Eureka.Test/DynamicPortAssignmentTest.cs
+++ b/src/Discovery/test/Eureka.Test/DynamicPortAssignmentTest.cs
@@ -38,4 +38,80 @@ public sealed class DynamicPortAssignmentTest
         infoManager.Instance.IsSecurePortEnabled.Should().BeTrue();
         infoManager.Instance.SecurePort.Should().BePositive();
     }
+
+    [Fact]
+    public async Task Does_not_override_explicitly_configured_secure_port()
+    {
+        var appSettings = new Dictionary<string, string?>
+        {
+            ["Eureka:Client:ShouldFetchRegistry"] = "false",
+            ["Eureka:Client:ShouldRegisterWithEureka"] = "false",
+            ["Eureka:Instance:SecurePort"] = "443",
+            ["Eureka:Instance:SecurePortEnabled"] = "true"
+        };
+
+        WebApplicationBuilder builder = TestWebApplicationBuilderFactory.CreateDefault(false);
+        builder.WebHost.UseSetting("urls", "http://*:0");
+        builder.Configuration.AddInMemoryCollection(appSettings);
+        builder.Services.AddEurekaDiscoveryClient();
+
+        await using WebApplication app = builder.Build();
+        await app.StartAsync(TestContext.Current.CancellationToken);
+
+        var infoManager = app.Services.GetRequiredService<EurekaApplicationInfoManager>();
+
+        infoManager.Instance.IsSecurePortEnabled.Should().BeTrue();
+        infoManager.Instance.SecurePort.Should().Be(443);
+    }
+
+    [Fact]
+    public async Task Does_not_override_explicitly_configured_non_secure_port()
+    {
+        var appSettings = new Dictionary<string, string?>
+        {
+            ["Eureka:Client:ShouldFetchRegistry"] = "false",
+            ["Eureka:Client:ShouldRegisterWithEureka"] = "false",
+            ["Eureka:Instance:Port"] = "80",
+            ["Eureka:Instance:NonSecurePortEnabled"] = "true"
+        };
+
+        WebApplicationBuilder builder = TestWebApplicationBuilderFactory.CreateDefault(false);
+        builder.WebHost.UseSetting("urls", "http://*:0");
+        builder.Configuration.AddInMemoryCollection(appSettings);
+        builder.Services.AddEurekaDiscoveryClient();
+
+        await using WebApplication app = builder.Build();
+        await app.StartAsync(TestContext.Current.CancellationToken);
+
+        var infoManager = app.Services.GetRequiredService<EurekaApplicationInfoManager>();
+
+        infoManager.Instance.IsNonSecurePortEnabled.Should().BeTrue();
+        infoManager.Instance.NonSecurePort.Should().Be(80);
+    }
+
+    [Fact]
+    public async Task Does_not_apply_dynamic_ports_when_UseAspNetCoreUrls_is_false()
+    {
+        var appSettings = new Dictionary<string, string?>
+        {
+            ["Eureka:Client:ShouldFetchRegistry"] = "false",
+            ["Eureka:Client:ShouldRegisterWithEureka"] = "false",
+            ["Eureka:Instance:UseAspNetCoreUrls"] = "false"
+        };
+
+        WebApplicationBuilder builder = TestWebApplicationBuilderFactory.CreateDefault(false);
+        builder.WebHost.UseSetting("urls", "http://*:0");
+        builder.Configuration.AddInMemoryCollection(appSettings);
+        builder.Services.AddEurekaDiscoveryClient();
+
+        await using WebApplication app = builder.Build();
+        await app.StartAsync(TestContext.Current.CancellationToken);
+
+        var infoManager = app.Services.GetRequiredService<EurekaApplicationInfoManager>();
+
+        infoManager.Instance.IsNonSecurePortEnabled.Should().BeFalse();
+        infoManager.Instance.NonSecurePort.Should().Be(0);
+        infoManager.Instance.IsSecurePortEnabled.Should().BeFalse();
+        infoManager.Instance.SecurePort.Should().Be(0);
+    }
 }

--- a/src/Discovery/test/Eureka.Test/EurekaInstanceOptionsTest.cs
+++ b/src/Discovery/test/Eureka.Test/EurekaInstanceOptionsTest.cs
@@ -43,6 +43,7 @@ public sealed class EurekaInstanceOptionsTest
         instanceOptions.SecureHealthCheckUrl.Should().BeNull();
         instanceOptions.AutoScalingGroupName.Should().BeNull();
         instanceOptions.DataCenterInfo.Name.Should().Be(DataCenterName.MyOwn);
+        instanceOptions.UseAspNetCoreUrls.Should().BeTrue();
         instanceOptions.UseNetworkInterfaces.Should().BeFalse();
     }
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->

<!-- If this is your first PR in this repo, please read our [Contributing Guidelines (https://github.com/SteeltoeOSS/.github/blob/master/CONTRIBUTING.md) and remember to sign the [Contributor License Agreement](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-license.md). Our bot will notify you shortly after the PR has been created. -->

## Description

- Detect explicitly configured `eureka:instance:port` or `eureka:instance:securePort` to avoid overwriting.
- Add public `UseAspNetCoreUrls` property (default: `true`, to match Consul) to allow disabling dynamic port detection.

Fixes #1665

## Quality checklist

<!-- Please run through the checklist below to ensure a smooth review and merge process for your PR. -->

- [ ] Your code complies with our [Coding Style](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-code-style.md).
- [ ] You've updated unit and/or integration tests for your change, where applicable.
- [ ] You've updated documentation for your change, where applicable.
      If your change affects other repositories, such as [Documentation](https://github.com/SteeltoeOSS/Documentation), [Samples](https://github.com/SteeltoeOSS/Samples) and/or [MainSite](https://github.com/SteeltoeOSS/MainSite), add linked PRs here.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
- [ ] You've added required license files and/or file headers (explaining where the code came from with proper attribution), where code is copied from StackOverflow, a blog, or OSS.
