### PR TITLE
Add IDiscoveryClient.InstancesFetched event

### DIFF
--- a/src/Common/src/Common/Discovery/DiscoveryInstancesFetchedEventArgs.cs
+++ b/src/Common/src/Common/Discovery/DiscoveryInstancesFetchedEventArgs.cs
@@ -1,0 +1,23 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+namespace Steeltoe.Common.Discovery;
+
+/// <summary>
+/// Provides data for the <see cref="IDiscoveryClient.InstancesFetched" /> event.
+/// </summary>
+public sealed class DiscoveryInstancesFetchedEventArgs : EventArgs
+{
+    /// <summary>
+    /// Gets the updated list of service instances, grouped by service ID.
+    /// </summary>
+    public IReadOnlyDictionary<string, IReadOnlyList<IServiceInstance>> InstancesByServiceId { get; }
+
+    public DiscoveryInstancesFetchedEventArgs(IReadOnlyDictionary<string, IReadOnlyList<IServiceInstance>> instancesByServiceId)
+    {
+        ArgumentNullException.ThrowIfNull(instancesByServiceId);
+
+        InstancesByServiceId = instancesByServiceId;
+    }
+}

--- a/src/Common/src/Common/Discovery/IDiscoveryClient.cs
+++ b/src/Common/src/Common/Discovery/IDiscoveryClient.cs
@@ -15,6 +15,11 @@ public interface IDiscoveryClient
     string Description { get; }
 
     /// <summary>
+    /// Occurs when service instances have been fetched from the discovery server.
+    /// </summary>
+    public event EventHandler<DiscoveryInstancesFetchedEventArgs> InstancesFetched;
+
+    /// <summary>
     /// Gets information used to register the local service instance (this app) to the discovery server.
     /// </summary>
     /// <returns>

--- a/src/Common/src/Common/PublicAPI.Unshipped.txt
+++ b/src/Common/src/Common/PublicAPI.Unshipped.txt
@@ -1,1 +1,5 @@
 #nullable enable
+Steeltoe.Common.Discovery.DiscoveryInstancesFetchedEventArgs
+Steeltoe.Common.Discovery.DiscoveryInstancesFetchedEventArgs.DiscoveryInstancesFetchedEventArgs(System.Collections.Generic.IReadOnlyDictionary<string!, System.Collections.Generic.IReadOnlyList<Steeltoe.Common.Discovery.IServiceInstance!>!>! instancesByServiceId) -> void
+Steeltoe.Common.Discovery.DiscoveryInstancesFetchedEventArgs.InstancesByServiceId.get -> System.Collections.Generic.IReadOnlyDictionary<string!, System.Collections.Generic.IReadOnlyList<Steeltoe.Common.Discovery.IServiceInstance!>!>!
+Steeltoe.Common.Discovery.IDiscoveryClient.InstancesFetched -> System.EventHandler<Steeltoe.Common.Discovery.DiscoveryInstancesFetchedEventArgs!>!

