### PR TITLE
Tweak vulnerability checks (fix broken builds)

### DIFF
--- a/.github/workflows/Steeltoe.All.yml
+++ b/.github/workflows/Steeltoe.All.yml
@@ -84,7 +84,7 @@ jobs:
         persist-credentials: false
 
     - name: Restore packages
-      run: dotnet restore ${{ env.SOLUTION_FILE }} /p:Configuration=Release --verbosity minimal
+      run: dotnet restore ${{ env.SOLUTION_FILE }} /p:Configuration=Release /p:NuGetAudit=false --verbosity minimal
 
     - name: Build solution
       run: dotnet build ${{ env.SOLUTION_FILE }} --no-restore --configuration Release --verbosity minimal

--- a/.github/workflows/component-shared-workflow.yml
+++ b/.github/workflows/component-shared-workflow.yml
@@ -75,7 +75,7 @@ jobs:
         persist-credentials: false
 
     - name: Restore packages
-      run: dotnet restore ${{ env.SOLUTION_FILE }} /p:Configuration=Release --verbosity minimal
+      run: dotnet restore ${{ env.SOLUTION_FILE }} /p:Configuration=Release /p:NuGetAudit=false --verbosity minimal
 
     - name: Build solution
       run: dotnet build ${{ env.SOLUTION_FILE }} --no-restore --configuration Release --verbosity minimal

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -45,7 +45,7 @@ jobs:
         persist-credentials: false
 
     - name: Restore packages
-      run: dotnet restore ${{ env.SOLUTION_FILE }} /p:Configuration=Release --verbosity minimal
+      run: dotnet restore ${{ env.SOLUTION_FILE }} /p:Configuration=Release /p:NuGetAudit=false --verbosity minimal
 
     - name: Calculate package version (for release)
       if: ${{ github.event_name == 'release' }}

--- a/.github/workflows/scan-vulnerable-dependencies.yml
+++ b/.github/workflows/scan-vulnerable-dependencies.yml
@@ -41,4 +41,4 @@ jobs:
         persist-credentials: false
 
     - name: Report vulnerable dependencies
-      run: dotnet restore ${{ env.SOLUTION_FILE }} --verbosity minimal /p:NuGetAudit=true /p:NuGetAuditMode=all /p:NuGetAuditLevel=low /p:TreatWarningsAsErrors=True
+      run: dotnet restore ${{ env.SOLUTION_FILE }} /p:Configuration=Release /p:NuGetAudit=true /p:NuGetAuditMode=all /p:NuGetAuditLevel=low --verbosity minimal

--- a/.github/workflows/scan-vulnerable-dependencies.yml
+++ b/.github/workflows/scan-vulnerable-dependencies.yml
@@ -41,4 +41,19 @@ jobs:
         persist-credentials: false
 
     - name: Report vulnerable dependencies
-      run: dotnet restore ${{ env.SOLUTION_FILE }} /p:Configuration=Release /p:NuGetAudit=true /p:NuGetAuditMode=all /p:NuGetAuditLevel=low --verbosity minimal
+      shell: pwsh
+      run: |
+        $ErrorActionPreference = 'Stop'
+        $PSNativeCommandUseErrorActionPreference = $true
+
+        $output = dotnet list ${{ env.SOLUTION_FILE }} package --vulnerable --include-transitive --format json --output-version 1 2>&1
+        $text = ($output | Out-String).TrimEnd()
+        $json = $text | ConvertFrom-Json
+
+        foreach ($project in $json.projects) {
+          if ($project.frameworks) {
+            Write-Host 'Vulnerable package references were found.'
+            dotnet list ${{ env.SOLUTION_FILE }} package --vulnerable --include-transitive
+            exit 1
+          }
+        }

--- a/.github/workflows/sonarcube.yml
+++ b/.github/workflows/sonarcube.yml
@@ -67,7 +67,7 @@ jobs:
         fetch-depth: 0
 
     - name: Restore packages
