### PR TITLE
Add missing logger categories in appsettings auto-completion

### DIFF
--- a/src/Bootstrap/src/AutoConfiguration/ConfigurationSchema.json
+++ b/src/Bootstrap/src/AutoConfiguration/ConfigurationSchema.json
@@ -1,0 +1,17 @@
+{
+  "definitions": {
+    "logLevel": {
+      "properties": {
+        "Steeltoe": {
+          "$ref": "#/definitions/logLevelThreshold"
+        },
+        "Steeltoe.Bootstrap": {
+          "$ref": "#/definitions/logLevelThreshold"
+        },
+        "Steeltoe.Bootstrap.AutoConfiguration": {
+          "$ref": "#/definitions/logLevelThreshold"
+        }
+      }
+    }
+  }
+}

--- a/src/Bootstrap/src/AutoConfiguration/Properties/AssemblyInfo.cs
+++ b/src/Bootstrap/src/AutoConfiguration/Properties/AssemblyInfo.cs
@@ -3,5 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Runtime.CompilerServices;
+using Aspire;
+
+[assembly: LoggingCategories("Steeltoe", "Steeltoe.Bootstrap", "Steeltoe.Bootstrap.AutoConfiguration")]
 
 [assembly: InternalsVisibleTo("Steeltoe.Bootstrap.AutoConfiguration.Test")]

--- a/src/Common/src/Common/ConfigurationSchema.json
+++ b/src/Common/src/Common/ConfigurationSchema.json
@@ -1,0 +1,14 @@
+{
+  "definitions": {
+    "logLevel": {
+      "properties": {
+        "Steeltoe": {
+          "$ref": "#/definitions/logLevelThreshold"
+        },
+        "Steeltoe.Common": {
+          "$ref": "#/definitions/logLevelThreshold"
+        }
+      }
+    }
+  }
+}

--- a/src/Common/src/Common/Properties/AssemblyInfo.cs
+++ b/src/Common/src/Common/Properties/AssemblyInfo.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Runtime.CompilerServices;
+using Aspire;
 
 [assembly: InternalsVisibleTo("Steeltoe.Bootstrap.AutoConfiguration")]
 [assembly: InternalsVisibleTo("Steeltoe.Bootstrap.AutoConfiguration.Test")]
@@ -11,13 +12,18 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("Steeltoe.Common.Hosting")]
 [assembly: InternalsVisibleTo("Steeltoe.Common.Hosting.Test")]
 [assembly: InternalsVisibleTo("Steeltoe.Common.Http")]
+[assembly: InternalsVisibleTo("Steeltoe.Common.Logging")]
+[assembly: InternalsVisibleTo("Steeltoe.Common.Net")]
 [assembly: InternalsVisibleTo("Steeltoe.Common.Test")]
+[assembly: InternalsVisibleTo("Steeltoe.Configuration.Abstractions")]
 [assembly: InternalsVisibleTo("Steeltoe.Configuration.CloudFoundry")]
 [assembly: InternalsVisibleTo("Steeltoe.Configuration.CloudFoundry.Test")]
 [assembly: InternalsVisibleTo("Steeltoe.Configuration.ConfigServer")]
 [assembly: InternalsVisibleTo("Steeltoe.Configuration.Encryption")]
 [assembly: InternalsVisibleTo("Steeltoe.Configuration.Kubernetes.ServiceBindings")]
 [assembly: InternalsVisibleTo("Steeltoe.Configuration.Placeholder")]
+[assembly: InternalsVisibleTo("Steeltoe.Configuration.RandomValue")]
+[assembly: InternalsVisibleTo("Steeltoe.Configuration.SpringBoot")]
 [assembly: InternalsVisibleTo("Steeltoe.Connectors")]
 [assembly: InternalsVisibleTo("Steeltoe.Connectors.EntityFrameworkCore")]
 [assembly: InternalsVisibleTo("Steeltoe.Discovery.Configuration")]
@@ -38,6 +44,11 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("Steeltoe.Management.Tasks")]
 [assembly: InternalsVisibleTo("Steeltoe.Management.Tracing")]
 [assembly: InternalsVisibleTo("Steeltoe.Management.Tracing.Test")]
