### PR TITLE
Fix broken build on .NET SDK v10.0.302

### DIFF
--- a/src/Security/src/Authentication.JwtBearer/Steeltoe.Security.Authentication.JwtBearer.csproj
+++ b/src/Security/src/Authentication.JwtBearer/Steeltoe.Security.Authentication.JwtBearer.csproj
@@ -11,8 +11,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="$(MatchTargetFrameworkVersion)" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="$(FoundationalVersion)" />
-    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="$(MicrosoftIdentityModelVersion)" />
-    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="$(MicrosoftIdentityModelVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Security/src/Authentication.OpenIdConnect/Steeltoe.Security.Authentication.OpenIdConnect.csproj
+++ b/src/Security/src/Authentication.OpenIdConnect/Steeltoe.Security.Authentication.OpenIdConnect.csproj
@@ -11,8 +11,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="$(MatchTargetFrameworkVersion)" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="$(FoundationalVersion)" />
-    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="$(MicrosoftIdentityModelVersion)" />
-    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="$(MicrosoftIdentityModelVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/versions.props
+++ b/versions.props
@@ -68,7 +68,6 @@
       -->
       10.0.*
     </FoundationalVersion>
-    <MicrosoftIdentityModelVersion>8.15.*</MicrosoftIdentityModelVersion>
     <MicrosoftDiagnosticsNETCoreClientVersion>0.2.652701</MicrosoftDiagnosticsNETCoreClientVersion>
     <MicrosoftDiagnosticsTracingTraceEventVersion>3.1.23</MicrosoftDiagnosticsTracingTraceEventVersion>
     <OpenTelemetryExporterPrometheusVersion>1.15.*-*</OpenTelemetryExporterPrometheusVersion>


### PR DESCRIPTION
Drop the dependencies on `Microsoft.IdentityModel.Protocols.OpenIdConnect` and `Microsoft.IdentityModel.Tokens` from libraries and tests. Their explicit versions conflict, while they are already pulled in by `Microsoft.AspNetCore.Authentication.JwtBearer`.

From what I can tell, these dependencies were introduced in #1311 (Steeltoe 4.0). My assumption is that they were added at the time to be able to use newer APIs or use newer versions that contained fixes we needed.