### PR TITLE
R#: Move inline suppressions for AccessToDisposedClosure in tests to .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -162,3 +162,7 @@ dotnet_diagnostic.JSON002.severity = silent
 
 # CA1848: Use the LoggerMessage delegates (depends on https://github.com/SteeltoeOSS/Steeltoe/issues/969)
 dotnet_diagnostic.CA1848.severity = silent
+
+[*Test.cs]
+resharper_access_to_disposed_closure_highlighting = none
+resharper_access_to_modified_closure_highlighting = none

--- a/src/Common/src/Common/Discovery/IDiscoveryClient.cs
+++ b/src/Common/src/Common/Discovery/IDiscoveryClient.cs
@@ -17,7 +17,7 @@ public interface IDiscoveryClient
     /// <summary>
     /// Occurs when service instances have been fetched from the discovery server.
     /// </summary>
-    public event EventHandler<DiscoveryInstancesFetchedEventArgs> InstancesFetched;
+    event EventHandler<DiscoveryInstancesFetchedEventArgs> InstancesFetched;
 
     /// <summary>
     /// Gets information used to register the local service instance (this app) to the discovery server.

--- a/src/Common/test/Hosting.Test/HostBuilderWrapperTest.cs
+++ b/src/Common/test/Hosting.Test/HostBuilderWrapperTest.cs
@@ -29,7 +29,6 @@ public sealed class HostBuilderWrapperTest
         HostBuilderWrapper wrapper = HostBuilderWrapper.Wrap(builder);
         wrapper.ConfigureServices(services => services.AddSingleton<InjectableType>());
         wrapper.ConfigureAppConfiguration(configurationBuilder => configurationBuilder.AddInMemoryCollection(appSettings));
-        // ReSharper disable once AccessToDisposedClosure
         wrapper.ConfigureLogging(loggingBuilder => loggingBuilder.AddProvider(capturingLoggerProvider));
         wrapper.ConfigureWebHost(hostBuilder => hostBuilder.UseUrls("http://*:8888"));
         wrapper.ConfigureServices((contextWrapper, _) => contextWrapper.HostEnvironment.ApplicationName = "TestApp");
@@ -65,7 +64,6 @@ public sealed class HostBuilderWrapperTest
         HostBuilderWrapper wrapper = HostBuilderWrapper.Wrap(builder);
         wrapper.ConfigureServices(services => services.AddSingleton<InjectableType>());
         wrapper.ConfigureAppConfiguration(configurationBuilder => configurationBuilder.AddInMemoryCollection(appSettings));
-        // ReSharper disable once AccessToDisposedClosure
         wrapper.ConfigureLogging(loggingBuilder => loggingBuilder.AddProvider(capturingLoggerProvider));
         wrapper.ConfigureServices((contextWrapper, _) => contextWrapper.HostEnvironment.ApplicationName = "TestApp");
 
@@ -100,7 +98,6 @@ public sealed class HostBuilderWrapperTest
         HostBuilderWrapper wrapper = HostBuilderWrapper.Wrap(builder);
         wrapper.ConfigureServices(services => services.AddSingleton<InjectableType>());
         wrapper.ConfigureAppConfiguration(configurationBuilder => configurationBuilder.AddInMemoryCollection(appSettings));
-        // ReSharper disable once AccessToDisposedClosure
         wrapper.ConfigureLogging(loggingBuilder => loggingBuilder.AddProvider(capturingLoggerProvider));
         wrapper.ConfigureWebHost(hostBuilder => hostBuilder.UseUrls("http://*:8888"));
         wrapper.ConfigureServices((contextWrapper, _) => contextWrapper.HostEnvironment.ApplicationName = "TestApp");
@@ -138,7 +135,6 @@ public sealed class HostBuilderWrapperTest
         HostBuilderWrapper wrapper = HostBuilderWrapper.Wrap(builder);
         wrapper.ConfigureServices(services => services.AddSingleton<InjectableType>());
         wrapper.ConfigureAppConfiguration(configurationBuilder => configurationBuilder.AddInMemoryCollection(appSettings));
-        // ReSharper disable once AccessToDisposedClosure
         wrapper.ConfigureLogging(loggingBuilder => loggingBuilder.AddProvider(capturingLoggerProvider));
         wrapper.ConfigureWebHost(hostBuilder => hostBuilder.UseUrls("http://*:8888"));
         wrapper.ConfigureServices((contextWrapper, _) => contextWrapper.HostEnvironment.ApplicationName = "TestApp");