+[assembly: InternalsVisibleTo("Steeltoe.Security.Authentication.JwtBearer")]
 [assembly: InternalsVisibleTo("Steeltoe.Security.Authentication.CloudFoundry.Test")]
+[assembly: InternalsVisibleTo("Steeltoe.Security.Authentication.OpenIdConnect")]
 [assembly: InternalsVisibleTo("Steeltoe.Security.Authorization.Certificate")]
+[assembly: InternalsVisibleTo("Steeltoe.Security.DataProtection.Redis")]
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]
+
+[assembly: LoggingCategories("Steeltoe", "Steeltoe.Common")]

--- a/src/Common/src/Hosting/ConfigurationSchema.json
+++ b/src/Common/src/Hosting/ConfigurationSchema.json
@@ -1,0 +1,17 @@
+{
+  "definitions": {
+    "logLevel": {
+      "properties": {
+        "Steeltoe": {
+          "$ref": "#/definitions/logLevelThreshold"
+        },
+        "Steeltoe.Common": {
+          "$ref": "#/definitions/logLevelThreshold"
+        },
+        "Steeltoe.Common.Hosting": {
+          "$ref": "#/definitions/logLevelThreshold"
+        }
+      }
+    }
+  }
+}

--- a/src/Common/src/Hosting/Properties/AssemblyInfo.cs
+++ b/src/Common/src/Hosting/Properties/AssemblyInfo.cs
@@ -3,6 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Runtime.CompilerServices;
+using Aspire;
+
+[assembly: LoggingCategories("Steeltoe", "Steeltoe.Common", "Steeltoe.Common.Hosting")]
 
 [assembly: InternalsVisibleTo("Steeltoe.Bootstrap.AutoConfiguration")]
 [assembly: InternalsVisibleTo("Steeltoe.Common.Hosting.Test")]

--- a/src/Common/src/Http/ConfigurationSchema.json
+++ b/src/Common/src/Http/ConfigurationSchema.json
@@ -1,0 +1,17 @@
+{
+  "definitions": {
+    "logLevel": {
+      "properties": {
+        "Steeltoe": {
+          "$ref": "#/definitions/logLevelThreshold"
+        },
+        "Steeltoe.Common": {
+          "$ref": "#/definitions/logLevelThreshold"
+        },
+        "Steeltoe.Common.Http": {
+          "$ref": "#/definitions/logLevelThreshold"
+        }
+      }
+    }
+  }
+}

--- a/src/Common/src/Http/Properties/AssemblyInfo.cs
+++ b/src/Common/src/Http/Properties/AssemblyInfo.cs
@@ -3,6 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Runtime.CompilerServices;
+using Aspire;
+
+[assembly: LoggingCategories("Steeltoe", "Steeltoe.Common", "Steeltoe.Common.Http")]
 
 [assembly: InternalsVisibleTo("Steeltoe.Common.Http.Test")]
 [assembly: InternalsVisibleTo("Steeltoe.Configuration.ConfigServer")]

--- a/src/Common/src/Logging/ConfigurationSchema.json
+++ b/src/Common/src/Logging/ConfigurationSchema.json
@@ -1,0 +1,17 @@
+{
+  "definitions": {
+    "logLevel": {
+      "properties": {
+        "Steeltoe": {
+          "$ref": "#/definitions/logLevelThreshold"
+        },
+        "Steeltoe.Common": {
+          "$ref": "#/definitions/logLevelThreshold"
+        },
+        "Steeltoe.Common.Logging": {
+          "$ref": "#/definitions/logLevelThreshold"
+        }
+      }
+    }
+  }
+}

--- a/src/Common/src/Logging/Properties/AssemblyInfo.cs
+++ b/src/Common/src/Logging/Properties/AssemblyInfo.cs
@@ -3,6 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Runtime.CompilerServices;
+using Aspire;
+
+[assembly: LoggingCategories("Steeltoe", "Steeltoe.Common", "Steeltoe.Common.Logging")]
 
 [assembly: InternalsVisibleTo("Steeltoe.Bootstrap.AutoConfiguration")]
 [assembly: InternalsVisibleTo("Steeltoe.Common.Logging.Test")]

