### PR TITLE
Fix flaky certificate tests failing with InvalidOperationException

### DIFF
--- a/src/Common/test/Certificates.Test/ConfigureCertificateOptionsTest.cs
+++ b/src/Common/test/Certificates.Test/ConfigureCertificateOptionsTest.cs
@@ -163,11 +163,11 @@ public sealed class ConfigureCertificateOptionsTest
         var optionsMonitor = serviceProvider.GetRequiredService<IOptionsMonitor<CertificateOptions>>();
         optionsMonitor.Get(certificateName).Certificate.Should().BeEquivalentTo(firstX509);
 
-        await File.WriteAllTextAsync(certificateFilePath, secondCertificateContent, TestContext.Current.CancellationToken);
-        await File.WriteAllTextAsync(privateKeyFilePath, secondPrivateKeyContent, TestContext.Current.CancellationToken);
-
-        using Task pollTask = WaitUntilCertificateChangedToAsync(secondX509, optionsMonitor, certificateName, TestContext.Current.CancellationToken);
-        await pollTask.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+        await WaitUntilCertificateChangedToAsync(certificateName, secondX509, optionsMonitor, async () =>
+        {
+            await File.WriteAllTextAsync(certificateFilePath, secondCertificateContent, TestContext.Current.CancellationToken);
+            await File.WriteAllTextAsync(privateKeyFilePath, secondPrivateKeyContent, TestContext.Current.CancellationToken);
+        });
 
         optionsMonitor.Get(certificateName).Certificate.Should().Be(secondX509);
     }
@@ -200,11 +200,11 @@ public sealed class ConfigureCertificateOptionsTest
         var optionsMonitor = serviceProvider.GetRequiredService<IOptionsMonitor<CertificateOptions>>();
         optionsMonitor.Get(certificateName).Certificate.Should().BeEquivalentTo(firstX509);
 
-        appSettings = BuildAppSettingsJson(certificateName, "secondInstance.crt", "secondInstance.key");
-        await File.WriteAllTextAsync(appSettingsPath, appSettings, TestContext.Current.CancellationToken);
-
-        using Task pollTask = WaitUntilCertificateChangedToAsync(secondX509, optionsMonitor, certificateName, TestContext.Current.CancellationToken);
-        await pollTask.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
+        await WaitUntilCertificateChangedToAsync(certificateName, secondX509, optionsMonitor, async () =>
+        {
+            appSettings = BuildAppSettingsJson(certificateName, "secondInstance.crt", "secondInstance.key");
+            await File.WriteAllTextAsync(appSettingsPath, appSettings, TestContext.Current.CancellationToken);
+        });
 
         optionsMonitor.Get(certificateName).Certificate.Should().Be(secondX509);
     }
@@ -235,13 +235,21 @@ public sealed class ConfigureCertificateOptionsTest
             """;
     }
 
-    private static async Task WaitUntilCertificateChangedToAsync(X509Certificate2 expectedCertificate, IOptionsMonitor<CertificateOptions> optionsMonitor,
-        string certificateName, CancellationToken cancellationToken)
+    private static async Task WaitUntilCertificateChangedToAsync(string certificateName, X509Certificate2 expectedCertificate,
+        IOptionsMonitor<CertificateOptions> optionsMonitor, Func<Task> triggerAction)
     {
-        while (!Equals(optionsMonitor.Get(certificateName).Certificate, expectedCertificate))
+        var completionSource = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        using IDisposable? changeListener = optionsMonitor.OnChange((options, name) =>
         {
-            await Task.Delay(50, cancellationToken);
-        }
+            if (name == certificateName && Equals(options.Certificate, expectedCertificate))
+            {
+                completionSource.TrySetResult();
+            }
+        });
+
+        await triggerAction();
+        await completionSource.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
     }
 
     private static string GetConfigurationKey(string? optionName, string propertyName)


### PR DESCRIPTION
## Description

The tests used `using Task` on a poll task that was still running when the `WaitAsync` timeout expired, causing `Task.Dispose()` to throw `InvalidOperationException` instead of a meaningful timeout failure.

Replace polling with `IOptionsMonitor.OnChange` and a `TaskCompletionSource`, registering the listener before triggering the file change to avoid race conditions.

## Quality checklist

- [x] Your code complies with our [Coding Style](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-code-style.md).
- [x] You've updated unit and/or integration tests for your change, where applicable.
- [ ] You've updated documentation for your change, where applicable.
      If your change affects other repositories, such as [Documentation](https://github.com/SteeltoeOSS/Documentation), [Samples](https://github.com/SteeltoeOSS/Samples) and/or [MainSite](https://github.com/SteeltoeOSS/MainSite), add linked PRs here.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
- [ ] You've added required license files and/or file headers (explaining where the code came from with proper attribution), where code is copied from StackOverflow, a blog, or OSS.
