### PR TITLE
Package updates

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "jetbrains.resharper.globaltools": {
-      "version": "2026.2.0.2",
+      "version": "2026.2.1",
       "commands": [
         "jb"
       ],
@@ -17,7 +17,7 @@
       "rollForward": false
     },
     "dotnet-coverage": {
-      "version": "18.9.0",
+      "version": "18.11.0",
       "commands": [
         "dotnet-coverage"
       ],

--- a/Steeltoe.Debug.ruleset
+++ b/Steeltoe.Debug.ruleset
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<RuleSet Name="Steeltoe Debug" Description="Code quality rules for Steeltoe debug builds" ToolsVersion="17.0">
+<RuleSet Name="Steeltoe Debug" Description="Code quality rules for Steeltoe debug builds" ToolsVersion="18.0">
   <Rules AnalyzerId="Microsoft.CodeAnalysis.CSharp.NetAnalyzers" RuleNamespace="Microsoft.CodeAnalysis.CSharp.NetAnalyzers">
     <Rule Id="CA1865" Action="Warning" />
     <Rule Id="CA1866" Action="Warning" />
@@ -128,6 +128,7 @@
     <Rule Id="S6798" Action="None" />
     <Rule Id="S6800" Action="None" />
     <Rule Id="S881" Action="Warning" />
+    <Rule Id="S8969" Action="None" />
   </Rules>
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
     <Rule Id="SA1000" Action="None" />

--- a/Steeltoe.Release.ruleset
+++ b/Steeltoe.Release.ruleset
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<RuleSet Name="Steeltoe Release" Description="Code quality rules for Steeltoe release builds" ToolsVersion="17.0">
+<RuleSet Name="Steeltoe Release" Description="Code quality rules for Steeltoe release builds" ToolsVersion="18.0">
   <Rules AnalyzerId="Microsoft.CodeAnalysis.CSharp.NetAnalyzers" RuleNamespace="Microsoft.CodeAnalysis.CSharp.NetAnalyzers">
     <Rule Id="CA1865" Action="Warning" />
     <Rule Id="CA1866" Action="Warning" />
@@ -113,6 +113,7 @@
     <Rule Id="S6798" Action="None" />
     <Rule Id="S6800" Action="None" />
     <Rule Id="S881" Action="Warning" />
+    <Rule Id="S8969" Action="None" />
   </Rules>
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
     <Rule Id="SA1000" Action="None" />

--- a/shared-test.props
+++ b/shared-test.props
@@ -15,7 +15,7 @@
     <PackageReference Include="coverlet.collector" Version="$(CoverletVersion)" PrivateAssets="All" />
     <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="$(MatchTargetFrameworkVersion)" />
-    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="$(FoundationalVersion)" />
+    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="$(TimeProviderTestingVersion)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
     <PackageReference Include="NSubstitute" Version="$(NSubstituteVersion)" />
     <PackageReference Include="xunit.v3" Version="$(XunitVersion)" />

--- a/shared-test.props
+++ b/shared-test.props
@@ -18,8 +18,8 @@
     <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="$(TimeProviderTestingVersion)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
     <PackageReference Include="NSubstitute" Version="$(NSubstituteVersion)" />
-    <PackageReference Include="xunit.v3" Version="$(XunitVersion)" />
     <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitVisualStudioVersion)" />
+    <PackageReference Include="xunit.v3" Version="$(XunitVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Bootstrap/test/AutoConfiguration.Test/Steeltoe.Bootstrap.AutoConfiguration.Test.csproj
+++ b/src/Bootstrap/test/AutoConfiguration.Test/Steeltoe.Bootstrap.AutoConfiguration.Test.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="$(MatchTargetFrameworkVersion)" />
     <PackageReference Include="MongoDB.Driver" Version="$(MongoDbDriverVersion)" />
     <PackageReference Include="MySqlConnector" Version="$(MySqlConnectorVersion)" />
+    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
     <PackageReference Include="Npgsql" Version="$(EntityFrameworkCoreTestVersion)" />
     <PackageReference Include="RabbitMQ.Client" Version="$(RabbitClientTestVersion)" />
   </ItemGroup>

