### PR TITLE
Migrate tests from Moq to NSubstitute

### DIFF
--- a/shared-test.props
+++ b/shared-test.props
@@ -17,7 +17,7 @@
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="$(MatchTargetFrameworkVersion)" />
     <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="$(FoundationalVersion)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
-    <PackageReference Include="Moq" Version="$(MoqVersion)" />
+    <PackageReference Include="NSubstitute" Version="$(NSubstituteVersion)" />
     <PackageReference Include="xunit.v3" Version="$(XunitVersion)" />
     <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitVisualStudioVersion)" />
   </ItemGroup>

--- a/src/Common/test/TestResources/Steeltoe.Common.TestResources.csproj
+++ b/src/Common/test/TestResources/Steeltoe.Common.TestResources.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="$(MatchTargetFrameworkVersion)" />
-    <PackageReference Include="Moq" Version="$(MoqVersion)" />
+    <PackageReference Include="NSubstitute" Version="$(NSubstituteVersion)" />
     <PackageReference Include="RichardSzalay.MockHttp" Version="$(MockHttpVersion)" />
     <PackageReference Include="System.Collections.Immutable" Version="$(FoundationalVersion)" />
     <PackageReference Include="xunit.v3.assert" Version="$(XunitVersion)" />

--- a/src/Connectors/test/Connectors.Test/CosmosDb/CosmosDbHealthContributorTest.cs
+++ b/src/Connectors/test/Connectors.Test/CosmosDb/CosmosDbHealthContributorTest.cs
@@ -6,9 +6,10 @@ using FluentAssertions.Extensions;
 using Microsoft.Azure.Cosmos;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
-using Moq;
-using Moq.Protected;
+using NSubstitute;
+using RichardSzalay.MockHttp;
 using Steeltoe.Common.HealthChecks;
+using Steeltoe.Common.TestResources;
 using Steeltoe.Connectors.CosmosDb;
 using Steeltoe.Connectors.CosmosDb.DynamicTypeAccess;
 
@@ -22,14 +23,12 @@ public sealed class CosmosDbHealthContributorTest
         const string serviceName = "Example";
         const string connectionString = "AccountEndpoint=https://localhost:8081;AccountKey=IA==";
 
-        var httpMessageHandlerMock = new Mock<HttpMessageHandler>();
-
-        httpMessageHandlerMock.Protected().Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
-            .Throws(new HttpRequestException("No connection could be made because ..."));
+        DelegateToMockHttpClientHandler httpMessageHandler = new DelegateToMockHttpClientHandler().Setup(mockHttp =>
+            mockHttp.When("*").Throw(new HttpRequestException("No connection could be made because ...")));
 
         var cosmosClient = new CosmosClient(connectionString, new CosmosClientOptions
         {
-            HttpClientFactory = () => new HttpClient(httpMessageHandlerMock.Object)
+            HttpClientFactory = () => new HttpClient(httpMessageHandler)
         });
 
         await using ServiceProvider serviceProvider = CreateServiceProvider(serviceName, connectionString, cosmosClient);
@@ -78,9 +77,9 @@ public sealed class CosmosDbHealthContributorTest
         const string serviceName = "Example";
         const string connectionString = "AccountEndpoint=https://localhost:8081;AccountKey=IA==";
 
-        var cosmosClientMock = new Mock<CosmosClient>();
+        var cosmosClient = Substitute.For<CosmosClient>();
 
-        await using ServiceProvider serviceProvider = CreateServiceProvider(serviceName, connectionString, cosmosClientMock.Object);
+        await using ServiceProvider serviceProvider = CreateServiceProvider(serviceName, connectionString, cosmosClient);
 
         using var healthContributor = new CosmosDbHealthContributor(serviceName, serviceProvider, CosmosDbPackageResolver.Default,
             NullLogger<CosmosDbHealthContributor>.Instance);
@@ -100,15 +99,15 @@ public sealed class CosmosDbHealthContributorTest
         const string serviceName = "Example";
         const string connectionString = "AccountEndpoint=https://localhost:8081;AccountKey=IA==";
 
-        var cosmosClientMock = new Mock<CosmosClient>();
+        var cosmosClient = Substitute.For<CosmosClient>();
 
