### PR TITLE
Gracefully handle access token fetch failure in Eureka and Config Server

### DIFF
--- a/src/Configuration/src/ConfigServer/ConfigServerConfigurationProvider.cs
+++ b/src/Configuration/src/ConfigServer/ConfigServerConfigurationProvider.cs
@@ -593,7 +593,7 @@ internal sealed partial class ConfigServerConfigurationProvider : ConfigurationP
     /// <returns>
     /// The HttpRequestMessage built from the path.
     /// </returns>
-    internal async Task<HttpRequestMessage> GetRequestMessageAsync(ConfigServerClientOptions optionsSnapshot, Uri requestUri,
+    internal async Task<HttpRequestMessage> GetConfigServerRequestMessageAsync(ConfigServerClientOptions optionsSnapshot, Uri requestUri,
         CancellationToken cancellationToken)
     {
         var uriWithoutUserInfo = new Uri(requestUri.GetComponents(UriComponents.HttpRequestUrl, UriFormat.UriEscaped));
@@ -641,18 +641,34 @@ internal sealed partial class ConfigServerConfigurationProvider : ConfigurationP
 
         foreach (Uri requestUri in requestUris)
         {
-            // Make Config Server URI from settings
-            Uri uri = BuildConfigServerUri(optionsSnapshot, requestUri, label);
-
-            LogTryingToConnect(uri.ToMaskedString());
-
-            // Get the request message
-            LogBuildingHttpRequest();
-            HttpRequestMessage request = await GetRequestMessageAsync(optionsSnapshot, uri, cancellationToken);
-
-            // Invoke Config Server
             try
             {
+                // Make Config Server URI from settings
+                Uri uri = BuildConfigServerUri(optionsSnapshot, requestUri, label);
+
+                LogTryingToConnect(uri.ToMaskedString());
+                HttpRequestMessage request;
+
+                try
+                {
+                    // Get the request message (potentially fetches access token)
+                    LogBuildingHttpRequest();
+                    request = await GetConfigServerRequestMessageAsync(optionsSnapshot, uri, cancellationToken);
+                }
+                catch (Exception exception) when (!exception.IsCancellation())
+                {
+                    if (!string.IsNullOrEmpty(optionsSnapshot.AccessTokenUri))
+                    {
+                        var accessTokenUri = new Uri(optionsSnapshot.AccessTokenUri);
+                        LogFailedToFetchAccessToken(exception, accessTokenUri.ToMaskedString());
+
+                        continue;
+                    }
+
+                    throw;
+                }
+
+                // Invoke Config Server
                 LogSendingHttpRequest();
                 using HttpResponseMessage response = await httpClient.SendAsync(request, cancellationToken);
 
@@ -808,7 +824,7 @@ internal sealed partial class ConfigServerConfigurationProvider : ConfigurationP
         {
             using HttpClient httpClient = CreateHttpClient(optionsSnapshot);
 
-            Uri uri = GetVaultRenewUri(optionsSnapshot);
+            Uri uri = BuildVaultRenewUri(optionsSnapshot);
             HttpRequestMessage message = await GetVaultRenewRequestMessageAsync(optionsSnapshot, uri, cancellationToken);
 
             LogRenewingVaultToken(obscuredToken, optionsSnapshot.TokenTtl, uri.ToMaskedString());
@@ -825,7 +841,7 @@ internal sealed partial class ConfigServerConfigurationProvider : ConfigurationP
         }
     }
 
-    private static Uri GetVaultRenewUri(ConfigServerClientOptions optionsSnapshot)
+    private static Uri BuildVaultRenewUri(ConfigServerClientOptions optionsSnapshot)
     {
         string baseUri = optionsSnapshot.Uri!.Split(',')[0].Trim();
 
@@ -1021,6 +1037,9 @@ internal sealed partial class ConfigServerConfigurationProvider : ConfigurationP
 
     [LoggerMessage(Level = LogLevel.Debug, Message = "Fetched access token from {AccessTokenUri}.")]
     private partial void LogAccessTokenFetched(string accessTokenUri);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Failed to fetch access token from '{AccessTokenUri}'.")]
+    private partial void LogFailedToFetchAccessToken(Exception exception, string accessTokenUri);
 
     [LoggerMessage(Level = LogLevel.Trace, Message = "Entered {Method}.")]
     private partial void LogRemoteLoadEntered(string method);

--- a/src/Configuration/test/ConfigServer.Test/ConfigServerConfigurationProviderTest.Loading.cs
+++ b/src/Configuration/test/ConfigServer.Test/ConfigServerConfigurationProviderTest.Loading.cs
@@ -8,6 +8,7 @@ using System.Reflection;
 using System.Text;
 using FluentAssertions.Extensions;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using RichardSzalay.MockHttp;
 using Steeltoe.Common.TestResources;
@@ -446,6 +447,38 @@ public sealed partial class ConfigServerConfigurationProviderTest
 
         provider.TryGet("key1", out string? value).Should().BeTrue();
         value.Should().Be("value1");
+    }
+
+    [Fact]
+    public void Load_MultipleConfigServers_SocketErrorFromAccessTokenUri_LogsWarnings()
+    {
+        using var loggerProvider = new CapturingLoggerProvider((_, level) => level == LogLevel.Warning);
+        using var loggerFactory = new LoggerFactory([loggerProvider]);
+
+        using var handler = new DelegateToMockHttpClientHandler();
+
+        handler.Mock.When(HttpMethod.Get, "http://auth-server.com")
+            .Throw(new HttpRequestException("Connection refused", new SocketException((int)SocketError.ConnectionRefused)));
+
+        var options = new ConfigServerClientOptions
+        {
+            Name = "myName",
+            AccessTokenUri = "http://auth-server.com",
+            Uri = "http://config-server1:8888,http://config-server2:8888"
+        };
+
+        using var provider = new ConfigServerConfigurationProvider(options, null, null, () => handler, loggerFactory);
+        provider.Load();
+
+        IList<string> logMessages = loggerProvider.GetAll();
+
+        logMessages.Should().BeEquivalentTo([
+            $"WARN {typeof(ConfigServerConfigurationProvider)}: Failed to fetch access token from 'http://auth-server.com/'.",
+            $"WARN {typeof(ConfigServerConfigurationProvider)}: Failed to fetch access token from 'http://auth-server.com/'.",
+            $"WARN {typeof(ConfigServerConfigurationProvider)}: Failed fetching remote configuration from server(s)."
+        ], assertionOptions => assertionOptions.WithStrictOrdering());
+
+        provider.InnerData.Should().BeEmpty();
     }
 
     [Fact]

--- a/src/Configuration/test/ConfigServer.Test/ConfigServerConfigurationProviderTest.cs
+++ b/src/Configuration/test/ConfigServer.Test/ConfigServerConfigurationProviderTest.cs
@@ -152,7 +152,9 @@ public sealed partial class ConfigServerConfigurationProviderTest
         provider.Load();
 
         Uri requestUri = provider.BuildConfigServerUri(provider.ClientOptions, new Uri(options.Uri), null);
-        HttpRequestMessage request = await provider.GetRequestMessageAsync(provider.ClientOptions, requestUri, TestContext.Current.CancellationToken);
+
+        HttpRequestMessage request =
+            await provider.GetConfigServerRequestMessageAsync(provider.ClientOptions, requestUri, TestContext.Current.CancellationToken);
 
         request.Method.Should().Be(HttpMethod.Get);
         request.RequestUri.Should().Be(requestUri);
@@ -177,7 +179,9 @@ public sealed partial class ConfigServerConfigurationProviderTest
         provider.Load();
 
         Uri requestUri = provider.BuildConfigServerUri(provider.ClientOptions, new Uri(options.Uri), null);
-        HttpRequestMessage request = await provider.GetRequestMessageAsync(provider.ClientOptions, requestUri, TestContext.Current.CancellationToken);
+
+        HttpRequestMessage request =
+            await provider.GetConfigServerRequestMessageAsync(provider.ClientOptions, requestUri, TestContext.Current.CancellationToken);
 
         request.Method.Should().Be(HttpMethod.Get);
         request.RequestUri.Should().Be(requestUri);
@@ -202,7 +206,9 @@ public sealed partial class ConfigServerConfigurationProviderTest
         provider.Load();
 
         Uri requestUri = provider.BuildConfigServerUri(provider.ClientOptions, new Uri(options.Uri), null);
-        HttpRequestMessage request = await provider.GetRequestMessageAsync(provider.ClientOptions, requestUri, TestContext.Current.CancellationToken);
+
+        HttpRequestMessage request =
+            await provider.GetConfigServerRequestMessageAsync(provider.ClientOptions, requestUri, TestContext.Current.CancellationToken);
 
         request.Method.Should().Be(HttpMethod.Get);
         request.RequestUri.Should().Be(requestUri);
@@ -225,7 +231,9 @@ public sealed partial class ConfigServerConfigurationProviderTest
         provider.Load();
 
         Uri requestUri = provider.BuildConfigServerUri(provider.ClientOptions, new Uri(options.Uri!), null);
-        HttpRequestMessage request = await provider.GetRequestMessageAsync(provider.ClientOptions, requestUri, TestContext.Current.CancellationToken);
+
+        HttpRequestMessage request =
+            await provider.GetConfigServerRequestMessageAsync(provider.ClientOptions, requestUri, TestContext.Current.CancellationToken);
 
         request.Method.Should().Be(HttpMethod.Get);
         request.RequestUri.Should().Be(requestUri);
@@ -260,7 +268,9 @@ public sealed partial class ConfigServerConfigurationProviderTest
         using var provider = new ConfigServerConfigurationProvider(options, null, null, () => handler, NullLoggerFactory.Instance);
 
         Uri requestUri = provider.BuildConfigServerUri(provider.ClientOptions, new Uri(options.Uri), null);
-        HttpRequestMessage request = await provider.GetRequestMessageAsync(provider.ClientOptions, requestUri, TestContext.Current.CancellationToken);
+
+        HttpRequestMessage request =
+            await provider.GetConfigServerRequestMessageAsync(provider.ClientOptions, requestUri, TestContext.Current.CancellationToken);
 
         handler.Mock.VerifyNoOutstandingExpectation();
 

--- a/src/Discovery/src/Eureka/EurekaClient.cs
+++ b/src/Discovery/src/Eureka/EurekaClient.cs
@@ -236,7 +236,24 @@ public sealed partial class EurekaClient
             Uri requestUri = GetRequestUri(serviceUri, path, queryString);
 
             HttpContent? requestContent = requestBody != null ? new StringContent(requestBody, Encoding.UTF8, MediaType) : null;
-            HttpRequestMessage request = await GetRequestMessageAsync(method, requestUri, requestContent, cancellationToken);
+            HttpRequestMessage request;
+
+            try
+            {
+                request = await GetRequestMessageAsync(clientOptions, method, requestUri, requestContent, cancellationToken);
+            }
+            catch (Exception exception) when (!exception.IsCancellation())
+            {
+                if (!string.IsNullOrEmpty(clientOptions.AccessTokenUri))
+                {
+                    var accessTokenUri = new Uri(clientOptions.AccessTokenUri);
+                    LogFailedToFetchAccessToken(exception, accessTokenUri.ToMaskedString(), attempt);
+
+                    continue;
+                }
+
+                throw;
+            }
 
             if (!string.IsNullOrEmpty(requestBody))
             {
@@ -306,7 +323,8 @@ public sealed partial class EurekaClient
         return requestUri;
     }
 
-    private async Task<HttpRequestMessage> GetRequestMessageAsync(HttpMethod method, Uri requestUri, HttpContent? content, CancellationToken cancellationToken)
+    private async Task<HttpRequestMessage> GetRequestMessageAsync(EurekaClientOptions optionsSnapshot, HttpMethod method, Uri requestUri, HttpContent? content,
+        CancellationToken cancellationToken)
     {
         var uriWithoutUserInfo = new Uri(requestUri.GetComponents(UriComponents.HttpRequestUrl, UriFormat.UriEscaped));
         var requestMessage = new HttpRequestMessage(method, uriWithoutUserInfo);
@@ -320,15 +338,13 @@ public sealed partial class EurekaClient
         }
         else
         {
-            EurekaClientOptions clientOptions = _optionsMonitor.CurrentValue;
-
-            if (!string.IsNullOrEmpty(clientOptions.AccessTokenUri))
+            if (!string.IsNullOrEmpty(optionsSnapshot.AccessTokenUri))
             {
                 using HttpClient httpClient = CreateHttpClient("AccessTokenForEureka", GetAccessTokenTimeout);
-                var accessTokenUri = new Uri(clientOptions.AccessTokenUri);
+                var accessTokenUri = new Uri(optionsSnapshot.AccessTokenUri);
 
-                string accessToken = await httpClient.GetAccessTokenAsync(accessTokenUri, clientOptions.ClientId,
-                    clientOptions.ClientSecret, cancellationToken);
+                string accessToken =
+                    await httpClient.GetAccessTokenAsync(accessTokenUri, optionsSnapshot.ClientId, optionsSnapshot.ClientSecret, cancellationToken);
 
                 LogAccessTokenFetched(accessTokenUri.ToMaskedString());
                 requestMessage.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
@@ -371,4 +387,7 @@ public sealed partial class EurekaClient
 
     [LoggerMessage(Level = LogLevel.Debug, Message = "Fetched access token from '{AccessTokenUri}'.")]
     private partial void LogAccessTokenFetched(string accessTokenUri);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Failed to fetch access token from '{AccessTokenUri}' in attempt {Attempt}.")]
+    private partial void LogFailedToFetchAccessToken(Exception exception, string accessTokenUri, int attempt);
 }

--- a/src/Discovery/test/Eureka.Test/Transport/EurekaClientTest.cs
+++ b/src/Discovery/test/Eureka.Test/Transport/EurekaClientTest.cs
@@ -195,6 +195,42 @@ public sealed class EurekaClientTest
     }
 
     [Fact]
+    public async Task RegisterAsync_ThrowsOnUnreachableAccessTokenServer()
+    {
+        using var capturingLoggerProvider = new CapturingLoggerProvider(category => category.StartsWith("Steeltoe.", StringComparison.Ordinal));
+
+        var services = new ServiceCollection();
+        services.AddLogging(options => options.SetMinimumLevel(LogLevel.Trace).AddProvider(capturingLoggerProvider));
+        services.AddOptions<EurekaClientOptions>().Configure(options => options.AccessTokenUri = "http://host-that-does-not-exist.net:9999/");
+        services.AddSingleton<IHttpClientFactory>(new TestHttpClientFactory());
+        services.AddSingleton<EurekaServiceUriStateManager>();
+        services.AddSingleton<EurekaClient>();
+        services.AddSingleton(TimeProvider.System);
+
+        await using ServiceProvider serviceProvider = services.BuildServiceProvider(true);
+        var client = serviceProvider.GetRequiredService<EurekaClient>();
+
+        var instance = new InstanceInfo("some", "FOOBAR", "localhost", "127.0.0.1", new DataCenterInfo(), TimeProvider.System)
+        {
+            NonSecurePort = 8080,
+            IsNonSecurePortEnabled = true,
+            SecurePort = 9090,
+            IsSecurePortEnabled = false,
+            LastUpdatedTimeUtc = new DateTime(638_440_245_328_236_418, DateTimeKind.Utc),
+            LastDirtyTimeUtc = new DateTime(638_440_245_328_236_418, DateTimeKind.Utc)
+        };
+
+        Func<Task> asyncAction = async () => await client.RegisterAsync(instance, TestContext.Current.CancellationToken);
+
+        await asyncAction.Should().ThrowExactlyAsync<EurekaTransportException>().WithMessage("Failed to execute request on all known Eureka servers.");
+
+        IList<string> logMessages = capturingLoggerProvider.GetAll();
+
+        logMessages.Should().BeEquivalentTo(
+            $"WARN {typeof(EurekaClient)}: Failed to fetch access token from 'http://host-that-does-not-exist.net:9999/' in attempt 1.");
+    }
+
+    [Fact]
     public async Task RegisterAsync_ThrowsOnErrorResponse()
     {
         using var capturingLoggerProvider = new CapturingLoggerProvider(category => category.StartsWith("Steeltoe.", StringComparison.Ordinal));


### PR DESCRIPTION
## Description

In the Eureka and Config Server clients, fetching an access token was outside the try/catch block. As a result, the exception on failure wasn't handled, the problem didn't get logged properly, and retries didn't work as expected.

## Quality checklist

- [x] Your code complies with our [Coding Style](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-code-style.md).
- [x] You've updated unit and/or integration tests for your change, where applicable.
- [ ] You've updated documentation for your change, where applicable.
      If your change affects other repositories, such as [Documentation](https://github.com/SteeltoeOSS/Documentation), [Samples](https://github.com/SteeltoeOSS/Samples) and/or [MainSite](https://github.com/SteeltoeOSS/MainSite), add linked PRs here.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
- [ ] You've added required license files and/or file headers (explaining where the code came from with proper attribution), where code is copied from StackOverflow, a blog, or OSS.
