### PR TITLE
Fix crash on shutdown: Eureka trying to unregister app that never registered

### DIFF
--- a/src/Discovery/src/Eureka/EurekaDiscoveryClient.cs
+++ b/src/Discovery/src/Eureka/EurekaDiscoveryClient.cs
@@ -37,6 +37,7 @@ public sealed partial class EurekaDiscoveryClient : IDiscoveryClient
     private readonly Timer? _cacheRefreshTimer;
     private readonly SemaphoreSlim _registerUnregisterAsyncLock = new(1);
     private readonly SemaphoreSlim _registryFetchAsyncLock = new(1);
+    private volatile bool _hasRegistered;
     private volatile bool _hasFirstHeartbeatCompleted;
 
     private volatile ApplicationInfoCollection _remoteApps;
@@ -195,7 +196,7 @@ public sealed partial class EurekaDiscoveryClient : IDiscoveryClient
 
         try
         {
-            if (!ReferenceEquals(_appInfoManager.Instance, InstanceInfo.Disabled))
+            if (_hasRegistered && !ReferenceEquals(_appInfoManager.Instance, InstanceInfo.Disabled))
             {
                 await DeregisterAsync(cancellationToken);
             }
@@ -268,6 +269,7 @@ public sealed partial class EurekaDiscoveryClient : IDiscoveryClient
                 LogRegistrationSucceeded(snapshot.AppName, snapshot.InstanceId);
 
                 snapshot.IsDirty = false;
+                _hasRegistered = true;
             }
         }
         finally

--- a/src/Discovery/test/Eureka.Test/EurekaDiscoveryClientTest.cs
+++ b/src/Discovery/test/Eureka.Test/EurekaDiscoveryClientTest.cs
@@ -418,6 +418,63 @@ public sealed class EurekaDiscoveryClientTest
     }
 
     [Fact]
+    public async Task ShutdownAsync_Unregisters_WhenRegistered()
+    {
+        var appSettings = new Dictionary<string, string?>
+        {
+            ["Eureka:Client:ShouldFetchRegistry"] = "false",
+            ["Eureka:Client:ShouldRegisterWithEureka"] = "true",
+            ["Eureka:Instance:AppName"] = "FOO",
+            ["Eureka:Instance:InstanceId"] = "localhost:foo"
+        };
+
+        WebApplicationBuilder builder = TestWebApplicationBuilderFactory.Create();
+        builder.Configuration.AddInMemoryCollection(appSettings);
+        builder.Services.AddEurekaDiscoveryClient();
+
+        var handler = new DelegateToMockHttpClientHandler();
+        handler.Mock.Expect(HttpMethod.Post, "http://localhost:8761/eureka/apps/FOO").Respond(HttpStatusCode.OK);
+        handler.Mock.Expect(HttpMethod.Delete, "http://localhost:8761/eureka/apps/FOO/localhost%3Afoo").Respond(HttpStatusCode.OK);
+
+        await using WebApplication webApplication = builder.Build();
+        webApplication.Services.GetRequiredService<HttpClientHandlerFactory>().Using(handler);
+
+        var discoveryClient = webApplication.Services.GetRequiredService<EurekaDiscoveryClient>();
+
+        await discoveryClient.ShutdownAsync(TestContext.Current.CancellationToken);
+
+        handler.Mock.VerifyNoOutstandingExpectation();
+    }
+
+    [Fact]
+    public async Task ShutdownAsync_DoesNotUnregister_WhenNotRegistered()
+    {
+        var appSettings = new Dictionary<string, string?>
+        {
+            ["Eureka:Client:ShouldFetchRegistry"] = "false",
+            ["Eureka:Client:ShouldRegisterWithEureka"] = "true",
+            ["Eureka:Instance:AppName"] = "FOO",
+            ["Eureka:Instance:InstanceId"] = "localhost:foo"
+        };
+
+        WebApplicationBuilder builder = TestWebApplicationBuilderFactory.Create();
+        builder.Configuration.AddInMemoryCollection(appSettings);
+        builder.Services.AddEurekaDiscoveryClient();
+
+        var handler = new DelegateToMockHttpClientHandler();
+        handler.Mock.Expect(HttpMethod.Post, "http://localhost:8761/eureka/apps/FOO").Respond(HttpStatusCode.NotFound);
+
+        await using WebApplication webApplication = builder.Build();
+        webApplication.Services.GetRequiredService<HttpClientHandlerFactory>().Using(handler);
+
+        var discoveryClient = webApplication.Services.GetRequiredService<EurekaDiscoveryClient>();
+
+        await discoveryClient.ShutdownAsync(TestContext.Current.CancellationToken);
+
+        handler.Mock.VerifyNoOutstandingExpectation();
+    }
+
+    [Fact]
     public async Task GetInstancesAsync_ReturnsExpected()
     {
         var appSettings = new Dictionary<string, string?>


### PR DESCRIPTION
## Description

Snapshot from sample logs before the fix (press Ctrl+C on running FortuneTellerWeb):

```text
dbug: Steeltoe.Discovery.Eureka.EurekaClient[868536339]
      HTTP DELETE request to 'http://localhost:8761/eureka/apps/STEELTOE.SAMPLES.FORTUNETELLERWEB/JVBD4M3%3ASteeltoe.Samples.FortuneTellerWeb%3A7233' returned status 404 in attempt 1.
info: Steeltoe.Discovery.Eureka.EurekaClient[601900377]
      HTTP DELETE request to 'http://localhost:8761/eureka/apps/STEELTOE.SAMPLES.FORTUNETELLERWEB/JVBD4M3%3ASteeltoe.Samples.FortuneTellerWeb%3A7233' failed with status 404: '{"timestamp":"2026-05-28T11:15:52.686+00:00","status":404,"error":"Not Found","path":"/eureka/apps/STEELTOE.SAMPLES.FORTUNETELLERWEB/JVBD4M3%3ASteeltoe.Samples.FortuneTellerWeb%3A7233"}'.
warn: Steeltoe.Discovery.Eureka.EurekaDiscoveryClient[1003466929]
      Deregister failed during shutdown.
      Steeltoe.Discovery.Eureka.Transport.EurekaTransportException: Failed to execute request on all known Eureka servers.
```
(omitted stack trace for clarity)

## Quality checklist

<!-- Please run through the checklist below to ensure a smooth review and merge process for your PR. -->

- [x] Your code complies with our [Coding Style](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-code-style.md).
- [x] You've updated unit and/or integration tests for your change, where applicable.
- [ ] You've updated documentation for your change, where applicable.
      If your change affects other repositories, such as [Documentation](https://github.com/SteeltoeOSS/Documentation), [Samples](https://github.com/SteeltoeOSS/Samples) and/or [MainSite](https://github.com/SteeltoeOSS/MainSite), add linked PRs here.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
- [ ] You've added required license files and/or file headers (explaining where the code came from with proper attribution), where code is copied from StackOverflow, a blog, or OSS.
