### PR TITLE
Prevent concurrent database health checks from sharing a single connection

### DIFF
--- a/src/Connectors/src/Connectors/MySql/MySqlServiceCollectionExtensions.cs
+++ b/src/Connectors/src/Connectors/MySql/MySqlServiceCollectionExtensions.cs
@@ -91,11 +91,10 @@ public static class MySqlServiceCollectionExtensions
 
         ConnectorShim<MySqlOptions> connectorShim = connectorFactoryShim.Get(serviceBindingName);
 
-        var connection = (DbConnection)connectorShim.GetConnection();
         string? hostName = GetHostNameFromConnectionString(packageResolver, connectorShim.Options.ConnectionString);
         var logger = serviceProvider.GetRequiredService<ILogger<RelationalDatabaseHealthContributor>>();
 
-        return new RelationalDatabaseHealthContributor(connection, hostName, logger)
+        return new RelationalDatabaseHealthContributor(() => (DbConnection)connectorShim.GetConnection(), "MySQL", hostName, logger)
         {
             ServiceName = serviceBindingName
         };

--- a/src/Connectors/src/Connectors/PostgreSql/PostgreSqlServiceCollectionExtensions.cs
+++ b/src/Connectors/src/Connectors/PostgreSql/PostgreSqlServiceCollectionExtensions.cs
@@ -92,11 +92,10 @@ public static class PostgreSqlServiceCollectionExtensions
 
         ConnectorShim<PostgreSqlOptions> connectorShim = connectorFactoryShim.Get(serviceBindingName);
 
-        var connection = (DbConnection)connectorShim.GetConnection();
         string? hostName = GetHostNameFromConnectionString(packageResolver, connectorShim.Options.ConnectionString);
         var logger = serviceProvider.GetRequiredService<ILogger<RelationalDatabaseHealthContributor>>();
 
-        return new RelationalDatabaseHealthContributor(connection, hostName, logger)
+        return new RelationalDatabaseHealthContributor(() => (DbConnection)connectorShim.GetConnection(), "PostgreSQL", hostName, logger)
         {
             ServiceName = serviceBindingName
         };

--- a/src/Connectors/src/Connectors/RelationalDatabaseHealthContributor.cs
+++ b/src/Connectors/src/Connectors/RelationalDatabaseHealthContributor.cs
@@ -10,24 +10,26 @@ using Steeltoe.Common.HealthChecks;
 
 namespace Steeltoe.Connectors;
 
-internal sealed partial class RelationalDatabaseHealthContributor : IHealthContributor, IDisposable
+internal sealed partial class RelationalDatabaseHealthContributor : IHealthContributor
 {
-    private readonly DbConnection _connection;
+    private readonly Func<DbConnection> _getConnection;
     private readonly ILogger<RelationalDatabaseHealthContributor> _logger;
 
     public string Id { get; }
     public string Host { get; }
     public string? ServiceName { get; set; }
 
-    public RelationalDatabaseHealthContributor(DbConnection connection, string? host, ILogger<RelationalDatabaseHealthContributor> logger)
+    public RelationalDatabaseHealthContributor(Func<DbConnection> getConnection, string databaseType, string? host,
+        ILogger<RelationalDatabaseHealthContributor> logger)
     {
-        ArgumentNullException.ThrowIfNull(connection);
+        ArgumentNullException.ThrowIfNull(getConnection);
+        ArgumentNullException.ThrowIfNull(databaseType);
         ArgumentNullException.ThrowIfNull(logger);
 
-        _connection = connection;
+        _getConnection = getConnection;
+        Id = databaseType;
         Host = host ?? string.Empty;
         _logger = logger;
-        Id = GetDatabaseType(connection);
     }
 
     public async Task<HealthCheckResult?> CheckHealthAsync(CancellationToken cancellationToken)
@@ -49,8 +51,9 @@ internal sealed partial class RelationalDatabaseHealthContributor : IHealthContr
 
         try
         {
-            await _connection.OpenAsync(cancellationToken);
-            DbCommand command = _connection.CreateCommand();
+            await using DbConnection connection = _getConnection();
+            await connection.OpenAsync(cancellationToken);
+            DbCommand command = connection.CreateCommand();
             command.CommandText = "SELECT 1;";
             await command.ExecuteScalarAsync(cancellationToken);
 
@@ -73,28 +76,8 @@ internal sealed partial class RelationalDatabaseHealthContributor : IHealthContr
             result.Description = $"{Id} health check failed";
             result.Details.Add("error", $"{exception.GetType().Name}: {exception.Message}");
         }
-        finally
-        {
-            await _connection.CloseAsync();
-        }
 
         return result;
-    }
-
-    private static string GetDatabaseType(DbConnection connection)
-    {
-        return connection.GetType().Name switch
-        {
-            "NpgsqlConnection" => "PostgreSQL",
-            "SqlConnection" => "SQL Server",
-            "MySqlConnection" => "MySQL",
-            _ => "unknown"
-        };
-    }
-
-    public void Dispose()
-    {
-        _connection.Dispose();
     }
 
     [LoggerMessage(Level = LogLevel.Trace, Message = "Checking {DbConnection} health at {Host}.")]