--- a/src/Common/src/Net/ConfigurationSchema.json
+++ b/src/Common/src/Net/ConfigurationSchema.json
@@ -1,0 +1,17 @@
+{
+  "definitions": {
+    "logLevel": {
+      "properties": {
+        "Steeltoe": {
+          "$ref": "#/definitions/logLevelThreshold"
+        },
+        "Steeltoe.Common": {
+          "$ref": "#/definitions/logLevelThreshold"
+        },
+        "Steeltoe.Common.Net": {
+          "$ref": "#/definitions/logLevelThreshold"
+        }
+      }
+    }
+  }
+}

--- a/src/Common/src/Net/Properties/AssemblyInfo.cs
+++ b/src/Common/src/Net/Properties/AssemblyInfo.cs
@@ -3,5 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Runtime.CompilerServices;
+using Aspire;
+
+[assembly: LoggingCategories("Steeltoe", "Steeltoe.Common", "Steeltoe.Common.Net")]
 
 [assembly: InternalsVisibleTo("Steeltoe.Common.Net.Test")]

--- a/src/Configuration/src/Abstractions/ConfigurationSchema.json
+++ b/src/Configuration/src/Abstractions/ConfigurationSchema.json
@@ -1,0 +1,17 @@
+{
+  "definitions": {
+    "logLevel": {
+      "properties": {
+        "Steeltoe": {
+          "$ref": "#/definitions/logLevelThreshold"
+        },
+        "Steeltoe.Configuration": {
+          "$ref": "#/definitions/logLevelThreshold"
+        },
+        "Steeltoe.Configuration.Abstractions": {
+          "$ref": "#/definitions/logLevelThreshold"
+        }
+      }
+    }
+  }
+}

--- a/src/Configuration/src/Abstractions/Properties/AssemblyInfo.cs
+++ b/src/Configuration/src/Abstractions/Properties/AssemblyInfo.cs
@@ -3,6 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Runtime.CompilerServices;
+using Aspire;
+
+[assembly: LoggingCategories("Steeltoe", "Steeltoe.Configuration", "Steeltoe.Configuration.Abstractions")]
 
 [assembly: InternalsVisibleTo("Steeltoe.Bootstrap.AutoConfiguration.Test")]
 [assembly: InternalsVisibleTo("Steeltoe.Configuration.CloudFoundry")]

--- a/src/Configuration/src/CloudFoundry/ConfigurationSchema.json
+++ b/src/Configuration/src/CloudFoundry/ConfigurationSchema.json
@@ -1,0 +1,17 @@
+{
+  "definitions": {
+    "logLevel": {
+      "properties": {
+        "Steeltoe": {
+          "$ref": "#/definitions/logLevelThreshold"
+        },
+        "Steeltoe.Configuration": {
+          "$ref": "#/definitions/logLevelThreshold"
+        },
+        "Steeltoe.Configuration.CloudFoundry": {
+          "$ref": "#/definitions/logLevelThreshold"
+        }
+      }
+    }
+  }
+}

--- a/src/Configuration/src/CloudFoundry/Properties/AssemblyInfo.cs
+++ b/src/Configuration/src/CloudFoundry/Properties/AssemblyInfo.cs
@@ -3,6 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Runtime.CompilerServices;
+using Aspire;
+
+[assembly: LoggingCategories("Steeltoe", "Steeltoe.Configuration", "Steeltoe.Configuration.CloudFoundry")]
 
 [assembly: InternalsVisibleTo("Steeltoe.Bootstrap.AutoConfiguration")]
 [assembly: InternalsVisibleTo("Steeltoe.Bootstrap.AutoConfiguration.Test")]