--- a/src/Common/src/Hosting/HostBuilderWrapper.cs
+++ b/src/Common/src/Hosting/HostBuilderWrapper.cs
@@ -148,9 +148,7 @@ internal sealed class HostBuilderWrapper
         }
         else
         {
-#pragma warning disable S4792 // Configuring loggers is security-sensitive
             _configureServicesActions.Add((contextWrapper, collection) => collection.AddLogging(builder => configureAction(contextWrapper, builder)));
-#pragma warning restore S4792 // Configuring loggers is security-sensitive
         }
     }
 

--- a/src/Common/src/Logging/BootstrapLoggerFactory.cs
+++ b/src/Common/src/Logging/BootstrapLoggerFactory.cs
@@ -24,9 +24,7 @@ public sealed class BootstrapLoggerFactory : ILoggerFactory
     private static readonly Action<ILoggingBuilder> ConfigureConsole = loggingBuilder =>
     {
         loggingBuilder.SetMinimumLevel(LogLevel.Trace);
-#pragma warning disable S4792 // Configuring loggers is security-sensitive
         loggingBuilder.AddConsole(options => options.MaxQueueLength = 1);
-#pragma warning restore S4792 // Configuring loggers is security-sensitive
 
         var appSettings = new Dictionary<string, string?>
         {
@@ -81,9 +79,7 @@ public sealed class BootstrapLoggerFactory : ILoggerFactory
     {
         ArgumentNullException.ThrowIfNull(configure);
 
-#pragma warning disable S4792 // Configuring loggers is security-sensitive
         return new BootstrapLoggerFactory(configure);
-#pragma warning restore S4792 // Configuring loggers is security-sensitive
     }
 
     /// <inheritdoc />

--- a/src/Connectors/src/Connectors/PublicAPI.Shipped.txt
+++ b/src/Connectors/src/Connectors/PublicAPI.Shipped.txt
@@ -112,3 +112,5 @@ Steeltoe.Connectors.SqlServer.SqlServerHostApplicationBuilderExtensions
 Steeltoe.Connectors.SqlServer.SqlServerOptions
 Steeltoe.Connectors.SqlServer.SqlServerOptions.SqlServerOptions() -> void
 Steeltoe.Connectors.SqlServer.SqlServerServiceCollectionExtensions
+virtual Steeltoe.Connectors.ConnectorCreateConnection.Invoke(System.IServiceProvider! serviceProvider, string! serviceBindingName) -> object!
+virtual Steeltoe.Connectors.ConnectorCreateHealthContributor.Invoke(System.IServiceProvider! serviceProvider, string! serviceBindingName) -> Steeltoe.Common.HealthChecks.IHealthContributor!

--- a/src/Connectors/test/Connectors.Test/RelationalDatabaseHealthContributorTest.cs
+++ b/src/Connectors/test/Connectors.Test/RelationalDatabaseHealthContributorTest.cs
@@ -32,7 +32,12 @@ public sealed class RelationalDatabaseHealthContributorTest
         result.Description.Should().Be("PostgreSQL health check failed");
         result.Details.Should().Contain("host", "localhost");
         result.Details.Should().Contain("service", "Example");
-        result.Details.Should().ContainKey("error").WhoseValue.As<string>().Should().StartWith("NpgsqlException: ");
+
+        string errorMessage = result.Details.Should().ContainKey("error").WhoseValue.As<string>();
+
+        errorMessage.Should().Match(error =>
+            error.StartsWith("NpgsqlException: Failed to connect", StringComparison.Ordinal) ||
+            error.StartsWith("TimeoutException: ", StringComparison.Ordinal));
     }
 
     [Fact(Skip = "Integration test - Requires local PostgreSQL server")]

--- a/src/Connectors/test/Connectors.Test/Steeltoe.Connectors.Test.csproj
+++ b/src/Connectors/test/Connectors.Test/Steeltoe.Connectors.Test.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net10.0;net9.0;net8.0</TargetFrameworks>
   </PropertyGroup>
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="$(MicrosoftAzureCosmosVersion)" />
+    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
     <PackageReference Include="System.Data.SqlClient" Version="$(SystemSqlClientVersion)" />
     <PackageReference Include="System.Text.Json" Version="$(FoundationalVersion)" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="$(MicrosoftSqlClientVersion)" />

--- a/src/Connectors/test/Connectors.Test/Steeltoe.Connectors.Test.csproj
+++ b/src/Connectors/test/Connectors.Test/Steeltoe.Connectors.Test.csproj
@@ -7,16 +7,16 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="$(MicrosoftAzureCosmosVersion)" />
-    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
-    <PackageReference Include="System.Data.SqlClient" Version="$(SystemSqlClientVersion)" />
-    <PackageReference Include="System.Text.Json" Version="$(FoundationalVersion)" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="$(MicrosoftSqlClientVersion)" />
     <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="$(MatchTargetFrameworkVersion)" />
     <PackageReference Include="MongoDB.Driver" Version="$(MongoDbDriverVersion)" />
-    <PackageReference Include="MySqlConnector" Version="$(MySqlConnectorVersion)" />
     <PackageReference Include="MySql.Data" Version="$(MySqlDataVersion)" />
+    <PackageReference Include="MySqlConnector" Version="$(MySqlConnectorVersion)" />
+    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
     <PackageReference Include="Npgsql" Version="$(EntityFrameworkCoreTestVersion)" />
     <PackageReference Include="RabbitMQ.Client" Version="$(RabbitClientTestVersion)" />
+    <PackageReference Include="System.Data.SqlClient" Version="$(SystemSqlClientVersion)" />
+    <PackageReference Include="System.Text.Json" Version="$(FoundationalVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Connectors/test/EntityFrameworkCore.Test/Steeltoe.Connectors.EntityFrameworkCore.Test.csproj
+++ b/src/Connectors/test/EntityFrameworkCore.Test/Steeltoe.Connectors.EntityFrameworkCore.Test.csproj
@@ -9,9 +9,9 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="$(EntityFrameworkCoreTestVersion)" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="$(EntityFrameworkCoreTestVersion)" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="$(EntityFrameworkCoreTestVersion)" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="$(EntityFrameworkCoreTestVersion)" />
     <PackageReference Include="Microting.EntityFrameworkCore.MySql" Condition="'$(TargetFramework)' != 'net9.0' And '$(TargetFramework)' != 'net8.0'" Version="$(EntityFrameworkCoreTestVersion)" />
     <PackageReference Include="MySql.EntityFrameworkCore" Version="$(EntityFrameworkCoreTestVersion)" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="$(EntityFrameworkCoreTestVersion)" />
     <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Condition="'$(TargetFramework)' == 'net9.0' Or '$(TargetFramework)' == 'net8.0'" Version="$(EntityFrameworkCoreTestVersion)" />
     <PackageReference Include="System.Text.Json" Version="$(FoundationalVersion)" />
   </ItemGroup>

--- a/src/Logging/src/Abstractions/PublicAPI.Shipped.txt
+++ b/src/Logging/src/Abstractions/PublicAPI.Shipped.txt
@@ -35,3 +35,4 @@ Steeltoe.Logging.MessageProcessingLogger.MessageProcessors.get -> System.Collect
 virtual Steeltoe.Logging.DynamicLoggerProvider.CreateMessageProcessingLogger(string! categoryName) -> Steeltoe.Logging.MessageProcessingLogger!
 virtual Steeltoe.Logging.DynamicLoggerProvider.Dispose(bool disposing) -> void
 virtual Steeltoe.Logging.MessageProcessingLogger.Log<TState>(Microsoft.Extensions.Logging.LogLevel logLevel, Microsoft.Extensions.Logging.EventId eventId, TState state, System.Exception? exception, System.Func<TState, System.Exception?, string!>! formatter) -> void
+virtual Steeltoe.Logging.LoggerFilter.Invoke(Microsoft.Extensions.Logging.LogLevel level) -> bool

--- a/src/Logging/src/DynamicConsole/LoggingBuilderExtensions.cs
+++ b/src/Logging/src/DynamicConsole/LoggingBuilderExtensions.cs
@@ -51,9 +51,7 @@ public static class LoggingBuilderExtensions
     {
         if (builder.Services.All(descriptor => descriptor.SafeGetImplementationType() != typeof(ConsoleLoggerProvider)))
         {
-#pragma warning disable S4792 // Configuring loggers is security-sensitive
             builder.AddConsole();
-#pragma warning restore S4792 // Configuring loggers is security-sensitive
         }
     }
 

--- a/src/Logging/src/DynamicSerilog/SerilogOptions.cs
+++ b/src/Logging/src/DynamicSerilog/SerilogOptions.cs
@@ -50,9 +50,7 @@ public sealed class SerilogOptions
             MinimumLevel.Default = defaultLevel;
         }
 