--- a/src/Configuration/test/ConfigServer.Discovery.Test/ConfigServerDiscoveryServiceTest.cs
+++ b/src/Configuration/test/ConfigServer.Discovery.Test/ConfigServerDiscoveryServiceTest.cs
@@ -114,6 +114,10 @@ public sealed class ConfigServerDiscoveryServiceTest
     {
         public string Description => throw new NotImplementedException();
 
+#pragma warning disable CS0067 // The event is never used
+        public event EventHandler<DiscoveryInstancesFetchedEventArgs>? InstancesFetched;
+#pragma warning restore CS0067 // The event is never used
+
         public Task<ISet<string>> GetServiceIdsAsync(CancellationToken cancellationToken)
         {
             throw new NotImplementedException();

--- a/src/Discovery/src/Configuration/ConfigurationDiscoveryClient.cs
+++ b/src/Discovery/src/Configuration/ConfigurationDiscoveryClient.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.ObjectModel;
 using Microsoft.Extensions.Options;
 using Steeltoe.Common.Discovery;
 
@@ -10,17 +11,69 @@ namespace Steeltoe.Discovery.Configuration;
 /// <summary>
 /// A discovery client that reads service instances from app configuration.
 /// </summary>
-public sealed class ConfigurationDiscoveryClient : IDiscoveryClient
+public sealed class ConfigurationDiscoveryClient : IDiscoveryClient, IDisposable
 {
     private readonly IOptionsMonitor<ConfigurationDiscoveryOptions> _optionsMonitor;
+    private readonly IDisposable? _changeTokenRegistration;
 
     public string Description => "A discovery client that returns service instances from app configuration.";
+
+    /// <summary>
+    /// Occurs when the configuration of service instances has been reloaded.
+    /// </summary>
+    public event EventHandler<DiscoveryInstancesFetchedEventArgs>? InstancesFetched;
 
     public ConfigurationDiscoveryClient(IOptionsMonitor<ConfigurationDiscoveryOptions> optionsMonitor)
     {
         ArgumentNullException.ThrowIfNull(optionsMonitor);
 
         _optionsMonitor = optionsMonitor;
+        _changeTokenRegistration = optionsMonitor.OnChange(OnOptionsChanged);
+    }
+
+    private void OnOptionsChanged(ConfigurationDiscoveryOptions options)
+    {
+        if (InstancesFetched != null)
+        {
+            ReadOnlyDictionary<string, IReadOnlyList<IServiceInstance>> instancesByServiceId = ToServiceInstanceMap(options.Services);
+            var eventArgs = new DiscoveryInstancesFetchedEventArgs(instancesByServiceId);
+            RaiseFetchEvent(eventArgs);
+        }
+    }
+
+    private static ReadOnlyDictionary<string, IReadOnlyList<IServiceInstance>> ToServiceInstanceMap(IList<ConfigurationServiceInstance> services)
+    {
+        // @formatter:wrap_chained_method_calls chop_always
+        // @formatter:wrap_before_first_method_call true
+
+        return services
+            .Where(service => service.ServiceId != null)
+            .GroupBy(service => service.ServiceId!, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(grouping => grouping.Key, grouping => (IReadOnlyList<IServiceInstance>)grouping
+                .Select(instance => (IServiceInstance)instance)
+                .ToList()
+                .AsReadOnly())
+            .AsReadOnly();
+
+        // @formatter:wrap_before_first_method_call restore
+        // @formatter:wrap_chained_method_calls restore
+    }
+
+    private void RaiseFetchEvent(DiscoveryInstancesFetchedEventArgs eventArgs)
+    {
+        // Execute on separate thread, so we won't block the configuration system in case the handler logic is expensive.
+        ThreadPool.QueueUserWorkItem(_ =>
+        {
+            try
+            {
+                InstancesFetched?.Invoke(this, eventArgs);
+            }
+            catch (Exception)
+            {
+                // Intentionally left empty. Adding a logger to the constructor is a breaking change.
+                // Adding an extra constructor confuses the service container.
+            }
+        });
     }
 
     /// <inheritdoc />
@@ -53,5 +106,11 @@ public sealed class ConfigurationDiscoveryClient : IDiscoveryClient
     public Task ShutdownAsync(CancellationToken cancellationToken)
     {
         return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        _changeTokenRegistration?.Dispose();
     }
 }

--- a/src/Discovery/src/Configuration/ConfigurationDiscoveryClient.cs
+++ b/src/Discovery/src/Configuration/ConfigurationDiscoveryClient.cs
@@ -50,9 +50,9 @@ public sealed class ConfigurationDiscoveryClient : IDiscoveryClient, IDisposable
             .Where(service => service.ServiceId != null)
             .GroupBy(service => service.ServiceId!, StringComparer.OrdinalIgnoreCase)
             .ToDictionary(grouping => grouping.Key, grouping => (IReadOnlyList<IServiceInstance>)grouping
-                .Select(instance => (IServiceInstance)instance)
+                .Cast<IServiceInstance>()
                 .ToList()
-                .AsReadOnly())
+                .AsReadOnly(), StringComparer.OrdinalIgnoreCase)
             .AsReadOnly();
 
         // @formatter:wrap_before_first_method_call restore

--- a/src/Discovery/src/Configuration/PublicAPI.Unshipped.txt
+++ b/src/Discovery/src/Configuration/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+Steeltoe.Discovery.Configuration.ConfigurationDiscoveryClient.Dispose() -> void
+Steeltoe.Discovery.Configuration.ConfigurationDiscoveryClient.InstancesFetched -> System.EventHandler<Steeltoe.Common.Discovery.DiscoveryInstancesFetchedEventArgs!>?

--- a/src/Discovery/src/Consul/Configuration/ConsulDiscoveryOptions.cs
+++ b/src/Discovery/src/Consul/Configuration/ConsulDiscoveryOptions.cs
@@ -176,8 +176,7 @@ public sealed class ConsulDiscoveryOptions
     /// <summary>
     /// Gets or sets a value indicating whether to register with the port number ASP.NET Core is listening on. Default value: true.
     /// <para />
-    /// This property is ignored when <see cref="Port" /> or <see cref="Scheme" /> is explicitly configured, or when <see cref="UseNetworkInterfaces" /> is
-    /// <c>true</c>.
+    /// This property is ignored when <see cref="Port" /> or <see cref="Scheme" /> is explicitly configured.
     /// </summary>
     public bool UseAspNetCoreUrls { get; set; } = true;
 }

--- a/src/Discovery/src/Consul/ConfigurationSchema.json
+++ b/src/Discovery/src/Consul/ConfigurationSchema.json
@@ -188,7 +188,7 @@
             },
             "UseAspNetCoreUrls": {
               "type": "boolean",
-              "description": "Gets or sets a value indicating whether to register with the port number ASP.NET Core is listening on. Default value: true.\n\nThis property is ignored when 'Steeltoe.Discovery.Consul.Configuration.ConsulDiscoveryOptions.Port' or 'Steeltoe.Discovery.Consul.Configuration.ConsulDiscoveryOptions.Scheme' is explicitly configured, or when 'Steeltoe.Discovery.Consul.Configuration.ConsulDiscoveryOptions.UseNetworkInterfaces' is true."
+              "description": "Gets or sets a value indicating whether to register with the port number ASP.NET Core is listening on. Default value: true.\n\nThis property is ignored when 'Steeltoe.Discovery.Consul.Configuration.ConsulDiscoveryOptions.Port' or 'Steeltoe.Discovery.Consul.Configuration.ConsulDiscoveryOptions.Scheme' is explicitly configured."
             },
             "UseNetworkInterfaces": {
               "type": "boolean",

--- a/src/Discovery/src/Consul/ConsulDiscoveryClient.cs
+++ b/src/Discovery/src/Consul/ConsulDiscoveryClient.cs
@@ -31,6 +31,13 @@ public sealed class ConsulDiscoveryClient : IDiscoveryClient
     public string Description => "A discovery client for HashiCorp Consul.";
 
     /// <summary>
+    /// This event is never raised. The Consul client doesn't implement caching.
+    /// </summary>
+#pragma warning disable CS0067 // The event is never used
+    public event EventHandler<DiscoveryInstancesFetchedEventArgs>? InstancesFetched;
+#pragma warning restore CS0067 // The event is never used
+
+    /// <summary>
     /// Initializes a new instance of the <see cref="ConsulDiscoveryClient" /> class.
     /// </summary>
     /// <param name="client">

--- a/src/Discovery/src/Consul/PostConfigureConsulDiscoveryOptions.cs
+++ b/src/Discovery/src/Consul/PostConfigureConsulDiscoveryOptions.cs
@@ -62,7 +62,7 @@ internal sealed class PostConfigureConsulDiscoveryOptions : IPostConfigureOption
             options.HostName = options.IPAddress;
         }
 
