### PR TITLE
Ignore case when comparing Connector configuration keys

### DIFF
--- a/src/Connectors/src/Connectors/ConnectionStringPostProcessor.cs
+++ b/src/Connectors/src/Connectors/ConnectionStringPostProcessor.cs
@@ -15,7 +15,7 @@ namespace Steeltoe.Connectors;
 internal abstract class ConnectionStringPostProcessor : IConfigurationPostProcessor
 {
     private const string ConnectionStringName = "ConnectionString";
-    public const string DefaultBindingName = "Default";
+    private const string DefaultBindingName = "Default";
 
     private static readonly string ClientBindingsConfigurationKey = ConfigurationPath.Combine("Steeltoe", "Client");
     public static readonly string ServiceBindingsConfigurationKey = ConfigurationPath.Combine("steeltoe", "service-bindings");
@@ -37,7 +37,7 @@ internal abstract class ConnectionStringPostProcessor : IConfigurationPostProces
         {
             bindingsByName.TryGetValue(DefaultBindingName, out BindingInfo? defaultBinding);
 
-            string? alternateBindingName = bindingsByName.Keys.SingleOrDefault(bindingName => bindingName != DefaultBindingName);
+            string? alternateBindingName = bindingsByName.Keys.SingleOrDefault(bindingName => !IsDefaultBindingName(bindingName));
             BindingInfo? alternateBinding = alternateBindingName == null ? null : bindingsByName[alternateBindingName];
 
             var bindingInfo = new BindingInfo
@@ -55,11 +55,16 @@ internal abstract class ConnectionStringPostProcessor : IConfigurationPostProces
         }
         else
         {
-            foreach ((string bindingName, BindingInfo bindingInfo) in bindingsByName.Where(binding => binding.Key != DefaultBindingName))
+            foreach ((string bindingName, BindingInfo bindingInfo) in bindingsByName.Where(binding => !IsDefaultBindingName(binding.Key)))
             {
                 SetConnectionString(configurationData, bindingName, bindingInfo);
             }
         }
+    }
+
+    public static bool IsDefaultBindingName(string bindingName)
+    {
+        return string.Equals(bindingName, DefaultBindingName, StringComparison.OrdinalIgnoreCase);
     }
 
     private static bool ShouldSetDefault(Dictionary<string, BindingInfo> bindingsByName)
@@ -68,7 +73,7 @@ internal abstract class ConnectionStringPostProcessor : IConfigurationPostProces
         {
             (string bindingName, BindingInfo binding) = bindingsByName.Single();
 
-            if (bindingName == DefaultBindingName && binding.IsClientOnly)
+            if (IsDefaultBindingName(bindingName) && binding.IsClientOnly)
             {
                 return true;
             }
@@ -78,7 +83,7 @@ internal abstract class ConnectionStringPostProcessor : IConfigurationPostProces
 
         if (bindingsByName.Count == 2 && bindingsByName.TryGetValue(DefaultBindingName, out BindingInfo? defaultBinding) && defaultBinding.IsClientOnly)
         {
-            BindingInfo alternateBinding = bindingsByName.Single(binding => binding.Key != DefaultBindingName).Value;
+            BindingInfo alternateBinding = bindingsByName.Single(binding => !IsDefaultBindingName(binding.Key)).Value;
 
             if (alternateBinding.IsServerOnly)
             {
@@ -91,7 +96,7 @@ internal abstract class ConnectionStringPostProcessor : IConfigurationPostProces
 
     private Dictionary<string, BindingInfo> GetBindingsByName(IConfiguration configuration)
     {
-        Dictionary<string, BindingInfo> bindingsByName = [];
+        var bindingsByName = new Dictionary<string, BindingInfo>(StringComparer.OrdinalIgnoreCase);
 
         foreach (IConfigurationSection clientBinding in GetBindingSections(configuration, ClientBindingsConfigurationKey))
         {

--- a/src/Connectors/src/Connectors/ConnectorOptionsBinder.cs
+++ b/src/Connectors/src/Connectors/ConnectorOptionsBinder.cs
@@ -30,7 +30,7 @@ internal static class ConnectorOptionsBinder
         {
             string bindingName = childSection.Key;
 
-            if (bindingName == ConnectionStringPostProcessor.DefaultBindingName)
+            if (ConnectionStringPostProcessor.IsDefaultBindingName(bindingName))
             {
                 services.Configure<TOptions>(childSection);
 
@@ -62,7 +62,7 @@ internal static class ConnectorOptionsBinder
             return false;
         }
 
-        if (sections is [{ Key: ConnectionStringPostProcessor.DefaultBindingName }])
+        if (sections is [{ } singleSection] && ConnectionStringPostProcessor.IsDefaultBindingName(singleSection.Key))
         {
             return false;
         }
@@ -81,6 +81,6 @@ internal static class ConnectorOptionsBinder
 
     private static HashSet<string> GetNamedOptions(IConfigurationSection[] childSections)
     {
-        return childSections.Select(section => section.Key == ConnectionStringPostProcessor.DefaultBindingName ? string.Empty : section.Key).ToHashSet();
+        return childSections.Select(section => ConnectionStringPostProcessor.IsDefaultBindingName(section.Key) ? string.Empty : section.Key).ToHashSet();
     }
 }

--- a/src/Connectors/test/Connectors.Test/PostgreSql/PostgreSqlConnectorTest.cs
+++ b/src/Connectors/test/Connectors.Test/PostgreSql/PostgreSqlConnectorTest.cs
@@ -488,7 +488,7 @@ public sealed class PostgreSqlConnectorTest
     {
         var appSettings = new Dictionary<string, string?>
         {
-            ["Steeltoe:Client:PostgreSql:Default:ConnectionString"] = "SERVER=localhost;DB=myDb;UID=myUser;PWD=myPass;Log Parameters=True"
+            ["Steeltoe:Client:PostgreSql:DEFAULT:ConnectionString"] = "SERVER=localhost;DB=myDb;UID=myUser;PWD=myPass;Log Parameters=True"
         };
 
         WebApplicationBuilder builder = TestWebApplicationBuilderFactory.Create();


### PR DESCRIPTION
## Description

Bugfix: Ignore case when comparing Connector configuration keys.

Fixes #1699.

## Quality checklist

- [x] Your code complies with our [Coding Style](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-code-style.md).
- [x] You've updated unit and/or integration tests for your change, where applicable.
- [ ] You've updated documentation for your change, where applicable.
      If your change affects other repositories, such as [Documentation](https://github.com/SteeltoeOSS/Documentation), [Samples](https://github.com/SteeltoeOSS/Samples) and/or [MainSite](https://github.com/SteeltoeOSS/MainSite), add linked PRs here.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
- [ ] You've added required license files and/or file headers (explaining where the code came from with proper attribution), where code is copied from StackOverflow, a blog, or OSS.