-#pragma warning disable S4792 // Configuring loggers is security-sensitive
         _serilogConfiguration = new LoggerConfiguration().ReadFrom.Configuration(configuration).ClearLevels(MinimumLevel);
-#pragma warning restore S4792 // Configuring loggers is security-sensitive
     }
 
     /// <summary>

--- a/src/Logging/src/DynamicSerilog/Steeltoe.Logging.DynamicSerilog.csproj
+++ b/src/Logging/src/DynamicSerilog/Steeltoe.Logging.DynamicSerilog.csproj
@@ -9,8 +9,8 @@
   <Import Project="..\..\..\..\shared.props" />
 
   <ItemGroup>
-    <PackageReference Include="Serilog.Extensions.Logging" Version="$(SerilogVersion)" />
-    <PackageReference Include="Serilog.Settings.Configuration" Version="$(SerilogVersion)" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="$(SerilogExtensionsLoggingVersion)" />
+    <PackageReference Include="Serilog.Settings.Configuration" Version="$(SerilogSettingsConfigurationVersion)" />
     <PackageReference Include="Serilog.Sinks.Console" Version="$(SerilogSinksConsoleVersion)" />
   </ItemGroup>
 

--- a/src/Management/src/Endpoint/Actuators/Loggers/EndpointServiceCollectionExtensions.cs
+++ b/src/Management/src/Endpoint/Actuators/Loggers/EndpointServiceCollectionExtensions.cs
@@ -40,9 +40,7 @@ public static class EndpointServiceCollectionExtensions
     {
         ArgumentNullException.ThrowIfNull(services);
 
-#pragma warning disable S4792 // Configuring loggers is security-sensitive
         services.AddLogging(loggingBuilder => loggingBuilder.AddDynamicConsole());
-#pragma warning restore S4792 // Configuring loggers is security-sensitive
 
         services.AddCoreActuatorServices<LoggersEndpointOptions, ConfigureLoggersEndpointOptions, LoggersEndpointMiddleware, ILoggersEndpointHandler,
             LoggersEndpointHandler, LoggersRequest, LoggersResponse?>(configureMiddleware);

--- a/src/Management/src/Endpoint/CoreActuatorServiceCollectionExtensions.cs
+++ b/src/Management/src/Endpoint/CoreActuatorServiceCollectionExtensions.cs
@@ -76,10 +76,7 @@ public static class CoreActuatorServiceCollectionExtensions
 
     private static void AddCommonActuatorServices(IServiceCollection services, bool configureMiddleware)
     {
-#pragma warning disable S4792 // Configuring loggers is security-sensitive
         services.AddLogging();
-#pragma warning restore S4792 // Configuring loggers is security-sensitive
-
         services.AddRouting();
         services.TryAddSingleton<ActuatorRouteMapper>();
         services.TryAddSingleton<ActuatorEndpointMapper>();

--- a/src/Management/src/Tracing/TracingServiceCollectionExtensions.cs
+++ b/src/Management/src/Tracing/TracingServiceCollectionExtensions.cs
@@ -31,9 +31,7 @@ public static class TracingServiceCollectionExtensions
         ArgumentNullException.ThrowIfNull(services);
 
         services.AddApplicationInstanceInfo();
-#pragma warning disable S4792 // Configuring loggers is security-sensitive
         services.AddLogging(loggingBuilder => loggingBuilder.AddDynamicConsole());
-#pragma warning restore S4792 // Configuring loggers is security-sensitive
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IDynamicMessageProcessor, TracingLogProcessor>());
 
         return services;

--- a/versions.props
+++ b/versions.props
@@ -22,7 +22,7 @@
     <RabbitClientTestVersion>7.2.*</RabbitClientTestVersion>
     <SerilogEnrichersThreadVersion>4.0.*</SerilogEnrichersThreadVersion>
     <SerilogExceptionsVersion>8.4.*</SerilogExceptionsVersion>
-    <SonarAnalyzerVersion>10.25.0.139117</SonarAnalyzerVersion>
+    <SonarAnalyzerVersion>10.33.0.1635</SonarAnalyzerVersion>
     <StyleCopVersion>1.2.0-beta.556</StyleCopVersion>
     <SystemCommandLineVersion>2.0.*</SystemCommandLineVersion>
     <SystemIdentityModelVersion>8.22.*</SystemIdentityModelVersion>

--- a/versions.props
+++ b/versions.props
@@ -8,28 +8,29 @@
     <AspNetCoreHealthChecksVersion>9.0.*</AspNetCoreHealthChecksVersion>
     <CoverletVersion>10.0.*</CoverletVersion>
     <FluentAssertionsVersion>7.2.*</FluentAssertionsVersion>
-    <MicrosoftAzureCosmosVersion>3.58.*</MicrosoftAzureCosmosVersion>
-    <MicrosoftBuildUtilitiesCoreVersion>18.7.*</MicrosoftBuildUtilitiesCoreVersion>
-    <MicrosoftCodeAnalysisVersion>5.0.*</MicrosoftCodeAnalysisVersion>
+    <MicrosoftAzureCosmosVersion>3.62.*</MicrosoftAzureCosmosVersion>
+    <MicrosoftBuildUtilitiesCoreVersion>18.9.*</MicrosoftBuildUtilitiesCoreVersion>
+    <MicrosoftCodeAnalysisVersion>5.9.*</MicrosoftCodeAnalysisVersion>
     <MicrosoftSqlClientVersion>7.0.*</MicrosoftSqlClientVersion>
-    <MockHttpVersion>7.0.*</MockHttpVersion>
-    <MongoDbDriverVersion>3.8.*</MongoDbDriverVersion>
+    <MockHttpVersion>7.1.*</MockHttpVersion>
+    <MongoDbDriverVersion>3.11.*</MongoDbDriverVersion>
     <MySqlConnectorVersion>2.6.*</MySqlConnectorVersion>
-    <MySqlDataVersion>9.7.*</MySqlDataVersion>
+    <MySqlDataVersion>26.7.*</MySqlDataVersion>
     <NewtonsoftJsonVersion>13.0.*</NewtonsoftJsonVersion>
     <NSubstituteVersion>6.2.*</NSubstituteVersion>
-    <PublicApiAnalyzersVersion>3.3.*</PublicApiAnalyzersVersion>
+    <PublicApiAnalyzersVersion>5.6.*</PublicApiAnalyzersVersion>
     <RabbitClientTestVersion>7.2.*</RabbitClientTestVersion>
     <SerilogEnrichersThreadVersion>4.0.*</SerilogEnrichersThreadVersion>
     <SerilogExceptionsVersion>8.4.*</SerilogExceptionsVersion>
     <SonarAnalyzerVersion>10.25.0.139117</SonarAnalyzerVersion>
     <StyleCopVersion>1.2.0-beta.556</StyleCopVersion>
     <SystemCommandLineVersion>2.0.*</SystemCommandLineVersion>
-    <SystemIdentityModelVersion>8.15.*</SystemIdentityModelVersion>
+    <SystemIdentityModelVersion>8.22.*</SystemIdentityModelVersion>
     <SystemSqlClientVersion>4.9.*</SystemSqlClientVersion>
-    <TestSdkVersion>18.5.*</TestSdkVersion>
+    <TestSdkVersion>18.9.*</TestSdkVersion>
+    <TimeProviderTestingVersion>10.9.*</TimeProviderTestingVersion>
     <XunitVersion>3.2.*</XunitVersion>
-    <XunitVisualStudioVersion>3.1.*</XunitVisualStudioVersion>
+    <XunitVisualStudioVersion>4.0.*</XunitVisualStudioVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">
@@ -53,7 +54,7 @@
     -->
 
     <BouncyCastleVersion>2.2.*</BouncyCastleVersion>
-    <ConsulVersion>1.7.14.*</ConsulVersion>
+    <ConsulVersion>1.8.*</ConsulVersion>
     <DotnetGCDumpVersion>9.0.652701</DotnetGCDumpVersion>
     <EntityFrameworkCoreVersion>8.0.*</EntityFrameworkCoreVersion>
     <FoundationalVersion>
@@ -67,8 +68,10 @@
     <MicrosoftDiagnosticsTracingTraceEventVersion>3.1.23</MicrosoftDiagnosticsTracingTraceEventVersion>
     <OpenTelemetryExporterPrometheusVersion>1.15.*-*</OpenTelemetryExporterPrometheusVersion>
     <OpenTelemetryVersion>1.15.*</OpenTelemetryVersion>
-    <SerilogVersion>9.0.*</SerilogVersion>
+    <SerilogExtensionsLoggingVersion>10.0.*</SerilogExtensionsLoggingVersion>
+    <SerilogSettingsConfigurationVersion>10.0.*</SerilogSettingsConfigurationVersion>
     <SerilogSinksConsoleVersion>6.1.*</SerilogSinksConsoleVersion>
+    <SerilogVersion>9.0.*</SerilogVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">


### PR DESCRIPTION
## Description

### Package updates that affect Steeltoe users
- `Consul` from 1.7.14.* to 1.8.*: The only change is that the package now follows SemVer
- `Serilog.Extensions.Logging` from 9.0.* to 10.0.*: Adds a `net10.0` target (released 10 months ago)
- `Serilog.Settings.Configuration` from 9.0.* to 10.0.*: Adds a `net10.0` target and minor fixes (released 9 months ago)

### Notes about internal dependency updates
- `Microsoft.Azure.Cosmos` from 3.58.* to 3.62.*: Should update [Samples](https://github.com/SteeltoeOSS/Samples) and [NetCoreToolTemplates](https://github.com/SteeltoeOSS/NetCoreToolTemplates) likewise; requires explicit reference to `Newtonsoft.Json`
- `MongoDB.Driver` from 3.8.* to 3.11.*: Should update [Samples](https://github.com/SteeltoeOSS/Samples) and [NetCoreToolTemplates](https://github.com/SteeltoeOSS/NetCoreToolTemplates) likewise
- `MySql.Data` from 9.7.* to 26.7.*: Should update [Samples](https://github.com/SteeltoeOSS/Samples) and [NetCoreToolTemplates](https://github.com/SteeltoeOSS/NetCoreToolTemplates) likewise
- `Microsoft.CodeAnalysis.PublicApiAnalyzers`: Changes to PublicAPI *shipped* files because `Delegate.Invoke` is now required
- `Microsoft.Extensions.TimeProvider.Testing` from 10.0.* to 10.9.*: This package was assumed to version along with the runtime, which appears not to be the case.
- `SonarAnalyzer.CSharp` from 10.25.0.139117 to 10.33.0.1635: Changes in rules (see below); updated `Steeltoe way` in SonarCloud to match up
- Sorted `PackageReference` entries alphabetically.

Full ReSharper code cleanup run at: https://github.com/SteeltoeOSS/Steeltoe/actions/runs/34225245010.

### Sonar rule changes
| Change | Rule  | Default Setting                           | Steeltoe Override                                             | Description                                     |
|--------|-------|-------------------------------------------|---------------------------------------------------------------|-------------------------------------------------|
| -      | S4792 |                                           |                                                               | Configuring loggers is security-sensitive       |
| *      | S5042 | Warning -> None                           |                                                               | Guard against "Zip Bomb" attacks                |
| +      | S8949 | Warning                                   |                                                               | Use overload that takes CancellationToken       |
| +      | S8969 | Warning                                   | None (false positives, already checked in IDE* and ReSharper) | ! operators should not be redundant             |
| +      | S8970 | Warning                                   |                                                               | Don't use ! when nullable disabled              |
| +      | S8717 | [SonarCloud-only]                         |                                                               | Don't use multiple [Key] attributes in EF Core  |
| +      | S8718 | [SonarCloud-only]                         |                                                               | About EF Core client-evaluated default values   |
| +      | S8733 | [SonarCloud-only]                         |                                                               | Use AsSplitQuery in EF Core                     |
| +      | S8747 | [SonarCloud-only]                         |                                                               | Don't narrow column types in EF Core migrations |
| +      | S9022 | [SonarCloud-only]                         |                                                               | Duplicate Include calls in EF Core              |
| +      | S9129 | [SonarCloud-only]                         |                                                               | Merge include chains in EF Core                 |

## Quality checklist

- [x] Your code complies with our [Coding Style](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-code-style.md).
- [ ] You've updated unit and/or integration tests for your change, where applicable.
- [x] You've updated documentation for your change, where applicable.
      If your change affects other repositories, such as [Documentation](https://github.com/SteeltoeOSS/Documentation) and/or [Samples](https://github.com/SteeltoeOSS/Samples), add linked PRs here.
      - https://github.com/SteeltoeOSS/Samples/pull/477
      - https://github.com/SteeltoeOSS/NetCoreToolTemplates/pull/150
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
- [ ] You've added required license files and/or file headers (explaining where the code came from with proper attribution), where code is copied from StackOverflow, a blog, or OSS.