-        if (options is { UseAspNetCoreUrls: true, Port: 0, Scheme: null, UseNetworkInterfaces: false })
+        if (options is { UseAspNetCoreUrls: true, Port: 0, Scheme: null })
         {
             ICollection<string> addresses = _configuration.GetListenAddresses();
             SetSchemeWithPortFromListenAddresses(options, addresses);

--- a/src/Discovery/src/Consul/PublicAPI.Unshipped.txt
+++ b/src/Discovery/src/Consul/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 #nullable enable
+Steeltoe.Discovery.Consul.ConsulDiscoveryClient.InstancesFetched -> System.EventHandler<Steeltoe.Common.Discovery.DiscoveryInstancesFetchedEventArgs!>?

--- a/src/Discovery/src/Eureka/EurekaDiscoveryClient.cs
+++ b/src/Discovery/src/Eureka/EurekaDiscoveryClient.cs
@@ -382,7 +382,7 @@ public sealed partial class EurekaDiscoveryClient : IDiscoveryClient
             .ToDictionary(grouping => grouping.Key, grouping => (IReadOnlyList<IServiceInstance>)grouping
                 .Select(instance => instance.ToServiceInstance())
                 .ToList()
-                .AsReadOnly())
+                .AsReadOnly(), StringComparer.OrdinalIgnoreCase)
             .AsReadOnly();
 
         // @formatter:wrap_before_first_method_call restore

