### PR TITLE
Log instead of throwing when localhost is used for registry server

### DIFF
--- a/src/Discovery/src/Consul/ConsulServiceCollectionExtensions.cs
+++ b/src/Discovery/src/Consul/ConsulServiceCollectionExtensions.cs
@@ -62,7 +62,7 @@ public static class ConsulServiceCollectionExtensions
     private static void ConfigureConsulOptions(IServiceCollection services)
     {
         services.AddOptions<ConsulOptions>().BindConfiguration(ConsulOptions.ConfigurationPrefix);
-        services.AddSingleton<IValidateOptions<ConsulOptions>, ValidateConsulOptions>();
+        services.AddSingleton<IPostConfigureOptions<ConsulOptions>, PostConfigureConsulOptions>();
     }
 
     private static void ConfigureConsulDiscoveryOptions(IServiceCollection services)

--- a/src/Discovery/src/Consul/PostConfigureConsulOptions.cs
+++ b/src/Discovery/src/Consul/PostConfigureConsulOptions.cs
@@ -11,15 +11,15 @@ namespace Steeltoe.Discovery.Consul;
 
 internal sealed partial class PostConfigureConsulOptions : IPostConfigureOptions<ConsulOptions>
 {
-    private readonly IOptionsMonitor<ConsulDiscoveryOptions> _discoveryOptionsMonitor;
+    private readonly IOptionsMonitor<ConsulDiscoveryOptions> _optionsMonitor;
     private readonly ILogger<PostConfigureConsulOptions> _logger;
 
-    public PostConfigureConsulOptions(IOptionsMonitor<ConsulDiscoveryOptions> discoveryOptionsMonitor, ILogger<PostConfigureConsulOptions> logger)
+    public PostConfigureConsulOptions(IOptionsMonitor<ConsulDiscoveryOptions> optionsMonitor, ILogger<PostConfigureConsulOptions> logger)
     {
-        ArgumentNullException.ThrowIfNull(discoveryOptionsMonitor);
+        ArgumentNullException.ThrowIfNull(optionsMonitor);
         ArgumentNullException.ThrowIfNull(logger);
 
-        _discoveryOptionsMonitor = discoveryOptionsMonitor;
+        _optionsMonitor = optionsMonitor;
         _logger = logger;
     }
 
@@ -27,14 +27,14 @@ internal sealed partial class PostConfigureConsulOptions : IPostConfigureOptions
     {
         ArgumentNullException.ThrowIfNull(options);
 
-        if (_discoveryOptionsMonitor.CurrentValue.Enabled && (Platform.IsContainerized || Platform.IsCloudHosted) && options.Host == "localhost")
+        if (_optionsMonitor.CurrentValue.Enabled && (Platform.IsContainerized || Platform.IsCloudHosted) && options.Host == "localhost")
         {
-            LogLocalhostConsulUrl(_logger, $"{options.Scheme}://{options.Host}:{options.Port}");
+            LogLocalhostConsulUrl($"{options.Scheme}://{options.Host}:{options.Port}");
         }
     }
 
     [LoggerMessage(EventId = 0, Level = LogLevel.Warning,
         Message = "Consul URL '{Url}' is unlikely to be valid in containerized or cloud environments. " +
             "Please configure Consul:Host with a non-localhost server.")]
-    private static partial void LogLocalhostConsulUrl(ILogger logger, string url);
+    private partial void LogLocalhostConsulUrl(string url);
 }

--- a/src/Discovery/src/Consul/PostConfigureConsulOptions.cs
+++ b/src/Discovery/src/Consul/PostConfigureConsulOptions.cs
@@ -9,20 +9,21 @@ using Steeltoe.Discovery.Consul.Configuration;
 
 namespace Steeltoe.Discovery.Consul;
 