-      run: dotnet restore ${{ env.SOLUTION_FILE }} /p:Configuration=Release --verbosity minimal
+      run: dotnet restore ${{ env.SOLUTION_FILE }} /p:Configuration=Release /p:NuGetAudit=false --verbosity minimal
 
     - name: Begin Sonar .NET scanner
       id: sonar_begin

--- a/.github/workflows/sonarcube.yml
+++ b/.github/workflows/sonarcube.yml
@@ -22,6 +22,7 @@ env:
   DOTNET_CLI_TELEMETRY_OPTOUT: 1
   DOTNET_NOLOGO: true
   SOLUTION_FILE: 'src/Steeltoe.All.slnx'
+  NUGET_VULNERABLE_PACKAGE_WARNINGS: '"NU1901;NU1902;NU1903;NU1904"'
   SONAR_TEST_ARGS: >-
     --no-build --configuration Release --collect "XPlat Code Coverage" --logger trx --results-directory ${{ github.workspace }}/TestOutput
     --settings coverlet.runsettings -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.UseSourceLink=false
@@ -66,9 +67,6 @@ jobs:
         # Sonar: Shallow clones should be disabled for a better relevancy of analysis.
         fetch-depth: 0
 
-    - name: Restore packages
-      run: dotnet restore ${{ env.SOLUTION_FILE }} /p:Configuration=Release /p:NuGetAudit=false --verbosity minimal
-
     - name: Begin Sonar .NET scanner
       id: sonar_begin
       env:
@@ -77,8 +75,11 @@ jobs:
         dotnet sonarscanner begin /k:"SteeltoeOSS_steeltoe" /o:"steeltoeoss" /d:sonar.token="${{ secrets.SONAR_TOKEN }}"
         /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.opencover.reportsPaths=**/coverage.opencover.xml
 
+    - name: Restore packages
+      run: dotnet restore ${{ env.SOLUTION_FILE }} --verbosity minimal /p:Configuration=Release /p:NuGetAuditLevel=low /p:WarningsNotAsErrors='${{ env.NUGET_VULNERABLE_PACKAGE_WARNINGS }}'
+
     - name: Build solution
-      run: dotnet build ${{ env.SOLUTION_FILE }} --no-restore --configuration Release --verbosity minimal
+      run: dotnet build ${{ env.SOLUTION_FILE }} --no-restore --configuration Release --verbosity minimal /p:NuGetAuditLevel=low /p:WarningsNotAsErrors='${{ env.NUGET_VULNERABLE_PACKAGE_WARNINGS }}'
 
     - name: Test
       run: dotnet test ${{ env.SOLUTION_FILE }} --filter "Category!=MemoryDumps" ${{ env.SONAR_TEST_ARGS }}


### PR DESCRIPTION
## Description

Turn off vulnerability checks in regular workflows; adapt the `scan-vulnerable-dependencies.yml` workflow to use `dotnet list package --vulnerable` and parse its JSON output. Force-downgrade `NU*` errors to warnings in the Sonar workflow, so that Sonar can see the warnings without breaking the build (which it unfortunately ignores).

> [!NOTE]
> The `Scan vulnerable dependencies` workflow is expected to fail in this PR. It shows that vulnerabilities are properly detected.

For reference, this is what the JSON output looks like with/without vulnerabilities:
[vulnerabilities-yes.json](https://github.com/user-attachments/files/27167682/vulnerabilities-yes.json)
[vulnerabilities-no.json](https://github.com/user-attachments/files/27167674/vulnerabilities-no.json)

## Quality checklist

- [x] Your code complies with our [Coding Style](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-code-style.md).
- [ ] You've updated unit and/or integration tests for your change, where applicable.
- [ ] You've updated documentation for your change, where applicable.
      If your change affects other repositories, such as [Documentation](https://github.com/SteeltoeOSS/Documentation), [Samples](https://github.com/SteeltoeOSS/Samples) and/or [MainSite](https://github.com/SteeltoeOSS/MainSite), add linked PRs here.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
- [ ] You've added required license files and/or file headers (explaining where the code came from with proper attribution), where code is copied from StackOverflow, a blog, or OSS.