--- a/src/Configuration/src/Kubernetes.ServiceBindings/ConfigurationSchema.json
+++ b/src/Configuration/src/Kubernetes.ServiceBindings/ConfigurationSchema.json
@@ -1,0 +1,20 @@
+{
+  "definitions": {
+    "logLevel": {
+      "properties": {
+        "Steeltoe": {
+          "$ref": "#/definitions/logLevelThreshold"
+        },
+        "Steeltoe.Configuration": {
+          "$ref": "#/definitions/logLevelThreshold"
+        },
+        "Steeltoe.Configuration.Kubernetes": {
+          "$ref": "#/definitions/logLevelThreshold"
+        },
+        "Steeltoe.Configuration.Kubernetes.ServiceBindings": {
+          "$ref": "#/definitions/logLevelThreshold"
+        }
+      }
+    }
+  }
+}

--- a/src/Configuration/src/Kubernetes.ServiceBindings/Properties/AssemblyInfo.cs
+++ b/src/Configuration/src/Kubernetes.ServiceBindings/Properties/AssemblyInfo.cs
@@ -3,6 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Runtime.CompilerServices;
+using Aspire;
+
+[assembly: LoggingCategories("Steeltoe", "Steeltoe.Configuration", "Steeltoe.Configuration.Kubernetes", "Steeltoe.Configuration.Kubernetes.ServiceBindings")]
 
 [assembly: InternalsVisibleTo("Steeltoe.Bootstrap.AutoConfiguration.Test")]
 [assembly: InternalsVisibleTo("Steeltoe.Configuration.Kubernetes.ServiceBindings.Test")]

--- a/src/Configuration/src/Placeholder/ConfigurationSchema.json
+++ b/src/Configuration/src/Placeholder/ConfigurationSchema.json
@@ -1,0 +1,17 @@
+{
+  "definitions": {
+    "logLevel": {
+      "properties": {
+        "Steeltoe": {
+          "$ref": "#/definitions/logLevelThreshold"
+        },
+        "Steeltoe.Configuration": {
+          "$ref": "#/definitions/logLevelThreshold"
+        },
+        "Steeltoe.Configuration.Placeholder": {
+          "$ref": "#/definitions/logLevelThreshold"
+        }
+      }
+    }
+  }
+}

--- a/src/Configuration/src/Placeholder/Properties/AssemblyInfo.cs
+++ b/src/Configuration/src/Placeholder/Properties/AssemblyInfo.cs
@@ -3,6 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Runtime.CompilerServices;
+using Aspire;
+
+[assembly: LoggingCategories("Steeltoe", "Steeltoe.Configuration", "Steeltoe.Configuration.Placeholder")]
 
 [assembly: InternalsVisibleTo("Steeltoe.Bootstrap.AutoConfiguration.Test")]
 [assembly: InternalsVisibleTo("Steeltoe.Configuration.ConfigServer")]

--- a/src/Configuration/src/RandomValue/ConfigurationSchema.json
+++ b/src/Configuration/src/RandomValue/ConfigurationSchema.json
@@ -1,0 +1,17 @@
+{
+  "definitions": {
+    "logLevel": {
+      "properties": {
+        "Steeltoe": {
+          "$ref": "#/definitions/logLevelThreshold"
+        },
+        "Steeltoe.Configuration": {
+          "$ref": "#/definitions/logLevelThreshold"
+        },
+        "Steeltoe.Configuration.RandomValue": {
+          "$ref": "#/definitions/logLevelThreshold"
+        }
+      }
+    }
+  }
+}

--- a/src/Configuration/src/RandomValue/Properties/AssemblyInfo.cs
+++ b/src/Configuration/src/RandomValue/Properties/AssemblyInfo.cs
@@ -3,6 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Runtime.CompilerServices;
+using Aspire;
+
+[assembly: LoggingCategories("Steeltoe", "Steeltoe.Configuration", "Steeltoe.Configuration.RandomValue")]
 
 [assembly: InternalsVisibleTo("Steeltoe.Bootstrap.AutoConfiguration.Test")]
 [assembly: InternalsVisibleTo("Steeltoe.Configuration.RandomValue.Test")]