-internal sealed partial class ValidateConsulOptions : IValidateOptions<ConsulOptions>
+internal sealed partial class PostConfigureConsulOptions : IPostConfigureOptions<ConsulOptions>
 {
-    private readonly ILogger<ValidateConsulOptions> _logger;
     private readonly IOptionsMonitor<ConsulDiscoveryOptions> _discoveryOptionsMonitor;
+    private readonly ILogger<PostConfigureConsulOptions> _logger;
 
-    public ValidateConsulOptions(IOptionsMonitor<ConsulDiscoveryOptions> discoveryOptionsMonitor, ILogger<ValidateConsulOptions> logger)
+    public PostConfigureConsulOptions(IOptionsMonitor<ConsulDiscoveryOptions> discoveryOptionsMonitor, ILogger<PostConfigureConsulOptions> logger)
     {
         ArgumentNullException.ThrowIfNull(discoveryOptionsMonitor);
+        ArgumentNullException.ThrowIfNull(logger);
 
         _discoveryOptionsMonitor = discoveryOptionsMonitor;
         _logger = logger;
     }
 
-    public ValidateOptionsResult Validate(string? name, ConsulOptions options)
+    public void PostConfigure(string? name, ConsulOptions options)
     {
         ArgumentNullException.ThrowIfNull(options);
 
@@ -30,8 +31,6 @@ internal sealed partial class ValidateConsulOptions : IValidateOptions<ConsulOpt
         {
             LogLocalhostConsulUrl(_logger, $"{options.Scheme}://{options.Host}:{options.Port}");
         }
-
-        return ValidateOptionsResult.Success;
     }
 
     [LoggerMessage(EventId = 0, Level = LogLevel.Warning,

--- a/src/Discovery/src/Consul/ValidateConsulOptions.cs
+++ b/src/Discovery/src/Consul/ValidateConsulOptions.cs
@@ -2,21 +2,24 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Steeltoe.Common;
 using Steeltoe.Discovery.Consul.Configuration;
 
 namespace Steeltoe.Discovery.Consul;
 
-internal sealed class ValidateConsulOptions : IValidateOptions<ConsulOptions>
+internal sealed partial class ValidateConsulOptions : IValidateOptions<ConsulOptions>
 {
+    private readonly ILogger<ValidateConsulOptions> _logger;
     private readonly IOptionsMonitor<ConsulDiscoveryOptions> _discoveryOptionsMonitor;
 
-    public ValidateConsulOptions(IOptionsMonitor<ConsulDiscoveryOptions> discoveryOptionsMonitor)
+    public ValidateConsulOptions(IOptionsMonitor<ConsulDiscoveryOptions> discoveryOptionsMonitor, ILogger<ValidateConsulOptions> logger)
     {
         ArgumentNullException.ThrowIfNull(discoveryOptionsMonitor);
 
         _discoveryOptionsMonitor = discoveryOptionsMonitor;
+        _logger = logger;
     }
 
     public ValidateOptionsResult Validate(string? name, ConsulOptions options)
@@ -25,11 +28,14 @@ internal sealed class ValidateConsulOptions : IValidateOptions<ConsulOptions>
 
         if (_discoveryOptionsMonitor.CurrentValue.Enabled && (Platform.IsContainerized || Platform.IsCloudHosted) && options.Host == "localhost")
         {
-            return ValidateOptionsResult.Fail(
-                $"Consul URL '{options.Scheme}://{options.Host}:{options.Port}' is not valid in containerized or cloud environments. " +
-                "Please configure Consul:Host with a non-localhost server.");
+            LogLocalhostConsulUrl(_logger, $"{options.Scheme}://{options.Host}:{options.Port}");
         }
 
         return ValidateOptionsResult.Success;
     }
+
+    [LoggerMessage(EventId = 0, Level = LogLevel.Warning,
+        Message = "Consul URL '{Url}' is unlikely to be valid in containerized or cloud environments. " +
+            "Please configure Consul:Host with a non-localhost server.")]
+    private static partial void LogLocalhostConsulUrl(ILogger logger, string url);
 }

--- a/src/Discovery/src/Eureka/ValidateEurekaClientOptions.cs
+++ b/src/Discovery/src/Eureka/ValidateEurekaClientOptions.cs
@@ -2,13 +2,14 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Steeltoe.Common;
 using Steeltoe.Discovery.Eureka.Configuration;
 
 namespace Steeltoe.Discovery.Eureka;
 
-internal sealed class ValidateEurekaClientOptions : IValidateOptions<EurekaClientOptions>
+internal sealed partial class ValidateEurekaClientOptions(ILogger<ValidateEurekaClientOptions> logger) : IValidateOptions<EurekaClientOptions>
 {
     public ValidateOptionsResult Validate(string? name, EurekaClientOptions options)
     {
@@ -39,8 +40,7 @@ internal sealed class ValidateEurekaClientOptions : IValidateOptions<EurekaClien
                 {
                     if (uri.Host == "localhost" && (Platform.IsContainerized || Platform.IsCloudHosted))
                     {
-                        errors.Add($"Eureka URL '{url}' is not valid in containerized or cloud environments. " +
-                            "Please configure Eureka:Client:ServiceUrl with a non-localhost address or add a service binding.");
+                        LogLocalhostEurekaUrl(logger, url);
                     }
                 }
             }
@@ -48,4 +48,9 @@ internal sealed class ValidateEurekaClientOptions : IValidateOptions<EurekaClien
 
         return errors.Count > 0 ? ValidateOptionsResult.Fail(errors) : ValidateOptionsResult.Success;
     }
+
+    [LoggerMessage(EventId = 0, Level = LogLevel.Warning,
+        Message = "Eureka URL '{Url}' is unlikely to be valid in containerized or cloud environments. " +
+            "Please configure Eureka:Client:ServiceUrl with a non-localhost address or add a service binding.")]
+    private static partial void LogLocalhostEurekaUrl(ILogger logger, string url);
 }

--- a/src/Discovery/src/Eureka/ValidateEurekaClientOptions.cs
+++ b/src/Discovery/src/Eureka/ValidateEurekaClientOptions.cs
@@ -9,8 +9,17 @@ using Steeltoe.Discovery.Eureka.Configuration;
 
 namespace Steeltoe.Discovery.Eureka;
 
-internal sealed partial class ValidateEurekaClientOptions(ILogger<ValidateEurekaClientOptions> logger) : IValidateOptions<EurekaClientOptions>
+internal sealed partial class ValidateEurekaClientOptions : IValidateOptions<EurekaClientOptions>
 {
+    private readonly ILogger<ValidateEurekaClientOptions> _logger;
+
+    public ValidateEurekaClientOptions(ILogger<ValidateEurekaClientOptions> logger)
+    {
+        ArgumentNullException.ThrowIfNull(logger);
+
+        _logger = logger;
+    }
+
     public ValidateOptionsResult Validate(string? name, EurekaClientOptions options)
     {
         ArgumentNullException.ThrowIfNull(options);
@@ -40,7 +49,7 @@ internal sealed partial class ValidateEurekaClientOptions(ILogger<ValidateEureka
                 {
                     if (uri.Host == "localhost" && (Platform.IsContainerized || Platform.IsCloudHosted))
                     {
-                        LogLocalhostEurekaUrl(logger, url);
+                        LogLocalhostEurekaUrl(url);
                     }
                 }
             }
@@ -52,5 +61,5 @@ internal sealed partial class ValidateEurekaClientOptions(ILogger<ValidateEureka
     [LoggerMessage(EventId = 0, Level = LogLevel.Warning,
         Message = "Eureka URL '{Url}' is unlikely to be valid in containerized or cloud environments. " +
             "Please configure Eureka:Client:ServiceUrl with a non-localhost address or add a service binding.")]
-    private static partial void LogLocalhostEurekaUrl(ILogger logger, string url);
+    private partial void LogLocalhostEurekaUrl(string url);
 }

--- a/src/Discovery/test/Consul.Test/ConsulServiceCollectionExtensionsTest.cs
+++ b/src/Discovery/test/Consul.Test/ConsulServiceCollectionExtensionsTest.cs
@@ -143,7 +143,7 @@ public sealed class ConsulServiceCollectionExtensionsTest
     }
 
     [Fact]
-    public async Task ConsulOptionsValidation_WarnsWhenRunningInCloudWithLocalhost()
+    public async Task PostConfigureConsulOptions_WarnsWhenRunningInCloudWithLocalhost()
     {
         using var scope = new EnvironmentVariableScope("DOTNET_RUNNING_IN_CONTAINER", "true");
         using var capturingLoggerProvider = new CapturingLoggerProvider();
@@ -162,9 +162,34 @@ public sealed class ConsulServiceCollectionExtensionsTest
 
         string? logEntry = capturingLoggerProvider.GetAll().Should().ContainSingle().Which;
 
-        logEntry.Should()
-            .Be(
-                $"WARN {typeof(PostConfigureConsulOptions).FullName}: Consul URL 'http://localhost:8500' is unlikely to be valid in containerized or cloud environments. " +
-                "Please configure Consul:Host with a non-localhost server.");
+        logEntry.Should().Be(
+            $"WARN {typeof(PostConfigureConsulOptions).FullName}: Consul URL 'http://localhost:8500' is unlikely to be valid in containerized or cloud environments. " +
+            "Please configure Consul:Host with a non-localhost server.");
+    }
+
+    [Fact]
+    public async Task PostConfigureConsulOptions_DoesNotWarnWhenConsulIsDisabled()
+    {
+        using var scope = new EnvironmentVariableScope("DOTNET_RUNNING_IN_CONTAINER", "true");
+        using var capturingLoggerProvider = new CapturingLoggerProvider();
+
+        var appSettings = new Dictionary<string, string?>
+        {
+            ["consul:discovery:enabled"] = "false"
+        };
+
+        var services = new ServiceCollection();
+        // ReSharper disable once AccessToDisposedClosure
+        services.AddLogging(builder => builder.AddProvider(capturingLoggerProvider));
+        services.AddSingleton<IConfiguration>(new ConfigurationBuilder().AddInMemoryCollection(appSettings).Build());
+        services.AddConsulDiscoveryClient();
+
+        await using ServiceProvider serviceProvider = services.BuildServiceProvider(true);
+        var consulOptions = serviceProvider.GetRequiredService<IOptions<ConsulOptions>>();
+
+        Action action = () => _ = consulOptions.Value;
+        action.Should().NotThrow();
+
+        capturingLoggerProvider.GetAll().Should().BeEmpty();
     }
 }

--- a/src/Discovery/test/Consul.Test/ConsulServiceCollectionExtensionsTest.cs
+++ b/src/Discovery/test/Consul.Test/ConsulServiceCollectionExtensionsTest.cs
@@ -164,7 +164,7 @@ public sealed class ConsulServiceCollectionExtensionsTest
 
         logEntry.Should()
             .Be(
-                $"WARN {typeof(ValidateConsulOptions).FullName}: Consul URL 'http://localhost:8500' is unlikely to be valid in containerized or cloud environments. " +
+                $"WARN {typeof(PostConfigureConsulOptions).FullName}: Consul URL 'http://localhost:8500' is unlikely to be valid in containerized or cloud environments. " +
                 "Please configure Consul:Host with a non-localhost server.");
     }
 }