--- a/src/Connectors/src/Connectors/SqlServer/SqlServerServiceCollectionExtensions.cs
+++ b/src/Connectors/src/Connectors/SqlServer/SqlServerServiceCollectionExtensions.cs
@@ -91,11 +91,10 @@ public static class SqlServerServiceCollectionExtensions
 
         ConnectorShim<SqlServerOptions> connectorShim = connectorFactoryShim.Get(serviceBindingName);
 
-        var connection = (DbConnection)connectorShim.GetConnection();
         string? hostName = GetHostNameFromConnectionString(packageResolver, connectorShim.Options.ConnectionString);
         var logger = serviceProvider.GetRequiredService<ILogger<RelationalDatabaseHealthContributor>>();
 
-        return new RelationalDatabaseHealthContributor(connection, hostName, logger)
+        return new RelationalDatabaseHealthContributor(() => (DbConnection)connectorShim.GetConnection(), "SQL Server", hostName, logger)
         {
             ServiceName = serviceBindingName
         };

--- a/src/Connectors/test/Connectors.Test/RelationalDatabaseHealthContributorTest.cs
+++ b/src/Connectors/test/Connectors.Test/RelationalDatabaseHealthContributorTest.cs
@@ -157,68 +157,6 @@ public sealed class RelationalDatabaseHealthContributorTest
     }
 
     [Fact]