-        cosmosClientMock.Setup(client => client.ReadAccountAsync()).Returns(async () =>
+        cosmosClient.ReadAccountAsync().Returns(async _ =>
         {
             await Task.Delay(3.Seconds(), TestContext.Current.CancellationToken);
             return null;
         });
 
-        await using ServiceProvider serviceProvider = CreateServiceProvider(serviceName, connectionString, cosmosClientMock.Object);
+        await using ServiceProvider serviceProvider = CreateServiceProvider(serviceName, connectionString, cosmosClient);
 
         using var healthContributor = new CosmosDbHealthContributor(serviceName, serviceProvider, CosmosDbPackageResolver.Default,
             NullLogger<CosmosDbHealthContributor>.Instance);

--- a/src/Connectors/test/Connectors.Test/MongoDb/MongoDbHealthContributorTest.cs
+++ b/src/Connectors/test/Connectors.Test/MongoDb/MongoDbHealthContributorTest.cs
@@ -6,7 +6,7 @@ using FluentAssertions.Extensions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using MongoDB.Driver;
-using Moq;
+using NSubstitute;
 using Steeltoe.Common.HealthChecks;
 using Steeltoe.Connectors.MongoDb;
 using Steeltoe.Connectors.MongoDb.DynamicTypeAccess;
@@ -48,9 +48,9 @@ public sealed class MongoDbHealthContributorTest
         const string serviceName = "Example";
         const string connectionString = "mongodb://localhost:27017";
 
-        var mongoClientMock = new Mock<IMongoClient>();
+        var mongoClient = Substitute.For<IMongoClient>();
 
-        await using ServiceProvider serviceProvider = CreateServiceProvider(serviceName, connectionString, mongoClientMock.Object);
+        await using ServiceProvider serviceProvider = CreateServiceProvider(serviceName, connectionString, mongoClient);
 
         var healthContributor = new MongoDbHealthContributor(serviceName, serviceProvider, MongoDbPackageResolver.Default,
             NullLogger<MongoDbHealthContributor>.Instance);
@@ -70,15 +70,15 @@ public sealed class MongoDbHealthContributorTest
         const string serviceName = "Example";
         const string connectionString = "mongodb://localhost:27017";
 
-        var mongoClientMock = new Mock<IMongoClient>();
+        var mongoClient = Substitute.For<IMongoClient>();
 
-        mongoClientMock.Setup(client => client.ListDatabaseNamesAsync(It.IsAny<CancellationToken>())).Returns((CancellationToken cancellationToken) =>
+        mongoClient.ListDatabaseNamesAsync(Arg.Any<CancellationToken>()).Returns(Task<IAsyncCursor<string>> (info) =>
         {
-            cancellationToken.ThrowIfCancellationRequested();
+            info.Arg<CancellationToken>().ThrowIfCancellationRequested();
             return null!;
         });
 
-        await using ServiceProvider serviceProvider = CreateServiceProvider(serviceName, connectionString, mongoClientMock.Object);
+        await using ServiceProvider serviceProvider = CreateServiceProvider(serviceName, connectionString, mongoClient);
 
         var healthContributor = new MongoDbHealthContributor(serviceName, serviceProvider, MongoDbPackageResolver.Default,
             NullLogger<MongoDbHealthContributor>.Instance);

--- a/src/Connectors/test/Connectors.Test/RabbitMQ/RabbitMQHealthContributorTest.cs
+++ b/src/Connectors/test/Connectors.Test/RabbitMQ/RabbitMQHealthContributorTest.cs
@@ -4,7 +4,7 @@
 
 using FluentAssertions.Extensions;
 using Microsoft.Extensions.Logging.Abstractions;
-using Moq;
+using NSubstitute;
 using RabbitMQ.Client;
 using Steeltoe.Common.HealthChecks;
 using Steeltoe.Connectors.RabbitMQ;
@@ -40,18 +40,18 @@ public sealed class RabbitMQHealthContributorTest
     [Fact]
     public async Task Is_Connected_Returns_Up_Status()
     {
-        var connectionMock = new Mock<IConnection>();
-        connectionMock.Setup(connection => connection.IsOpen).Returns(true);
+        var connection = Substitute.For<IConnection>();
+        connection.IsOpen.Returns(true);
 
-        connectionMock.Setup(connection => connection.ServerProperties).Returns(new Dictionary<string, object?>
+        connection.ServerProperties.Returns(new Dictionary<string, object?>
         {
             ["version"] = "1.2.3"u8.ToArray()
         });
 
-        var connectionFactoryMock = new Mock<IConnectionFactory>();
-        connectionFactoryMock.Setup(factory => factory.CreateConnectionAsync(It.IsAny<CancellationToken>())).Returns(Task.FromResult(connectionMock.Object));
+        var connectionFactory = Substitute.For<IConnectionFactory>();
+        connectionFactory.CreateConnectionAsync(Arg.Any<CancellationToken>()).Returns(Task.FromResult(connection));
 
-        using var healthContributor = new RabbitMQHealthContributor(connectionFactoryMock.Object, "localhost", NullLogger<RabbitMQHealthContributor>.Instance)
+        using var healthContributor = new RabbitMQHealthContributor(connectionFactory, "localhost", NullLogger<RabbitMQHealthContributor>.Instance)
         {
             ServiceName = "Example"
         };
@@ -69,18 +69,18 @@ public sealed class RabbitMQHealthContributorTest
     [Fact]
     public async Task Lost_Connection_Returns_Down_Status()
     {
-        var connectionMock = new Mock<IConnection>();
-        connectionMock.Setup(connection => connection.IsOpen).Returns(true);
+        var connection = Substitute.For<IConnection>();
+        connection.IsOpen.Returns(true);
 
-        connectionMock.Setup(connection => connection.ServerProperties).Returns(new Dictionary<string, object?>
+        connection.ServerProperties.Returns(new Dictionary<string, object?>
         {
             ["version"] = "1.2.3"u8.ToArray()
         });
 
-        var connectionFactoryMock = new Mock<IConnectionFactory>();
-        connectionFactoryMock.Setup(factory => factory.CreateConnectionAsync(It.IsAny<CancellationToken>())).Returns(Task.FromResult(connectionMock.Object));
+        var connectionFactory = Substitute.For<IConnectionFactory>();
+        connectionFactory.CreateConnectionAsync(Arg.Any<CancellationToken>()).Returns(Task.FromResult(connection));
 
-        using var healthContributor = new RabbitMQHealthContributor(connectionFactoryMock.Object, "localhost", NullLogger<RabbitMQHealthContributor>.Instance)
+        using var healthContributor = new RabbitMQHealthContributor(connectionFactory, "localhost", NullLogger<RabbitMQHealthContributor>.Instance)
         {
             ServiceName = "Example"
         };
@@ -88,7 +88,7 @@ public sealed class RabbitMQHealthContributorTest
         // Ensure initial connection is obtained.
         _ = await healthContributor.CheckHealthAsync(TestContext.Current.CancellationToken);
 
-        connectionMock.Setup(connection => connection.IsOpen).Returns(false);
+        connection.IsOpen.Returns(false);
 
         HealthCheckResult? result = await healthContributor.CheckHealthAsync(TestContext.Current.CancellationToken);
 
@@ -103,8 +103,8 @@ public sealed class RabbitMQHealthContributorTest
     [Fact]
     public async Task Canceled_Throws()
     {
-        var connectionFactoryMock = new Mock<IConnectionFactory>();
-        using var healthContributor = new RabbitMQHealthContributor(connectionFactoryMock.Object, "localhost", NullLogger<RabbitMQHealthContributor>.Instance);
+        var connectionFactory = Substitute.For<IConnectionFactory>();
+        using var healthContributor = new RabbitMQHealthContributor(connectionFactory, "localhost", NullLogger<RabbitMQHealthContributor>.Instance);
 
         using var source = new CancellationTokenSource();
         await source.CancelAsync();

--- a/src/Connectors/test/Connectors.Test/Redis/RedisConnectorTest.cs
+++ b/src/Connectors/test/Connectors.Test/Redis/RedisConnectorTest.cs
@@ -9,7 +9,7 @@ using Microsoft.Extensions.Caching.StackExchangeRedis;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
-using Moq;
+using NSubstitute;
 using StackExchange.Redis;
 using Steeltoe.Common.HealthChecks;
 using Steeltoe.Common.TestResources;
@@ -372,17 +372,15 @@ public sealed class RedisConnectorTest
 
     private static object GetMockedConnectionMultiplexer(string? connectionString)
     {
-        var databaseMock = new Mock<IDatabase>();
+        var database = Substitute.For<IDatabase>();
 
-        var connectionMultiplexerMock = new Mock<IConnectionMultiplexer>();
-        connectionMultiplexerMock.Setup(connectionMultiplexer => connectionMultiplexer.Configuration).Returns(connectionString!);
+        var connectionMultiplexer = Substitute.For<IConnectionMultiplexer>();
+        connectionMultiplexer.Configuration.Returns(connectionString);
+        connectionMultiplexer.GetDatabase(Arg.Any<int>(), Arg.Any<object>()).Returns(database);
 
-        connectionMultiplexerMock.Setup(connectionMultiplexer => connectionMultiplexer.GetDatabase(It.IsAny<int>(), It.IsAny<object>()))
-            .Returns(databaseMock.Object);
+        database.Multiplexer.Returns(connectionMultiplexer);
 
-        databaseMock.Setup(database => database.Multiplexer).Returns(connectionMultiplexerMock.Object);
-
-        return connectionMultiplexerMock.Object;
+        return connectionMultiplexer;
     }
 
     private static async Task<IConnectionMultiplexer> ExtractUnderlyingMultiplexerFromRedisCacheAsync(RedisCache redisCache,

--- a/src/Connectors/test/Connectors.Test/Redis/RedisHealthContributorTest.cs
+++ b/src/Connectors/test/Connectors.Test/Redis/RedisHealthContributorTest.cs
@@ -4,7 +4,8 @@
 
 using FluentAssertions.Extensions;
 using Microsoft.Extensions.Logging.Abstractions;
-using Moq;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
 using StackExchange.Redis;
 using Steeltoe.Common.HealthChecks;
 using Steeltoe.Connectors.Redis;
@@ -16,9 +17,9 @@ public sealed class RedisHealthContributorTest
     [Fact]
     public async Task Not_Connected_Returns_Down_Status()
     {
-        var connectionMultiplexerMock = new Mock<IConnectionMultiplexer>();
+        var connectionMultiplexer = Substitute.For<IConnectionMultiplexer>();
 
-        connectionMultiplexerMock.Setup(connectionMultiplexer => connectionMultiplexer.GetDatabase(It.IsAny<int>(), It.IsAny<object?>()))
+        connectionMultiplexer.GetDatabase(Arg.Any<int>(), Arg.Any<object?>())
             .Throws(new RedisConnectionException(ConnectionFailureType.UnableToConnect, "It was not possible to connect ..."));
 
         using var healthContributor = new RedisHealthContributor("localhost", NullLogger<RedisHealthContributor>.Instance)
@@ -26,7 +27,7 @@ public sealed class RedisHealthContributorTest
             ServiceName = "Example"
         };
 
-        healthContributor.SetConnectionMultiplexer(connectionMultiplexerMock.Object);
+        healthContributor.SetConnectionMultiplexer(connectionMultiplexer);
 
         HealthCheckResult? result = await healthContributor.CheckHealthAsync(TestContext.Current.CancellationToken);
 
@@ -41,20 +42,18 @@ public sealed class RedisHealthContributorTest
     [Fact]
     public async Task Is_Connected_Returns_Up_Status()
     {
-        var databaseMock = new Mock<IDatabase>();
-        databaseMock.Setup(database => database.PingAsync(It.IsAny<CommandFlags>())).Returns(Task.FromResult(50.Milliseconds()));
+        var database = Substitute.For<IDatabase>();
+        database.PingAsync(Arg.Any<CommandFlags>()).Returns(Task.FromResult(50.Milliseconds()));
 
-        var connectionMultiplexerMock = new Mock<IConnectionMultiplexer>();
-
-        connectionMultiplexerMock.Setup(connectionMultiplexer => connectionMultiplexer.GetDatabase(It.IsAny<int>(), It.IsAny<object?>()))
-            .Returns(databaseMock.Object);
+        var connectionMultiplexer = Substitute.For<IConnectionMultiplexer>();
+        connectionMultiplexer.GetDatabase(Arg.Any<int>(), Arg.Any<object?>()).Returns(database);
 
         using var healthContributor = new RedisHealthContributor("localhost", NullLogger<RedisHealthContributor>.Instance)
         {
             ServiceName = "Example"
         };
 
-        healthContributor.SetConnectionMultiplexer(connectionMultiplexerMock.Object);
+        healthContributor.SetConnectionMultiplexer(connectionMultiplexer);
 
         HealthCheckResult? result = await healthContributor.CheckHealthAsync(TestContext.Current.CancellationToken);
 

--- a/src/Connectors/test/Connectors.Test/RelationalDatabaseHealthContributorTest.cs
+++ b/src/Connectors/test/Connectors.Test/RelationalDatabaseHealthContributorTest.cs
@@ -2,13 +2,14 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
+using System.Data;
 using System.Data.Common;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.Logging.Abstractions;
-using Moq;
-using Moq.Protected;
 using MySqlConnector;
 using Npgsql;
+using NSubstitute;
 using Steeltoe.Common.HealthChecks;
 
 namespace Steeltoe.Connectors.Test;
@@ -134,18 +135,17 @@ public sealed class RelationalDatabaseHealthContributorTest
     [Fact]
     public async Task Is_Connected_Returns_Up_Status()
     {
-        var commandMock = new Mock<DbCommand>();
-        commandMock.Setup(command => command.ExecuteScalarAsync(It.IsAny<CancellationToken>())).Returns(Task.FromResult<object?>(1));
+        var command = Substitute.For<DbCommand>();
+        command.ExecuteScalarAsync(Arg.Any<CancellationToken>()).Returns(Task.FromResult<object?>(1));
 
-        var connectionMock = new Mock<DbConnection>();
-        connectionMock.Setup(connection => connection.Open());
-        connectionMock.Protected().Setup<DbCommand>("CreateDbCommand").Returns(() => commandMock.Object);
+        await using var connection = new FakeDbConnection(command);
 
-        var healthContributor = new RelationalDatabaseHealthContributor(() => connectionMock.Object, "SQL Server", "localhost",
-            NullLogger<RelationalDatabaseHealthContributor>.Instance)
-        {
-            ServiceName = "Example"
-        };
+        var healthContributor =
+            // ReSharper disable once AccessToDisposedClosure
+            new RelationalDatabaseHealthContributor(() => connection, "SQL Server", "localhost", NullLogger<RelationalDatabaseHealthContributor>.Instance)
+            {
+                ServiceName = "Example"
+            };
 
         HealthCheckResult? result = await healthContributor.CheckHealthAsync(TestContext.Current.CancellationToken);
 
@@ -159,16 +159,16 @@ public sealed class RelationalDatabaseHealthContributorTest
     [Fact]
     public async Task Canceled_Throws()
     {
-        var connectionMock = new Mock<DbConnection>();
+        var connection = Substitute.For<DbConnection>();
 
-        connectionMock.Setup(connection => connection.OpenAsync(It.IsAny<CancellationToken>())).Returns((CancellationToken cancellationToken) =>
+        connection.OpenAsync(Arg.Any<CancellationToken>()).Returns(info =>
         {
-            cancellationToken.ThrowIfCancellationRequested();
-            return null!;
+            info.Arg<CancellationToken>().ThrowIfCancellationRequested();
+            return Task.CompletedTask;
         });
 
-        var healthContributor = new RelationalDatabaseHealthContributor(() => connectionMock.Object, "SQL Server", "localhost",
-            NullLogger<RelationalDatabaseHealthContributor>.Instance);
+        var healthContributor =
+            new RelationalDatabaseHealthContributor(() => connection, "SQL Server", "localhost", NullLogger<RelationalDatabaseHealthContributor>.Instance);
 
         using var source = new CancellationTokenSource();
         await source.CancelAsync();
@@ -178,5 +178,43 @@ public sealed class RelationalDatabaseHealthContributorTest
         // ReSharper restore AccessToDisposedClosure
 
         await action.Should().ThrowExactlyAsync<OperationCanceledException>();
+    }
+
+    private sealed class FakeDbConnection(DbCommand command) : DbConnection
+    {
+        [AllowNull]
+        public override string ConnectionString
+        {
+            get;
+            set => field = value ?? string.Empty;
+        } = string.Empty;
+
+        public override string ServerVersion => string.Empty;
+        public override string DataSource => string.Empty;
+        public override string Database => string.Empty;
+        public override ConnectionState State => ConnectionState.Open;
+
+        public override void ChangeDatabase(string databaseName)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override void Open()
+        {
+        }
+
+        protected override DbTransaction BeginDbTransaction(IsolationLevel isolationLevel)
+        {
+            throw new NotSupportedException();
+        }
+
+        protected override DbCommand CreateDbCommand()
+        {
+            return command;
+        }
+
+        public override void Close()
+        {
+        }
     }
 }

--- a/src/Discovery/test/Consul.Test/Discovery/ConsulDiscoveryClientTest.cs
+++ b/src/Discovery/test/Consul.Test/Discovery/ConsulDiscoveryClientTest.cs
@@ -4,7 +4,7 @@
 
 using Consul;
 using Microsoft.Extensions.Logging.Abstractions;
-using Moq;
+using NSubstitute;
 using Steeltoe.Common.Discovery;
 using Steeltoe.Common.TestResources;
 using Steeltoe.Discovery.Consul.Configuration;
@@ -60,17 +60,16 @@ public sealed class ConsulDiscoveryClientTest
             ]
         };
 
-        var healthMoq = new Mock<IHealthEndpoint>();
+        var health = Substitute.For<IHealthEndpoint>();
 
-        healthMoq.Setup(endpoint =>
-                endpoint.Service("ServiceId", options.DefaultQueryTag, options.QueryPassing, QueryOptions.Default, It.IsAny<CancellationToken>()))
+        health.Service("ServiceId", options.DefaultQueryTag, options.QueryPassing, QueryOptions.Default, Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(queryResult));
 
-        var clientMoq = new Mock<IConsulClient>();
-        clientMoq.Setup(client => client.Health).Returns(healthMoq.Object);
+        var client = Substitute.For<IConsulClient>();
+        client.Health.Returns(health);
 
         TestOptionsMonitor<ConsulDiscoveryOptions> optionsMonitor = TestOptionsMonitor.Create(options);
-        var discoveryClient = new ConsulDiscoveryClient(clientMoq.Object, optionsMonitor, NullLoggerFactory.Instance);
+        var discoveryClient = new ConsulDiscoveryClient(client, optionsMonitor, NullLoggerFactory.Instance);
 
         List<IServiceInstance> serviceInstances = [];
 
@@ -131,14 +130,14 @@ public sealed class ConsulDiscoveryClientTest
             }
         };
 
-        var catalogMoq = new Mock<ICatalogEndpoint>();
-        catalogMoq.Setup(endpoint => endpoint.Services(null, null, QueryOptions.Default, It.IsAny<CancellationToken>())).Returns(Task.FromResult(queryResult));
+        var catalog = Substitute.For<ICatalogEndpoint>();
+        catalog.Services(null, null, QueryOptions.Default, Arg.Any<CancellationToken>()).Returns(Task.FromResult(queryResult));
 
-        var clientMoq = new Mock<IConsulClient>();
-        clientMoq.Setup(client => client.Catalog).Returns(catalogMoq.Object);
+        var client = Substitute.For<IConsulClient>();
+        client.Catalog.Returns(catalog);
 
         TestOptionsMonitor<ConsulDiscoveryOptions> optionsMonitor = TestOptionsMonitor.Create(options);
-        var discoveryClient = new ConsulDiscoveryClient(clientMoq.Object, optionsMonitor, NullLoggerFactory.Instance);
+        var discoveryClient = new ConsulDiscoveryClient(client, optionsMonitor, NullLoggerFactory.Instance);
         ISet<string> serviceIds = await discoveryClient.GetServiceIdsAsync(TestContext.Current.CancellationToken);
 
         serviceIds.Should().HaveCount(2);
@@ -205,20 +204,20 @@ public sealed class ConsulDiscoveryClientTest
             ]
         };
 
-        var catalogMoq = new Mock<ICatalogEndpoint>();
-        catalogMoq.Setup(endpoint => endpoint.Services(null, null, QueryOptions.Default, It.IsAny<CancellationToken>())).Returns(Task.FromResult(queryResult1));
+        var catalog = Substitute.For<ICatalogEndpoint>();
+        catalog.Services(null, null, QueryOptions.Default, Arg.Any<CancellationToken>()).Returns(Task.FromResult(queryResult1));
 
-        var clientMoq = new Mock<IConsulClient>();
-        clientMoq.Setup(client => client.Catalog).Returns(catalogMoq.Object);
+        var client = Substitute.For<IConsulClient>();
+        client.Catalog.Returns(catalog);
 
-        var healthMoq = new Mock<IHealthEndpoint>();
-        clientMoq.Setup(client => client.Health).Returns(healthMoq.Object);
+        var health = Substitute.For<IHealthEndpoint>();
+        client.Health.Returns(health);
 
-        healthMoq.Setup(h => h.Service("ServiceId", options.DefaultQueryTag, options.QueryPassing, QueryOptions.Default, It.IsAny<CancellationToken>()))
+        health.Service("ServiceId", options.DefaultQueryTag, options.QueryPassing, QueryOptions.Default, Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(queryResult2));
 
         TestOptionsMonitor<ConsulDiscoveryOptions> optionsMonitor = TestOptionsMonitor.Create(options);
-        var discoveryClient = new ConsulDiscoveryClient(clientMoq.Object, optionsMonitor, NullLoggerFactory.Instance);
+        var discoveryClient = new ConsulDiscoveryClient(client, optionsMonitor, NullLoggerFactory.Instance);
         IList<IServiceInstance> serviceInstances = await discoveryClient.GetAllInstancesAsync(QueryOptions.Default, TestContext.Current.CancellationToken);
 
         serviceInstances.Should().HaveCount(2);

--- a/src/Discovery/test/Consul.Test/Discovery/ConsulHealthContributorTest.cs
+++ b/src/Discovery/test/Consul.Test/Discovery/ConsulHealthContributorTest.cs
@@ -3,7 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using Consul;
-using Moq;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
 using Steeltoe.Common.HealthChecks;
 using Steeltoe.Common.TestResources;
 using Steeltoe.Discovery.Consul.Configuration;
@@ -16,14 +17,14 @@ public sealed class ConsulHealthContributorTest
     [Fact]
     public async Task GetLeaderStatusAsync_ReturnsExpected()
     {
-        var statusMoq = new Mock<IStatusEndpoint>();
-        statusMoq.Setup(endpoint => endpoint.Leader(It.IsAny<CancellationToken>())).Returns(Task.FromResult("the-status"));
+        var status = Substitute.For<IStatusEndpoint>();
+        status.Leader(Arg.Any<CancellationToken>()).Returns(Task.FromResult("the-status"));
 
-        var clientMoq = new Mock<IConsulClient>();
-        clientMoq.Setup(client => client.Status).Returns(statusMoq.Object);
+        var client = Substitute.For<IConsulClient>();
+        client.Status.Returns(status);
 
         var optionsMonitor = new TestOptionsMonitor<ConsulDiscoveryOptions>();
-        var healthContributor = new ConsulHealthContributor(clientMoq.Object, optionsMonitor);
+        var healthContributor = new ConsulHealthContributor(client, optionsMonitor);
         string result = await healthContributor.GetLeaderStatusAsync(TestContext.Current.CancellationToken);
 
         result.Should().Be("the-status");
@@ -49,14 +50,14 @@ public sealed class ConsulHealthContributorTest
             }
         };
 
-        var catalogMoq = new Mock<ICatalogEndpoint>();
-        catalogMoq.Setup(endpoint => endpoint.Services(It.IsAny<CancellationToken>())).Returns(Task.FromResult(queryResult));
+        var catalog = Substitute.For<ICatalogEndpoint>();
+        catalog.Services(Arg.Any<CancellationToken>()).Returns(Task.FromResult(queryResult));
 
-        var clientMoq = new Mock<IConsulClient>();
-        clientMoq.Setup(client => client.Catalog).Returns(catalogMoq.Object);
+        var client = Substitute.For<IConsulClient>();
+        client.Catalog.Returns(catalog);
 
         var optionsMonitor = new TestOptionsMonitor<ConsulDiscoveryOptions>();
-        var healthContributor = new ConsulHealthContributor(clientMoq.Object, optionsMonitor);
+        var healthContributor = new ConsulHealthContributor(client, optionsMonitor);
         Dictionary<string, string[]> result = await healthContributor.GetCatalogServicesAsync(TestContext.Current.CancellationToken);
 
         result.Should().HaveCount(2);
@@ -85,18 +86,18 @@ public sealed class ConsulHealthContributorTest
             }
         };
 
-        var statusMoq = new Mock<IStatusEndpoint>();
-        statusMoq.Setup(endpoint => endpoint.Leader(It.IsAny<CancellationToken>())).Returns(Task.FromResult("the-status"));
+        var status = Substitute.For<IStatusEndpoint>();
+        status.Leader(Arg.Any<CancellationToken>()).Returns(Task.FromResult("the-status"));
 
-        var catalogMoq = new Mock<ICatalogEndpoint>();
-        catalogMoq.Setup(endpoint => endpoint.Services(It.IsAny<CancellationToken>())).Returns(Task.FromResult(queryResult));
+        var catalog = Substitute.For<ICatalogEndpoint>();
+        catalog.Services(Arg.Any<CancellationToken>()).Returns(Task.FromResult(queryResult));
 
-        var clientMoq = new Mock<IConsulClient>();
-        clientMoq.Setup(client => client.Status).Returns(statusMoq.Object);
-        clientMoq.Setup(client => client.Catalog).Returns(catalogMoq.Object);
+        var client = Substitute.For<IConsulClient>();
+        client.Status.Returns(status);
+        client.Catalog.Returns(catalog);
 
         var optionsMonitor = new TestOptionsMonitor<ConsulDiscoveryOptions>();
-        var healthContributor = new ConsulHealthContributor(clientMoq.Object, optionsMonitor);
+        var healthContributor = new ConsulHealthContributor(client, optionsMonitor);
         HealthCheckResult? result = await healthContributor.CheckHealthAsync(TestContext.Current.CancellationToken);
 
         result.Should().NotBeNull();
@@ -114,11 +115,11 @@ public sealed class ConsulHealthContributorTest
             Enabled = false
         };
 