--- a/src/Discovery/test/Consul.Test/ConsulServiceCollectionExtensionsTest.cs
+++ b/src/Discovery/test/Consul.Test/ConsulServiceCollectionExtensionsTest.cs
@@ -5,6 +5,7 @@
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Steeltoe.Common.Discovery;
 using Steeltoe.Common.HealthChecks;
@@ -142,12 +143,14 @@ public sealed class ConsulServiceCollectionExtensionsTest
     }
 
     [Fact]
-    public async Task ConsulOptionsValidation_FailsWhenRunningInCloudWithLocalhost()
+    public async Task ConsulOptionsValidation_WarnsWhenRunningInCloudWithLocalhost()
     {
         using var scope = new EnvironmentVariableScope("DOTNET_RUNNING_IN_CONTAINER", "true");
+        using var capturingLoggerProvider = new CapturingLoggerProvider();
 
         var services = new ServiceCollection();
-        services.AddLogging();
+        // ReSharper disable once AccessToDisposedClosure
+        services.AddLogging(builder => builder.AddProvider(capturingLoggerProvider));
         services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
         services.AddConsulDiscoveryClient();
 
@@ -155,9 +158,13 @@ public sealed class ConsulServiceCollectionExtensionsTest
         var consulOptions = serviceProvider.GetRequiredService<IOptions<ConsulOptions>>();
 
         Action action = () => _ = consulOptions.Value;
+        action.Should().NotThrow();
 
-        action.Should().ThrowExactly<OptionsValidationException>().WithMessage(
-            "Consul URL 'http://localhost:8500' is not valid in containerized or cloud environments. " +
-            "Please configure Consul:Host with a non-localhost server.");
+        string? logEntry = capturingLoggerProvider.GetAll().Should().ContainSingle().Which;
+
+        logEntry.Should()
+            .Be(
+                $"WARN {typeof(ValidateConsulOptions).FullName}: Consul URL 'http://localhost:8500' is unlikely to be valid in containerized or cloud environments. " +
+                "Please configure Consul:Host with a non-localhost server.");
     }
 }