--- a/src/Configuration/src/SpringBoot/ConfigurationSchema.json
+++ b/src/Configuration/src/SpringBoot/ConfigurationSchema.json
@@ -1,0 +1,17 @@
+{
+  "definitions": {
+    "logLevel": {
+      "properties": {
+        "Steeltoe": {
+          "$ref": "#/definitions/logLevelThreshold"
+        },
+        "Steeltoe.Configuration": {
+          "$ref": "#/definitions/logLevelThreshold"
+        },
+        "Steeltoe.Configuration.SpringBoot": {
+          "$ref": "#/definitions/logLevelThreshold"
+        }
+      }
+    }
+  }
+}

--- a/src/Configuration/src/SpringBoot/Properties/AssemblyInfo.cs
+++ b/src/Configuration/src/SpringBoot/Properties/AssemblyInfo.cs
@@ -3,6 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Runtime.CompilerServices;
+using Aspire;
+
+[assembly: LoggingCategories("Steeltoe", "Steeltoe.Configuration", "Steeltoe.Configuration.SpringBoot")]
 
 [assembly: InternalsVisibleTo("Steeltoe.Bootstrap.AutoConfiguration.Test")]
 [assembly: InternalsVisibleTo("Steeltoe.Configuration.SpringBoot.Test")]

--- a/src/Connectors/src/EntityFrameworkCore/ConfigurationSchema.json
+++ b/src/Connectors/src/EntityFrameworkCore/ConfigurationSchema.json
@@ -1,0 +1,17 @@
+{
+  "definitions": {
+    "logLevel": {
+      "properties": {
+        "Steeltoe": {
+          "$ref": "#/definitions/logLevelThreshold"
+        },
+        "Steeltoe.Connectors": {
+          "$ref": "#/definitions/logLevelThreshold"
+        },
+        "Steeltoe.Connectors.EntityFrameworkCore": {
+          "$ref": "#/definitions/logLevelThreshold"
+        }
+      }
+    }
+  }
+}

--- a/src/Connectors/src/EntityFrameworkCore/Properties/AssemblyInfo.cs
+++ b/src/Connectors/src/EntityFrameworkCore/Properties/AssemblyInfo.cs
@@ -3,5 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Runtime.CompilerServices;
+using Aspire;
+
+[assembly: LoggingCategories("Steeltoe", "Steeltoe.Connectors", "Steeltoe.Connectors.EntityFrameworkCore")]
 
 [assembly: InternalsVisibleTo("Steeltoe.Connectors.EntityFrameworkCore.Test")]

--- a/src/Discovery/src/HttpClients/ConfigurationSchema.json
+++ b/src/Discovery/src/HttpClients/ConfigurationSchema.json
@@ -1,0 +1,17 @@
+{
+  "definitions": {
+    "logLevel": {
+      "properties": {
+        "Steeltoe": {
+          "$ref": "#/definitions/logLevelThreshold"
+        },
+        "Steeltoe.Discovery": {
+          "$ref": "#/definitions/logLevelThreshold"
+        },
+        "Steeltoe.Discovery.HttpClients": {
+          "$ref": "#/definitions/logLevelThreshold"
+        }
+      }
+    }
+  }
+}

--- a/src/Discovery/src/HttpClients/Properties/AssemblyInfo.cs
+++ b/src/Discovery/src/HttpClients/Properties/AssemblyInfo.cs
@@ -3,5 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Runtime.CompilerServices;
+using Aspire;
+
+[assembly: LoggingCategories("Steeltoe", "Steeltoe.Discovery", "Steeltoe.Discovery.HttpClients")]
 
 [assembly: InternalsVisibleTo("Steeltoe.Discovery.HttpClients.Test")]

--- a/src/Logging/src/Abstractions/ConfigurationSchema.json
+++ b/src/Logging/src/Abstractions/ConfigurationSchema.json
@@ -1,0 +1,17 @@
+{
+  "definitions": {
+    "logLevel": {
+      "properties": {
+        "Steeltoe": {
+          "$ref": "#/definitions/logLevelThreshold"
+        },
+        "Steeltoe.Logging": {
+          "$ref": "#/definitions/logLevelThreshold"
+        },
+        "Steeltoe.Logging.Abstractions": {
+          "$ref": "#/definitions/logLevelThreshold"
+        }
+      }
+    }
+  }
+}