--- a/src/Discovery/src/Eureka/EurekaDiscoveryClient.cs
+++ b/src/Discovery/src/Eureka/EurekaDiscoveryClient.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.ObjectModel;
 using System.Text;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -68,6 +69,9 @@ public sealed partial class EurekaDiscoveryClient : IDiscoveryClient
     /// Occurs after applications have been fetched from Eureka.
     /// </summary>
     public event EventHandler<ApplicationsFetchedEventArgs>? ApplicationsFetched;
+
+    /// <inheritdoc />
+    public event EventHandler<DiscoveryInstancesFetchedEventArgs>? InstancesFetched;
 
     public EurekaDiscoveryClient(EurekaApplicationInfoManager appInfoManager, EurekaClient eurekaClient,
         IOptionsMonitor<EurekaClientOptions> clientOptionsMonitor, HealthCheckHandlerProvider healthCheckHandlerProvider, TimeProvider timeProvider,
@@ -326,7 +330,8 @@ public sealed partial class EurekaDiscoveryClient : IDiscoveryClient
 
         await _registryFetchAsyncLock.WaitAsync(cancellationToken);
 
-        ApplicationsFetchedEventArgs eventArgs;
+        ApplicationsFetchedEventArgs? applicationsEventArgs = null;
+        DiscoveryInstancesFetchedEventArgs? instancesEventArgs = null;
 
         try
         {
@@ -344,33 +349,75 @@ public sealed partial class EurekaDiscoveryClient : IDiscoveryClient
 
             UpdateLastRemoteInstanceStatusFromCache();
 
-            eventArgs = new ApplicationsFetchedEventArgs(_remoteApps);
+            if (ApplicationsFetched != null)
+            {
+                applicationsEventArgs = new ApplicationsFetchedEventArgs(_remoteApps);
+            }
+
+            if (InstancesFetched != null)
+            {
+                ReadOnlyDictionary<string, IReadOnlyList<IServiceInstance>> instancesByServiceId = ToServiceInstanceMap(_remoteApps);
+                instancesEventArgs = new DiscoveryInstancesFetchedEventArgs(instancesByServiceId);
+            }
         }
         finally
         {
             _registryFetchAsyncLock.Release();
         }
 
-        OnApplicationsFetched(eventArgs);
+        if (applicationsEventArgs != null || instancesEventArgs != null)
+        {
+            RaiseFetchEvents(applicationsEventArgs, instancesEventArgs);
+        }
     }
 