--- a/src/Discovery/test/Eureka.Test/EurekaClientOptionsTest.cs
+++ b/src/Discovery/test/Eureka.Test/EurekaClientOptionsTest.cs
@@ -210,7 +210,7 @@ public sealed class EurekaClientOptionsTest
     }
 
     [Fact]
-    public async Task ClientOptionsValidation_WarnsWhenRunningInCloudWithLocalhost()
+    public async Task ValidateEurekaClientOptions_WarnsWhenRunningInCloudWithLocalhost()
     {
         using var scope = new EnvironmentVariableScope("DOTNET_RUNNING_IN_CONTAINER", "true");
         using var capturingLoggerProvider = new CapturingLoggerProvider();
@@ -228,10 +228,35 @@ public sealed class EurekaClientOptionsTest
 
         string? logEntry = capturingLoggerProvider.GetAll().Should().ContainSingle().Which;
 
-        logEntry.Should()
-            .Be(
-                $"WARN {typeof(ValidateEurekaClientOptions).FullName}: Eureka URL 'http://localhost:8761/eureka/' is unlikely to be valid in containerized or cloud environments. " +
-                "Please configure Eureka:Client:ServiceUrl with a non-localhost address or add a service binding.");
+        logEntry.Should().Be(
+            $"WARN {typeof(ValidateEurekaClientOptions).FullName}: Eureka URL 'http://localhost:8761/eureka/' is unlikely to be valid in containerized or cloud environments. " +
+            "Please configure Eureka:Client:ServiceUrl with a non-localhost address or add a service binding.");
+    }
+
+    [Fact]
+    public async Task ValidateEurekaClientOptions_DoesNotWarnWhenEurekaIsDisabled()
+    {
+        using var scope = new EnvironmentVariableScope("DOTNET_RUNNING_IN_CONTAINER", "true");
+        using var capturingLoggerProvider = new CapturingLoggerProvider();
+
+        var appSettings = new Dictionary<string, string?>
+        {
+            ["eureka:client:enabled"] = "false"
+        };
+
+        var services = new ServiceCollection();
+        // ReSharper disable once AccessToDisposedClosure
+        services.AddLogging(builder => builder.AddProvider(capturingLoggerProvider));
+        services.AddSingleton<IConfiguration>(new ConfigurationBuilder().AddInMemoryCollection(appSettings).Build());
+        services.AddEurekaDiscoveryClient();
+
+        await using ServiceProvider serviceProvider = services.BuildServiceProvider(true);
+        var clientOptions = serviceProvider.GetRequiredService<IOptions<EurekaClientOptions>>();
+
+        Action action = () => _ = clientOptions.Value;
+        action.Should().NotThrow();
+
+        capturingLoggerProvider.GetAll().Should().BeEmpty();
     }
 
     [Fact]