-    public async Task Concurrent_Health_Checks_Use_Independent_Connections()
-    {
-        var secondCheckCompleted = new TaskCompletionSource();
-        var createdConnections = new List<Mock<DbConnection>>();
-        int connectionCounter = 0;
-
-        var healthContributor = new RelationalDatabaseHealthContributor(CreateConnectionThatWaitsForSecondCheck, "SQL Server", "localhost",
-            NullLogger<RelationalDatabaseHealthContributor>.Instance)
-        {
-            ServiceName = "Example"
-        };
-
-        Task<HealthCheckResult?> firstCheckTask = healthContributor.CheckHealthAsync(TestContext.Current.CancellationToken);
-
-        HealthCheckResult? secondResult = await healthContributor.CheckHealthAsync(TestContext.Current.CancellationToken);
-        secondCheckCompleted.SetResult();
-
-        HealthCheckResult? firstResult = await firstCheckTask;
-
-        createdConnections.Should().HaveCount(2);
-        createdConnections[0].Object.Should().NotBeSameAs(createdConnections[1].Object);
-
-        firstResult.Should().NotBeNull();
-        firstResult.Status.Should().Be(HealthStatus.Up);
-        firstResult.Details.Should().NotContainKey("error");
-
-        secondResult.Should().NotBeNull();
-        secondResult.Status.Should().Be(HealthStatus.Up);
-        secondResult.Details.Should().NotContainKey("error");
-        return;
-
-        DbConnection CreateConnectionThatWaitsForSecondCheck()
-        {
-            // Index 0 is the first health check's connection; index 1 is the second health check's connection.
-            int index = Interlocked.Increment(ref connectionCounter) - 1;
-
-            var commandMock = new Mock<DbCommand>();
-            var connectionMock = new Mock<DbConnection>();
-
-            commandMock.Setup(command => command.ExecuteScalarAsync(It.IsAny<CancellationToken>())).Returns(async () =>
-            {
-                if (index == 0)
-                {
-                    // Hold the first check's connection open until the second check has fully completed, including
-                    // disposing its own connection. If both checks shared a single connection instance, closing it
-                    // from the second check would fail the first check's still-in-flight command with
-                    // "Invalid operation. The connection is closed."
-                    await secondCheckCompleted.Task;
-                }
-
-                return 1;
-            });
-
-            connectionMock.Setup(connection => connection.OpenAsync(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
-            connectionMock.Protected().Setup<DbCommand>("CreateDbCommand").Returns(() => commandMock.Object);
-            createdConnections.Add(connectionMock);
-
-            return connectionMock.Object;
-        }
-    }
-
-    [Fact]
     public async Task Canceled_Throws()
     {
         var connectionMock = new Mock<DbConnection>();

--- a/src/Connectors/test/Connectors.Test/RelationalDatabaseHealthContributorTest.cs
+++ b/src/Connectors/test/Connectors.Test/RelationalDatabaseHealthContributorTest.cs
@@ -18,9 +18,8 @@ public sealed class RelationalDatabaseHealthContributorTest
     [Fact]
     public async Task PostgreSQL_Not_Connected_Returns_Down_Status()
     {
-        DbConnection connection = new NpgsqlConnection("Server=localhost;Port=9999;Timeout=1");
-
-        using var healthContributor = new RelationalDatabaseHealthContributor(connection, "localhost", NullLogger<RelationalDatabaseHealthContributor>.Instance)
+        var healthContributor = new RelationalDatabaseHealthContributor(() => new NpgsqlConnection("Server=localhost;Port=9999;Timeout=1"), "PostgreSQL",
+            "localhost", NullLogger<RelationalDatabaseHealthContributor>.Instance)
         {
             ServiceName = "Example"
         };
@@ -38,9 +37,8 @@ public sealed class RelationalDatabaseHealthContributorTest
     [Fact(Skip = "Integration test - Requires local PostgreSQL server")]
     public async Task PostgreSQL_Integration_Is_Connected_Returns_Up_Status()
     {
-        DbConnection connection = new NpgsqlConnection("Server=localhost;User ID=steeltoe;Password=steeltoe");
-
-        using var healthContributor = new RelationalDatabaseHealthContributor(connection, "localhost", NullLogger<RelationalDatabaseHealthContributor>.Instance)
+        var healthContributor = new RelationalDatabaseHealthContributor(() => new NpgsqlConnection("Server=localhost;User ID=steeltoe;Password=steeltoe"),
+            "PostgreSQL", "localhost", NullLogger<RelationalDatabaseHealthContributor>.Instance)
         {
             ServiceName = "Example"
         };
@@ -57,9 +55,8 @@ public sealed class RelationalDatabaseHealthContributorTest
     [Fact]
     public async Task MySQL_Not_Connected_Returns_Down_Status()
     {
-        DbConnection connection = new MySqlConnection("Server=localhost;Port=9999;Connect Timeout=1");
-
-        using var healthContributor = new RelationalDatabaseHealthContributor(connection, "localhost", NullLogger<RelationalDatabaseHealthContributor>.Instance)
+        var healthContributor = new RelationalDatabaseHealthContributor(() => new MySqlConnection("Server=localhost;Port=9999;Connect Timeout=1"), "MySQL",
+            "localhost", NullLogger<RelationalDatabaseHealthContributor>.Instance)
         {
             ServiceName = "Example"
         };
@@ -77,9 +74,8 @@ public sealed class RelationalDatabaseHealthContributorTest
     [Fact(Skip = "Integration test - Requires local MySQL server")]
     public async Task MySQL_Integration_Is_Connected_Returns_Up_Status()
     {
-        DbConnection connection = new MySqlConnection("Server=localhost;User ID=steeltoe;Password=steeltoe");
-
-        using var healthContributor = new RelationalDatabaseHealthContributor(connection, "localhost", NullLogger<RelationalDatabaseHealthContributor>.Instance)
+        var healthContributor = new RelationalDatabaseHealthContributor(() => new MySqlConnection("Server=localhost;User ID=steeltoe;Password=steeltoe"),
+            "MySQL", "localhost", NullLogger<RelationalDatabaseHealthContributor>.Instance)
         {
             ServiceName = "Example"
         };
@@ -97,9 +93,9 @@ public sealed class RelationalDatabaseHealthContributorTest
     public async Task SQLServer_Not_Connected_Returns_Down_Status()
     {
         // Using a known host/port, so running this test doesn't take 15 seconds (the Connect Timeout only kicks in *after* establishing the socket connection).
-        DbConnection connection = new SqlConnection("Server=tcp:www.microsoft.com,80;Connect Timeout=1;Connect Retry Count=0");
-
-        using var healthContributor = new RelationalDatabaseHealthContributor(connection, "localhost", NullLogger<RelationalDatabaseHealthContributor>.Instance)
+        var healthContributor = new RelationalDatabaseHealthContributor(
+            () => new SqlConnection("Server=tcp:www.microsoft.com,80;Connect Timeout=1;Connect Retry Count=0"), "SQL Server", "localhost",
+            NullLogger<RelationalDatabaseHealthContributor>.Instance)
         {
             ServiceName = "Example"
         };
@@ -120,9 +116,8 @@ public sealed class RelationalDatabaseHealthContributorTest
     [Fact(Skip = "Integration test - Requires local SQL Server instance")]
     public async Task SQLServer_Integration_Is_Connected_Returns_Up_Status()
     {
-        DbConnection connection = new SqlConnection(@"Server=(localdb)\mssqllocaldb");
-
-        using var healthContributor = new RelationalDatabaseHealthContributor(connection, "localhost", NullLogger<RelationalDatabaseHealthContributor>.Instance)
+        var healthContributor = new RelationalDatabaseHealthContributor(() => new SqlConnection(@"Server=(localdb)\mssqllocaldb"), "SQL Server", "localhost",
+            NullLogger<RelationalDatabaseHealthContributor>.Instance)
         {
             ServiceName = "Example"
         };
@@ -146,11 +141,11 @@ public sealed class RelationalDatabaseHealthContributorTest
         connectionMock.Setup(connection => connection.Open());
         connectionMock.Protected().Setup<DbCommand>("CreateDbCommand").Returns(() => commandMock.Object);
 
-        using var healthContributor =
-            new RelationalDatabaseHealthContributor(connectionMock.Object, "localhost", NullLogger<RelationalDatabaseHealthContributor>.Instance)
-            {
-                ServiceName = "Example"
-            };
+        var healthContributor = new RelationalDatabaseHealthContributor(() => connectionMock.Object, "SQL Server", "localhost",
+            NullLogger<RelationalDatabaseHealthContributor>.Instance)
+        {
+            ServiceName = "Example"
+        };
 
         HealthCheckResult? result = await healthContributor.CheckHealthAsync(TestContext.Current.CancellationToken);
 
@@ -159,6 +154,68 @@ public sealed class RelationalDatabaseHealthContributorTest
         result.Details.Should().Contain("host", "localhost");
         result.Details.Should().Contain("service", "Example");
         result.Details.Should().NotContainKey("error");
+    }
+
+    [Fact]
+    public async Task Concurrent_Health_Checks_Use_Independent_Connections()
+    {
+        var secondCheckCompleted = new TaskCompletionSource();
+        var createdConnections = new List<Mock<DbConnection>>();
+        int connectionCounter = 0;
+
+        var healthContributor = new RelationalDatabaseHealthContributor(CreateConnectionThatWaitsForSecondCheck, "SQL Server", "localhost",
+            NullLogger<RelationalDatabaseHealthContributor>.Instance)
+        {
+            ServiceName = "Example"
+        };
+
+        Task<HealthCheckResult?> firstCheckTask = healthContributor.CheckHealthAsync(TestContext.Current.CancellationToken);
+
+        HealthCheckResult? secondResult = await healthContributor.CheckHealthAsync(TestContext.Current.CancellationToken);
+        secondCheckCompleted.SetResult();
+
+        HealthCheckResult? firstResult = await firstCheckTask;
+
+        createdConnections.Should().HaveCount(2);
+        createdConnections[0].Object.Should().NotBeSameAs(createdConnections[1].Object);
+
+        firstResult.Should().NotBeNull();
+        firstResult.Status.Should().Be(HealthStatus.Up);
+        firstResult.Details.Should().NotContainKey("error");
+
+        secondResult.Should().NotBeNull();
+        secondResult.Status.Should().Be(HealthStatus.Up);
+        secondResult.Details.Should().NotContainKey("error");
+        return;
+
+        DbConnection CreateConnectionThatWaitsForSecondCheck()
+        {
+            // Index 0 is the first health check's connection; index 1 is the second health check's connection.
+            int index = Interlocked.Increment(ref connectionCounter) - 1;
+
+            var commandMock = new Mock<DbCommand>();
+            var connectionMock = new Mock<DbConnection>();
+
+            commandMock.Setup(command => command.ExecuteScalarAsync(It.IsAny<CancellationToken>())).Returns(async () =>
+            {
+                if (index == 0)
+                {
+                    // Hold the first check's connection open until the second check has fully completed, including
+                    // disposing its own connection. If both checks shared a single connection instance, closing it
+                    // from the second check would fail the first check's still-in-flight command with
+                    // "Invalid operation. The connection is closed."
+                    await secondCheckCompleted.Task;
+                }
+
+                return 1;
+            });
+
+            connectionMock.Setup(connection => connection.OpenAsync(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+            connectionMock.Protected().Setup<DbCommand>("CreateDbCommand").Returns(() => commandMock.Object);
+            createdConnections.Add(connectionMock);
+
+            return connectionMock.Object;
+        }
     }
 
     [Fact]
@@ -172,8 +229,8 @@ public sealed class RelationalDatabaseHealthContributorTest
             return null!;
         });
 
-        using var healthContributor =
-            new RelationalDatabaseHealthContributor(connectionMock.Object, "localhost", NullLogger<RelationalDatabaseHealthContributor>.Instance);
+        var healthContributor = new RelationalDatabaseHealthContributor(() => connectionMock.Object, "SQL Server", "localhost",
+            NullLogger<RelationalDatabaseHealthContributor>.Instance);
 
         using var source = new CancellationTokenSource();
         await source.CancelAsync();


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->

<!-- If this is your first PR in this repo, please read our [Contributing Guidelines (https://github.com/SteeltoeOSS/.github/blob/master/CONTRIBUTING.md) and remember to sign the [Contributor License Agreement](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-license.md). Our bot will notify you shortly after the PR has been created. -->

## Description

- Update RelationalDatabaseHealthContributor to take a connection factory so each health check manages its own connection, avoiding overlapping checks opening and closing the same connection at the same time.
- Pass the database type name directly to skip reflection.

Fixes #1732 

## Quality checklist

<!-- Please run through the checklist below to ensure a smooth review and merge process for your PR. -->

- [x] Your code complies with our [Coding Style](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-code-style.md).
- [x] You've updated unit and/or integration tests for your change, where applicable.
- [ ] You've updated documentation for your change, where applicable.
      If your change affects other repositories, such as [Documentation](https://github.com/SteeltoeOSS/Documentation) and/or [Samples](https://github.com/SteeltoeOSS/Samples), add linked PRs here.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
- [x] You've added required license files and/or file headers (explaining where the code came from with proper attribution), where code is copied from StackOverflow, a blog, or OSS.