--- a/src/Logging/src/Abstractions/Properties/AssemblyInfo.cs
+++ b/src/Logging/src/Abstractions/Properties/AssemblyInfo.cs
@@ -3,5 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Runtime.CompilerServices;
+using Aspire;
+
+[assembly: LoggingCategories("Steeltoe", "Steeltoe.Logging", "Steeltoe.Logging.Abstractions")]
 
 [assembly: InternalsVisibleTo("Steeltoe.Logging.DynamicSerilog.Test")]

--- a/src/Management/src/Abstractions/ConfigurationSchema.json
+++ b/src/Management/src/Abstractions/ConfigurationSchema.json
@@ -1,0 +1,17 @@
+{
+  "definitions": {
+    "logLevel": {
+      "properties": {
+        "Steeltoe": {
+          "$ref": "#/definitions/logLevelThreshold"
+        },
+        "Steeltoe.Management": {
+          "$ref": "#/definitions/logLevelThreshold"
+        },
+        "Steeltoe.Management.Abstractions": {
+          "$ref": "#/definitions/logLevelThreshold"
+        }
+      }
+    }
+  }
+}

--- a/src/Management/src/Abstractions/Properties/AssemblyInfo.cs
+++ b/src/Management/src/Abstractions/Properties/AssemblyInfo.cs
@@ -3,6 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Runtime.CompilerServices;
+using Aspire;
+
+[assembly: LoggingCategories("Steeltoe", "Steeltoe.Management", "Steeltoe.Management.Abstractions")]
 
 [assembly: InternalsVisibleTo("Steeltoe.Management.Endpoint")]
 [assembly: InternalsVisibleTo("Steeltoe.Management.Endpoint.Test")]