-    private void OnApplicationsFetched(ApplicationsFetchedEventArgs? args)
+    private static ReadOnlyDictionary<string, IReadOnlyList<IServiceInstance>> ToServiceInstanceMap(ApplicationInfoCollection apps)
     {
-        if (args != null)
+        // @formatter:wrap_chained_method_calls chop_always
+        // @formatter:wrap_before_first_method_call true
+
+        return apps
+            .SelectMany(app => app.Instances)
+            .GroupBy(instance => instance.AppName, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(grouping => grouping.Key, grouping => (IReadOnlyList<IServiceInstance>)grouping
+                .Select(instance => instance.ToServiceInstance())
+                .ToList()
+                .AsReadOnly())
+            .AsReadOnly();
+
+        // @formatter:wrap_before_first_method_call restore
+        // @formatter:wrap_chained_method_calls restore
+    }
+
+    private void RaiseFetchEvents(ApplicationsFetchedEventArgs? applicationsEventArgs, DiscoveryInstancesFetchedEventArgs? instancesEventArgs)
+    {
+        // Execute on separate thread, so we won't block the periodic refresh in case the handler logic is expensive.
+        ThreadPool.QueueUserWorkItem(_ =>
         {
-            // Execute on separate thread, so we won't block the periodic refresh in case the handler logic is expensive.
-            ThreadPool.QueueUserWorkItem(_ =>
+            try
             {
-                try
+                if (applicationsEventArgs != null)
                 {
-                    ApplicationsFetched?.Invoke(this, args);
+                    ApplicationsFetched?.Invoke(this, applicationsEventArgs);
                 }
-                catch (Exception exception)
+            }
+            catch (Exception exception)
+            {
+                LogFailedToHandleEvent(exception, nameof(ApplicationsFetched));
+            }
+
+            try
+            {
+                if (instancesEventArgs != null)
                 {
-                    LogFailedToHandleEvent(exception, nameof(ApplicationsFetched));
+                    InstancesFetched?.Invoke(this, instancesEventArgs);
                 }
-            });
-        }
+            }
+            catch (Exception exception)
+            {
+                LogFailedToHandleEvent(exception, nameof(InstancesFetched));
+            }
+        });
     }
 
     internal async Task<ApplicationInfoCollection> FetchFullRegistryAsync(CancellationToken cancellationToken)

--- a/src/Discovery/src/Eureka/PublicAPI.Unshipped.txt
+++ b/src/Discovery/src/Eureka/PublicAPI.Unshipped.txt
@@ -1,3 +1,4 @@
 #nullable enable
 Steeltoe.Discovery.Eureka.Configuration.EurekaInstanceOptions.UseAspNetCoreUrls.get -> bool
 Steeltoe.Discovery.Eureka.Configuration.EurekaInstanceOptions.UseAspNetCoreUrls.set -> void
+Steeltoe.Discovery.Eureka.EurekaDiscoveryClient.InstancesFetched -> System.EventHandler<Steeltoe.Common.Discovery.DiscoveryInstancesFetchedEventArgs!>?

--- a/src/Discovery/test/Configuration.Test/ConfigurationDiscoveryClientTest.cs
+++ b/src/Discovery/test/Configuration.Test/ConfigurationDiscoveryClientTest.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
+using FluentAssertions.Extensions;
+using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -187,5 +189,89 @@ public sealed class ConfigurationDiscoveryClientTest
         services.AddConfigurationDiscoveryClient();
 
         services.Count.Should().Be(beforeServiceCount);
+    }
+
+    [Fact]
+    public async Task InstancesFetched_event_is_raised_after_configuration_change()
+    {
+        var fileProvider = new MemoryFileProvider();
+
+        fileProvider.IncludeAppSettingsJsonFile("""
+            {
+              "Discovery": {
+                "Services": [
+                  {
+                    "ServiceId": "serviceA",
+                    "host": "instanceA1",
+                    "port": 443,
+                    "isSecure": true
+                  },
+                  {
+                    "ServiceId": "serviceA",
+                    "host": "instanceA2",
+                    "port": 443,
+                    "isSecure": true
+                  },
+                  {
+                    "ServiceId": "serviceB",
+                    "host": "instanceB1",
+                    "port": 443,
+                    "isSecure": true
+                  }
+                ]
+              }
+            }
+            """);
+
+        WebApplicationBuilder builder = TestWebApplicationBuilderFactory.Create();
+        builder.Configuration.AddInMemoryAppSettingsJsonFile(fileProvider);
+        builder.Services.AddConfigurationDiscoveryClient();
+        await using WebApplication webApplication = builder.Build();
+
+        ConfigurationDiscoveryClient discoveryClient = webApplication.Services.GetServices<IDiscoveryClient>().OfType<ConfigurationDiscoveryClient>().Single();
+        int eventCount = 0;
+        DiscoveryInstancesFetchedEventArgs? eventArgs = null;
+
+        discoveryClient.InstancesFetched += (_, args) =>
+        {
+            eventCount++;
+            eventArgs = args;
+        };
+
+        fileProvider.ReplaceAppSettingsJsonFile("""
+            {
+              "Discovery": {
+                "Services": [
+                  {
+                    "ServiceId": "serviceA",
+                    "host": "instanceA1",
+                    "port": 443,
+                    "isSecure": true
+                  },
+                  {
+                    "ServiceId": "serviceB",
+                    "host": "instanceB1",
+                    "port": 443,
+                    "isSecure": true
+                  },
+                  {
+                    "ServiceId": "serviceB",
+                    "host": "instanceB2",
+                    "port": 443,
+                    "isSecure": true
+                  }
+                ]
+              }
+            }
+            """);
+
+        fileProvider.NotifyChanged();
+
+        SpinWait.SpinUntil(() => eventCount == 1, 5.Seconds()).Should().BeTrue();
+
+        eventArgs.Should().NotBeNull();
+        eventArgs.InstancesByServiceId.Should().HaveCount(2);
+        eventArgs.InstancesByServiceId.Should().ContainKey("serviceA").WhoseValue.Should().HaveCount(1);
+        eventArgs.InstancesByServiceId.Should().ContainKey("serviceB").WhoseValue.Should().HaveCount(2);
     }
 }