-        var clientMoq = new Mock<IConsulClient>();
-        clientMoq.Setup(client => client.Catalog).Throws<NotImplementedException>();
+        var client = Substitute.For<IConsulClient>();
+        client.Catalog.Throws<NotImplementedException>();
 
         TestOptionsMonitor<ConsulDiscoveryOptions> optionsMonitor = TestOptionsMonitor.Create(options);
-        var healthContributor = new ConsulHealthContributor(clientMoq.Object, optionsMonitor);
+        var healthContributor = new ConsulHealthContributor(client, optionsMonitor);
         HealthCheckResult? result = await healthContributor.CheckHealthAsync(TestContext.Current.CancellationToken);
 
         result.Should().BeNull();

--- a/src/Discovery/test/Consul.Test/Discovery/PostConfigureConsulDiscoveryOptionsTest.cs
+++ b/src/Discovery/test/Consul.Test/Discovery/PostConfigureConsulDiscoveryOptionsTest.cs
@@ -8,7 +8,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
-using Moq;
+using NSubstitute;
 using Steeltoe.Common.Extensions;
 using Steeltoe.Common.Net;
 using Steeltoe.Common.TestResources;
@@ -53,16 +53,16 @@ public sealed class PostConfigureConsulDiscoveryOptionsTest
     [Fact]
     public async Task DoesNotUseNetworkInterfacesByDefault()
     {
-        var domainNameResolverMock = new Mock<IDomainNameResolver>();
-        var inetUtilsMock = new Mock<InetUtils>(domainNameResolverMock.Object, new TestOptionsMonitor<InetOptions>(), NullLogger<InetUtils>.Instance);
-        inetUtilsMock.Setup(inetUtils => inetUtils.FindFirstNonLoopbackHostInfo()).Returns(new HostInfo("FromMock", "254.254.254.254")).Verifiable();
+        var domainNameResolver = Substitute.For<IDomainNameResolver>();
+        var inetUtils = Substitute.For<InetUtils>(domainNameResolver, new TestOptionsMonitor<InetOptions>(), NullLogger<InetUtils>.Instance);
+        inetUtils.FindFirstNonLoopbackHostInfo().Returns(new HostInfo("FromMock", "254.254.254.254"));
 
         IConfiguration configuration = new ConfigurationBuilder().Build();
 
         var services = new ServiceCollection();
         services.AddSingleton(configuration);
-        services.AddSingleton(domainNameResolverMock.Object);
-        services.AddSingleton(inetUtilsMock.Object);
+        services.AddSingleton(domainNameResolver);
+        services.AddSingleton(inetUtils);
         services.AddApplicationInstanceInfo();
         services.AddOptions<ConsulDiscoveryOptions>().BindConfiguration(ConsulDiscoveryOptions.ConfigurationPrefix);
         services.AddSingleton<IPostConfigureOptions<ConsulDiscoveryOptions>, PostConfigureConsulDiscoveryOptions>();
@@ -72,15 +72,15 @@ public sealed class PostConfigureConsulDiscoveryOptionsTest
 
         _ = optionsMonitor.CurrentValue;
 
-        inetUtilsMock.Verify(n => n.FindFirstNonLoopbackHostInfo(), Times.Never);
+        inetUtils.DidNotReceive().FindFirstNonLoopbackHostInfo();
     }
 
     [Fact]
     public async Task CanUseNetworkInterfaces()
     {
-        var domainNameResolverMock = new Mock<IDomainNameResolver>();
-        var inetUtilsMock = new Mock<InetUtils>(domainNameResolverMock.Object, new TestOptionsMonitor<InetOptions>(), NullLogger<InetUtils>.Instance);
-        inetUtilsMock.Setup(inetUtils => inetUtils.FindFirstNonLoopbackHostInfo()).Returns(new HostInfo("FromMock", "254.254.254.254")).Verifiable();
+        var domainNameResolver = Substitute.For<IDomainNameResolver>();
+        var inetUtils = Substitute.For<InetUtils>(domainNameResolver, new TestOptionsMonitor<InetOptions>(), NullLogger<InetUtils>.Instance);
+        inetUtils.FindFirstNonLoopbackHostInfo().Returns(new HostInfo("FromMock", "254.254.254.254"));
 
         var appSettings = new Dictionary<string, string?>
         {
@@ -91,8 +91,8 @@ public sealed class PostConfigureConsulDiscoveryOptionsTest
 
         var services = new ServiceCollection();
         services.AddSingleton(configuration);
-        services.AddSingleton(domainNameResolverMock.Object);
-        services.AddSingleton(inetUtilsMock.Object);
+        services.AddSingleton(domainNameResolver);
+        services.AddSingleton(inetUtils);
         services.AddApplicationInstanceInfo();
         services.AddOptions<ConsulDiscoveryOptions>().BindConfiguration(ConsulDiscoveryOptions.ConfigurationPrefix);
         services.AddSingleton<IPostConfigureOptions<ConsulDiscoveryOptions>, PostConfigureConsulDiscoveryOptions>();
@@ -105,7 +105,7 @@ public sealed class PostConfigureConsulDiscoveryOptionsTest
         options.HostName.Should().Be("FromMock");
         options.IPAddress.Should().Be("254.254.254.254");
 
-        inetUtilsMock.Verify(n => n.FindFirstNonLoopbackHostInfo(), Times.Once);
+        inetUtils.Received(1).FindFirstNonLoopbackHostInfo();
     }
 
     [FactSkippedOnPlatform(nameof(OSPlatform.OSX))]
@@ -137,7 +137,9 @@ public sealed class PostConfigureConsulDiscoveryOptionsTest
         noSlowReverseDnsQuery.Stop();
 
         options.HostName.Should().NotBeNull();
-        noSlowReverseDnsQuery.ElapsedMilliseconds.Should().BeInRange(0, 2000); // testing with an actual reverse dns query results in around 5000 ms
+
+        // Testing with an actual reverse dns query results in around 5000 ms.
+        noSlowReverseDnsQuery.ElapsedMilliseconds.Should().BeInRange(0, 2000);
     }
 
     [Fact]

