### PR TITLE
Hide transitive vulnerabilities in tests

### DIFF
--- a/.github/workflows/scan-vulnerable-dependencies.yml
+++ b/.github/workflows/scan-vulnerable-dependencies.yml
@@ -49,11 +49,36 @@ jobs:
         $output = dotnet list ${{ env.SOLUTION_FILE }} package --vulnerable --include-transitive --format json --output-version 1 2>&1
         $text = ($output | Out-String).TrimEnd()
         $json = $text | ConvertFrom-Json
+        $hasVulnerabilities = $false
 
         foreach ($project in $json.projects) {
-          if ($project.frameworks) {
-            Write-Host 'Vulnerable package references were found.'
-            dotnet list ${{ env.SOLUTION_FILE }} package --vulnerable --include-transitive
-            exit 1
+          if (-not $project.frameworks) {
+            continue
           }
+
+          $isTestProject = $project.path -like '*/test/*'
+
+          foreach ($framework in $project.frameworks) {
+            foreach ($package in $framework.topLevelPackages) {
+              $hasVulnerabilities = $true
+
+              foreach ($vulnerability in $package.vulnerabilities) {
+                Write-Host "$($project.path) ($($framework.framework)): top-level $($package.id) $($package.resolvedVersion) – $($vulnerability.severity): $($vulnerability.advisoryurl)"
+              }
+            }
+
+            if (-not $isTestProject) {
+              foreach ($package in $framework.transitivePackages) {
+                $hasVulnerabilities = $true
+
+                foreach ($vulnerability in $package.vulnerabilities) {
+                  Write-Host "$($project.path) ($($framework.framework)): transitive $($package.id) $($package.resolvedVersion) – $($vulnerability.severity): $($vulnerability.advisoryurl)"
+                }
+              }
+            }
+          }
+        }
+
+        if ($hasVulnerabilities) {
+          exit 1
         }

--- a/shared-test.props
+++ b/shared-test.props
@@ -3,6 +3,7 @@
     <OutputType>Exe</OutputType>
     <TestTfmsInParallel>false</TestTfmsInParallel>
     <NoWarn>$(NoWarn);S2094;S3717;SA1602;CA1062;CA1707;NU5104</NoWarn>
+    <NuGetAuditMode>direct</NuGetAuditMode>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Description

Turns off reporting _transitive_ vulnerabilities in test projects.

Script with tests used to verify the PowerShell script works properly:
[test-scan-logic.ps1.txt](https://github.com/user-attachments/files/27582516/test-scan-logic.ps1.txt)

## Quality checklist

- [x] Your code complies with our [Coding Style](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-code-style.md).
- [ ] You've updated unit and/or integration tests for your change, where applicable.
- [ ] You've updated documentation for your change, where applicable.
      If your change affects other repositories, such as [Documentation](https://github.com/SteeltoeOSS/Documentation), [Samples](https://github.com/SteeltoeOSS/Samples) and/or [MainSite](https://github.com/SteeltoeOSS/MainSite), add linked PRs here.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
- [ ] You've added required license files and/or file headers (explaining where the code came from with proper attribution), where code is copied from StackOverflow, a blog, or OSS.