--- a/src/Discovery/test/Configuration.Test/ConfigurationDiscoveryClientTest.cs
+++ b/src/Discovery/test/Configuration.Test/ConfigurationDiscoveryClientTest.cs
@@ -271,7 +271,7 @@ public sealed class ConfigurationDiscoveryClientTest
 
         eventArgs.Should().NotBeNull();
         eventArgs.InstancesByServiceId.Should().HaveCount(2);
-        eventArgs.InstancesByServiceId.Should().ContainKey("serviceA").WhoseValue.Should().HaveCount(1);
-        eventArgs.InstancesByServiceId.Should().ContainKey("serviceB").WhoseValue.Should().HaveCount(2);
+        eventArgs.InstancesByServiceId.Should().ContainKey("ServiceA").WhoseValue.Should().HaveCount(1);
+        eventArgs.InstancesByServiceId.Should().ContainKey("ServiceB").WhoseValue.Should().HaveCount(2);
     }
 }

--- a/src/Discovery/test/Eureka.Test/EurekaDiscoveryClientTest.cs
+++ b/src/Discovery/test/Eureka.Test/EurekaDiscoveryClientTest.cs
@@ -685,7 +685,7 @@ public sealed class EurekaDiscoveryClientTest
         newInstanceInfo.ActionType.Should().Be(ActionType.Modified);
 
         instancesEventArgs.Should().NotBeNull();
-        IServiceInstance newServiceInstance = instancesEventArgs.InstancesByServiceId.Should().ContainKey("FOO").WhoseValue.Should().ContainSingle().Which;
+        IServiceInstance newServiceInstance = instancesEventArgs.InstancesByServiceId.Should().ContainKey("foo").WhoseValue.Should().ContainSingle().Which;
         newServiceInstance.Uri.ToString().Should().Be("http://modified-host:8080/");
     }
 