--- a/src/Discovery/test/Consul.Test/Discovery/TtlSchedulerTest.cs
+++ b/src/Discovery/test/Consul.Test/Discovery/TtlSchedulerTest.cs
@@ -5,7 +5,7 @@
 using Consul;
 using FluentAssertions.Extensions;
 using Microsoft.Extensions.Logging.Abstractions;
-using Moq;
+using NSubstitute;
 using Steeltoe.Common.TestResources;
 using Steeltoe.Discovery.Consul.Configuration;
 
@@ -16,9 +16,9 @@ public sealed class TtlSchedulerTest
     [Fact]
     public async Task Add_Throws_Invalid_InstanceId()
     {
-        var clientMoq = new Mock<IConsulClient>();
+        var client = Substitute.For<IConsulClient>();
         var optionsMonitor = new TestOptionsMonitor<ConsulDiscoveryOptions>();
-        await using var scheduler = new TtlScheduler(optionsMonitor, clientMoq.Object, NullLoggerFactory.Instance);
+        await using var scheduler = new TtlScheduler(optionsMonitor, client, NullLoggerFactory.Instance);
 
         // ReSharper disable once AccessToDisposedClosure
         Action action = () => scheduler.Add(string.Empty);
@@ -29,14 +29,14 @@ public sealed class TtlSchedulerTest
     [Fact]
     public async Task Add_DoesNothing_NoHeartbeatOptionsConfigured()
     {
-        var clientMoq = new Mock<IConsulClient>();
+        var client = Substitute.For<IConsulClient>();
 
         var optionsMonitor = TestOptionsMonitor.Create(new ConsulDiscoveryOptions
         {
             Heartbeat = null
         });
 
-        await using var scheduler = new TtlScheduler(optionsMonitor, clientMoq.Object, NullLoggerFactory.Instance);
+        await using var scheduler = new TtlScheduler(optionsMonitor, client, NullLoggerFactory.Instance);
         scheduler.Add("foobar");
 
         scheduler.ServiceHeartbeats.Should().BeEmpty();
@@ -45,13 +45,13 @@ public sealed class TtlSchedulerTest
     [Fact]
     public async Task Add_AddsTimer()
     {
-        var agentMoq = new Mock<IAgentEndpoint>();
-        var clientMoq = new Mock<IConsulClient>();
-        clientMoq.Setup(client => client.Agent).Returns(agentMoq.Object);
+        var agent = Substitute.For<IAgentEndpoint>();
+        var client = Substitute.For<IConsulClient>();
+        client.Agent.Returns(agent);
 
         var optionsMonitor = new TestOptionsMonitor<ConsulDiscoveryOptions>();
 
-        await using var scheduler = new TtlScheduler(optionsMonitor, clientMoq.Object, NullLoggerFactory.Instance);
+        await using var scheduler = new TtlScheduler(optionsMonitor, client, NullLoggerFactory.Instance);
         scheduler.Add("foobar");
 
         scheduler.ServiceHeartbeats.Should().NotBeEmpty();
@@ -62,9 +62,9 @@ public sealed class TtlSchedulerTest
     [Fact]
     public async Task Can_Change_Timer_Interval()
     {
-        var agentMoq = new Mock<IAgentEndpoint>();
-        var clientMoq = new Mock<IConsulClient>();
-        clientMoq.Setup(client => client.Agent).Returns(agentMoq.Object);
+        var agent = Substitute.For<IAgentEndpoint>();
+        var client = Substitute.For<IConsulClient>();
+        client.Agent.Returns(agent);
 
         var options = new ConsulDiscoveryOptions
         {
@@ -77,7 +77,7 @@ public sealed class TtlSchedulerTest
 
         TestOptionsMonitor<ConsulDiscoveryOptions> optionsMonitor = TestOptionsMonitor.Create(options);
 
-        await using var scheduler = new TtlScheduler(optionsMonitor, clientMoq.Object, NullLoggerFactory.Instance);
+        await using var scheduler = new TtlScheduler(optionsMonitor, client, NullLoggerFactory.Instance);
         scheduler.Add(options.InstanceId);
 
         PeriodicHeartbeat heartbeat = scheduler.ServiceHeartbeats.Should().ContainKey(options.InstanceId).WhoseValue;
@@ -93,9 +93,9 @@ public sealed class TtlSchedulerTest
     [Fact]
     public async Task Remove_Throws_Invalid_InstanceId()
     {
-        var clientMoq = new Mock<IConsulClient>();
+        var client = Substitute.For<IConsulClient>();
         var optionsMonitor = new TestOptionsMonitor<ConsulDiscoveryOptions>();
-        await using var scheduler = new TtlScheduler(optionsMonitor, clientMoq.Object, NullLoggerFactory.Instance);
+        await using var scheduler = new TtlScheduler(optionsMonitor, client, NullLoggerFactory.Instance);
 
         // ReSharper disable once AccessToDisposedClosure
         Func<Task> action = async () => await scheduler.RemoveAsync(string.Empty);
@@ -106,12 +106,12 @@ public sealed class TtlSchedulerTest
     [Fact]
     public async Task Remove_RemovesTimer()
     {
-        var agentMoq = new Mock<IAgentEndpoint>();
-        var clientMoq = new Mock<IConsulClient>();
-        clientMoq.Setup(client => client.Agent).Returns(agentMoq.Object);
+        var agent = Substitute.For<IAgentEndpoint>();
+        var client = Substitute.For<IConsulClient>();
+        client.Agent.Returns(agent);
 
         var optionsMonitor = new TestOptionsMonitor<ConsulDiscoveryOptions>();
-        await using var scheduler = new TtlScheduler(optionsMonitor, clientMoq.Object, NullLoggerFactory.Instance);
+        await using var scheduler = new TtlScheduler(optionsMonitor, client, NullLoggerFactory.Instance);
         scheduler.Add("foobar");
 
         scheduler.ServiceHeartbeats.Should().NotBeEmpty();
@@ -125,9 +125,9 @@ public sealed class TtlSchedulerTest
     [Fact]
     public async Task Timer_CallsPassTTL()
     {
-        var agentMoq = new Mock<IAgentEndpoint>();
-        var clientMoq = new Mock<IConsulClient>();
-        clientMoq.Setup(client => client.Agent).Returns(agentMoq.Object);
+        var agent = Substitute.For<IAgentEndpoint>();
+        var client = Substitute.For<IConsulClient>();
+        client.Agent.Returns(agent);
 
         var optionsMonitor = TestOptionsMonitor.Create(new ConsulDiscoveryOptions
         {
@@ -137,12 +137,12 @@ public sealed class TtlSchedulerTest
             }
         });
 
-        await using var scheduler = new TtlScheduler(optionsMonitor, clientMoq.Object, NullLoggerFactory.Instance);
+        await using var scheduler = new TtlScheduler(optionsMonitor, client, NullLoggerFactory.Instance);
         scheduler.Add("foobar");
 
         await Task.Delay(2500.Milliseconds(), TestContext.Current.CancellationToken);
 
-        agentMoq.Verify(a => a.PassTTL("service:foobar", "ttl", It.IsAny<CancellationToken>()), Times.AtLeastOnce);
+        await agent.Received().PassTTL("service:foobar", "ttl", Arg.Any<CancellationToken>());
         await scheduler.RemoveAsync("foobar");
     }
 }

--- a/src/Discovery/test/Consul.Test/Registry/ConsulServiceRegistrarTest.cs
+++ b/src/Discovery/test/Consul.Test/Registry/ConsulServiceRegistrarTest.cs
@@ -4,7 +4,7 @@
 
 using Consul;
 using Microsoft.Extensions.Logging.Abstractions;
-using Moq;
+using NSubstitute;
 using Steeltoe.Common.TestResources;
 using Steeltoe.Discovery.Consul.Configuration;
 using Steeltoe.Discovery.Consul.Registry;
@@ -21,14 +21,14 @@ public sealed class ConsulServiceRegistrarTest
         var optionsMonitor = new TestOptionsMonitor<ConsulDiscoveryOptions>();
         ConsulRegistration registration = TestRegistrationFactory.Create(new Dictionary<string, string?>());
 
-        (Mock<IConsulClient> clientMock, Mock<IAgentEndpoint> agentMock) = CreateConsulClientAgentMock(registration);
-        await using var registry = new ConsulServiceRegistry(clientMock.Object, optionsMonitor, null, NullLogger<ConsulServiceRegistry>.Instance);
+        (IConsulClient client, IAgentEndpoint agent) = CreateConsulClientAgentSubstitute(registration);
+        await using var registry = new ConsulServiceRegistry(client, optionsMonitor, null, NullLogger<ConsulServiceRegistry>.Instance);
         await using var registrar = new ConsulServiceRegistrar(registry, optionsMonitor, registration, NullLogger<ConsulServiceRegistrar>.Instance);
 
         await registrar.StartAsync(TestContext.Current.CancellationToken);
 
         registrar.IsRunning.Should().BeTrue();
-        agentMock.Verify(agent => agent.ServiceRegister(registration.InnerRegistration, It.IsAny<CancellationToken>()), Times.Once);
+        await agent.Received(1).ServiceRegister(registration.InnerRegistration, Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -41,14 +41,14 @@ public sealed class ConsulServiceRegistrarTest
 
         ConsulRegistration registration = TestRegistrationFactory.Create(new Dictionary<string, string?>());
 
-        (Mock<IConsulClient> clientMock, Mock<IAgentEndpoint> agentMock) = CreateConsulClientAgentMock(registration);
-        await using var registry = new ConsulServiceRegistry(clientMock.Object, optionsMonitor, null, NullLogger<ConsulServiceRegistry>.Instance);
+        (IConsulClient client, IAgentEndpoint agent) = CreateConsulClientAgentSubstitute(registration);
+        await using var registry = new ConsulServiceRegistry(client, optionsMonitor, null, NullLogger<ConsulServiceRegistry>.Instance);
         await using var registrar = new ConsulServiceRegistrar(registry, optionsMonitor, registration, NullLogger<ConsulServiceRegistrar>.Instance);
 
         await registrar.StartAsync(TestContext.Current.CancellationToken);
 
         registrar.IsRunning.Should().BeTrue();
-        agentMock.Verify(agent => agent.ServiceRegister(registration.InnerRegistration, It.IsAny<CancellationToken>()), Times.Never);
+        await agent.DidNotReceive().ServiceRegister(registration.InnerRegistration, Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -61,14 +61,14 @@ public sealed class ConsulServiceRegistrarTest
 
         ConsulRegistration registration = TestRegistrationFactory.Create(new Dictionary<string, string?>());
 
-        (Mock<IConsulClient> clientMock, Mock<IAgentEndpoint> agentMock) = CreateConsulClientAgentMock(registration);
-        await using var registry = new ConsulServiceRegistry(clientMock.Object, optionsMonitor, null, NullLogger<ConsulServiceRegistry>.Instance);
+        (IConsulClient client, IAgentEndpoint agent) = CreateConsulClientAgentSubstitute(registration);
+        await using var registry = new ConsulServiceRegistry(client, optionsMonitor, null, NullLogger<ConsulServiceRegistry>.Instance);
         await using var registrar = new ConsulServiceRegistrar(registry, optionsMonitor, registration, NullLogger<ConsulServiceRegistrar>.Instance);
 
         await registrar.StartAsync(TestContext.Current.CancellationToken);
 
         registrar.IsRunning.Should().BeFalse();
-        agentMock.Verify(agent => agent.ServiceRegister(registration.InnerRegistration, It.IsAny<CancellationToken>()), Times.Never);
+        await agent.DidNotReceive().ServiceRegister(registration.InnerRegistration, Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -77,8 +77,8 @@ public sealed class ConsulServiceRegistrarTest
         var optionsMonitor = new TestOptionsMonitor<ConsulDiscoveryOptions>();
         ConsulRegistration registration = TestRegistrationFactory.Create(new Dictionary<string, string?>());
 
-        (Mock<IConsulClient> clientMock, Mock<IAgentEndpoint> agentMock) = CreateConsulClientAgentMock(registration);
-        await using var registry = new ConsulServiceRegistry(clientMock.Object, optionsMonitor, null, NullLogger<ConsulServiceRegistry>.Instance);
+        (IConsulClient client, IAgentEndpoint agent) = CreateConsulClientAgentSubstitute(registration);
+        await using var registry = new ConsulServiceRegistry(client, optionsMonitor, null, NullLogger<ConsulServiceRegistry>.Instance);
         var registrar = new ConsulServiceRegistrar(registry, optionsMonitor, registration, NullLogger<ConsulServiceRegistrar>.Instance);
 
         await using (registrar)
@@ -87,7 +87,7 @@ public sealed class ConsulServiceRegistrarTest
         }
 
         registrar.IsRunning.Should().BeFalse();
-        agentMock.Verify(agent => agent.ServiceDeregister(registration.InstanceId, It.IsAny<CancellationToken>()), Times.Once);
+        await agent.Received(1).ServiceDeregister(registration.InstanceId, Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -100,8 +100,8 @@ public sealed class ConsulServiceRegistrarTest
 
         ConsulRegistration registration = TestRegistrationFactory.Create(new Dictionary<string, string?>());
 
-        (Mock<IConsulClient> clientMock, Mock<IAgentEndpoint> agentMock) = CreateConsulClientAgentMock(registration);
-        await using var registry = new ConsulServiceRegistry(clientMock.Object, optionsMonitor, null, NullLogger<ConsulServiceRegistry>.Instance);
+        (IConsulClient client, IAgentEndpoint agent) = CreateConsulClientAgentSubstitute(registration);
+        await using var registry = new ConsulServiceRegistry(client, optionsMonitor, null, NullLogger<ConsulServiceRegistry>.Instance);
         var registrar = new ConsulServiceRegistrar(registry, optionsMonitor, registration, NullLogger<ConsulServiceRegistrar>.Instance);
 
         await using (registrar)
@@ -109,21 +109,18 @@ public sealed class ConsulServiceRegistrarTest
             await registrar.StartAsync(TestContext.Current.CancellationToken);
         }
 
-        agentMock.Verify(agent => agent.ServiceDeregister(registration.InstanceId, It.IsAny<CancellationToken>()), Times.Never);
+        await agent.DidNotReceive().ServiceDeregister(registration.InstanceId, Arg.Any<CancellationToken>());
     }
 
-    private static (Mock<IConsulClient> ClientMock, Mock<IAgentEndpoint> AgentMock) CreateConsulClientAgentMock(ConsulRegistration registration)
+    private static (IConsulClient Client, IAgentEndpoint Agent) CreateConsulClientAgentSubstitute(ConsulRegistration registration)
     {
-        var agentMock = new Mock<IAgentEndpoint>();
+        var agent = Substitute.For<IAgentEndpoint>();
+        agent.ServiceRegister(registration.InnerRegistration, Arg.Any<CancellationToken>()).Returns(Task.FromResult(DefaultWriteResult));
+        agent.ServiceDeregister(registration.InstanceId, Arg.Any<CancellationToken>()).Returns(Task.FromResult(DefaultWriteResult));
 
-        agentMock.Setup(agent => agent.ServiceRegister(registration.InnerRegistration, It.IsAny<CancellationToken>()))
-            .Returns(Task.FromResult(DefaultWriteResult));
+        var client = Substitute.For<IConsulClient>();
+        client.Agent.Returns(agent);
 
-        agentMock.Setup(agent => agent.ServiceDeregister(registration.InstanceId, It.IsAny<CancellationToken>())).Returns(Task.FromResult(DefaultWriteResult));
-
-        var clientMock = new Mock<IConsulClient>();
-        clientMock.Setup(client => client.Agent).Returns(agentMock.Object);
-
-        return (clientMock, agentMock);
+        return (client, agent);
     }
 }

--- a/src/Discovery/test/Consul.Test/Registry/ConsulServiceRegistryTest.cs
+++ b/src/Discovery/test/Consul.Test/Registry/ConsulServiceRegistryTest.cs
@@ -4,7 +4,7 @@
 
 using Consul;
 using Microsoft.Extensions.Logging.Abstractions;
-using Moq;
+using NSubstitute;
 using Steeltoe.Common.TestResources;
 using Steeltoe.Discovery.Consul.Configuration;
 using Steeltoe.Discovery.Consul.Registry;
@@ -16,13 +16,13 @@ public sealed class ConsulServiceRegistryTest
     [Fact]
     public async Task RegisterAsync_CallsServiceRegister_AddsHeartbeatToScheduler()
     {
-        var agentMoq = new Mock<IAgentEndpoint>();
-        var clientMoq = new Mock<IConsulClient>();
-        clientMoq.Setup(client => client.Agent).Returns(agentMoq.Object);
+        var agent = Substitute.For<IAgentEndpoint>();
+        var client = Substitute.For<IConsulClient>();
+        client.Agent.Returns(agent);
 
         var optionsMonitor = new TestOptionsMonitor<ConsulDiscoveryOptions>();
-        await using var scheduler = new TtlScheduler(optionsMonitor, clientMoq.Object, NullLoggerFactory.Instance);
-        await using var registry = new ConsulServiceRegistry(clientMoq.Object, optionsMonitor, scheduler, NullLogger<ConsulServiceRegistry>.Instance);
+        await using var scheduler = new TtlScheduler(optionsMonitor, client, NullLoggerFactory.Instance);
+        await using var registry = new ConsulServiceRegistry(client, optionsMonitor, scheduler, NullLogger<ConsulServiceRegistry>.Instance);
 
         var appSettings = new Dictionary<string, string?>
         {
@@ -32,7 +32,7 @@ public sealed class ConsulServiceRegistryTest
         ConsulRegistration registration = TestRegistrationFactory.Create(appSettings);
         await registry.RegisterAsync(registration, TestContext.Current.CancellationToken);
 
-        agentMoq.Verify(endpoint => endpoint.ServiceRegister(registration.InnerRegistration, It.IsAny<CancellationToken>()), Times.Once);
+        await agent.Received(1).ServiceRegister(registration.InnerRegistration, Arg.Any<CancellationToken>());
 
         scheduler.ServiceHeartbeats.Should().ContainSingle();
         scheduler.ServiceHeartbeats.Should().ContainKey(registration.InstanceId);
@@ -41,13 +41,13 @@ public sealed class ConsulServiceRegistryTest
     [Fact]
     public async Task DeregisterAsync_CallsServiceDeregister_RemovesHeartbeatFromScheduler()
     {
-        var agentMoq = new Mock<IAgentEndpoint>();
-        var clientMoq = new Mock<IConsulClient>();
-        clientMoq.Setup(client => client.Agent).Returns(agentMoq.Object);
+        var agent = Substitute.For<IAgentEndpoint>();
+        var client = Substitute.For<IConsulClient>();
+        client.Agent.Returns(agent);
 
         var optionsMonitor = new TestOptionsMonitor<ConsulDiscoveryOptions>();
-        await using var scheduler = new TtlScheduler(optionsMonitor, clientMoq.Object, NullLoggerFactory.Instance);
-        await using var registry = new ConsulServiceRegistry(clientMoq.Object, optionsMonitor, scheduler, NullLogger<ConsulServiceRegistry>.Instance);
+        await using var scheduler = new TtlScheduler(optionsMonitor, client, NullLoggerFactory.Instance);
+        await using var registry = new ConsulServiceRegistry(client, optionsMonitor, scheduler, NullLogger<ConsulServiceRegistry>.Instance);
 
         var appSettings = new Dictionary<string, string?>
         {
@@ -57,26 +57,26 @@ public sealed class ConsulServiceRegistryTest
         ConsulRegistration registration = TestRegistrationFactory.Create(appSettings);
         await registry.RegisterAsync(registration, TestContext.Current.CancellationToken);
 
-        agentMoq.Verify(endpoint => endpoint.ServiceRegister(registration.InnerRegistration, It.IsAny<CancellationToken>()), Times.Once);
+        await agent.Received(1).ServiceRegister(registration.InnerRegistration, Arg.Any<CancellationToken>());
 
         scheduler.ServiceHeartbeats.Should().ContainSingle();
         scheduler.ServiceHeartbeats.Should().ContainKey(registration.InstanceId);
 
         await registry.DeregisterAsync(registration, TestContext.Current.CancellationToken);
 
-        agentMoq.Verify(endpoint => endpoint.ServiceDeregister(registration.InnerRegistration.ID, It.IsAny<CancellationToken>()), Times.Once);
+        await agent.Received(1).ServiceDeregister(registration.InnerRegistration.ID, Arg.Any<CancellationToken>());
         scheduler.ServiceHeartbeats.Should().BeEmpty();
     }
 
     [Fact]
     public async Task SetStatusAsync_ThrowsInvalidStatus()
     {
-        var agentMoq = new Mock<IAgentEndpoint>();
-        var clientMoq = new Mock<IConsulClient>();
-        clientMoq.Setup(client => client.Agent).Returns(agentMoq.Object);
+        var agent = Substitute.For<IAgentEndpoint>();
+        var client = Substitute.For<IConsulClient>();
+        client.Agent.Returns(agent);
 
         var optionsMonitor = new TestOptionsMonitor<ConsulDiscoveryOptions>();
-        await using var scheduler = new TtlScheduler(optionsMonitor, clientMoq.Object, NullLoggerFactory.Instance);
+        await using var scheduler = new TtlScheduler(optionsMonitor, client, NullLoggerFactory.Instance);
 
         var appSettings = new Dictionary<string, string?>
         {
@@ -85,7 +85,7 @@ public sealed class ConsulServiceRegistryTest
 
         ConsulRegistration registration = TestRegistrationFactory.Create(appSettings);
 
-        await using var registry = new ConsulServiceRegistry(clientMoq.Object, optionsMonitor, scheduler, NullLogger<ConsulServiceRegistry>.Instance);
+        await using var registry = new ConsulServiceRegistry(client, optionsMonitor, scheduler, NullLogger<ConsulServiceRegistry>.Instance);
 
         // ReSharper disable once AccessToDisposedClosure
         Func<Task> action = async () => await registry.SetStatusAsync(registration, string.Empty, TestContext.Current.CancellationToken);
@@ -96,12 +96,12 @@ public sealed class ConsulServiceRegistryTest
     [Fact]
     public async Task SetStatusAsync_CallsConsulClient()
     {
-        var agentMoq = new Mock<IAgentEndpoint>();
-        var clientMoq = new Mock<IConsulClient>();
-        clientMoq.Setup(client => client.Agent).Returns(agentMoq.Object);
+        var agent = Substitute.For<IAgentEndpoint>();
+        var client = Substitute.For<IConsulClient>();
+        client.Agent.Returns(agent);
 
         var optionsMonitor = new TestOptionsMonitor<ConsulDiscoveryOptions>();
-        await using var scheduler = new TtlScheduler(optionsMonitor, clientMoq.Object, NullLoggerFactory.Instance);
+        await using var scheduler = new TtlScheduler(optionsMonitor, client, NullLoggerFactory.Instance);
 
         var appSettings = new Dictionary<string, string?>
         {
@@ -110,12 +110,12 @@ public sealed class ConsulServiceRegistryTest
 
         ConsulRegistration registration = TestRegistrationFactory.Create(appSettings);
 
-        await using var registry = new ConsulServiceRegistry(clientMoq.Object, optionsMonitor, scheduler, NullLogger<ConsulServiceRegistry>.Instance);
+        await using var registry = new ConsulServiceRegistry(client, optionsMonitor, scheduler, NullLogger<ConsulServiceRegistry>.Instance);
         await registry.SetStatusAsync(registration, "Up", TestContext.Current.CancellationToken);
-        agentMoq.Verify(endpoint => endpoint.DisableServiceMaintenance(registration.InstanceId, It.IsAny<CancellationToken>()), Times.Once);
+        await agent.Received(1).DisableServiceMaintenance(registration.InstanceId, Arg.Any<CancellationToken>());
 
         await registry.SetStatusAsync(registration, "Out_of_Service", TestContext.Current.CancellationToken);
-        agentMoq.Verify(endpoint => endpoint.EnableServiceMaintenance(registration.InstanceId, "OUT_OF_SERVICE", It.IsAny<CancellationToken>()), Times.Once);
+        await agent.Received(1).EnableServiceMaintenance(registration.InstanceId, "OUT_OF_SERVICE", Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -149,14 +149,14 @@ public sealed class ConsulServiceRegistryTest
 
         Task<QueryResult<HealthCheck[]>> result = Task.FromResult(queryResult);
 
-        var clientMoq = new Mock<IConsulClient>();
-        var healthMoq = new Mock<IHealthEndpoint>();
+        var client = Substitute.For<IConsulClient>();
+        var health = Substitute.For<IHealthEndpoint>();
 
-        clientMoq.Setup(client => client.Health).Returns(healthMoq.Object);
-        healthMoq.Setup(endpoint => endpoint.Checks(registration.ServiceId, QueryOptions.Default, It.IsAny<CancellationToken>())).Returns(result);
+        client.Health.Returns(health);
+        health.Checks(registration.ServiceId, QueryOptions.Default, Arg.Any<CancellationToken>()).Returns(result);
 
-        await using var scheduler = new TtlScheduler(optionsMonitor, clientMoq.Object, NullLoggerFactory.Instance);
-        await using var registry = new ConsulServiceRegistry(clientMoq.Object, optionsMonitor, scheduler, NullLogger<ConsulServiceRegistry>.Instance);
+        await using var scheduler = new TtlScheduler(optionsMonitor, client, NullLoggerFactory.Instance);
+        await using var registry = new ConsulServiceRegistry(client, optionsMonitor, scheduler, NullLogger<ConsulServiceRegistry>.Instance);
 
         string status = await registry.GetStatusAsync(registration, TestContext.Current.CancellationToken);
         status.Should().Be("OUT_OF_SERVICE");

--- a/src/Discovery/test/Consul.Test/Registry/TestRegistrationFactory.cs
+++ b/src/Discovery/test/Consul.Test/Registry/TestRegistrationFactory.cs
@@ -5,7 +5,7 @@
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
-using Moq;
+using NSubstitute;
 using Steeltoe.Common;
 using Steeltoe.Common.Extensions;
 using Steeltoe.Common.Net;
@@ -31,9 +31,9 @@ internal static class TestRegistrationFactory
         var options = new ConsulDiscoveryOptions();
         configuration.GetSection("consul:discovery").Bind(options);
 
-        var domainNameResolverMock = new Mock<IDomainNameResolver>();
-        var inetUtilsMock = new Mock<InetUtils>(domainNameResolverMock.Object, new TestOptionsMonitor<InetOptions>(), NullLogger<InetUtils>.Instance);
-        var configurer = new PostConfigureConsulDiscoveryOptions(configuration, domainNameResolverMock.Object, inetUtilsMock.Object, appInfo);
+        var domainNameResolver = Substitute.For<IDomainNameResolver>();
+        var inetUtils = Substitute.For<InetUtils>(domainNameResolver, new TestOptionsMonitor<InetOptions>(), NullLogger<InetUtils>.Instance);
+        var configurer = new PostConfigureConsulDiscoveryOptions(configuration, domainNameResolver, inetUtils, appInfo);
         configurer.PostConfigure(null, options);
 
         TestOptionsMonitor<ConsulDiscoveryOptions> optionsMonitor = TestOptionsMonitor.Create(options);

--- a/src/Discovery/test/Eureka.Test/PostConfigureEurekaInstanceOptionsTest.cs
+++ b/src/Discovery/test/Eureka.Test/PostConfigureEurekaInstanceOptionsTest.cs
@@ -11,7 +11,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
-using Moq;
+using NSubstitute;
 using Steeltoe.Common.Extensions;
 using Steeltoe.Common.Net;
 using Steeltoe.Common.TestResources;
@@ -174,14 +174,14 @@ public sealed class PostConfigureEurekaInstanceOptionsTest
     [Fact]
     public async Task Does_not_use_network_interfaces_by_default()
     {
-        var domainNameResolverMock = new Mock<IDomainNameResolver>();
-        var inetUtilsMock = new Mock<InetUtils>(domainNameResolverMock.Object, new TestOptionsMonitor<InetOptions>(), NullLogger<InetUtils>.Instance);
-        inetUtilsMock.Setup(inetUtils => inetUtils.FindFirstNonLoopbackHostInfo()).Returns(new HostInfo("FromMock", "254.254.254.254"));
+        var domainNameResolver = Substitute.For<IDomainNameResolver>();
+        var inetUtils = Substitute.For<InetUtils>(domainNameResolver, new TestOptionsMonitor<InetOptions>(), NullLogger<InetUtils>.Instance);
+        inetUtils.FindFirstNonLoopbackHostInfo().Returns(new HostInfo("FromMock", "254.254.254.254"));
 
         await using ServiceProvider serviceProvider = BuildTestServiceProvider(null, services =>
         {
-            services.AddSingleton(domainNameResolverMock.Object);
-            services.AddSingleton(inetUtilsMock.Object);
+            services.AddSingleton(domainNameResolver);
+            services.AddSingleton(inetUtils);
         });
 
         var optionsMonitor = serviceProvider.GetRequiredService<IOptionsMonitor<EurekaInstanceOptions>>();
@@ -195,9 +195,9 @@ public sealed class PostConfigureEurekaInstanceOptionsTest
     [Fact]
     public async Task Can_use_network_interfaces()
     {
-        var domainNameResolverMock = new Mock<IDomainNameResolver>();
-        var inetUtilsMock = new Mock<InetUtils>(domainNameResolverMock.Object, new TestOptionsMonitor<InetOptions>(), NullLogger<InetUtils>.Instance);
-        inetUtilsMock.Setup(inetUtils => inetUtils.FindFirstNonLoopbackHostInfo()).Returns(new HostInfo("FromMock", "254.254.254.254"));
+        var domainNameResolver = Substitute.For<IDomainNameResolver>();
+        var inetUtils = Substitute.For<InetUtils>(domainNameResolver, new TestOptionsMonitor<InetOptions>(), NullLogger<InetUtils>.Instance);
+        inetUtils.FindFirstNonLoopbackHostInfo().Returns(new HostInfo("FromMock", "254.254.254.254"));
 
         var appSettings = new Dictionary<string, string?>
         {
@@ -206,8 +206,8 @@ public sealed class PostConfigureEurekaInstanceOptionsTest
 
         await using ServiceProvider serviceProvider = BuildTestServiceProvider(appSettings, services =>
         {
-            services.AddSingleton(domainNameResolverMock.Object);
-            services.AddSingleton(inetUtilsMock.Object);
+            services.AddSingleton(domainNameResolver);
+            services.AddSingleton(inetUtils);
         });
 
         var optionsMonitor = serviceProvider.GetRequiredService<IOptionsMonitor<EurekaInstanceOptions>>();
@@ -237,7 +237,7 @@ public sealed class PostConfigureEurekaInstanceOptionsTest
 
         instanceOptions.HostName.Should().NotBeNull();
 
-        // testing with an actual reverse dns query results in around 5000 ms
+        // Testing with an actual reverse dns query results in around 5000 ms.
         noSlowReverseDnsQuery.ElapsedMilliseconds.Should().BeInRange(0, 1500);
     }
 

--- a/src/Security/test/DataProtection.Redis.Test/RedisDataProtectionBuilderExtensionsTest.net80.cs
+++ b/src/Security/test/DataProtection.Redis.Test/RedisDataProtectionBuilderExtensionsTest.net80.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-using Moq;
+using NSubstitute;
 using StackExchange.Redis;
 
 namespace Steeltoe.Security.DataProtection.Redis.Test;
@@ -12,31 +12,29 @@ partial class RedisDataProtectionBuilderExtensionsTest
     private static object GetMockedConnectionMultiplexer(string? connectionString)
     {
         Dictionary<string, byte[]> innerStore = [];
-        var databaseMock = new Mock<IDatabase>();
 
-        databaseMock.Setup(database => database.HashGet(It.IsAny<RedisKey>(), It.IsAny<RedisValue[]>(), It.IsAny<CommandFlags>()))
-            .Returns((RedisKey key, RedisValue[] _, CommandFlags _) => GetRedisValues(key));
+        var database = Substitute.For<IDatabase>();
+        database.HashGet(Arg.Any<RedisKey>(), Arg.Any<RedisValue[]>(), Arg.Any<CommandFlags>()).Returns(info => GetRedisValues(info.Arg<RedisKey>()));
 
-        databaseMock.Setup(database => database.HashGetAsync(It.IsAny<RedisKey>(), It.IsAny<RedisValue[]>(), It.IsAny<CommandFlags>()))
-            .Returns((RedisKey key, RedisValue[] _, CommandFlags _) => Task.FromResult(GetRedisValues(key)));
+        database.HashGetAsync(Arg.Any<RedisKey>(), Arg.Any<RedisValue[]>(), Arg.Any<CommandFlags>())
+            .Returns(info => Task.FromResult(GetRedisValues(info.Arg<RedisKey>())));
 
-        databaseMock.Setup(database =>
-                database.ScriptEvaluateAsync(It.IsAny<string>(), It.IsAny<RedisKey[]?>(), It.IsAny<RedisValue[]?>(), It.IsAny<CommandFlags>()))
-            .Returns((string _, RedisKey[]? keys, RedisValue[]? values, CommandFlags _) =>
-            {
-                innerStore[keys![0]!] = values![3]!;
-                return Task.FromResult(RedisResult.Create(keys[0]));
-            });
+        database.ScriptEvaluateAsync(Arg.Any<string>(), Arg.Any<RedisKey[]?>(), Arg.Any<RedisValue[]?>(), Arg.Any<CommandFlags>()).Returns(info =>
+        {
+            RedisKey[]? keys = info.Arg<RedisKey[]?>();
+            RedisValue[]? values = info.Arg<RedisValue[]?>();
 
-        var connectionMultiplexerMock = new Mock<IConnectionMultiplexer>();
-        connectionMultiplexerMock.Setup(connectionMultiplexer => connectionMultiplexer.Configuration).Returns(connectionString!);
+            innerStore[keys![0]!] = values![3]!;
+            return Task.FromResult(RedisResult.Create(keys[0]));
+        });
 
-        connectionMultiplexerMock.Setup(connectionMultiplexer => connectionMultiplexer.GetDatabase(It.IsAny<int>(), It.IsAny<object?>()))
-            .Returns(databaseMock.Object);
+        var connectionMultiplexer = Substitute.For<IConnectionMultiplexer>();
+        connectionMultiplexer.Configuration.Returns(connectionString);
+        connectionMultiplexer.GetDatabase(Arg.Any<int>(), Arg.Any<object?>()).Returns(database);
 
-        databaseMock.Setup(database => database.Multiplexer).Returns(connectionMultiplexerMock.Object);
+        database.Multiplexer.Returns(connectionMultiplexer);
 
-        return connectionMultiplexerMock.Object;
+        return connectionMultiplexer;
 
         RedisValue[] GetRedisValues(RedisKey key)
         {

--- a/src/Security/test/DataProtection.Redis.Test/RedisDataProtectionBuilderExtensionsTest.other.cs
+++ b/src/Security/test/DataProtection.Redis.Test/RedisDataProtectionBuilderExtensionsTest.other.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-using Moq;
+using NSubstitute;
 using StackExchange.Redis;
 
 namespace Steeltoe.Security.DataProtection.Redis.Test;
@@ -12,31 +12,30 @@ partial class RedisDataProtectionBuilderExtensionsTest
     private static object GetMockedConnectionMultiplexer(string? connectionString)
     {
         Dictionary<string, byte[]> innerStore = [];
-        var databaseMock = new Mock<IDatabase>();
 
-        databaseMock.Setup(database => database.HashGet(It.IsAny<RedisKey>(), It.IsAny<RedisValue[]>(), It.IsAny<CommandFlags>()))
-            .Returns((RedisKey key, RedisValue[] _, CommandFlags _) => GetRedisValues(key));
+        var database = Substitute.For<IDatabase>();
+        database.HashGet(Arg.Any<RedisKey>(), Arg.Any<RedisValue[]>(), Arg.Any<CommandFlags>()).Returns(info => GetRedisValues(info.Arg<RedisKey>()));
 
-        databaseMock.Setup(database => database.HashGetAsync(It.IsAny<RedisKey>(), It.IsAny<RedisValue[]>(), It.IsAny<CommandFlags>()))
-            .Returns((RedisKey key, RedisValue[] _, CommandFlags _) => Task.FromResult(GetRedisValues(key)));
+        database.HashGetAsync(Arg.Any<RedisKey>(), Arg.Any<RedisValue[]>(), Arg.Any<CommandFlags>())
+            .Returns(info => Task.FromResult(GetRedisValues(info.Arg<RedisKey>())));
 
-        databaseMock.Setup(database => database.HashSetAsync(It.IsAny<RedisKey>(), It.IsAny<HashEntry[]>(), It.IsAny<CommandFlags>()))
-            .Returns((RedisKey key, HashEntry[] hashFields, CommandFlags _) =>
-            {
-                byte[] data = hashFields[2].Value!;
-                innerStore[key!] = data;
-                return Task.CompletedTask;
-            });
+        database.HashSetAsync(Arg.Any<RedisKey>(), Arg.Any<HashEntry[]>(), Arg.Any<CommandFlags>()).Returns(info =>
+        {
+            var key = info.Arg<RedisKey>();
+            HashEntry[] hashFields = info.Arg<HashEntry[]>();
 
-        var connectionMultiplexerMock = new Mock<IConnectionMultiplexer>();
-        connectionMultiplexerMock.Setup(connectionMultiplexer => connectionMultiplexer.Configuration).Returns(connectionString!);
+            byte[] data = hashFields[2].Value!;
+            innerStore[key!] = data;
+            return Task.CompletedTask;
+        });
 
-        connectionMultiplexerMock.Setup(connectionMultiplexer => connectionMultiplexer.GetDatabase(It.IsAny<int>(), It.IsAny<object?>()))
-            .Returns(databaseMock.Object);
+        var connectionMultiplexer = Substitute.For<IConnectionMultiplexer>();
+        connectionMultiplexer.Configuration.Returns(connectionString);
+        connectionMultiplexer.GetDatabase(Arg.Any<int>(), Arg.Any<object?>()).Returns(database);
 
-        databaseMock.Setup(database => database.Multiplexer).Returns(connectionMultiplexerMock.Object);
+        database.Multiplexer.Returns(connectionMultiplexer);
 
-        return connectionMultiplexerMock.Object;
+        return connectionMultiplexer;
 
         RedisValue[] GetRedisValues(RedisKey key)
         {

--- a/versions.props
+++ b/versions.props
@@ -14,10 +14,10 @@
     <MicrosoftSqlClientVersion>7.0.*</MicrosoftSqlClientVersion>
     <MockHttpVersion>7.0.*</MockHttpVersion>
     <MongoDbDriverVersion>3.8.*</MongoDbDriverVersion>
-    <MoqVersion>4.20.69</MoqVersion>
     <MySqlConnectorVersion>2.6.*</MySqlConnectorVersion>
     <MySqlDataVersion>9.7.*</MySqlDataVersion>
     <NewtonsoftJsonVersion>13.0.*</NewtonsoftJsonVersion>
+    <NSubstituteVersion>6.2.*</NSubstituteVersion>
     <PublicApiAnalyzersVersion>3.3.*</PublicApiAnalyzersVersion>
     <RabbitClientTestVersion>7.2.*</RabbitClientTestVersion>
     <SerilogEnrichersThreadVersion>4.0.*</SerilogEnrichersThreadVersion>


### PR DESCRIPTION
## Description

Migrate tests from Moq to NSubstitute. The `FakeDbConnection` is required because neither NSubstitute nor FakeItEasy can mock protected members.

Fixes #1735.

## Quality checklist

- [x] Your code complies with our [Coding Style](https://github.com/SteeltoeOSS/.github/blob/main/contributing-docs/contributing-code-style.md).
- [x] You've updated unit and/or integration tests for your change, where applicable.
- [ ] You've updated documentation for your change, where applicable.
      If your change affects other repositories, such as [Documentation](https://github.com/SteeltoeOSS/Documentation) and/or [Samples](https://github.com/SteeltoeOSS/Samples), add linked PRs here.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
- [ ] You've added required license files and/or file headers (explaining where the code came from with proper attribution), where code is copied from StackOverflow, a blog, or OSS.