--- a/src/Discovery/test/Eureka.Test/EurekaClientOptionsTest.cs
+++ b/src/Discovery/test/Eureka.Test/EurekaClientOptionsTest.cs
@@ -4,6 +4,7 @@
 
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Steeltoe.Common.TestResources;
 using Steeltoe.Discovery.Eureka.Configuration;
@@ -167,28 +168,6 @@ public sealed class EurekaClientOptionsTest
     }
 
     [Fact]
-    public async Task ClientOptionsValidation_SucceedsWhenEurekaIsTurnedOff()
-    {
-        using var scope = new EnvironmentVariableScope("DOTNET_RUNNING_IN_CONTAINER", "true");
-
-        var appSettings = new Dictionary<string, string?>
-        {
-            ["eureka:client:enabled"] = "false"
-        };
-
-        var services = new ServiceCollection();
-        services.AddSingleton<IConfiguration>(new ConfigurationBuilder().AddInMemoryCollection(appSettings).Build());
-        services.AddEurekaDiscoveryClient();
-
-        await using ServiceProvider serviceProvider = services.BuildServiceProvider(true);
-        var clientOptions = serviceProvider.GetRequiredService<IOptions<EurekaClientOptions>>();
-
-        Action action = () => _ = clientOptions.Value;
-
-        action.Should().NotThrow();
-    }
-
-    [Fact]
     public async Task ClientOptionsValidation_FailsWhenServiceUrlIsNotProvided()
     {
         var appSettings = new Dictionary<string, string?>
@@ -231,22 +210,28 @@ public sealed class EurekaClientOptionsTest
     }
 
     [Fact]