--- a/src/Discovery/test/Eureka.Test/EurekaDiscoveryClientTest.cs
+++ b/src/Discovery/test/Eureka.Test/EurekaDiscoveryClientTest.cs
@@ -88,7 +88,7 @@ public sealed class EurekaDiscoveryClientTest
                 "instance": [
                   {
                     "instanceId": "localhost:foo",
-                    "hostName": "localhost",
+                    "hostName": "modified-host",
                     "app": "FOO",
                     "ipAddr": "192.168.56.1",
                     "status": "UP",
@@ -635,7 +635,7 @@ public sealed class EurekaDiscoveryClientTest
     }
 
     [Fact]
-    public async Task ApplicationEventsFireOnChangeDuringFetch()
+    public async Task ApplicationEventsFireAfterFetch()
     {
         var appSettings = new Dictionary<string, string?>
         {
@@ -655,17 +655,38 @@ public sealed class EurekaDiscoveryClientTest
         webApplication.Services.GetRequiredService<HttpClientHandlerFactory>().Using(handler);
 
         var discoveryClient = webApplication.Services.GetRequiredService<EurekaDiscoveryClient>();
-        int eventCount = 0;
+        int applicationsEventCount = 0;
+        ApplicationsFetchedEventArgs? applicationsEventArgs = null;
+        int instancesEventCount = 0;
+        DiscoveryInstancesFetchedEventArgs? instancesEventArgs = null;
 
-        discoveryClient.ApplicationsFetched += (_, _) => eventCount++;
+        discoveryClient.ApplicationsFetched += (_, args) =>
+        {
+            applicationsEventCount++;
+            applicationsEventArgs = args;
+        };
+
+        discoveryClient.InstancesFetched += (_, args) =>
+        {
+            instancesEventCount++;
+            instancesEventArgs = args;
+        };
 
         await discoveryClient.FetchRegistryAsync(true, TestContext.Current.CancellationToken);
-        SpinWait.SpinUntil(() => eventCount == 1, 5.Seconds()).Should().BeTrue();
+        SpinWait.SpinUntil(() => applicationsEventCount == 1 && instancesEventCount == 1, 5.Seconds()).Should().BeTrue();
 
         await discoveryClient.FetchRegistryAsync(false, TestContext.Current.CancellationToken);
-        SpinWait.SpinUntil(() => eventCount == 2, 5.Seconds()).Should().BeTrue();
+        SpinWait.SpinUntil(() => applicationsEventCount == 2 && instancesEventCount == 2, 5.Seconds()).Should().BeTrue();
 
         handler.Mock.VerifyNoOutstandingExpectation();
+
+        applicationsEventArgs.Should().NotBeNull();
+        InstanceInfo newInstanceInfo = applicationsEventArgs.Applications.Should().ContainSingle().Which.Instances.Should().ContainSingle().Which;
+        newInstanceInfo.ActionType.Should().Be(ActionType.Modified);
+
+        instancesEventArgs.Should().NotBeNull();
+        IServiceInstance newServiceInstance = instancesEventArgs.InstancesByServiceId.Should().ContainKey("FOO").WhoseValue.Should().ContainSingle().Which;
+        newServiceInstance.Uri.ToString().Should().Be("http://modified-host:8080/");
     }
 
     private sealed class ExtraRequestHeadersDelegatingHandler : DelegatingHandler

--- a/src/Discovery/test/HttpClients.Test/LoadBalancers/RoundRobinLoadBalancerTest.cs
+++ b/src/Discovery/test/HttpClients.Test/LoadBalancers/RoundRobinLoadBalancerTest.cs
@@ -257,6 +257,10 @@ public sealed class RoundRobinLoadBalancerTest
 
         public string Description => throw new NotImplementedException();
 
+#pragma warning disable CS0067 // The event is never used
+        public event EventHandler<DiscoveryInstancesFetchedEventArgs>? InstancesFetched;
+#pragma warning restore CS0067 // The event is never used
+
         public Task<ISet<string>> GetServiceIdsAsync(CancellationToken cancellationToken)
         {
             throw new NotImplementedException();
@@ -288,6 +292,10 @@ public sealed class RoundRobinLoadBalancerTest
     private sealed class ThrowingDiscoveryClient : IDiscoveryClient
     {
         public string Description => throw new NotImplementedException();
+
+#pragma warning disable CS0067 // The event is never used
+        public event EventHandler<DiscoveryInstancesFetchedEventArgs>? InstancesFetched;
+#pragma warning restore CS0067 // The event is never used
 
         public IServiceInstance GetLocalServiceInstance()
         {


### PR DESCRIPTION
## Description

Adds `IDiscoveryClient.InstancesFetched` event that enables responding to changes in remote services and their instances.
Implemented for Eureka and configuration-based clients.

Reverts the change from #1666 that added taking `UseNetworkInterfaces` into account to determine Consul ports.

## Quality checklist

- [x] Your code complies with our [Coding Style](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-code-style.md).
- [x] You've updated unit and/or integration tests for your change, where applicable.
- [ ] You've updated documentation for your change, where applicable.
      If your change affects other repositories, such as [Documentation](https://github.com/SteeltoeOSS/Documentation), [Samples](https://github.com/SteeltoeOSS/Samples) and/or [MainSite](https://github.com/SteeltoeOSS/MainSite), add linked PRs here.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
- [ ] You've added required license files and/or file headers (explaining where the code came from with proper attribution), where code is copied from StackOverflow, a blog, or OSS.
