### PR TITLE
Follow-up changes for new `IDiscoveryClient.InstancesFetched` event

### DIFF
--- a/src/Discovery/src/Eureka/EurekaDiscoveryClient.cs
+++ b/src/Discovery/src/Eureka/EurekaDiscoveryClient.cs
@@ -373,20 +373,19 @@ public sealed partial class EurekaDiscoveryClient : IDiscoveryClient
 
     private static ReadOnlyDictionary<string, IReadOnlyList<IServiceInstance>> ToServiceInstanceMap(ApplicationInfoCollection apps)
     {
-        // @formatter:wrap_chained_method_calls chop_always
-        // @formatter:wrap_before_first_method_call true
+        var dictionary = new Dictionary<string, IReadOnlyList<IServiceInstance>>(StringComparer.OrdinalIgnoreCase);
 
-        return apps
-            .SelectMany(app => app.Instances)
-            .GroupBy(instance => instance.AppName, StringComparer.OrdinalIgnoreCase)
-            .ToDictionary(grouping => grouping.Key, grouping => (IReadOnlyList<IServiceInstance>)grouping
-                .Select(instance => instance.ToServiceInstance())
-                .ToList()
-                .AsReadOnly(), StringComparer.OrdinalIgnoreCase)
-            .AsReadOnly();
+        foreach (string vipAddress in apps.VipInstanceMap.Keys.ToArray())
+        {
+            ReadOnlyCollection<InstanceInfo> instancesByVipAddress = apps.GetInstancesByVipAddress(vipAddress);
 
-        // @formatter:wrap_before_first_method_call restore
-        // @formatter:wrap_chained_method_calls restore
+            if (instancesByVipAddress.Count > 0)
+            {
+                dictionary[vipAddress] = instancesByVipAddress.Select(instance => instance.ToServiceInstance()).ToList().AsReadOnly();
+            }
+        }
+
+        return new ReadOnlyDictionary<string, IReadOnlyList<IServiceInstance>>(dictionary);
     }
 
     private void RaiseFetchEvents(ApplicationsFetchedEventArgs? applicationsEventArgs, DiscoveryInstancesFetchedEventArgs? instancesEventArgs)

--- a/src/Discovery/src/HttpClients/LoadBalancers/ServiceInstancesResolver.cs
+++ b/src/Discovery/src/HttpClients/LoadBalancers/ServiceInstancesResolver.cs
@@ -83,6 +83,7 @@ public sealed partial class ServiceInstancesResolver
 
             if (instancesFromCache != null)
             {
+                instancesFromCache = RemoveDuplicatesByUri(instancesFromCache);
                 LogReturningInstancesFromCache(instancesFromCache.Count);
                 return instancesFromCache;
             }
@@ -103,6 +104,8 @@ public sealed partial class ServiceInstancesResolver
             }
         }
 
+        instances = RemoveDuplicatesByUri(instances);
+
         if (_distributedCache != null)
         {
             byte[] cacheValue = ToCacheValue(instances);
@@ -110,6 +113,22 @@ public sealed partial class ServiceInstancesResolver
         }
 
         return instances;
+    }
+
+    private static List<IServiceInstance> RemoveDuplicatesByUri(List<IServiceInstance> instances)
+    {
+        var seenUris = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var result = new List<IServiceInstance>();
+
+        foreach (IServiceInstance instance in instances)
+        {
+            if (seenUris.Add(instance.Uri.AbsoluteUri))
+            {
+                result.Add(instance);
+            }
+        }
+
+        return result;
     }
 
     private static List<IServiceInstance>? FromCacheValue(byte[]? cacheValue)

--- a/src/Discovery/test/Configuration.Test/ConfigurationDiscoveryClientTest.cs
+++ b/src/Discovery/test/Configuration.Test/ConfigurationDiscoveryClientTest.cs
@@ -229,13 +229,13 @@ public sealed class ConfigurationDiscoveryClientTest
         await using WebApplication webApplication = builder.Build();
 
         ConfigurationDiscoveryClient discoveryClient = webApplication.Services.GetServices<IDiscoveryClient>().OfType<ConfigurationDiscoveryClient>().Single();
-        int eventCount = 0;
         DiscoveryInstancesFetchedEventArgs? eventArgs = null;