-    public async Task ClientOptionsValidation_FailsWhenRunningInCloudWithLocalhost()
+    public async Task ClientOptionsValidation_WarnsWhenRunningInCloudWithLocalhost()
     {
         using var scope = new EnvironmentVariableScope("DOTNET_RUNNING_IN_CONTAINER", "true");
+        using var capturingLoggerProvider = new CapturingLoggerProvider();
 
         var services = new ServiceCollection();
+        // ReSharper disable once AccessToDisposedClosure
+        services.AddLogging(builder => builder.AddProvider(capturingLoggerProvider));
         services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
         services.AddEurekaDiscoveryClient();
 
         await using ServiceProvider serviceProvider = services.BuildServiceProvider(true);
         var clientOptions = serviceProvider.GetRequiredService<IOptions<EurekaClientOptions>>();
-
         Action action = () => _ = clientOptions.Value;
+        action.Should().NotThrow();
 
-        action.Should().ThrowExactly<OptionsValidationException>().WithMessage(
-            "Eureka URL 'http://localhost:8761/eureka/' is not valid in containerized or cloud environments. " +
-            "Please configure Eureka:Client:ServiceUrl with a non-localhost address or add a service binding.");
+        string? logEntry = capturingLoggerProvider.GetAll().Should().ContainSingle().Which;
+
+        logEntry.Should()
+            .Be(
+                $"WARN {typeof(ValidateEurekaClientOptions).FullName}: Eureka URL 'http://localhost:8761/eureka/' is unlikely to be valid in containerized or cloud environments. " +
+                "Please configure Eureka:Client:ServiceUrl with a non-localhost address or add a service binding.");
     }
 
     [Fact]


### PR DESCRIPTION
## Description

I've recently tried running both Eureka and apps inside a devcontainer, and that's prompted me to revisit #829.

Since this is a containerized environment where apps can run as native executables, we now have a use case where 'localhost' is a valid hostname for the service registry.

## Quality checklist

<!-- Please run through the checklist below to ensure a smooth review and merge process for your PR. -->

- [x] Your code complies with our [Coding Style](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-code-style.md).
- [x] You've updated unit and/or integration tests for your change, where applicable.
- [ ] You've updated documentation for your change, where applicable.
      If your change affects other repositories, such as [Documentation](https://github.com/SteeltoeOSS/Documentation) and/or [Samples](https://github.com/SteeltoeOSS/Samples), add linked PRs here.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
- [x] You've added required license files and/or file headers (explaining where the code came from with proper attribution), where code is copied from StackOverflow, a blog, or OSS.