--- a/src/Management/src/Tracing/ConfigurationSchema.json
+++ b/src/Management/src/Tracing/ConfigurationSchema.json
@@ -1,4 +1,19 @@
 {
+  "definitions": {
+    "logLevel": {
+      "properties": {
+        "Steeltoe": {
+          "$ref": "#/definitions/logLevelThreshold"
+        },
+        "Steeltoe.Management": {
+          "$ref": "#/definitions/logLevelThreshold"
+        },
+        "Steeltoe.Management.Tracing": {
+          "$ref": "#/definitions/logLevelThreshold"
+        }
+      }
+    }
+  },
   "type": "object",
   "properties": {
     "Spring": {

--- a/src/Management/src/Tracing/Properties/AssemblyInfo.cs
+++ b/src/Management/src/Tracing/Properties/AssemblyInfo.cs
@@ -7,5 +7,6 @@ using Aspire;
 using Steeltoe.Common.Configuration;
 
 [assembly: ConfigurationSchema("Spring:Application", typeof(SpringApplicationSettings))]
+[assembly: LoggingCategories("Steeltoe", "Steeltoe.Management", "Steeltoe.Management.Tracing")]
 
 [assembly: InternalsVisibleTo("Steeltoe.Management.Tracing.Test")]

--- a/src/Security/src/Authentication.JwtBearer/ConfigurationSchema.json
+++ b/src/Security/src/Authentication.JwtBearer/ConfigurationSchema.json
@@ -1,0 +1,20 @@
+{
+  "definitions": {
+    "logLevel": {
+      "properties": {
+        "Steeltoe": {
+          "$ref": "#/definitions/logLevelThreshold"
+        },
+        "Steeltoe.Security": {
+          "$ref": "#/definitions/logLevelThreshold"
+        },
+        "Steeltoe.Security.Authentication": {
+          "$ref": "#/definitions/logLevelThreshold"
+        },
+        "Steeltoe.Security.Authentication.JwtBearer": {
+          "$ref": "#/definitions/logLevelThreshold"
+        }
+      }
+    }
+  }
+}

--- a/src/Security/src/Authentication.JwtBearer/Properties/AssemblyInfo.cs
+++ b/src/Security/src/Authentication.JwtBearer/Properties/AssemblyInfo.cs
@@ -3,5 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Runtime.CompilerServices;
+using Aspire;
+
+[assembly: LoggingCategories("Steeltoe", "Steeltoe.Security", "Steeltoe.Security.Authentication", "Steeltoe.Security.Authentication.JwtBearer")]
 
 [assembly: InternalsVisibleTo("Steeltoe.Security.Authentication.JwtBearer.Test")]

--- a/src/Security/src/Authentication.OpenIdConnect/ConfigurationSchema.json
+++ b/src/Security/src/Authentication.OpenIdConnect/ConfigurationSchema.json
@@ -1,0 +1,20 @@
+{
+  "definitions": {
+    "logLevel": {
+      "properties": {
+        "Steeltoe": {
+          "$ref": "#/definitions/logLevelThreshold"
+        },
+        "Steeltoe.Security": {
+          "$ref": "#/definitions/logLevelThreshold"
+        },
+        "Steeltoe.Security.Authentication": {
+          "$ref": "#/definitions/logLevelThreshold"
+        },
+        "Steeltoe.Security.Authentication.OpenIdConnect": {
+          "$ref": "#/definitions/logLevelThreshold"
+        }
+      }
+    }
+  }
+}

--- a/src/Security/src/Authentication.OpenIdConnect/Properties/AssemblyInfo.cs
+++ b/src/Security/src/Authentication.OpenIdConnect/Properties/AssemblyInfo.cs
@@ -3,5 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Runtime.CompilerServices;
+using Aspire;
+
+[assembly: LoggingCategories("Steeltoe", "Steeltoe.Security", "Steeltoe.Security.Authentication", "Steeltoe.Security.Authentication.OpenIdConnect")]
 
 [assembly: InternalsVisibleTo("Steeltoe.Security.Authentication.OpenIdConnect.Test")]

--- a/src/Security/src/DataProtection.Redis/ConfigurationSchema.json
+++ b/src/Security/src/DataProtection.Redis/ConfigurationSchema.json
@@ -1,0 +1,20 @@
+{
+  "definitions": {
+    "logLevel": {
+      "properties": {
+        "Steeltoe": {
+          "$ref": "#/definitions/logLevelThreshold"
+        },
+        "Steeltoe.Security": {
+          "$ref": "#/definitions/logLevelThreshold"
+        },
+        "Steeltoe.Security.DataProtection": {
+          "$ref": "#/definitions/logLevelThreshold"
+        },
+        "Steeltoe.Security.DataProtection.Redis": {
+          "$ref": "#/definitions/logLevelThreshold"
+        }
+      }
+    }
+  }
+}

--- a/src/Security/src/DataProtection.Redis/Properties/AssemblyInfo.cs
+++ b/src/Security/src/DataProtection.Redis/Properties/AssemblyInfo.cs
@@ -3,5 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Runtime.CompilerServices;
+using Aspire;
+
+[assembly: LoggingCategories("Steeltoe", "Steeltoe.Security", "Steeltoe.Security.DataProtection", "Steeltoe.Security.DataProtection.Redis")]
 
 [assembly: InternalsVisibleTo("Steeltoe.Security.DataProtection.Redis.Test")]


### PR DESCRIPTION
## Description

Update `AssemblyInfo.cs` files to include logging categories for all Steeltoe assemblies.

## Quality checklist

- [x] Your code complies with our [Coding Style](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-code-style.md).
- [ ] You've updated unit and/or integration tests for your change, where applicable.
- [ ] You've updated documentation for your change, where applicable.
      If your change affects other repositories, such as [Documentation](https://github.com/SteeltoeOSS/Documentation), [Samples](https://github.com/SteeltoeOSS/Samples) and/or [MainSite](https://github.com/SteeltoeOSS/MainSite), add linked PRs here.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
- [ ] You've added required license files and/or file headers (explaining where the code came from with proper attribution), where code is copied from StackOverflow, a blog, or OSS.