+        int eventCount = 0;
 
         discoveryClient.InstancesFetched += (_, args) =>
         {
-            eventCount++;
             eventArgs = args;
+            Interlocked.Increment(ref eventCount);
         };
 
         fileProvider.ReplaceAppSettingsJsonFile("""

--- a/src/Discovery/test/Eureka.Test/EurekaDiscoveryClientTest.cs
+++ b/src/Discovery/test/Eureka.Test/EurekaDiscoveryClientTest.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
+using System.Globalization;
 using System.Net;
 using FluentAssertions.Extensions;
 using Microsoft.AspNetCore.Builder;
@@ -655,38 +656,127 @@ public sealed class EurekaDiscoveryClientTest
         webApplication.Services.GetRequiredService<HttpClientHandlerFactory>().Using(handler);
 
         var discoveryClient = webApplication.Services.GetRequiredService<EurekaDiscoveryClient>();
-        int applicationsEventCount = 0;
         ApplicationsFetchedEventArgs? applicationsEventArgs = null;
-        int instancesEventCount = 0;
+        int applicationsEventCount = 0;
         DiscoveryInstancesFetchedEventArgs? instancesEventArgs = null;
+        int instancesEventCount = 0;
 
         discoveryClient.ApplicationsFetched += (_, args) =>
         {
-            applicationsEventCount++;
             applicationsEventArgs = args;
+            Interlocked.Increment(ref applicationsEventCount);
         };
 
         discoveryClient.InstancesFetched += (_, args) =>
         {
-            instancesEventCount++;
             instancesEventArgs = args;
+            Interlocked.Increment(ref instancesEventCount);
         };
 
         await discoveryClient.FetchRegistryAsync(true, TestContext.Current.CancellationToken);
         SpinWait.SpinUntil(() => applicationsEventCount == 1 && instancesEventCount == 1, 5.Seconds()).Should().BeTrue();
 
+        applicationsEventArgs.Should().NotBeNull();
+        InstanceInfo oldInstanceFromAppEvent = applicationsEventArgs.Applications.Should().ContainSingle().Which.Instances.Should().ContainSingle().Which;
+        oldInstanceFromAppEvent.ActionType.Should().Be(ActionType.Added);
+
+        instancesEventArgs.Should().NotBeNull();
+        IServiceInstance oldInstanceFromEvent = instancesEventArgs.InstancesByServiceId.Should().ContainKey("foo").WhoseValue.Should().ContainSingle().Which;
+        oldInstanceFromEvent.Uri.ToString().Should().Be("http://localhost:8080/");
+
+        IList<IServiceInstance> oldInstancesFromGet = await discoveryClient.GetInstancesAsync("foo", TestContext.Current.CancellationToken);
+        oldInstancesFromGet.Should().ContainSingle().Which.Uri.Should().Be(oldInstanceFromEvent.Uri);
+
         await discoveryClient.FetchRegistryAsync(false, TestContext.Current.CancellationToken);
         SpinWait.SpinUntil(() => applicationsEventCount == 2 && instancesEventCount == 2, 5.Seconds()).Should().BeTrue();
 
+        InstanceInfo newInstanceFromAppEvent = applicationsEventArgs.Applications.Should().ContainSingle().Which.Instances.Should().ContainSingle().Which;
+        newInstanceFromAppEvent.ActionType.Should().Be(ActionType.Modified);
+
+        IServiceInstance newInstanceFromEvent = instancesEventArgs.InstancesByServiceId.Should().ContainKey("foo").WhoseValue.Should().ContainSingle().Which;
+        newInstanceFromEvent.Uri.ToString().Should().Be("http://modified-host:8080/");
+
+        IList<IServiceInstance> newInstancesFromGet = await discoveryClient.GetInstancesAsync("foo", TestContext.Current.CancellationToken);
+        newInstancesFromGet.Should().ContainSingle().Which.Uri.Should().Be(newInstanceFromEvent.Uri);
+
         handler.Mock.VerifyNoOutstandingExpectation();
+    }
 
-        applicationsEventArgs.Should().NotBeNull();
-        InstanceInfo newInstanceInfo = applicationsEventArgs.Applications.Should().ContainSingle().Which.Instances.Should().ContainSingle().Which;
-        newInstanceInfo.ActionType.Should().Be(ActionType.Modified);
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task InstancesFetched_returns_same_data_as_GetInstancesAsync(bool filterOnlyUpInstances)
+    {
+        const string registryJson = """
+            {
+              "applications": {
+                "application": [
+                  {
+                    "name": "ignored",
+                    "instance": [
+                      {
+                        "instanceId": "id1",
+                        "hostName": "h1",
+                        "app": "app1",
+                        "ipAddr": "10.0.0.1",
+                        "status": "UP",
+                        "dataCenterInfo": {
+                          "@class": "com.netflix.appinfo.InstanceInfo$DefaultDataCenterInfo",
+                          "name": "MyOwn"
+                        },
+                        "vipAddress": "vapp1"
+                      },
+                      {
+                        "instanceId": "id2",
+                        "hostName": "h2",
+                        "app": "app1",
+                        "ipAddr": "10.0.0.2",
+                        "status": "DOWN",
+                        "dataCenterInfo": {
+                          "@class": "com.netflix.appinfo.InstanceInfo$DefaultDataCenterInfo",
+                          "name": "MyOwn"
+                        },
+                        "vipAddress": "vapp1"
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+            """;
 
-        instancesEventArgs.Should().NotBeNull();
-        IServiceInstance newServiceInstance = instancesEventArgs.InstancesByServiceId.Should().ContainKey("foo").WhoseValue.Should().ContainSingle().Which;
-        newServiceInstance.Uri.ToString().Should().Be("http://modified-host:8080/");
+        var appSettings = new Dictionary<string, string?>
+        {
+            ["Eureka:Client:ShouldFetchRegistry"] = "false",
+            ["Eureka:Client:ShouldRegisterWithEureka"] = "false",
+            ["Eureka:Client:ShouldFilterOnlyUpInstances"] = filterOnlyUpInstances.ToString(CultureInfo.InvariantCulture)
+        };
+
+        WebApplicationBuilder builder = TestWebApplicationBuilderFactory.Create();
+        builder.Configuration.AddInMemoryCollection(appSettings);
+        builder.Services.AddEurekaDiscoveryClient();
+
+        var handler = new DelegateToMockHttpClientHandler();
+        handler.Mock.Expect(HttpMethod.Get, "http://localhost:8761/eureka/apps").Respond("application/json", registryJson);
+
+        await using WebApplication webApplication = builder.Build();
+        webApplication.Services.GetRequiredService<HttpClientHandlerFactory>().Using(handler);
+
+        var discoveryClient = webApplication.Services.GetRequiredService<EurekaDiscoveryClient>();
+        DiscoveryInstancesFetchedEventArgs? eventArgs = null;
+        discoveryClient.InstancesFetched += (_, args) => eventArgs = args;
+
+        await discoveryClient.FetchRegistryAsync(true, TestContext.Current.CancellationToken);
+        SpinWait.SpinUntil(() => eventArgs != null, 5.Seconds()).Should().BeTrue();
+
+        eventArgs.Should().NotBeNull();
+
+        IList<IServiceInstance> instancesFromGet = await discoveryClient.GetInstancesAsync("vapp1", TestContext.Current.CancellationToken);
+        IReadOnlyList<IServiceInstance> instancesFromEvent = eventArgs.InstancesByServiceId.Should().ContainKey("vapp1").WhoseValue;
+
+        instancesFromEvent.Should().BeEquivalentTo(instancesFromGet);
+
+        handler.Mock.VerifyNoOutstandingExpectation();
     }
 
     private sealed class ExtraRequestHeadersDelegatingHandler : DelegatingHandler

--- a/src/Discovery/test/HttpClients.Test/LoadBalancers/RoundRobinLoadBalancerTest.cs
+++ b/src/Discovery/test/HttpClients.Test/LoadBalancers/RoundRobinLoadBalancerTest.cs
@@ -113,6 +113,67 @@ public sealed class RoundRobinLoadBalancerTest
     }
 
     [Fact]
+    public async Task ResolveServiceInstanceAsync_RemovesDuplicates_CaseInsensitive()
+    {
+        var client = new TestDiscoveryClient([
+            new TestServiceInstance(new Uri("HTTPS://CASE-HOST:1234/")),
+            new TestServiceInstance(new Uri("https://case-host:1234/"))
+        ], "svc");
+
+        var resolver = new ServiceInstancesResolver([client], NullLogger<ServiceInstancesResolver>.Instance);
+        var loadBalancer = new RoundRobinLoadBalancer(resolver, null, null, NullLogger<RoundRobinLoadBalancer>.Instance);
+
+        Uri first = await loadBalancer.ResolveServiceInstanceAsync(new Uri("https://svc/api"), TestContext.Current.CancellationToken);
+        Uri second = await loadBalancer.ResolveServiceInstanceAsync(new Uri("https://svc/api"), TestContext.Current.CancellationToken);
+
+        first.Should().Be(second);
+    }
+
+    [Fact]
+    public async Task ResolveServiceInstanceAsync_RemovesDuplicates_CaseInsensitive_MultipleDiscoveryClients()
+    {
+        var targetUri = new Uri("https://merged:1/");
+        var clientA = new TestDiscoveryClient([new TestServiceInstance(targetUri)], "svc");
+        var clientB = new TestDiscoveryClient([new TestServiceInstance(targetUri)], "svc");
+
+        var resolver = new ServiceInstancesResolver([
+            clientA,
+            clientB
+        ], NullLogger<ServiceInstancesResolver>.Instance);
+
+        var loadBalancer = new RoundRobinLoadBalancer(resolver, null, null, NullLogger<RoundRobinLoadBalancer>.Instance);
+
+        Uri first = await loadBalancer.ResolveServiceInstanceAsync(new Uri("https://svc/api"), TestContext.Current.CancellationToken);
+        Uri second = await loadBalancer.ResolveServiceInstanceAsync(new Uri("https://svc/api"), TestContext.Current.CancellationToken);
+
+        first.Should().Be(second);
+    }
+
+    [Fact]
+    public async Task ResolveServiceInstanceAsync_RemovesDuplicates_Rotates()
+    {
+        var shared = new Uri("https://shared:100/");
+        var other = new Uri("https://other:100/");
+
+        var client = new TestDiscoveryClient([
+            new TestServiceInstance(shared),
+            new TestServiceInstance(shared),
+            new TestServiceInstance(other)
+        ], "svc");
+
+        var resolver = new ServiceInstancesResolver([client], NullLogger<ServiceInstancesResolver>.Instance);
+        var loadBalancer = new RoundRobinLoadBalancer(resolver, null, null, NullLogger<RoundRobinLoadBalancer>.Instance);
+
+        Uri first = await loadBalancer.ResolveServiceInstanceAsync(new Uri("https://svc/api"), TestContext.Current.CancellationToken);
+        Uri second = await loadBalancer.ResolveServiceInstanceAsync(new Uri("https://svc/api"), TestContext.Current.CancellationToken);
+        Uri third = await loadBalancer.ResolveServiceInstanceAsync(new Uri("https://svc/api"), TestContext.Current.CancellationToken);
+
+        first.Should().Be(new Uri(shared, "api"));
+        second.Should().Be(new Uri(other, "api"));
+        third.Should().Be(first);
+    }
+
+    [Fact]
     public async Task ResolveServiceInstanceAsync_SkipsOverThrowingDiscoveryClients()
     {
         ConfigurationDiscoveryOptions options = CreateTestServiceInstances();
@@ -134,15 +195,28 @@ public sealed class RoundRobinLoadBalancerTest
     [Fact]
     public async Task ResolveServiceInstanceAsync_CachesInstances()
     {
-        ConfigurationDiscoveryOptions options = CreateTestServiceInstances();
+        var options = new ConfigurationDiscoveryOptions
+        {
+            Services =
+            {
+                new ConfigurationServiceInstance
+                {
+                    ServiceId = "fruit-service",
+                    Host = "before-reload",
+                    Port = 8000,
+                    IsSecure = true
+                }
+            }
+        };
+
         TestOptionsMonitor<ConfigurationDiscoveryOptions> optionsMonitor = TestOptionsMonitor.Create(options);
         var client = new ConfigurationDiscoveryClient(optionsMonitor);
         IDistributedCache distributedCache = GetCache();
         var resolver = new ServiceInstancesResolver([client], distributedCache, null, NullLogger<ServiceInstancesResolver>.Instance);
         var loadBalancer = new RoundRobinLoadBalancer(resolver, null, null, NullLogger<RoundRobinLoadBalancer>.Instance);
 
-        Uri fruitUri = await loadBalancer.ResolveServiceInstanceAsync(new Uri("https://fruit-service/api"), TestContext.Current.CancellationToken);
-        fruitUri.Should().Be("https://fruit-ball:8000/api");
+        Uri first = await loadBalancer.ResolveServiceInstanceAsync(new Uri("https://fruit-service/api"), TestContext.Current.CancellationToken);
+        first.Should().Be("https://before-reload:8000/api");
 
         optionsMonitor.Change(new ConfigurationDiscoveryOptions
         {
@@ -151,15 +225,15 @@ public sealed class RoundRobinLoadBalancerTest
                 new ConfigurationServiceInstance
                 {
                     ServiceId = "fruit-service",
-                    Host = "CHANGED",
+                    Host = "after-reload",
                     Port = 8000,
                     IsSecure = true
                 }
             }
         });
 
-        fruitUri = await loadBalancer.ResolveServiceInstanceAsync(new Uri("https://fruit-service/api"), TestContext.Current.CancellationToken);
-        fruitUri.Should().Be("https://fruit-ball:8000/api");
+        Uri second = await loadBalancer.ResolveServiceInstanceAsync(new Uri("https://fruit-service/api"), TestContext.Current.CancellationToken);
+        second.Should().Be(first);
     }
 
     private static ConfigurationDiscoveryOptions CreateTestServiceInstances()
@@ -251,9 +325,10 @@ public sealed class RoundRobinLoadBalancerTest
         public IReadOnlyDictionary<string, string?> Metadata => throw new NotImplementedException();
     }
 
-    private sealed class TestDiscoveryClient(IServiceInstance? instance = null) : IDiscoveryClient
+    private sealed class TestDiscoveryClient(IList<IServiceInstance> instances, string? serviceId = null) : IDiscoveryClient
     {
-        private readonly IServiceInstance? _instance = instance;
+        private readonly IList<IServiceInstance> _instances = instances;
+        private readonly string? _serviceId = serviceId;
 
         public string Description => throw new NotImplementedException();
 
@@ -261,31 +336,34 @@ public sealed class RoundRobinLoadBalancerTest
         public event EventHandler<DiscoveryInstancesFetchedEventArgs>? InstancesFetched;
 #pragma warning restore CS0067 // The event is never used
 
+        public TestDiscoveryClient()
+            : this([])
+        {
+        }
+
+        public TestDiscoveryClient(IServiceInstance instance, string? serviceId = null)
+            : this([instance], serviceId)
+        {
+        }
+
         public Task<ISet<string>> GetServiceIdsAsync(CancellationToken cancellationToken)
         {
-            throw new NotImplementedException();
+            throw new NotSupportedException();
         }
 
         public Task<IList<IServiceInstance>> GetInstancesAsync(string serviceId, CancellationToken cancellationToken)
         {
-            IList<IServiceInstance> instances = [];
-
-            if (_instance != null)
-            {
-                instances.Add(_instance);
-            }
-
-            return Task.FromResult(instances);
+            return Task.FromResult(_serviceId == null || serviceId == _serviceId ? _instances : []);
         }
 
-        public IServiceInstance GetLocalServiceInstance()
+        public IServiceInstance? GetLocalServiceInstance()
         {
-            throw new NotImplementedException();
+            return null;
         }
 
         public Task ShutdownAsync(CancellationToken cancellationToken)
         {
-            throw new NotImplementedException();
+            return Task.CompletedTask;
         }
     }
 


### PR DESCRIPTION
## Description

- Adjusted data in `EurekaDiscoveryClient.InstancesFetched` event to match what's returned from `GetInstancesAsync` (follow-up for #1672)
  - Keyed by VIP addresses instead of app names
  - Take `options.ReturnUpInstancesOnly` into account
  - Don't return an empty collection when no instances are found
- Remove duplicate URLs (case-insensitive) in load balancers. This could happen when both client-side and platform-based load balancing are active.

I considered using the new event in load balancers to evict entries in the distributed cache (which is disabled by default). The load balancer's caching exists because Consul doesn't cache on its own. Another reason is to prevent all app instances to simultaniously query Eureka at startup (the cache in `EurekaDiscoveryClient` is not distributed). So subscribing to the event is useless for Consul, because it never raises it. For Eureka, it doesn't help with app startup. Aside from that, the load balancer in a single app instance can't draw conclusions about when to evict cache keys, as it may be unaware of other app instances that added cache keys for remote services not used by the first app.

## Quality checklist

- [x] Your code complies with our [Coding Style](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-code-style.md).
- [x] You've updated unit and/or integration tests for your change, where applicable.
- [ ] You've updated documentation for your change, where applicable.
      If your change affects other repositories, such as [Documentation](https://github.com/SteeltoeOSS/Documentation), [Samples](https://github.com/SteeltoeOSS/Samples) and/or [MainSite](https://github.com/SteeltoeOSS/MainSite), add linked PRs here.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
- [ ] You've added required license files and/or file headers (explaining where the code came from with proper attribution), where code is copied from StackOverflow, a blog, or OSS.