--- a/src/Common/test/Logging.Test/BootstrapperLoggerFactoryTest.cs
+++ b/src/Common/test/Logging.Test/BootstrapperLoggerFactoryTest.cs
@@ -20,7 +20,6 @@ public sealed class BootstrapperLoggerFactoryTest
         var bootstrapLoggerFactory = BootstrapLoggerFactory.CreateEmpty(loggingBuilder =>
         {
             loggingBuilder.SetMinimumLevel(LogLevel.Trace);
-            // ReSharper disable once AccessToDisposedClosure
             loggingBuilder.AddProvider(capturingLoggerProvider);
         });
 

--- a/src/Configuration/test/CloudFoundry.Test/CloudfoundryConfigurationProviderTest.cs
+++ b/src/Configuration/test/CloudFoundry.Test/CloudfoundryConfigurationProviderTest.cs
@@ -216,7 +216,6 @@ public sealed class CloudFoundryConfigurationProviderTest
 
         _ = Task.Run(() =>
         {
-            // ReSharper disable once AccessToDisposedClosure
             while (!tokenSource.IsCancellationRequested)
             {
                 configurationRoot.Reload();

--- a/src/Configuration/test/ConfigServer.Discovery.Test/ConfigServerClientOptionsTest.cs
+++ b/src/Configuration/test/ConfigServer.Discovery.Test/ConfigServerClientOptionsTest.cs
@@ -90,7 +90,6 @@ public sealed class ConfigServerClientOptionsTest
 
         var configurationBuilder = new ConfigurationBuilder();
         configurationBuilder.AddInMemoryAppSettingsJsonFile(fileProvider);
-        // ReSharper disable once AccessToDisposedClosure
         configurationBuilder.AddConfigServer(new ConfigServerClientOptions(), configureOptions, () => handler, NullLoggerFactory.Instance);
         IConfigurationRoot configuration = configurationBuilder.Build();
 
@@ -306,7 +305,6 @@ public sealed class ConfigServerClientOptionsTest
 
         var configurationBuilder = new ConfigurationBuilder();
         configurationBuilder.AddInMemoryAppSettingsJsonFile(fileProvider);
-        // ReSharper disable once AccessToDisposedClosure
         configurationBuilder.AddConfigServer(new ConfigServerClientOptions(), configureOptions, () => handler, NullLoggerFactory.Instance);
         IConfigurationRoot configuration = configurationBuilder.Build();
 

--- a/src/Configuration/test/ConfigServer.Test/ConfigServerClientOptionsTest.cs
+++ b/src/Configuration/test/ConfigServer.Test/ConfigServerClientOptionsTest.cs
@@ -265,7 +265,6 @@ public sealed class ConfigServerClientOptionsTest
 
         var configurationBuilder = new ConfigurationBuilder();
         configurationBuilder.AddInMemoryAppSettingsJsonFile(fileProvider);
-        // ReSharper disable once AccessToDisposedClosure
         configurationBuilder.AddConfigServer(new ConfigServerClientOptions(), null, () => handler, NullLoggerFactory.Instance);
         IConfigurationRoot configuration = configurationBuilder.Build();
 
@@ -368,7 +367,6 @@ public sealed class ConfigServerClientOptionsTest
         var configurationBuilder = new ConfigurationBuilder();
         configurationBuilder.AddInMemoryAppSettingsJsonFile(fileProvider);
         configurationBuilder.AddPlaceholderResolver();
-        // ReSharper disable once AccessToDisposedClosure
         configurationBuilder.AddConfigServer(defaultOptions, configureOptions, () => handler, NullLoggerFactory.Instance);
         IConfigurationRoot configuration = configurationBuilder.Build();
 

--- a/src/Configuration/test/ConfigServer.Test/ConfigServerConfigurationProviderTest.Settings.cs
+++ b/src/Configuration/test/ConfigServer.Test/ConfigServerConfigurationProviderTest.Settings.cs
@@ -7,6 +7,8 @@ using FluentAssertions.Extensions;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
 
+// ReSharper disable AccessToDisposedClosure
+
 namespace Steeltoe.Configuration.ConfigServer.Test;
 
 public sealed partial class ConfigServerConfigurationProviderTest
@@ -65,9 +67,7 @@ public sealed partial class ConfigServerConfigurationProviderTest
 
         using var provider = new ConfigServerConfigurationProvider(options, null, null, null, NullLoggerFactory.Instance);
 
-        // ReSharper disable AccessToDisposedClosure
         Action action = () => provider.BuildConfigServerUri(provider.ClientOptions, null!, null);
-        // ReSharper restore AccessToDisposedClosure
 
         action.Should().ThrowExactly<ArgumentNullException>();
     }

--- a/src/Configuration/test/ConfigServer.Test/ConfigServerConfigurationProviderTest.cs
+++ b/src/Configuration/test/ConfigServer.Test/ConfigServerConfigurationProviderTest.cs
@@ -264,7 +264,6 @@ public sealed partial class ConfigServerConfigurationProviderTest
                 }
                 """);
 
-        // ReSharper disable once AccessToDisposedClosure
         using var provider = new ConfigServerConfigurationProvider(options, null, null, () => handler, NullLoggerFactory.Instance);
 
         Uri requestUri = provider.BuildConfigServerUri(provider.ClientOptions, new Uri(options.Uri), null);
@@ -294,7 +293,6 @@ public sealed partial class ConfigServerConfigurationProviderTest
         handler.Mock.Expect(HttpMethod.Post, "http://localhost:8888/vault/v1/auth/token/renew-self").WithHeaders("X-Vault-Token", "MyVaultToken")
             .WithContent("{\"increment\":300}").Respond(HttpStatusCode.NoContent);
 
-        // ReSharper disable once AccessToDisposedClosure
         using var provider = new ConfigServerConfigurationProvider(options, null, null, () => handler, NullLoggerFactory.Instance);
         provider.Load();
 
@@ -324,7 +322,6 @@ public sealed partial class ConfigServerConfigurationProviderTest
         handler.Mock.Expect(HttpMethod.Post, "http://localhost:8888/vault/v1/auth/token/renew-self").WithHeaders("X-Vault-Token", "MyVaultToken")
             .WithHeaders("Authorization", "Bearer secret").WithContent("{\"increment\":300}").Respond(HttpStatusCode.NoContent);
 
-        // ReSharper disable once AccessToDisposedClosure
         using var provider = new ConfigServerConfigurationProvider(options, null, null, () => handler, NullLoggerFactory.Instance);
 
         await provider.RefreshVaultTokenAsync(provider.ClientOptions, TestContext.Current.CancellationToken);

--- a/src/Connectors/test/Connectors.Test/CosmosDb/CosmosDbHealthContributorTest.cs
+++ b/src/Connectors/test/Connectors.Test/CosmosDb/CosmosDbHealthContributorTest.cs
@@ -116,9 +116,7 @@ public sealed class CosmosDbHealthContributorTest
         using var source = new CancellationTokenSource();
         await source.CancelAsync();
 
-        // ReSharper disable AccessToDisposedClosure
         Func<Task> action = async () => await healthContributor.CheckHealthAsync(source.Token);
-        // ReSharper restore AccessToDisposedClosure
 
         await action.Should().ThrowExactlyAsync<TaskCanceledException>();
     }

--- a/src/Connectors/test/Connectors.Test/MongoDb/MongoDbHealthContributorTest.cs
+++ b/src/Connectors/test/Connectors.Test/MongoDb/MongoDbHealthContributorTest.cs
@@ -86,7 +86,6 @@ public sealed class MongoDbHealthContributorTest
         using var source = new CancellationTokenSource();
         await source.CancelAsync();
 
-        // ReSharper disable once AccessToDisposedClosure
         Func<Task> action = async () => await healthContributor.CheckHealthAsync(source.Token);
 
         await action.Should().ThrowExactlyAsync<OperationCanceledException>();

--- a/src/Connectors/test/Connectors.Test/RabbitMQ/RabbitMQHealthContributorTest.cs
+++ b/src/Connectors/test/Connectors.Test/RabbitMQ/RabbitMQHealthContributorTest.cs
@@ -109,9 +109,7 @@ public sealed class RabbitMQHealthContributorTest
         using var source = new CancellationTokenSource();
         await source.CancelAsync();
 
-        // ReSharper disable AccessToDisposedClosure
         Func<Task> action = async () => await healthContributor.CheckHealthAsync(source.Token);
-        // ReSharper restore AccessToDisposedClosure
 
         await action.Should().ThrowExactlyAsync<OperationCanceledException>();
     }

--- a/src/Connectors/test/Connectors.Test/Redis/RedisHealthContributorTest.cs
+++ b/src/Connectors/test/Connectors.Test/Redis/RedisHealthContributorTest.cs
@@ -74,9 +74,7 @@ public sealed class RedisHealthContributorTest
         using var source = new CancellationTokenSource();
         await source.CancelAsync();
 
-        // ReSharper disable AccessToDisposedClosure
         Func<Task> action = async () => await healthContributor.CheckHealthAsync(source.Token);
-        // ReSharper restore AccessToDisposedClosure
 
         await action.Should().ThrowExactlyAsync<OperationCanceledException>();
     }

--- a/src/Connectors/test/Connectors.Test/RelationalDatabaseHealthContributorTest.cs
+++ b/src/Connectors/test/Connectors.Test/RelationalDatabaseHealthContributorTest.cs
@@ -175,9 +175,7 @@ public sealed class RelationalDatabaseHealthContributorTest
         using var source = new CancellationTokenSource();
         await source.CancelAsync();
 
-        // ReSharper disable AccessToDisposedClosure
         Func<Task> action = async () => await healthContributor.CheckHealthAsync(source.Token);
-        // ReSharper restore AccessToDisposedClosure
 
         await action.Should().ThrowExactlyAsync<OperationCanceledException>();
     }

--- a/src/Connectors/test/EntityFrameworkCore.Test/MySql/Pomelo/MySqlDbContextOptionsBuilderExtensionsTest.cs
+++ b/src/Connectors/test/EntityFrameworkCore.Test/MySql/Pomelo/MySqlDbContextOptionsBuilderExtensionsTest.cs
@@ -88,7 +88,6 @@ public sealed class MySqlDbContextOptionsBuilderExtensionsTest
         await using WebApplication app = builder.Build();
         await using AsyncServiceScope scope = app.Services.CreateAsyncScope();
 
-        // ReSharper disable once AccessToDisposedClosure
         Action action = () => _ = scope.ServiceProvider.GetRequiredService<GoodDbContext>();
 
         action.Should().ThrowExactly<InvalidOperationException>().WithMessage("Server version must be specified when no connection string is provided.");

--- a/src/Discovery/test/Consul.Test/Discovery/TtlSchedulerTest.cs
+++ b/src/Discovery/test/Consul.Test/Discovery/TtlSchedulerTest.cs
@@ -20,7 +20,6 @@ public sealed class TtlSchedulerTest
         var optionsMonitor = new TestOptionsMonitor<ConsulDiscoveryOptions>();
         await using var scheduler = new TtlScheduler(optionsMonitor, clientMoq.Object, NullLoggerFactory.Instance);
 
-        // ReSharper disable once AccessToDisposedClosure
         Action action = () => scheduler.Add(string.Empty);
 
         action.Should().ThrowExactly<ArgumentException>();
@@ -97,7 +96,6 @@ public sealed class TtlSchedulerTest
         var optionsMonitor = new TestOptionsMonitor<ConsulDiscoveryOptions>();
         await using var scheduler = new TtlScheduler(optionsMonitor, clientMoq.Object, NullLoggerFactory.Instance);
 
-        // ReSharper disable once AccessToDisposedClosure
         Func<Task> action = async () => await scheduler.RemoveAsync(string.Empty);
 
         await action.Should().ThrowExactlyAsync<ArgumentException>();

--- a/src/Discovery/test/Consul.Test/Registry/ConsulServiceRegistryTest.cs
+++ b/src/Discovery/test/Consul.Test/Registry/ConsulServiceRegistryTest.cs
@@ -87,7 +87,6 @@ public sealed class ConsulServiceRegistryTest
 
         await using var registry = new ConsulServiceRegistry(clientMoq.Object, optionsMonitor, scheduler, NullLogger<ConsulServiceRegistry>.Instance);
 
-        // ReSharper disable once AccessToDisposedClosure
         Func<Task> action = async () => await registry.SetStatusAsync(registration, string.Empty, TestContext.Current.CancellationToken);
 
         await action.Should().ThrowExactlyAsync<ArgumentException>();

--- a/src/Discovery/test/Eureka.Test/Transport/EurekaClientTest.cs
+++ b/src/Discovery/test/Eureka.Test/Transport/EurekaClientTest.cs
@@ -13,8 +13,6 @@ using Steeltoe.Discovery.Eureka.AppInfo;
 using Steeltoe.Discovery.Eureka.Configuration;
 using Steeltoe.Discovery.Eureka.Transport;
 
-// ReSharper disable AccessToDisposedClosure
-
 namespace Steeltoe.Discovery.Eureka.Test.Transport;
 
 public sealed class EurekaClientTest

--- a/src/Discovery/test/HttpClients.Test/DiscoveryHostApplicationBuilderExtensionsTest.cs
+++ b/src/Discovery/test/HttpClients.Test/DiscoveryHostApplicationBuilderExtensionsTest.cs
@@ -51,7 +51,6 @@ public sealed class DiscoveryHostApplicationBuilderExtensionsTest
 
         using IHost host = hostBuilder.Build();
 
-        // ReSharper disable once AccessToDisposedClosure
         Func<Task> action = async () => await host.StartAsync(TestContext.Current.CancellationToken);
 
         await action.Should().NotThrowAsync();

--- a/src/Discovery/test/HttpClients.Test/DiscoveryWebApplicationBuilderExtensionsTest.cs
+++ b/src/Discovery/test/HttpClients.Test/DiscoveryWebApplicationBuilderExtensionsTest.cs
@@ -73,7 +73,6 @@ public sealed class DiscoveryWebApplicationBuilderExtensionsTest
 
         await using WebApplication host = builder.Build();
 
-        // ReSharper disable once AccessToDisposedClosure
         Task<EurekaDiscoveryClient> resolveTask = Task.Run(() => _ = host.Services.GetServices<IDiscoveryClient>().OfType<EurekaDiscoveryClient>().Single());
 
         Func<Task> action = async () => await resolveTask.WaitAsync(5.Seconds(), TestContext.Current.CancellationToken);

--- a/src/Discovery/test/HttpClients.Test/LoadBalancers/DiscoveryHttpClientHandlerTest.cs
+++ b/src/Discovery/test/HttpClients.Test/LoadBalancers/DiscoveryHttpClientHandlerTest.cs
@@ -17,7 +17,6 @@ public sealed class DiscoveryHttpClientHandlerTest
         var handler = new DiscoveryHttpClientHandler(loadBalancer, TimeProvider.System);
         using var invoker = new HttpMessageInvoker(handler);
 
-        // ReSharper disable once AccessToDisposedClosure
         Func<Task> action = async () => _ = await invoker.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
 
         await action.Should().ThrowExactlyAsync<DataException>();
@@ -33,7 +32,6 @@ public sealed class DiscoveryHttpClientHandlerTest
         var handler = new DiscoveryHttpClientHandler(loadBalancer, TimeProvider.System);
         using var invoker = new HttpMessageInvoker(handler);
 
-        // ReSharper disable once AccessToDisposedClosure
         Func<Task> action = async () => _ = await invoker.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
 
         await action.Should().ThrowExactlyAsync<HttpRequestException>();

--- a/src/Discovery/test/HttpClients.Test/LoadBalancers/DiscoveryHttpDelegatingHandlerTest.cs
+++ b/src/Discovery/test/HttpClients.Test/LoadBalancers/DiscoveryHttpDelegatingHandlerTest.cs
@@ -55,7 +55,6 @@ public sealed class DiscoveryHttpDelegatingHandlerTest
 
         using var invoker = new HttpMessageInvoker(handler);
 
-        // ReSharper disable once AccessToDisposedClosure
         Func<Task> action = async () => await invoker.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
 
         await action.Should().ThrowExactlyAsync<OperationCanceledException>();
@@ -80,7 +79,6 @@ public sealed class DiscoveryHttpDelegatingHandlerTest
 
         using var invoker = new HttpMessageInvoker(handler);
 
-        // ReSharper disable once AccessToDisposedClosure
         Func<Task> action = async () => await invoker.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
 
         await action.Should().ThrowExactlyAsync<DataException>();

--- a/src/Management/test/Endpoint.Test/Actuators/All/AllActuatorsTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/All/AllActuatorsTest.cs
@@ -62,7 +62,6 @@ public sealed class AllActuatorsTest
 
         foreach (Type middlewareType in middlewareTypes)
         {
-            // ReSharper disable once AccessToDisposedClosure
             Action action = () => serviceProvider.GetRequiredService(middlewareType);
 
             action.Should().NotThrow();
@@ -72,10 +71,8 @@ public sealed class AllActuatorsTest
         {
             Action action = () =>
             {
-                // ReSharper disable AccessToDisposedClosure
                 _ = serviceProvider.GetRequiredService<CloudFoundryEndpointMiddleware>();
                 _ = serviceProvider.GetRequiredService<PermissionsProvider>();
-                // ReSharper restore AccessToDisposedClosure
             };
 
             action.Should().NotThrow();

--- a/src/Management/test/Endpoint.Test/Actuators/CloudFoundry/CloudFoundryActuatorTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/CloudFoundry/CloudFoundryActuatorTest.cs
@@ -43,11 +43,9 @@ public sealed class CloudFoundryActuatorTest
         services.AddCloudFoundryActuator();
         await using ServiceProvider serviceProvider = services.BuildServiceProvider(true);
 
-        // ReSharper disable once AccessToDisposedClosure
         Action middlewareAction = () => serviceProvider.GetRequiredService<CloudFoundryEndpointMiddleware>();
         middlewareAction.Should().NotThrow();
 
-        // ReSharper disable once AccessToDisposedClosure
         Action providerAction = () => serviceProvider.GetRequiredService<PermissionsProvider>();
         providerAction.Should().NotThrow();
     }

--- a/src/Management/test/Endpoint.Test/Actuators/CloudFoundry/CloudFoundrySecurityMiddlewareTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/CloudFoundry/CloudFoundrySecurityMiddlewareTest.cs
@@ -316,7 +316,6 @@ public sealed class CloudFoundrySecurityMiddlewareTest : IDisposable
         WebApplicationBuilder builder = TestWebApplicationBuilderFactory.Create();
         await using WebApplication app = builder.Build();
 
-        // ReSharper disable once AccessToDisposedClosure
         Action action = () => app.UseCloudFoundrySecurity();
 
         action.Should().ThrowExactly<InvalidOperationException>().WithMessage("Please call IServiceCollection.AddCloudFoundryActuator first.");
@@ -337,7 +336,6 @@ public sealed class CloudFoundrySecurityMiddlewareTest : IDisposable
         WebApplicationBuilder builder = TestWebApplicationBuilderFactory.Create();
         builder.Configuration.AddInMemoryCollection(appSettings);
         builder.Configuration.AddCloudFoundry();
-        // ReSharper disable once AccessToDisposedClosure
         builder.Services.AddLogging(options => options.SetMinimumLevel(LogLevel.Trace).AddProvider(capturingLoggerProvider));
         builder.Services.AddCloudFoundryActuator();
         await using WebApplication app = builder.Build();

--- a/src/Management/test/Endpoint.Test/Actuators/DbMigrations/DbMigrationsActuatorTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/DbMigrations/DbMigrationsActuatorTest.cs
@@ -30,7 +30,6 @@ public sealed class DbMigrationsActuatorTest
         services.AddDbMigrationsActuator();
         await using ServiceProvider serviceProvider = services.BuildServiceProvider(true);
 
-        // ReSharper disable once AccessToDisposedClosure
         Action action = () => serviceProvider.GetRequiredService<DbMigrationsEndpointMiddleware>();
 
         action.Should().NotThrow();

--- a/src/Management/test/Endpoint.Test/Actuators/Environment/EnvironmentActuatorTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/Environment/EnvironmentActuatorTest.cs
@@ -32,7 +32,6 @@ public sealed class EnvironmentActuatorTest
         services.AddEnvironmentActuator();
         await using ServiceProvider serviceProvider = services.BuildServiceProvider(true);
 
-        // ReSharper disable once AccessToDisposedClosure
         Action action = () => serviceProvider.GetRequiredService<EnvironmentEndpointMiddleware>();
 
         action.Should().NotThrow();

--- a/src/Management/test/Endpoint.Test/Actuators/Health/HealthActuatorTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/Health/HealthActuatorTest.cs
@@ -40,7 +40,6 @@ public sealed class HealthActuatorTest
         services.AddHealthActuator();
         await using ServiceProvider serviceProvider = services.BuildServiceProvider(true);
 
-        // ReSharper disable once AccessToDisposedClosure
         Action action = () => serviceProvider.GetRequiredService<HealthEndpointMiddleware>();
 
         action.Should().NotThrow();

--- a/src/Management/test/Endpoint.Test/Actuators/Health/HealthAggregationTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/Health/HealthAggregationTest.cs
@@ -450,9 +450,7 @@ public sealed class HealthAggregationTest
         using var source = new CancellationTokenSource();
         source.CancelAfter(1.Seconds());
 
-        // ReSharper disable AccessToDisposedClosure
         Func<Task> action = async () => await aggregator.AggregateAsync(contributors, [], emptyServiceProvider, source.Token);
-        // ReSharper restore AccessToDisposedClosure
 
         await action.Should().ThrowExactlyAsync<TaskCanceledException>();
     }
@@ -574,7 +572,6 @@ public sealed class HealthAggregationTest
         builder.Services.AddHealthActuator();
         await using WebApplication host = builder.Build();
 
-        // ReSharper disable once AccessToDisposedClosure
         Action action = () => host.Services.GetRequiredService<TestDbContext>();
         action.Should().ThrowExactly<InvalidOperationException>();
 

--- a/src/Management/test/Endpoint.Test/Actuators/HeapDump/HeapDumpActuatorTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/HeapDump/HeapDumpActuatorTest.cs
@@ -29,7 +29,6 @@ public sealed class HeapDumpActuatorTest
         services.AddHeapDumpActuator();
         await using ServiceProvider serviceProvider = services.BuildServiceProvider(true);
 
-        // ReSharper disable once AccessToDisposedClosure
         Action action = () => serviceProvider.GetRequiredService<HeapDumpEndpointMiddleware>();
 
         action.Should().NotThrow();

--- a/src/Management/test/Endpoint.Test/Actuators/HttpExchanges/HttpExchangesActuatorTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/HttpExchanges/HttpExchangesActuatorTest.cs
@@ -33,7 +33,6 @@ public sealed class HttpExchangesActuatorTest
         services.AddHttpExchangesActuator();
         await using ServiceProvider serviceProvider = services.BuildServiceProvider(true);
 
-        // ReSharper disable once AccessToDisposedClosure
         Action action = () => serviceProvider.GetRequiredService<HttpExchangesEndpointMiddleware>();
 
         action.Should().NotThrow();

--- a/src/Management/test/Endpoint.Test/Actuators/Hypermedia/HypermediaActuatorTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/Hypermedia/HypermediaActuatorTest.cs
@@ -30,7 +30,6 @@ public sealed class HypermediaActuatorTest
         services.AddHypermediaActuator();
         await using ServiceProvider serviceProvider = services.BuildServiceProvider(true);
 
-        // ReSharper disable once AccessToDisposedClosure
         Action action = () => serviceProvider.GetRequiredService<HypermediaEndpointMiddleware>();
 
         action.Should().NotThrow();

--- a/src/Management/test/Endpoint.Test/Actuators/Info/InfoActuatorTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/Info/InfoActuatorTest.cs
@@ -50,7 +50,6 @@ public sealed class InfoActuatorTest
         services.AddInfoActuator();
         await using ServiceProvider serviceProvider = services.BuildServiceProvider(true);
 
-        // ReSharper disable once AccessToDisposedClosure
         Action action = () => serviceProvider.GetRequiredService<InfoEndpointMiddleware>();
 
         action.Should().NotThrow();

--- a/src/Management/test/Endpoint.Test/Actuators/Loggers/LoggersActuatorTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/Loggers/LoggersActuatorTest.cs
@@ -33,7 +33,6 @@ public sealed class LoggersActuatorTest
         services.AddLoggersActuator();
         await using ServiceProvider serviceProvider = services.BuildServiceProvider(true);
 
-        // ReSharper disable once AccessToDisposedClosure
         Action action = () => serviceProvider.GetRequiredService<LoggersEndpointMiddleware>();
 
         action.Should().NotThrow();

--- a/src/Management/test/Endpoint.Test/Actuators/Refresh/HttpVerbInConventionalRoutingTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/Refresh/HttpVerbInConventionalRoutingTest.cs
@@ -255,7 +255,6 @@ public sealed class HttpVerbInConventionalRoutingTest
         builder.Services.AddMvc(options => options.EnableEndpointRouting = false);
         await using WebApplication host = builder.Build();
 
-        // ReSharper disable once AccessToDisposedClosure
         Action action = () => host.UseActuatorEndpoints(configureEndpointsCallback);
 
         action.Should().ThrowExactly<NotSupportedException>().WithMessage("Customizing endpoints is only supported when using endpoint routing.");

--- a/src/Management/test/Endpoint.Test/Actuators/Refresh/RefreshActuatorTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/Refresh/RefreshActuatorTest.cs
@@ -31,7 +31,6 @@ public sealed class RefreshActuatorTest
         services.AddRefreshActuator();
         await using ServiceProvider serviceProvider = services.BuildServiceProvider(true);
 
-        // ReSharper disable once AccessToDisposedClosure
         Action action = () => serviceProvider.GetRequiredService<RefreshEndpointMiddleware>();
 
         action.Should().NotThrow();

--- a/src/Management/test/Endpoint.Test/Actuators/RouteMappings/RouteMappingsActuatorTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/RouteMappings/RouteMappingsActuatorTest.cs
@@ -39,7 +39,6 @@ public sealed partial class RouteMappingsActuatorTest
         services.AddRouteMappingsActuator();
         await using ServiceProvider serviceProvider = services.BuildServiceProvider(true);
 
-        // ReSharper disable once AccessToDisposedClosure
         Action action = () => serviceProvider.GetRequiredService<RouteMappingsEndpointMiddleware>();
 
         action.Should().NotThrow();

--- a/src/Management/test/Endpoint.Test/Actuators/Services/ServicesActuatorTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/Services/ServicesActuatorTest.cs
@@ -35,7 +35,6 @@ public sealed class ServicesActuatorTest
         services.AddServicesActuator();
         await using ServiceProvider serviceProvider = services.BuildServiceProvider(true);
 
-        // ReSharper disable once AccessToDisposedClosure
         Action action = () => serviceProvider.GetRequiredService<ServicesEndpointMiddleware>();
 
         action.Should().NotThrow();

--- a/src/Management/test/Endpoint.Test/Actuators/ThreadDump/ThreadDumpActuatorTest.cs
+++ b/src/Management/test/Endpoint.Test/Actuators/ThreadDump/ThreadDumpActuatorTest.cs
@@ -27,7 +27,6 @@ public sealed class ThreadDumpActuatorTest
         services.AddThreadDumpActuator();
         await using ServiceProvider serviceProvider = services.BuildServiceProvider(true);
 
-        // ReSharper disable once AccessToDisposedClosure
         Action action = () => serviceProvider.GetRequiredService<ThreadDumpEndpointMiddleware>();
 
         action.Should().NotThrow();

--- a/src/Management/test/Endpoint.Test/SpringBootAdminClient/HostBuilderTest.cs
+++ b/src/Management/test/Endpoint.Test/SpringBootAdminClient/HostBuilderTest.cs
@@ -515,7 +515,6 @@ public sealed class HostBuilderTest
         bool isServerOnline = false;
         using var handler = new DelegateToMockHttpClientHandler();
 
-        // ReSharper disable once AccessToModifiedClosure
         MockedRequest registerMock = handler.Mock.When(HttpMethod.Post, "http://sba-server.com/instances").Respond(_ => isServerOnline
             ? new HttpResponseMessage(HttpStatusCode.OK)
             {

--- a/src/Management/test/Tasks.Test/TaskHostExtensionsTest.cs
+++ b/src/Management/test/Tasks.Test/TaskHostExtensionsTest.cs
@@ -199,7 +199,6 @@ public sealed class TaskHostExtensionsTest
         WebApplicationBuilder builder = TestWebApplicationBuilderFactory.Create(args);
 
         using var capturingLoggerProvider = new CapturingLoggerProvider(category => category.StartsWith("Steeltoe.", StringComparison.Ordinal));
-        // ReSharper disable once AccessToDisposedClosure
         builder.Services.AddLogging(options => options.AddProvider(capturingLoggerProvider));
 
         WebApplication app = builder.Build();

--- a/src/Steeltoe.All.sln.DotSettings
+++ b/src/Steeltoe.All.sln.DotSettings
@@ -600,7 +600,6 @@
 	<s:String x:Key="/Default/CodeStyle/CSharpVarKeywordUsage/ForSimpleTypes/@EntryValue">UseVarWhenEvident</s:String>
 	<s:Boolean x:Key="/Default/CodeStyle/CSharpVarKeywordUsage/UseRoslynLogicForEvidentTypes/@EntryValue">False</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeStyle/EditorConfig/EnableClangFormatSupport/@EntryValue">False</s:Boolean>
-	<s:Boolean x:Key="/Default/CodeStyle/EditorConfig/EnableEditorConfigSupport/@EntryValue">False</s:Boolean>
 	<s:String x:Key="/Default/CodeStyle/FileHeader/FileHeaderText/@EntryValue">Licensed to the .NET Foundation under one or more agreements.&#xD;
 The .NET Foundation licenses this file to you under the Apache 2.0 License.&#xD;
 See the LICENSE file in the project root for more information.&#xD;


### PR DESCRIPTION
## Description

Globally turn off all "Access to disposed closure" ReSharper warnings in `*Test.cs` via `.editorconfig`.

> [!NOTE]
> Because this is a PR, code cleanup only runs on changed files. A full code cleanup run is available at: https://github.com/SteeltoeOSS/Steeltoe/actions/runs/24809590721.

## Quality checklist

- [x] Your code complies with our [Coding Style](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-code-style.md).
- [x] You've updated unit and/or integration tests for your change, where applicable.
- [ ] You've updated documentation for your change, where applicable.
      If your change affects other repositories, such as [Documentation](https://github.com/SteeltoeOSS/Documentation), [Samples](https://github.com/SteeltoeOSS/Samples) and/or [MainSite](https://github.com/SteeltoeOSS/MainSite), add linked PRs here.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
- [ ] You've added required license files and/or file headers (explaining where the code came from with proper attribution), where code is copied from StackOverflow, a blog, or OSS.
